### PR TITLE
Use Debian base images in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-# Build stage
-FROM golang:1.22-alpine AS builder
-WORKDIR /src
+# Build stage (Debian-based Go image)
+FROM golang:1.24-bullseye AS builder
+WORKDIR /app
+
 COPY go.mod go.sum ./
 RUN go mod download
+
 COPY . .
-RUN CGO_ENABLED=0 go build -o /gpt-proxy .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o llm-proxy ./
 
 # Runtime stage
-FROM alpine:3.20
-COPY --from=builder /gpt-proxy /usr/local/bin/gpt-proxy
+FROM debian:bullseye-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/llm-proxy /usr/local/bin/llm-proxy
+
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/gpt-proxy"]
+CMD ["/usr/local/bin/llm-proxy"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ variables:
 
 ```bash
 SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx \
-  ./gpt-proxy --port=8080 --log_level=info
+  ./llm-proxy --port=8080 --log_level=info
 ```
 
 Once running, send a request with the secret key:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,11 +21,11 @@ func Execute() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "gpt-proxy",
+	Use:   "llm-proxy",
 	Short: "Tiny HTTP proxy for ChatGPT",
 	Long:  "Accepts GET /?prompt=…&key=SECRET and forwards to OpenAI.",
-	Example: `gpt-proxy --service_secret=mysecret --openai_api_key=sk-xxxxx --log_level=debug
-SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug gpt-proxy`,
+	Example: `llm-proxy --service_secret=mysecret --openai_api_key=sk-xxxxx --log_level=debug
+SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// fill in from env if flags didn't
 		if cfg.ServiceSecret == "" {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/temirov/llm-proxy/cmd"
 )
 
-// main is the entry point for gpt-proxy.
+// main is the entry point for llm-proxy.
 func main() {
 	_ = gotenv.Load()
 


### PR DESCRIPTION
## Summary
- rebuild gpt-proxy using `golang:1.24-bullseye` builder
- run on `debian:bullseye-slim` runtime image
- rename binary to llm-proxy

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68758b1125908327b064557cd077601c