### PR TITLE
Expose system prompt as optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ variables:
 | `--openai_api_key` / `OPENAI_API_KEY` | OpenAI API key used for requests                    |
 | `--port` / `GPT_PORT`                 | Port for the HTTP server (default `8080`)           |
 | `--log_level` / `LOG_LEVEL`           | `debug` or `info` (default `info`)                  |
+| `--system_prompt` / `SYSTEM_PROMPT`   | Optional system prompt text                         |
 
 ## Running
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,9 @@ SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy`,
 		if cfg.LogLevel == "" {
 			cfg.LogLevel = viper.GetString("log_level")
 		}
+		if cfg.SystemPrompt == "" {
+			cfg.SystemPrompt = viper.GetString("system_prompt")
+		}
 
 		// choose zap config based on log level
 		var logger *zap.Logger
@@ -65,6 +68,7 @@ func init() {
 	viper.BindEnv("openai_api_key", "OPENAI_API_KEY")
 	viper.BindEnv("service_secret", "SERVICE_SECRET")
 	viper.BindEnv("log_level", "LOG_LEVEL")
+	viper.BindEnv("system_prompt", "SYSTEM_PROMPT")
 
 	rootCmd.Flags().StringVar(
 		&cfg.ServiceSecret,
@@ -89,6 +93,12 @@ func init() {
 		"log_level",
 		"info",
 		"logging level: debug or info (env: LOG_LEVEL)",
+	)
+	rootCmd.Flags().StringVar(
+		&cfg.SystemPrompt,
+		"system_prompt",
+		"",
+		"system prompt sent to the model (env: SYSTEM_PROMPT)",
 	)
 
 	viper.BindPFlags(rootCmd.Flags())


### PR DESCRIPTION
## Summary
- allow configuring the system prompt
- support CLI flag `--system_prompt`, env variable `SYSTEM_PROMPT`, and HTTP query parameter `system_prompt`
- update tests for new argument and add override test
- document the new option in the README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68769dac8aa083279f0cc577598d9c47