### PR TITLE
refactor: improve test readability with descriptive names

### DIFF
--- a/tests/integration/integration1_test.go
+++ b/tests/integration/integration1_test.go
@@ -12,31 +12,31 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestIntegration_ResponseDelivered(t *testing.T) {
+func TestIntegration_ResponseDelivered(testingContext *testing.T) {
 	// Fake upstream that serves /v1/models and /v1/responses.
-	openAISrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		switch {
-		case strings.HasSuffix(r.URL.Path, "/v1/models"):
-			w.Header().Set("Content-Type", "application/json")
-			io.WriteString(w, `{"object":"list","data":[{"id":"gpt-4.1","object":"model"}]}`)
+		case strings.HasSuffix(httpRequest.URL.Path, "/v1/models"):
+			responseWriter.Header().Set("Content-Type", "application/json")
+			io.WriteString(responseWriter, `{"object":"list","data":[{"id":"gpt-4.1","object":"model"}]}`)
 			return
-		case strings.HasSuffix(r.URL.Path, "/v1/responses"):
-			w.Header().Set("Content-Type", "application/json")
-			io.WriteString(w, `{"output_text":"INTEGRATION_OK"}`)
+		case strings.HasSuffix(httpRequest.URL.Path, "/v1/responses"):
+			responseWriter.Header().Set("Content-Type", "application/json")
+			io.WriteString(responseWriter, `{"output_text":"INTEGRATION_OK"}`)
 			return
 		default:
-			http.NotFound(w, r)
+			http.NotFound(responseWriter, httpRequest)
 			return
 		}
 	}))
-	defer openAISrv.Close()
+	defer openAIServer.Close()
 
 	// Inject URLs + client.
-	proxy.SetModelsURL(openAISrv.URL + "/v1/models")
-	proxy.SetResponsesURL(openAISrv.URL + "/v1/responses")
-	proxy.HTTPClient = openAISrv.Client()
-	t.Cleanup(proxy.ResetModelsURL)
-	t.Cleanup(proxy.ResetResponsesURL)
+	proxy.SetModelsURL(openAIServer.URL + "/v1/models")
+	proxy.SetResponsesURL(openAIServer.URL + "/v1/responses")
+	proxy.HTTPClient = openAIServer.Client()
+	testingContext.Cleanup(proxy.ResetModelsURL)
+	testingContext.Cleanup(proxy.ResetResponsesURL)
 
 	// Build app router and serve it.
 	logger, _ := zap.NewDevelopment()
@@ -49,55 +49,55 @@ func TestIntegration_ResponseDelivered(t *testing.T) {
 		QueueSize:     4,
 	}, logger.Sugar())
 	if err != nil {
-		t.Fatalf("BuildRouter error: %v", err)
+		testingContext.Fatalf("BuildRouter error: %v", err)
 	}
 
-	appSrv := httptest.NewServer(router)
-	defer appSrv.Close()
+	applicationServer := httptest.NewServer(router)
+	defer applicationServer.Close()
 
-	resp, err := http.Get(appSrv.URL + "/?prompt=ping&key=sekret")
+	httpResponse, err := http.Get(applicationServer.URL + "/?prompt=ping&key=sekret")
 	if err != nil {
-		t.Fatalf("request error: %v", err)
+		testingContext.Fatalf("request error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer httpResponse.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status=%d body=%s", resp.StatusCode, string(b))
+	if httpResponse.StatusCode != http.StatusOK {
+		responseBytes, _ := io.ReadAll(httpResponse.Body)
+		testingContext.Fatalf("status=%d body=%s", httpResponse.StatusCode, string(responseBytes))
 	}
-	body, _ := io.ReadAll(resp.Body)
-	if got := strings.TrimSpace(string(body)); got != "INTEGRATION_OK" {
-		t.Fatalf("body=%q; want INTEGRATION_OK", got)
+	responseBody, _ := io.ReadAll(httpResponse.Body)
+	if responseText := strings.TrimSpace(string(responseBody)); responseText != "INTEGRATION_OK" {
+		testingContext.Fatalf("body=%q; want INTEGRATION_OK", responseText)
 	}
 }
 
-func TestIntegration_ResponseDelivered_WithWebSearch(t *testing.T) {
+func TestIntegration_ResponseDelivered_WithWebSearch(testingContext *testing.T) {
 	var captured any
 
-	openAISrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		switch {
-		case strings.HasSuffix(r.URL.Path, "/v1/models"):
-			w.Header().Set("Content-Type", "application/json")
-			io.WriteString(w, `{"object":"list","data":[{"id":"gpt-4.1","object":"model"}]}`)
+		case strings.HasSuffix(httpRequest.URL.Path, "/v1/models"):
+			responseWriter.Header().Set("Content-Type", "application/json")
+			io.WriteString(responseWriter, `{"object":"list","data":[{"id":"gpt-4.1","object":"model"}]}`)
 			return
-		case strings.HasSuffix(r.URL.Path, "/v1/responses"):
-			body, _ := io.ReadAll(r.Body)
+		case strings.HasSuffix(httpRequest.URL.Path, "/v1/responses"):
+			body, _ := io.ReadAll(httpRequest.Body)
 			_ = json.Unmarshal(body, &captured)
-			w.Header().Set("Content-Type", "application/json")
-			io.WriteString(w, `{"output_text":"SEARCH_OK"}`)
+			responseWriter.Header().Set("Content-Type", "application/json")
+			io.WriteString(responseWriter, `{"output_text":"SEARCH_OK"}`)
 			return
 		default:
-			http.NotFound(w, r)
+			http.NotFound(responseWriter, httpRequest)
 			return
 		}
 	}))
-	defer openAISrv.Close()
+	defer openAIServer.Close()
 
-	proxy.SetModelsURL(openAISrv.URL + "/v1/models")
-	proxy.SetResponsesURL(openAISrv.URL + "/v1/responses")
-	proxy.HTTPClient = openAISrv.Client()
-	t.Cleanup(proxy.ResetModelsURL)
-	t.Cleanup(proxy.ResetResponsesURL)
+	proxy.SetModelsURL(openAIServer.URL + "/v1/models")
+	proxy.SetResponsesURL(openAIServer.URL + "/v1/responses")
+	proxy.HTTPClient = openAIServer.Client()
+	testingContext.Cleanup(proxy.ResetModelsURL)
+	testingContext.Cleanup(proxy.ResetResponsesURL)
 
 	logger, _ := zap.NewDevelopment()
 	defer logger.Sync()
@@ -109,35 +109,35 @@ func TestIntegration_ResponseDelivered_WithWebSearch(t *testing.T) {
 		QueueSize:     4,
 	}, logger.Sugar())
 	if err != nil {
-		t.Fatalf("BuildRouter error: %v", err)
+		testingContext.Fatalf("BuildRouter error: %v", err)
 	}
 
-	appSrv := httptest.NewServer(router)
-	defer appSrv.Close()
+	applicationServer := httptest.NewServer(router)
+	defer applicationServer.Close()
 
-	resp, err := http.Get(appSrv.URL + "/?prompt=ping&key=sekret&web_search=1")
+	httpResponse, err := http.Get(applicationServer.URL + "/?prompt=ping&key=sekret&web_search=1")
 	if err != nil {
-		t.Fatalf("request error: %v", err)
+		testingContext.Fatalf("request error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer httpResponse.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status=%d body=%s", resp.StatusCode, string(b))
+	if httpResponse.StatusCode != http.StatusOK {
+		responseBytes, _ := io.ReadAll(httpResponse.Body)
+		testingContext.Fatalf("status=%d body=%s", httpResponse.StatusCode, string(responseBytes))
 	}
-	body, _ := io.ReadAll(resp.Body)
-	if got := strings.TrimSpace(string(body)); got != "SEARCH_OK" {
-		t.Fatalf("body=%q; want SEARCH_OK", got)
+	responseBody, _ := io.ReadAll(httpResponse.Body)
+	if responseText := strings.TrimSpace(string(responseBody)); responseText != "SEARCH_OK" {
+		testingContext.Fatalf("body=%q; want SEARCH_OK", responseText)
 	}
 
 	// Assert that the tool was sent.
-	m, _ := captured.(map[string]any)
-	tools, ok := m["tools"].([]any)
-	if !ok || len(tools) == 0 {
-		t.Fatalf("tools missing when web_search=1")
+	capturedMap, _ := captured.(map[string]any)
+	tools, toolsFound := capturedMap["tools"].([]any)
+	if !toolsFound || len(tools) == 0 {
+		testingContext.Fatalf("tools missing when web_search=1")
 	}
-	first, _ := tools[0].(map[string]any)
-	if first["type"] != "web_search" {
-		t.Fatalf("tool type=%v; want web_search", first["type"])
+	firstTool, _ := tools[0].(map[string]any)
+	if firstTool["type"] != "web_search" {
+		testingContext.Fatalf("tool type=%v; want web_search", firstTool["type"])
 	}
 }

--- a/tests/integration/integration_models_test.go
+++ b/tests/integration/integration_models_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/temirov/llm-proxy/internal/proxy"
 )
 
-func TestIntegration_ModelSpec_SuppressesTemperatureAndTools_ForMini(t *testing.T) {
+func TestIntegration_ModelSpec_SuppressesTemperatureAndTools_ForMini(testingContext *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	client, captured := makeHTTPClient(t, true)
+	client, captured := makeHTTPClient(testingContext, true)
 	proxy.HTTPClient = client
 	proxy.SetModelsURL("https://mock.local/v1/models")
 	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	t.Cleanup(proxy.ResetModelsURL)
-	t.Cleanup(proxy.ResetResponsesURL)
+	testingContext.Cleanup(proxy.ResetModelsURL)
+	testingContext.Cleanup(proxy.ResetResponsesURL)
 
 	router, err := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: "sekret",
@@ -28,41 +28,41 @@ func TestIntegration_ModelSpec_SuppressesTemperatureAndTools_ForMini(t *testing.
 		LogLevel:      "debug",
 		WorkerCount:   1,
 		QueueSize:     8,
-	}, newLogger(t))
+	}, newLogger(testingContext))
 	if err != nil {
-		t.Fatalf("BuildRouter failed: %v", err)
+		testingContext.Fatalf("BuildRouter failed: %v", err)
 	}
 
-	srv := httptest.NewServer(router)
-	t.Cleanup(srv.Close)
+	testServer := httptest.NewServer(router)
+	testingContext.Cleanup(testServer.Close)
 
-	u, _ := url.Parse(srv.URL)
-	q := u.Query()
-	q.Set("prompt", "ping")
-	q.Set("key", "sekret")
-	q.Set("web_search", "1")
-	q.Set("model", "gpt-5-mini")
-	u.RawQuery = q.Encode()
+	parsedURL, _ := url.Parse(testServer.URL)
+	queryValues := parsedURL.Query()
+	queryValues.Set("prompt", "ping")
+	queryValues.Set("key", "sekret")
+	queryValues.Set("web_search", "1")
+	queryValues.Set("model", "gpt-5-mini")
+	parsedURL.RawQuery = queryValues.Encode()
 
-	res, err := http.Get(u.String())
+	httpResponse, err := http.Get(parsedURL.String())
 	if err != nil {
-		t.Fatalf("GET failed: %v", err)
+		testingContext.Fatalf("GET failed: %v", err)
 	}
-	defer res.Body.Close()
-	_, _ = io.ReadAll(res.Body)
+	defer httpResponse.Body.Close()
+	_, _ = io.ReadAll(httpResponse.Body)
 
 	payload := *captured
-	if _, ok := payload["temperature"]; ok {
-		t.Fatalf("temperature must be omitted for gpt-5-mini, got: %v", payload["temperature"])
+	if _, valueFound := payload["temperature"]; valueFound {
+		testingContext.Fatalf("temperature must be omitted for gpt-5-mini, got: %v", payload["temperature"])
 	}
-	if _, ok := payload["tools"]; ok {
-		t.Fatalf("tools must be omitted for gpt-5-mini, got: %v", payload["tools"])
+	if _, valueFound := payload["tools"]; valueFound {
+		testingContext.Fatalf("tools must be omitted for gpt-5-mini, got: %v", payload["tools"])
 	}
 	if _, hasInput := payload["input"]; !hasInput {
-		t.Fatalf("input must be present for responses API")
+		testingContext.Fatalf("input must be present for responses API")
 	}
 	if _, hasMessages := payload["messages"]; hasMessages {
-		t.Fatalf("messages must not be present for responses API payload")
+		testingContext.Fatalf("messages must not be present for responses API payload")
 	}
 	time.Sleep(10 * time.Millisecond)
 }

--- a/tests/integration/long_request_test.go
+++ b/tests/integration/long_request_test.go
@@ -32,7 +32,7 @@ const (
 func makeSlowHTTPClient(testingInstance *testing.T) *http.Client {
 	testingInstance.Helper()
 	return &http.Client{
-		Transport: rt(func(request *http.Request) (*http.Response, error) {
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
 			switch request.URL.String() {
 			case proxy.ModelsURL():
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(modelsListBody)), Header: make(http.Header)}, nil


### PR DESCRIPTION
## Summary
- rename HTTP handler parameters `w` and `r` to `responseWriter` and `httpRequest`
- replace abbreviated test variables with descriptive names across suite

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b95bddb85483279f6ff8ae772b10bc