### PR TITLE
Handle queue overflow with timeout

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -37,6 +37,8 @@ const (
 	errorOpenAIModelValidation       = "OpenAI model validation error"
 	errorWebSearchUnsupportedByModel = "web_search is not supported by the selected model"
 	errorResponseFormat              = "response formatting error"
+	// errorQueueFull indicates that the internal request queue cannot accept additional tasks.
+	errorQueueFull = "request queue full"
 
 	toolTypeWebSearch = "web_search"
 


### PR DESCRIPTION
## Summary
- prevent blocked queue sends with timeout-based select and return 503 when queue is full
- add queue full error constant and documentation
- expand router tests to exercise queue exhaustion logic

## Testing
- `go test -run . -timeout 30s -v ./tests/llm-proxy`
- `go test -v ./tests/integration`


------
https://chatgpt.com/codex/tasks/task_e_68b95b96ec9483278c3d0d269c7f87f0