### PR TITLE
Support CSV response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,17 @@ curl --get \
   "http://localhost:8080/"
 ```
 
-The response body contains the model's reply as plain text.
+The response body contains the model's reply as plain text by default.
+
+You can request alternative formats using either the `format` query parameter or
+the `Accept` header. Supported values are:
+
+- `text/csv` – the reply as a single CSV cell with internal quotes doubled
+  and a trailing newline
+- `application/json` – JSON object containing `request` and `response` fields
+- `application/xml` – XML document `<response request="...">...</response>`
+
+If no supported value is provided, `text/plain` is returned.
 
 ## License
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -122,6 +122,133 @@ func TestChatHandler_Success(t *testing.T) {
 	}
 }
 
+func TestChatHandler_CSVFormat(t *testing.T) {
+	original := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			const respBody = `{"choices":[{"message":{"content":"Hello, world!"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(respBody)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+		Timeout: 5 * time.Second,
+	}
+	defer func() { http.DefaultClient = original }()
+
+	gin.SetMode(gin.TestMode)
+	taskQueue := make(chan requestTask, 1)
+	go func() {
+		for task := range taskQueue {
+			text, err := openAIRequest("ignored", task.prompt, task.systemPrompt, zap.NewExample().Sugar())
+			task.reply <- result{text: text, err: err}
+		}
+	}()
+	router := gin.New()
+	router.GET("/", chatHandler(taskQueue, "", zap.NewExample().Sugar()))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/?prompt=anything", nil)
+	request.Header.Set("Accept", "text/csv")
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("csv code = %d; want %d", recorder.Code, http.StatusOK)
+	}
+	if ct := recorder.Header().Get("Content-Type"); ct != "text/csv" {
+		t.Errorf("csv content type = %q; want %q", ct, "text/csv")
+	}
+	if body := recorder.Body.String(); body != "\"Hello, world!\"\n" {
+		t.Errorf("csv body = %q; want %q", body, "\"Hello, world!\"\n")
+	}
+}
+
+func TestChatHandler_FormatParam(t *testing.T) {
+	original := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			const respBody = `{"choices":[{"message":{"content":"Hello"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(respBody)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+		Timeout: 5 * time.Second,
+	}
+	defer func() { http.DefaultClient = original }()
+
+	gin.SetMode(gin.TestMode)
+	taskQueue := make(chan requestTask, 1)
+	go func() {
+		for task := range taskQueue {
+			text, err := openAIRequest("ignored", task.prompt, task.systemPrompt, zap.NewExample().Sugar())
+			task.reply <- result{text: text, err: err}
+		}
+	}()
+	router := gin.New()
+	router.GET("/", chatHandler(taskQueue, "", zap.NewExample().Sugar()))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/?prompt=anything&format=application/json", nil)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("param code = %d; want %d", recorder.Code, http.StatusOK)
+	}
+	if ct := recorder.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("param content type = %q; want %q", ct, "application/json")
+	}
+	expected := `{"request":"anything","response":"Hello"}`
+	if body := strings.TrimSpace(recorder.Body.String()); body != expected {
+		t.Errorf("param body = %q; want %q", body, expected)
+	}
+}
+
+func TestChatHandler_XMLHeader(t *testing.T) {
+	original := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			const respBody = `{"choices":[{"message":{"content":"Hi"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(respBody)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+		Timeout: 5 * time.Second,
+	}
+	defer func() { http.DefaultClient = original }()
+
+	gin.SetMode(gin.TestMode)
+	taskQueue := make(chan requestTask, 1)
+	go func() {
+		for task := range taskQueue {
+			text, err := openAIRequest("ignored", task.prompt, task.systemPrompt, zap.NewExample().Sugar())
+			task.reply <- result{text: text, err: err}
+		}
+	}()
+	router := gin.New()
+	router.GET("/", chatHandler(taskQueue, "", zap.NewExample().Sugar()))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/?prompt=q", nil)
+	request.Header.Set("Accept", "application/xml")
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("xml code = %d; want %d", recorder.Code, http.StatusOK)
+	}
+	if ct := recorder.Header().Get("Content-Type"); ct != "application/xml" {
+		t.Errorf("xml content type = %q; want %q", ct, "application/xml")
+	}
+	expected := `<response request="q">Hi</response>`
+	if body := strings.TrimSpace(recorder.Body.String()); body != expected {
+		t.Errorf("xml body = %q; want %q", body, expected)
+	}
+}
+
 func TestChatHandler_APIError(t *testing.T) {
 	original := http.DefaultClient
 	http.DefaultClient = &http.Client{


### PR DESCRIPTION
## Summary
- add `format` query parameter and new `preferredMime` helper
- expand `formatResponse` to return JSON and XML
- return CSV when requested via header or param
- document new response formats
- test formatting for JSON and XML

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876c7eae3c8832783e8ad14b8b1f2a3