### PR TITLE
refactor: add HTTP log constants

### DIFF
--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -8,6 +8,14 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// logEventReadResponseBodyFailed identifies failures while reading an HTTP response body.
+	logEventReadResponseBodyFailed = "read response body failed"
+
+	// logFieldLatencyMs represents the log field key for HTTP latency in milliseconds.
+	logFieldLatencyMs = "latency_ms"
+)
+
 // BuildHTTPRequestWithHeaders constructs an HTTP request and applies headers.
 func BuildHTTPRequestWithHeaders(method string, requestURL string, body io.Reader, headers map[string]string) (*http.Request, error) {
 	httpRequest, httpRequestError := http.NewRequest(method, requestURL, body)
@@ -27,7 +35,7 @@ func PerformHTTPRequest(do func(*http.Request) (*http.Response, error), httpRequ
 	latencyMillis := time.Since(startTime).Milliseconds()
 	if httpError != nil {
 		if structuredLogger != nil {
-			structuredLogger.Errorw(logEventOnTransportError, "err", httpError, "latency_ms", latencyMillis)
+			structuredLogger.Errorw(logEventOnTransportError, "err", httpError, logFieldLatencyMs, latencyMillis)
 		}
 		return 0, nil, latencyMillis, httpError
 	}
@@ -36,7 +44,7 @@ func PerformHTTPRequest(do func(*http.Request) (*http.Response, error), httpRequ
 	responseBytes, readError := io.ReadAll(httpResponse.Body)
 	if readError != nil {
 		if structuredLogger != nil {
-			structuredLogger.Errorw("read response body failed", "err", readError)
+			structuredLogger.Errorw(logEventReadResponseBodyFailed, "err", readError)
 		}
 		return httpResponse.StatusCode, nil, latencyMillis, readError
 	}


### PR DESCRIPTION
## Summary
- centralize http log strings for latency and read errors
- use constants when logging latency and response body errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b93d5043888327b378b68adcf3335a