### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,38 @@
+name: Test and Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+      - name: Run tests
+        run: go test ./...
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to registry
+        uses: docker/login-action@v2
+        if: github.event_name == "push"
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        if: github.event_name == "push"
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-# Build stage
-FROM golang:1.22-alpine AS builder
-WORKDIR /src
+# Build stage (Debian-based Go image)
+FROM golang:1.24-bullseye AS builder
+WORKDIR /app
+
 COPY go.mod go.sum ./
 RUN go mod download
+
 COPY . .
-RUN CGO_ENABLED=0 go build -o /gpt-proxy .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o llm-proxy ./
 
 # Runtime stage
-FROM alpine:3.20
-COPY --from=builder /gpt-proxy /usr/local/bin/gpt-proxy
+FROM debian:bullseye-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/llm-proxy /usr/local/bin/llm-proxy
+
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/gpt-proxy"]
+CMD ["/usr/local/bin/llm-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /gpt-proxy .
+
+# Runtime stage
+FROM alpine:3.20
+COPY --from=builder /gpt-proxy /usr/local/bin/gpt-proxy
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/gpt-proxy"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ variables:
 
 ```bash
 SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx \
-  ./gpt-proxy --port=8080 --log_level=info
+  ./llm-proxy --port=8080 --log_level=info
 ```
 
 Once running, send a request with the secret key:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,11 +21,11 @@ func Execute() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "gpt-proxy",
+	Use:   "llm-proxy",
 	Short: "Tiny HTTP proxy for ChatGPT",
 	Long:  "Accepts GET /?prompt=…&key=SECRET and forwards to OpenAI.",
-	Example: `gpt-proxy --service_secret=mysecret --openai_api_key=sk-xxxxx --log_level=debug
-SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug gpt-proxy`,
+	Example: `llm-proxy --service_secret=mysecret --openai_api_key=sk-xxxxx --log_level=debug
+SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// fill in from env if flags didn't
 		if cfg.ServiceSecret == "" {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/temirov/llm-proxy/cmd"
 )
 
-// main is the entry point for gpt-proxy.
+// main is the entry point for llm-proxy.
 func main() {
 	_ = gotenv.Load()
 


### PR DESCRIPTION
## Summary
- add Dockerfile to build the Go proxy binary
- create GitHub Actions workflow to run tests and push a Docker image on successful pushes
- remove QEMU setup step since it's unnecessary for this workflow

## Testing
- `go test ./...`
- *(Docker build command failed: `bash: command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_e_68757a20454c8327b1a5f95ff6625479