### PR TITLE
Clarify model and test identifiers

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -35,6 +35,7 @@ const (
 	errorOpenAIAPINoText             = "OpenAI API error (no text)"
 	errorOpenAIFailedStatus          = "OpenAI API error (failed status)"
 	errorOpenAIModelValidation       = "OpenAI model validation error"
+	errorUnknownModel                = "unknown model: %s"
 	errorWebSearchUnsupportedByModel = "web_search is not supported by the selected model"
 	errorResponseFormat              = "response formatting error"
 

--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -2,36 +2,47 @@ package proxy
 
 import "strings"
 
+// modelCapabilities describes the features supported by a model.
+//
+// The flags indicate the API flavor and whether optional features such as web
+// search and temperature are available.
 type modelCapabilities struct {
 	apiFlavor           string
 	supportsWebSearch   bool
 	supportsTemperature bool
 }
 
+// modelPattern associates a model prefix with its capabilities.
+//
+// When a model identifier matches the prefix, the corresponding capabilities
+// are applied.
 type modelPattern struct {
-	prefix string
-	caps   modelCapabilities
+	prefix       string
+	capabilities modelCapabilities
 }
 
 var capabilityTable = []modelPattern{
-	{prefix: "gpt-4o-mini", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: false, supportsTemperature: true}},
-	{prefix: "gpt-4o", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: true, supportsTemperature: true}},
-	{prefix: "gpt-4.1", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: true, supportsTemperature: true}},
-	{prefix: "gpt-5-mini", caps: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: false, supportsTemperature: false}},
+	{prefix: "gpt-4o-mini", capabilities: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: false, supportsTemperature: true}},
+	{prefix: "gpt-4o", capabilities: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: true, supportsTemperature: true}},
+	{prefix: "gpt-4.1", capabilities: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: true, supportsTemperature: true}},
+	{prefix: "gpt-5-mini", capabilities: modelCapabilities{apiFlavor: apiResponses, supportsWebSearch: false, supportsTemperature: false}},
 }
 
+// lookupModelCapabilities finds the capability configuration for the provided
+// model identifier. It returns the capabilities and true if a match is found.
 func lookupModelCapabilities(modelIdentifier string) (modelCapabilities, bool) {
 	for _, entry := range capabilityTable {
 		if modelIdentifier == entry.prefix || strings.HasPrefix(modelIdentifier, entry.prefix) {
-			return entry.caps, true
+			return entry.capabilities, true
 		}
 	}
 	return modelCapabilities{}, false
 }
 
+// modelSupportsWebSearch reports whether the model allows web search.
 func modelSupportsWebSearch(modelIdentifier string) bool {
-	if caps, ok := lookupModelCapabilities(modelIdentifier); ok {
-		return caps.supportsWebSearch
+	if capabilities, ok := lookupModelCapabilities(modelIdentifier); ok {
+		return capabilities.supportsWebSearch
 	}
 	return false
 }

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -12,22 +12,24 @@ import (
 	"go.uber.org/zap"
 )
 
+// TestIntegration_WebSearch_UnsupportedModel_Returns400 verifies that a request
+// with web search enabled for an unsupported model results in a bad request.
 func TestIntegration_WebSearch_UnsupportedModel_Returns400(t *testing.T) {
-	openAISrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		switch {
-		case strings.HasSuffix(r.URL.Path, "/v1/models"):
-			io.WriteString(w, `{"data":[{"id":"gpt-4o-mini"},{"id":"gpt-4o"}]}`)
-		case strings.HasSuffix(r.URL.Path, "/v1/responses"):
-			io.WriteString(w, `{"output_text":"SHOULD_NOT_BE_CALLED"}`)
+		case strings.HasSuffix(httpRequest.URL.Path, "/v1/models"):
+			io.WriteString(responseWriter, `{"data":[{"id":"gpt-4o-mini"},{"id":"gpt-4o"}]}`)
+		case strings.HasSuffix(httpRequest.URL.Path, "/v1/responses"):
+			io.WriteString(responseWriter, `{"output_text":"SHOULD_NOT_BE_CALLED"}`)
 		default:
-			http.NotFound(w, r)
+			http.NotFound(responseWriter, httpRequest)
 		}
 	}))
-	defer openAISrv.Close()
+	defer openAIServer.Close()
 
-	proxy.SetModelsURL(openAISrv.URL + "/v1/models")
-	proxy.SetResponsesURL(openAISrv.URL + "/v1/responses")
-	proxy.HTTPClient = openAISrv.Client()
+	proxy.SetModelsURL(openAIServer.URL + "/v1/models")
+	proxy.SetResponsesURL(openAIServer.URL + "/v1/responses")
+	proxy.HTTPClient = openAIServer.Client()
 	t.Cleanup(proxy.ResetModelsURL)
 	t.Cleanup(proxy.ResetResponsesURL)
 
@@ -45,50 +47,53 @@ func TestIntegration_WebSearch_UnsupportedModel_Returns400(t *testing.T) {
 		t.Fatalf("BuildRouter error: %v", err)
 	}
 
-	app := httptest.NewServer(router)
-	defer app.Close()
+	proxyServer := httptest.NewServer(router)
+	defer proxyServer.Close()
 
-	req, _ := http.NewRequest("GET", app.URL+"/?prompt=x&key=sekret&model=gpt-4o-mini&web_search=1", nil)
-	res, err := http.DefaultClient.Do(req)
+	proxyRequest, _ := http.NewRequest("GET", proxyServer.URL+"/?prompt=x&key=sekret&model=gpt-4o-mini&web_search=1", nil)
+	proxyResponse, err := http.DefaultClient.Do(proxyRequest)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer res.Body.Close()
+	defer proxyResponse.Body.Close()
 
-	if res.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status=%d want=%d", res.StatusCode, http.StatusBadRequest)
+	if proxyResponse.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want=%d", proxyResponse.StatusCode, http.StatusBadRequest)
 	}
-	body, _ := io.ReadAll(res.Body)
-	if !strings.Contains(string(body), "web_search is not supported") {
-		t.Fatalf("body=%q missing capability message", string(body))
+	responseBody, _ := io.ReadAll(proxyResponse.Body)
+	if !strings.Contains(string(responseBody), "web_search is not supported") {
+		t.Fatalf("body=%q missing capability message", string(responseBody))
 	}
 }
 
+// TestIntegration_TemperatureUnsupportedModel_RetriesWithoutTemperature ensures
+// that the proxy retries requests without the temperature parameter when the
+// upstream model does not support it.
 func TestIntegration_TemperatureUnsupportedModel_RetriesWithoutTemperature(t *testing.T) {
 	var observed any
 
-	openAISrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		switch {
-		case strings.HasSuffix(r.URL.Path, "/v1/models"):
-			io.WriteString(w, `{"data":[{"id":"gpt-5-mini"}]}`)
-		case strings.HasSuffix(r.URL.Path, "/v1/responses"):
-			body, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(body, &observed)
-			if strings.Contains(string(body), `"temperature"`) {
-				w.WriteHeader(http.StatusBadRequest)
-				io.WriteString(w, `{"error":{"message":"Unsupported parameter: 'temperature'"}}`)
+		case strings.HasSuffix(httpRequest.URL.Path, "/v1/models"):
+			io.WriteString(responseWriter, `{"data":[{"id":"gpt-5-mini"}]}`)
+		case strings.HasSuffix(httpRequest.URL.Path, "/v1/responses"):
+			requestBody, _ := io.ReadAll(httpRequest.Body)
+			_ = json.Unmarshal(requestBody, &observed)
+			if strings.Contains(string(requestBody), `"temperature"`) {
+				responseWriter.WriteHeader(http.StatusBadRequest)
+				io.WriteString(responseWriter, `{"error":{"message":"Unsupported parameter: 'temperature'"}}`)
 				return
 			}
-			io.WriteString(w, `{"output_text":"TEMPLESS_OK"}`)
+			io.WriteString(responseWriter, `{"output_text":"TEMPLESS_OK"}`)
 		default:
-			http.NotFound(w, r)
+			http.NotFound(responseWriter, httpRequest)
 		}
 	}))
-	defer openAISrv.Close()
+	defer openAIServer.Close()
 
-	proxy.SetModelsURL(openAISrv.URL + "/v1/models")
-	proxy.SetResponsesURL(openAISrv.URL + "/v1/responses")
-	proxy.HTTPClient = openAISrv.Client()
+	proxy.SetModelsURL(openAIServer.URL + "/v1/models")
+	proxy.SetResponsesURL(openAIServer.URL + "/v1/responses")
+	proxy.HTTPClient = openAIServer.Client()
 	t.Cleanup(proxy.ResetModelsURL)
 	t.Cleanup(proxy.ResetResponsesURL)
 
@@ -106,21 +111,21 @@ func TestIntegration_TemperatureUnsupportedModel_RetriesWithoutTemperature(t *te
 		t.Fatalf("BuildRouter error: %v", err)
 	}
 
-	app := httptest.NewServer(router)
-	defer app.Close()
+	proxyServer := httptest.NewServer(router)
+	defer proxyServer.Close()
 
-	res, err := http.Get(app.URL + "/?prompt=hello&key=sekret&model=gpt-5-mini")
+	proxyResponse, err := http.Get(proxyServer.URL + "/?prompt=hello&key=sekret&model=gpt-5-mini")
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer res.Body.Close()
+	defer proxyResponse.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(res.Body)
-		t.Fatalf("status=%d body=%s", res.StatusCode, string(b))
+	if proxyResponse.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(proxyResponse.Body)
+		t.Fatalf("status=%d body=%s", proxyResponse.StatusCode, string(bodyBytes))
 	}
-	b, _ := io.ReadAll(res.Body)
-	if strings.TrimSpace(string(b)) != "TEMPLESS_OK" {
-		t.Fatalf("body=%q want %q", string(b), "TEMPLESS_OK")
+	bodyBytes, _ := io.ReadAll(proxyResponse.Body)
+	if strings.TrimSpace(string(bodyBytes)) != "TEMPLESS_OK" {
+		t.Fatalf("body=%q want %q", string(bodyBytes), "TEMPLESS_OK")
 	}
 }


### PR DESCRIPTION
## Summary
- Rename capability struct field `caps` to `capabilities` and document model capability lookup helpers
- Replace `mu` with `modelMutex` in model validator and add constant for unknown model errors
- Expand abbreviated names in integration tests for clearer intent

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b95b833f108327844f5415dc01e9d9