### PR TITLE
refactor: centralize logging constants

### DIFF
--- a/internal/logging/constants.go
+++ b/internal/logging/constants.go
@@ -1,0 +1,7 @@
+package logging
+
+// LogFieldLatencyMilliseconds is the key for HTTP latency in milliseconds.
+const LogFieldLatencyMilliseconds = "latency_ms"
+
+// LogEventReadResponseBodyFailed identifies failures while reading an HTTP response body.
+const LogEventReadResponseBodyFailed = "read response body failed"

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -59,7 +59,6 @@ const (
 
 	logFieldHTTPStatus   = "http_status"
 	logFieldAPIStatus    = "api_status"
-	logFieldLatencyMs    = "latency_ms"
 	logFieldResponseText = "response_text"
 	logFieldMethod       = "method"
 	logFieldPath         = "path"
@@ -78,7 +77,6 @@ const (
 	logEventResponseSent                  = "response sent"
 	logEventMarshalRequestPayload         = "marshal request payload failed"
 	logEventBuildHTTPRequest              = "build HTTP request failed"
-	logEventReadResponseBodyFailed        = "read response body failed"
 	logEventRetryingWithoutParam          = "retrying without parameter"
 	logEventParseWebSearchParameterFailed = "parse web_search parameter failed"
 

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/temirov/llm-proxy/internal/logging"
 	"github.com/temirov/llm-proxy/internal/utils"
 	"go.uber.org/zap"
 )
@@ -41,11 +42,11 @@ func requestResponseLogger(structuredLogger *zap.SugaredLogger) gin.HandlerFunc 
 		ginContext.Next()
 
 		responseStatus := ginContext.Writer.Status()
-		responseLatencyMillis := time.Since(requestStart).Milliseconds()
+		responseLatencyMilliseconds := time.Since(requestStart).Milliseconds()
 		structuredLogger.Infow(
 			logEventResponseSent,
 			logFieldStatus, responseStatus,
-			logFieldLatencyMs, responseLatencyMillis,
+			logging.LogFieldLatencyMilliseconds, responseLatencyMilliseconds,
 		)
 	}
 }

--- a/internal/proxy/model_validator.go
+++ b/internal/proxy/model_validator.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/temirov/llm-proxy/internal/logging"
 	"go.uber.org/zap"
 )
 
@@ -37,14 +38,14 @@ func (validator *modelValidator) refresh() error {
 
 	startTime := time.Now()
 	httpResponse, httpError := HTTPClient.Do(httpRequest)
-	latencyMillis := time.Since(startTime).Milliseconds()
+	latencyMilliseconds := time.Since(startTime).Milliseconds()
 	if httpError != nil {
-		validator.logger.Errorw(logEventOpenAIModelsListError, "err", httpError, logFieldLatencyMs, latencyMillis)
+		validator.logger.Errorw(logEventOpenAIModelsListError, "err", httpError, logging.LogFieldLatencyMilliseconds, latencyMilliseconds)
 		return httpError
 	}
 	defer httpResponse.Body.Close()
 
-	validator.logger.Infow(logEventOpenAIModelsList, logFieldHTTPStatus, httpResponse.StatusCode, logFieldLatencyMs, latencyMillis)
+	validator.logger.Infow(logEventOpenAIModelsList, logFieldHTTPStatus, httpResponse.StatusCode, logging.LogFieldLatencyMilliseconds, latencyMilliseconds)
 	if httpResponse.StatusCode != http.StatusOK {
 		bodyBytes, readError := io.ReadAll(httpResponse.Body)
 		if readError != nil {


### PR DESCRIPTION
## Summary
- centralize HTTP latency and read-response logging constants in new logging package
- update proxy and utility code to use shared logging constants

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b94fd9ae748327a808023bc7af0e7d