### PR TITLE
Implement worker queue for chat requests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,12 @@ SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy`,
 		if config.SystemPrompt == "" {
 			config.SystemPrompt = viper.GetString("system_prompt")
 		}
+		if config.WorkerCount == 0 {
+			config.WorkerCount = viper.GetInt("workers")
+		}
+		if config.QueueSize == 0 {
+			config.QueueSize = viper.GetInt("queue_size")
+		}
 
 		var logger *zap.Logger
 		normalizedLevel := strings.ToLower(config.LogLevel)
@@ -67,6 +73,8 @@ func init() {
 	viper.BindEnv("service_secret", "SERVICE_SECRET")
 	viper.BindEnv("log_level", "LOG_LEVEL")
 	viper.BindEnv("system_prompt", "SYSTEM_PROMPT")
+	viper.BindEnv("workers", "GPT_WORKERS")
+	viper.BindEnv("queue_size", "GPT_QUEUE_SIZE")
 
 	rootCmd.Flags().StringVar(
 		&config.ServiceSecret,
@@ -97,6 +105,18 @@ func init() {
 		"system_prompt",
 		"",
 		"system prompt sent to the model (env: SYSTEM_PROMPT)",
+	)
+	rootCmd.Flags().IntVar(
+		&config.WorkerCount,
+		"workers",
+		defaultWorkers,
+		"number of worker goroutines (env: GPT_WORKERS)",
+	)
+	rootCmd.Flags().IntVar(
+		&config.QueueSize,
+		"queue_size",
+		defaultQueueSize,
+		"request queue size (env: GPT_QUEUE_SIZE)",
 	)
 
 	viper.BindPFlags(rootCmd.Flags())


### PR DESCRIPTION
## Summary
- add worker count and queue size settings
- send OpenAI requests using a worker pool
- queue requests in `chatHandler` and support timeouts
- expose new `--workers` and `--queue_size` flags
- test queue success, API error, system prompt override and timeout

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876ada3786483279f5e19fe75ac4ab0