### PR TITLE
Centralize model capability metadata

### DIFF
--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -2,43 +2,49 @@ package proxy
 
 import "strings"
 
+// API flavor constants.
+const apiFlavorResponses = "responses"
+
+// Model prefix constants.
+const (
+	modelPrefixGPT4oMini = "gpt-4o-mini"
+	modelPrefixGPT4o     = "gpt-4o"
+	modelPrefixGPT41     = "gpt-4.1"
+	modelPrefixGPT5Mini  = "gpt-5-mini"
+)
+
+// modelCapabilities describes the features supported by a model.
 type modelCapabilities struct {
 	apiFlavor           string
 	supportsWebSearch   bool
 	supportsTemperature bool
 }
 
-type modelPattern struct {
-	prefix string
-	caps   modelCapabilities
+// modelCapabilityPattern maps a model prefix to its capabilities.
+type modelCapabilityPattern struct {
+	prefix     string
+	capability modelCapabilities
 }
 
-var capabilityTable = []modelPattern{
-	{prefix: "gpt-4o-mini", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: false, supportsTemperature: true}},
-	{prefix: "gpt-4o", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: true, supportsTemperature: true}},
-	{prefix: "gpt-4.1", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: true, supportsTemperature: true}},
-	{prefix: "gpt-5-mini", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: false, supportsTemperature: false}},
+var capabilityTable = []modelCapabilityPattern{
+	{prefix: modelPrefixGPT4oMini, capability: modelCapabilities{apiFlavor: apiFlavorResponses, supportsWebSearch: false, supportsTemperature: true}},
+	{prefix: modelPrefixGPT4o, capability: modelCapabilities{apiFlavor: apiFlavorResponses, supportsWebSearch: true, supportsTemperature: true}},
+	{prefix: modelPrefixGPT41, capability: modelCapabilities{apiFlavor: apiFlavorResponses, supportsWebSearch: true, supportsTemperature: true}},
+	{prefix: modelPrefixGPT5Mini, capability: modelCapabilities{apiFlavor: apiFlavorResponses, supportsWebSearch: false, supportsTemperature: false}},
 }
 
+// lookupModelCapabilities finds capabilities for the given model identifier.
 func lookupModelCapabilities(modelIdentifier string) (modelCapabilities, bool) {
 	for _, entry := range capabilityTable {
 		if modelIdentifier == entry.prefix || strings.HasPrefix(modelIdentifier, entry.prefix) {
-			return entry.caps, true
+			return entry.capability, true
 		}
 	}
 	return modelCapabilities{}, false
 }
 
-func modelSupportsWebSearch(modelIdentifier string) bool {
-	if caps, ok := lookupModelCapabilities(modelIdentifier); ok {
-		return caps.supportsWebSearch
-	}
-	return false
-}
-
-// mustRejectWebSearchAtIngress lists models for which we hard-fail if web_search=1 is requested.
-// Keep 4o-mini strict to save upstream calls, while allowing other minis to be handled adaptively.
+// mustRejectWebSearchAtIngress lists models for which web search requests should fail fast.
 func mustRejectWebSearchAtIngress(modelIdentifier string) bool {
 	normalizedModelID := strings.ToLower(strings.TrimSpace(modelIdentifier))
-	return strings.HasPrefix(normalizedModelID, "gpt-4o-mini")
+	return strings.HasPrefix(normalizedModelID, modelPrefixGPT4oMini)
 }

--- a/internal/proxy/model_specs.go
+++ b/internal/proxy/model_specs.go
@@ -2,27 +2,11 @@ package proxy
 
 import "strings"
 
-const (
-	apiResponses = "responses"
-)
-
-type modelSpecification struct {
-	API                   string
-	IncludeTemperature    bool
-	IncludeWebSearchTools bool
-}
-
-func resolveModelSpecification(modelIdentifier string) modelSpecification {
+// resolveModelSpecification returns capabilities using the shared capability table.
+func resolveModelSpecification(modelIdentifier string) modelCapabilities {
 	lower := strings.ToLower(strings.TrimSpace(modelIdentifier))
-
-	switch {
-	case strings.HasPrefix(lower, "gpt-4.1"):
-		return modelSpecification{API: apiResponses, IncludeTemperature: true, IncludeWebSearchTools: true}
-	case strings.HasPrefix(lower, "gpt-4o"):
-		return modelSpecification{API: apiResponses, IncludeTemperature: true, IncludeWebSearchTools: true}
-	case strings.HasPrefix(lower, "gpt-5-mini"):
-		return modelSpecification{API: apiResponses, IncludeTemperature: false, IncludeWebSearchTools: false}
-	default:
-		return modelSpecification{API: apiResponses, IncludeTemperature: false, IncludeWebSearchTools: false}
+	if capability, found := lookupModelCapabilities(lower); found {
+		return capability
 	}
+	return modelCapabilities{apiFlavor: apiFlavorResponses}
 }

--- a/internal/proxy/model_specs_test.go
+++ b/internal/proxy/model_specs_test.go
@@ -1,0 +1,24 @@
+package proxy
+
+import "testing"
+
+// TestResolveModelSpecification verifies that model capabilities come from the capability table.
+func TestResolveModelSpecification(t *testing.T) {
+	testCases := []struct {
+		modelIdentifier   string
+		expectTemperature bool
+		expectWebSearch   bool
+	}{
+		{modelPrefixGPT4o, true, true},
+		{modelPrefixGPT5Mini, false, false},
+	}
+	for _, tc := range testCases {
+		capability := resolveModelSpecification(tc.modelIdentifier)
+		if capability.supportsTemperature != tc.expectTemperature {
+			t.Fatalf("model %s temperature=%v want=%v", tc.modelIdentifier, capability.supportsTemperature, tc.expectTemperature)
+		}
+		if capability.supportsWebSearch != tc.expectWebSearch {
+			t.Fatalf("model %s webSearch=%v want=%v", tc.modelIdentifier, capability.supportsWebSearch, tc.expectWebSearch)
+		}
+	}
+}

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -40,17 +40,17 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 		{keyRole: keyUser, keyContent: userPrompt},
 	}
 
-	modelSpecification := resolveModelSpecification(modelIdentifier)
+	modelCapabilities := resolveModelSpecification(modelIdentifier)
 
 	requestPayload := map[string]any{
 		keyModel:           modelIdentifier,
 		keyInput:           messageList,
 		keyMaxOutputTokens: maxOutputTokens,
 	}
-	if modelSpecification.IncludeTemperature {
+	if modelCapabilities.supportsTemperature {
 		requestPayload[keyTemperature] = 0.7
 	}
-	if webSearchEnabled && modelSpecification.IncludeWebSearchTools {
+	if webSearchEnabled && modelCapabilities.supportsWebSearch {
 		requestPayload[keyTools] = []any{map[string]any{keyType: toolTypeWebSearch}}
 		requestPayload[keyToolChoice] = keyAuto
 	}


### PR DESCRIPTION
## Summary
- centralize model capability metadata in a single table with descriptive constants
- derive model specifications from the shared capability table
- update tests and add unit test for capability resolution

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b95b796a008327b80a08555b5a2eb2