### PR TITLE
Consolidate HTTP log constants

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,4 +1,9 @@
 package constants
 
-// LogFieldLatencyMilliseconds identifies the structured log field name for latency in milliseconds.
-const LogFieldLatencyMilliseconds = "latency_ms"
+const (
+	// LogFieldLatencyMilliseconds identifies the structured log field name for latency in milliseconds.
+	LogFieldLatencyMilliseconds = "latency_ms"
+
+	// LogEventReadResponseBodyFailed identifies failures while reading an HTTP response body.
+	LogEventReadResponseBodyFailed = "read response body failed"
+)

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -10,11 +10,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// logEventReadResponseBodyFailed identifies failures while reading an HTTP response body.
-	logEventReadResponseBodyFailed = "read response body failed"
-)
-
 // BuildHTTPRequestWithHeaders constructs an HTTP request and applies headers.
 func BuildHTTPRequestWithHeaders(method string, requestURL string, body io.Reader, headers map[string]string) (*http.Request, error) {
 	httpRequest, httpRequestError := http.NewRequest(method, requestURL, body)
@@ -65,7 +60,7 @@ func PerformHTTPRequest(do func(*http.Request) (*http.Response, error), httpRequ
 	responseBytes, readError := io.ReadAll(httpResponse.Body)
 	if readError != nil {
 		if structuredLogger != nil {
-			structuredLogger.Errorw(logEventReadResponseBodyFailed, "err", readError)
+			structuredLogger.Errorw(constants.LogEventReadResponseBodyFailed, "err", readError)
 		}
 		return httpResponse.StatusCode, nil, latencyMillis, readError
 	}


### PR DESCRIPTION
## Summary
- centralize latency and read-response-body log constants in `internal/constants`
- use shared log constants in `internal/utils/http.go`

## Testing
- `go test ./internal/proxy -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9c78b917483279e443fbe8cd67d25