### PR TITLE
Use apiResponses constant and clarify model ID handling

### DIFF
--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -14,10 +14,10 @@ type modelPattern struct {
 }
 
 var capabilityTable = []modelPattern{
-	{prefix: "gpt-4o-mini", caps: modelCapabilities{apiFlavor: "responses", supportsWebSearch: false, supportsTemperature: true}},
-	{prefix: "gpt-4o", caps: modelCapabilities{apiFlavor: "responses", supportsWebSearch: true, supportsTemperature: true}},
-	{prefix: "gpt-4.1", caps: modelCapabilities{apiFlavor: "responses", supportsWebSearch: true, supportsTemperature: true}},
-	{prefix: "gpt-5-mini", caps: modelCapabilities{apiFlavor: "responses", supportsWebSearch: false, supportsTemperature: false}},
+	{prefix: "gpt-4o-mini", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: false, supportsTemperature: true}},
+	{prefix: "gpt-4o", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: true, supportsTemperature: true}},
+	{prefix: "gpt-4.1", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: true, supportsTemperature: true}},
+	{prefix: "gpt-5-mini", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: false, supportsTemperature: false}},
 }
 
 func lookupModelCapabilities(modelIdentifier string) (modelCapabilities, bool) {
@@ -39,6 +39,6 @@ func modelSupportsWebSearch(modelIdentifier string) bool {
 // mustRejectWebSearchAtIngress lists models for which we hard-fail if web_search=1 is requested.
 // Keep 4o-mini strict to save upstream calls, while allowing other minis to be handled adaptively.
 func mustRejectWebSearchAtIngress(modelIdentifier string) bool {
-	m := strings.ToLower(strings.TrimSpace(modelIdentifier))
-	return strings.HasPrefix(m, "gpt-4o-mini")
+	normalizedModelID := strings.ToLower(strings.TrimSpace(modelIdentifier))
+	return strings.HasPrefix(normalizedModelID, "gpt-4o-mini")
 }


### PR DESCRIPTION
## Summary
- use shared apiResponses constant for model capability definitions
- rename ingress rejection helper variable to normalizedModelID

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b93d1a28e483279cf38730c932a45e