### PR TITLE
refactor: centralize log level constants

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -50,8 +50,6 @@ const (
 	envMaxOutputTokens            = "GPT_MAX_OUTPUT_TOKENS"
 
 	quoteCharacters = "\"'"
-	logLevelDebug   = "debug"
-	logLevelInfo    = "info"
 )
 
 var config proxy.Configuration
@@ -88,7 +86,7 @@ SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy`,
 			config.LogLevel = viper.GetString(keyLogLevel)
 		}
 		if config.LogLevel == "" {
-			config.LogLevel = logLevelInfo
+			config.LogLevel = proxy.LogLevelInfo
 		}
 		if !cmd.Flags().Changed(flagSystemPrompt) {
 			config.SystemPrompt = viper.GetString(keySystemPrompt)
@@ -127,7 +125,7 @@ SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy`,
 		var logger *zap.Logger
 		var loggerError error
 		switch strings.ToLower(config.LogLevel) {
-		case logLevelDebug:
+		case proxy.LogLevelDebug:
 			logger, loggerError = zap.NewDevelopment()
 		default:
 			logger, loggerError = zap.NewProduction()

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -1,6 +1,12 @@
 package proxy
 
 const (
+	// LogLevelDebug indicates that the application should log debug information.
+	LogLevelDebug = "debug"
+
+	// LogLevelInfo indicates that the application should log informational messages.
+	LogLevelInfo = "info"
+
 	headerAuthorization       = "Authorization"
 	headerContentType         = "Content-Type"
 	headerAccept              = "Accept"

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -50,14 +50,14 @@ func BuildRouter(config Configuration, structuredLogger *zap.SugaredLogger) (*gi
 		return nil, validatorError
 	}
 
-	if strings.ToLower(config.LogLevel) == "debug" {
+	if strings.ToLower(config.LogLevel) == LogLevelDebug {
 		gin.SetMode(gin.DebugMode)
 	} else {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
 	router := gin.New()
-	if lvl := strings.ToLower(config.LogLevel); lvl == "info" || lvl == "debug" {
+	if lvl := strings.ToLower(config.LogLevel); lvl == LogLevelInfo || lvl == LogLevelDebug {
 		router.Use(requestResponseLogger(structuredLogger))
 	}
 


### PR DESCRIPTION
## Summary
- move log level constants to shared proxy constants
- update root command and router to use shared constants

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9500b3db8832787d7bd39b6fcc969