### PR TITLE
Handle response marshalling errors

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -30,6 +30,7 @@ const (
 	errorOpenAIFailedStatus          = "OpenAI API error (failed status)"
 	errorOpenAIModelValidation       = "OpenAI model validation error"
 	errorWebSearchUnsupportedByModel = "web_search is not supported by the selected model"
+	errorResponseFormat              = "response formatting error"
 
 	toolTypeWebSearch = "web_search"
 
@@ -49,6 +50,7 @@ const (
 	jsonFieldID         = "id"
 	jsonFieldStatus     = "status"
 	jsonFieldOutputText = "output_text"
+	jsonFieldResponse   = "response"
 
 	statusCompleted = "completed"
 	statusSucceeded = "succeeded"
@@ -77,6 +79,7 @@ const (
 	logEventRequestReceived               = "request received"
 	logEventResponseSent                  = "response sent"
 	logEventMarshalRequestPayload         = "marshal request payload failed"
+	logEventMarshalResponsePayload        = "marshal response payload failed"
 	logEventBuildHTTPRequest              = "build HTTP request failed"
 	logEventReadResponseBodyFailed        = "read response body failed"
 	logEventRetryingWithoutParam          = "retrying without parameter"

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -152,7 +152,7 @@ func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validat
 				return
 			}
 			mime := preferredMime(ginContext)
-			formattedBody, contentType := formatResponse(outcome.text, mime, userPrompt)
+			formattedBody, contentType := formatResponse(outcome.text, mime, userPrompt, structuredLogger)
 			ginContext.Data(http.StatusOK, contentType, []byte(formattedBody))
 		case <-time.After(requestTimeout):
 			ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)


### PR DESCRIPTION
## Summary
- define `jsonFieldResponse` and supporting error/log constants
- log marshal failures and return fallback text
- propagate logger to `formatResponse` for error reporting

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b94fe205ac8327b9bde533729b7d09