### PR TITLE
Rename variables for clarity

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -97,7 +97,7 @@ func serve(config Configuration, logger *zap.SugaredLogger) error {
 	}
 
 	taskQueue := make(chan requestTask, config.QueueSize)
-	for i := 0; i < config.WorkerCount; i++ {
+	for workerIndex := 0; workerIndex < config.WorkerCount; workerIndex++ {
 		go func() {
 			for task := range taskQueue {
 				text, err := openAIRequest(config.OpenAIKey, task.prompt, task.systemPrompt, logger)
@@ -206,27 +206,27 @@ func openAIRequest(openAIKey, prompt, systemPrompt string, logger *zap.SugaredLo
 	return content, nil
 }
 
-func preferredMime(c *gin.Context) string {
-	if q := c.Query("format"); q != "" {
-		return q
+func preferredMime(ctx *gin.Context) string {
+	if formatParam := ctx.Query("format"); formatParam != "" {
+		return formatParam
 	}
-	return c.GetHeader("Accept")
+	return ctx.GetHeader("Accept")
 }
 
 func formatResponse(text, mime, prompt string) (string, string) {
 	switch {
 	case strings.Contains(mime, "application/json"):
-		b, _ := json.Marshal(map[string]string{"request": prompt, "response": text})
-		return string(b), "application/json"
+		encoded, _ := json.Marshal(map[string]string{"request": prompt, "response": text})
+		return string(encoded), "application/json"
 	case strings.Contains(mime, "application/xml"), strings.Contains(mime, "text/xml"):
-		type xmlResp struct {
+		type xmlResponse struct {
 			XMLName xml.Name `xml:"response"`
 			Request string   `xml:"request,attr"`
 			Text    string   `xml:",chardata"`
 		}
-		r := xmlResp{Request: prompt, Text: text}
-		b, _ := xml.Marshal(r)
-		return string(b), "application/xml"
+		xmlResp := xmlResponse{Request: prompt, Text: text}
+		encoded, _ := xml.Marshal(xmlResp)
+		return string(encoded), "application/xml"
 	case strings.Contains(mime, "text/csv"):
 		escaped := strings.ReplaceAll(text, "\"", "\"\"")
 		return fmt.Sprintf("\"%s\"\n", escaped), "text/csv"

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -297,9 +297,9 @@ func TestChatHandler_SystemPromptOverride(t *testing.T) {
 			var payload map[string]any
 			_ = json.Unmarshal(body, &payload)
 			if msgs, ok := payload["messages"].([]any); ok && len(msgs) > 0 {
-				if m, ok := msgs[0].(map[string]any); ok {
-					if c, ok := m["content"].(string); ok {
-						got = c
+				if messageMap, ok := msgs[0].(map[string]any); ok {
+					if content, ok := messageMap["content"].(string); ok {
+						got = content
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- rename worker loop variable, `preferredMime` arguments and locals
- rename encoding variables in `formatResponse`
- rename variables in tests for clarity

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687702ab84f48327bebfbd4e4c5d67d1