### PR TITLE
refactor: clarify request URI sanitization

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -13,6 +13,8 @@ const (
 	queryParameterSystemPrompt = "system_prompt"
 	queryParameterFormat       = "format"
 
+	redactedPlaceholder = "***REDACTED***"
+
 	mimeApplicationJSON = "application/json"
 	mimeApplicationXML  = "application/xml"
 	mimeTextXML         = "text/xml"

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -12,14 +12,15 @@ import (
 	"go.uber.org/zap"
 )
 
-func sanitizeRequestURI(u *url.URL) string {
-	q := u.Query()
-	if q.Has(queryParameterKey) {
-		q.Set(queryParameterKey, "***REDACTED***")
+// sanitizeRequestURI replaces sensitive query parameter values with a placeholder.
+func sanitizeRequestURI(requestURL *url.URL) string {
+	queryParameters := requestURL.Query()
+	if queryParameters.Has(queryParameterKey) {
+		queryParameters.Set(queryParameterKey, redactedPlaceholder)
 	}
-	u2 := *u
-	u2.RawQuery = q.Encode()
-	return u2.RequestURI()
+	sanitizedURL := *requestURL
+	sanitizedURL.RawQuery = queryParameters.Encode()
+	return sanitizedURL.RequestURI()
 }
 
 // requestResponseLogger emits structured request and response metadata for traceability.


### PR DESCRIPTION
## Summary
- ensure request URI redaction uses a constant placeholder
- improve readability of sanitizeRequestURI with descriptive names and docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b93d398fd48327a6fe7aad0f0f6d30