### PR TITLE
refactor: centralize latency log field

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,4 @@
+package constants
+
+// LogFieldLatencyMilliseconds identifies the structured log field name for latency in milliseconds.
+const LogFieldLatencyMilliseconds = "latency_ms"

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -67,7 +67,6 @@ const (
 
 	logFieldHTTPStatus   = "http_status"
 	logFieldAPIStatus    = "api_status"
-	logFieldLatencyMs    = "latency_ms"
 	logFieldResponseText = "response_text"
 	logFieldMethod       = "method"
 	logFieldPath         = "path"

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/temirov/llm-proxy/internal/constants"
 	"github.com/temirov/llm-proxy/internal/utils"
 	"go.uber.org/zap"
 )
@@ -45,7 +46,7 @@ func requestResponseLogger(structuredLogger *zap.SugaredLogger) gin.HandlerFunc 
 		structuredLogger.Infow(
 			logEventResponseSent,
 			logFieldStatus, responseStatus,
-			logFieldLatencyMs, responseLatencyMillis,
+			constants.LogFieldLatencyMilliseconds, responseLatencyMillis,
 		)
 	}
 }

--- a/internal/proxy/model_validator.go
+++ b/internal/proxy/model_validator.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/temirov/llm-proxy/internal/constants"
 	"go.uber.org/zap"
 )
 
@@ -39,12 +40,12 @@ func (validator *modelValidator) refresh() error {
 	httpResponse, httpError := HTTPClient.Do(httpRequest)
 	latencyMillis := time.Since(startTime).Milliseconds()
 	if httpError != nil {
-		validator.logger.Errorw(logEventOpenAIModelsListError, "err", httpError, logFieldLatencyMs, latencyMillis)
+		validator.logger.Errorw(logEventOpenAIModelsListError, "err", httpError, constants.LogFieldLatencyMilliseconds, latencyMillis)
 		return httpError
 	}
 	defer httpResponse.Body.Close()
 
-	validator.logger.Infow(logEventOpenAIModelsList, logFieldHTTPStatus, httpResponse.StatusCode, logFieldLatencyMs, latencyMillis)
+	validator.logger.Infow(logEventOpenAIModelsList, logFieldHTTPStatus, httpResponse.StatusCode, constants.LogFieldLatencyMilliseconds, latencyMillis)
 	if httpResponse.StatusCode != http.StatusOK {
 		bodyBytes, readError := io.ReadAll(httpResponse.Body)
 		if readError != nil {

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/temirov/llm-proxy/internal/constants"
 	"github.com/temirov/llm-proxy/internal/utils"
 	"go.uber.org/zap"
 )
@@ -128,7 +129,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 		logEventOpenAIResponse,
 		logFieldHTTPStatus, statusCode,
 		logFieldAPIStatus, apiStatus,
-		logFieldLatencyMs, latencyMillis,
+		constants.LogFieldLatencyMilliseconds, latencyMillis,
 		logFieldResponseText, outputText,
 	)
 

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -6,15 +6,13 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/temirov/llm-proxy/internal/constants"
 	"go.uber.org/zap"
 )
 
 const (
 	// logEventReadResponseBodyFailed identifies failures while reading an HTTP response body.
 	logEventReadResponseBodyFailed = "read response body failed"
-
-	// logFieldLatencyMs represents the log field key for HTTP latency in milliseconds.
-	logFieldLatencyMs = "latency_ms"
 )
 
 // BuildHTTPRequestWithHeaders constructs an HTTP request and applies headers.
@@ -58,7 +56,7 @@ func PerformHTTPRequest(do func(*http.Request) (*http.Response, error), httpRequ
 	latencyMillis := time.Since(startTime).Milliseconds()
 	if retryError != nil {
 		if structuredLogger != nil {
-			structuredLogger.Errorw(logEventOnTransportError, "err", retryError, logFieldLatencyMs, latencyMillis)
+			structuredLogger.Errorw(logEventOnTransportError, "err", retryError, constants.LogFieldLatencyMilliseconds, latencyMillis)
 		}
 		return 0, nil, latencyMillis, retryError
 	}


### PR DESCRIPTION
## Summary
- extract shared `LogFieldLatencyMilliseconds` constant
- use shared constant in proxy and utils packages
- remove duplicate latency log field definitions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b95b8c12c0832783b429a3accefc58