### PR TITLE
refactor: reuse HTTP utility

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -78,7 +78,6 @@ const (
 	logEventResponseSent                  = "response sent"
 	logEventMarshalRequestPayload         = "marshal request payload failed"
 	logEventBuildHTTPRequest              = "build HTTP request failed"
-	logEventReadResponseBodyFailed        = "read response body failed"
 	logEventRetryingWithoutParam          = "retrying without parameter"
 	logEventParseWebSearchParameterFailed = "parse web_search parameter failed"
 


### PR DESCRIPTION
## Summary
- add retryable HTTP helper with exponential backoff
- use shared HTTP helper in OpenAI proxy instead of local duplicate
- drop unused log constant

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9502090ec8327b2803736d66457ab