### PR TITLE
Improve test clarity with descriptive names

### DIFF
--- a/tests/integration/integration2_test.go
+++ b/tests/integration/integration2_test.go
@@ -16,18 +16,20 @@ import (
 	"go.uber.org/zap"
 )
 
-// roundTripper to stub both /models and /responses.
-type rt func(req *http.Request) (*http.Response, error)
+// roundTripperFunc stubs both /models and /responses.
+type roundTripperFunc func(httpRequest *http.Request) (*http.Response, error)
 
-func (f rt) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+func (roundTripper roundTripperFunc) RoundTrip(httpRequest *http.Request) (*http.Response, error) {
+	return roundTripper(httpRequest)
+}
 
-func makeHTTPClient(t *testing.T, wantWebSearch bool) (*http.Client, *map[string]any) {
-	t.Helper()
+func makeHTTPClient(testingInstance *testing.T, wantWebSearch bool) (*http.Client, *map[string]any) {
+	testingInstance.Helper()
 	var captured map[string]any
 
 	return &http.Client{
-		Transport: rt(func(req *http.Request) (*http.Response, error) {
-			switch req.URL.String() {
+		Transport: roundTripperFunc(func(httpRequest *http.Request) (*http.Response, error) {
+			switch httpRequest.URL.String() {
 			case proxy.ModelsURL():
 				// Return known models so validator passes for tests using gpt-4.1 and gpt-5-mini.
 				body := `{"data":[{"id":"gpt-4.1"},{"id":"gpt-5-mini"}]}`
@@ -38,8 +40,8 @@ func makeHTTPClient(t *testing.T, wantWebSearch bool) (*http.Client, *map[string
 				}, nil
 			case proxy.ResponsesURL():
 				// Capture JSON payload to assert tools presence.
-				if req.Body != nil {
-					buf, _ := io.ReadAll(req.Body)
+				if httpRequest.Body != nil {
+					buf, _ := io.ReadAll(httpRequest.Body)
 					_ = json.Unmarshal(buf, &captured)
 				}
 				// Different body based on whether caller asked for search.
@@ -55,7 +57,7 @@ func makeHTTPClient(t *testing.T, wantWebSearch bool) (*http.Client, *map[string
 				}, nil
 			default:
 				// If an unexpected URL is hit, fail loudly.
-				t.Fatalf("unexpected request to %s", req.URL.String())
+				testingInstance.Fatalf("unexpected request to %s", httpRequest.URL.String())
 				return nil, nil
 			}
 		}),
@@ -63,21 +65,22 @@ func makeHTTPClient(t *testing.T, wantWebSearch bool) (*http.Client, *map[string
 	}, &captured
 }
 
-func newLogger(t *testing.T) *zap.SugaredLogger {
-	t.Helper()
+func newLogger(testingInstance *testing.T) *zap.SugaredLogger {
+	testingInstance.Helper()
 	l, _ := zap.NewDevelopment()
-	t.Cleanup(func() { _ = l.Sync() })
+	testingInstance.Cleanup(func() { _ = l.Sync() })
 	return l.Sugar()
 }
 
-func TestIntegration_ResponseDelivered_Plain(t *testing.T) {
+// TestIntegration_ResponseDelivered_Plain validates basic response delivery without web search.
+func TestIntegration_ResponseDelivered_Plain(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	proxy.HTTPClient, _ = makeHTTPClient(t, false)
+	proxy.HTTPClient, _ = makeHTTPClient(testingInstance, false)
 	proxy.SetModelsURL("https://mock.local/v1/models")
 	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	t.Cleanup(proxy.ResetModelsURL)
-	t.Cleanup(proxy.ResetResponsesURL)
+	testingInstance.Cleanup(proxy.ResetModelsURL)
+	testingInstance.Cleanup(proxy.ResetResponsesURL)
 
 	router, err := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: "sekret",
@@ -85,43 +88,44 @@ func TestIntegration_ResponseDelivered_Plain(t *testing.T) {
 		LogLevel:      "debug",
 		WorkerCount:   1,
 		QueueSize:     8,
-	}, newLogger(t))
+	}, newLogger(testingInstance))
 	if err != nil {
-		t.Fatalf("BuildRouter failed: %v", err)
+		testingInstance.Fatalf("BuildRouter failed: %v", err)
 	}
 
-	srv := httptest.NewServer(router)
-	t.Cleanup(srv.Close)
+	server := httptest.NewServer(router)
+	testingInstance.Cleanup(server.Close)
 
-	u, _ := url.Parse(srv.URL)
-	q := u.Query()
-	q.Set("prompt", "ping")
-	q.Set("key", "sekret")
-	u.RawQuery = q.Encode()
+	requestURL, _ := url.Parse(server.URL)
+	queryValues := requestURL.Query()
+	queryValues.Set("prompt", "ping")
+	queryValues.Set("key", "sekret")
+	requestURL.RawQuery = queryValues.Encode()
 
-	res, err := http.Get(u.String())
-	if err != nil {
-		t.Fatalf("GET failed: %v", err)
+	httpResponse, requestError := http.Get(requestURL.String())
+	if requestError != nil {
+		testingInstance.Fatalf("GET failed: %v", requestError)
 	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		t.Fatalf("status=%d want=%d", res.StatusCode, http.StatusOK)
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode != http.StatusOK {
+		testingInstance.Fatalf("status=%d want=%d", httpResponse.StatusCode, http.StatusOK)
 	}
-	b, _ := io.ReadAll(res.Body)
-	if string(b) != "INTEGRATION_OK" {
-		t.Fatalf("body=%q want=%q", string(b), "INTEGRATION_OK")
+	responseBytes, _ := io.ReadAll(httpResponse.Body)
+	if string(responseBytes) != "INTEGRATION_OK" {
+		testingInstance.Fatalf("body=%q want=%q", string(responseBytes), "INTEGRATION_OK")
 	}
 }
 
-func TestIntegration_WebSearch_SendsTool(t *testing.T) {
+// TestIntegration_WebSearch_SendsTool confirms that web search requests include the correct tool in the payload.
+func TestIntegration_WebSearch_SendsTool(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	client, captured := makeHTTPClient(t, true)
+	client, captured := makeHTTPClient(testingInstance, true)
 	proxy.HTTPClient = client
 	proxy.SetModelsURL("https://mock.local/v1/models")
 	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	t.Cleanup(proxy.ResetModelsURL)
-	t.Cleanup(proxy.ResetResponsesURL)
+	testingInstance.Cleanup(proxy.ResetModelsURL)
+	testingInstance.Cleanup(proxy.ResetResponsesURL)
 
 	router, err := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: "sekret",
@@ -129,70 +133,69 @@ func TestIntegration_WebSearch_SendsTool(t *testing.T) {
 		LogLevel:      "debug",
 		WorkerCount:   1,
 		QueueSize:     8,
-	}, newLogger(t))
+	}, newLogger(testingInstance))
 	if err != nil {
-		t.Fatalf("BuildRouter failed: %v", err)
+		testingInstance.Fatalf("BuildRouter failed: %v", err)
 	}
 
-	srv := httptest.NewServer(router)
-	t.Cleanup(srv.Close)
+	server := httptest.NewServer(router)
+	testingInstance.Cleanup(server.Close)
 
-	u, _ := url.Parse(srv.URL)
-	q := u.Query()
-	q.Set("prompt", "ping")
-	q.Set("key", "sekret")
-	q.Set("web_search", "1")
-	u.RawQuery = q.Encode()
+	requestURL, _ := url.Parse(server.URL)
+	queryValues := requestURL.Query()
+	queryValues.Set("prompt", "ping")
+	queryValues.Set("key", "sekret")
+	queryValues.Set("web_search", "1")
+	requestURL.RawQuery = queryValues.Encode()
 
-	res, err := http.Get(u.String())
-	if err != nil {
-		t.Fatalf("GET failed: %v", err)
+	httpResponse, requestError := http.Get(requestURL.String())
+	if requestError != nil {
+		testingInstance.Fatalf("GET failed: %v", requestError)
 	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		t.Fatalf("status=%d want=%d", res.StatusCode, http.StatusOK)
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode != http.StatusOK {
+		testingInstance.Fatalf("status=%d want=%d", httpResponse.StatusCode, http.StatusOK)
 	}
-	b, _ := io.ReadAll(res.Body)
-	if string(b) != "SEARCH_OK" {
-		t.Fatalf("body=%q want=%q", string(b), "SEARCH_OK")
+	responseBytes, _ := io.ReadAll(httpResponse.Body)
+	if string(responseBytes) != "SEARCH_OK" {
+		testingInstance.Fatalf("body=%q want=%q", string(responseBytes), "SEARCH_OK")
 	}
 
 	// Assert tool was sent.
 	tools, ok := (*captured)["tools"].([]any)
 	if !ok || len(tools) == 0 {
-		t.Fatalf("tools missing in payload when web_search=1; captured=%v", *captured)
+		testingInstance.Fatalf("tools missing in payload when web_search=1; captured=%v", *captured)
 	}
 	first, _ := tools[0].(map[string]any)
 	if first["type"] != "web_search" {
-		t.Fatalf("tool type=%v want=web_search", first["type"])
+		testingInstance.Fatalf("tool type=%v want=web_search", first["type"])
 	}
 }
 
-func TestIntegration_RejectsWrongKeyAndMissingSecrets(t *testing.T) {
+// TestIntegration_RejectsWrongKeyAndMissingSecrets ensures that configuration errors and wrong API keys are handled correctly.
+func TestIntegration_RejectsWrongKeyAndMissingSecrets(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	// First, BuildRouter should fail if missing secrets.
 	_, err := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: "",
 		OpenAIKey:     "sk-test",
-	}, newLogger(t))
+	}, newLogger(testingInstance))
 	if err == nil || !strings.Contains(err.Error(), "SERVICE_SECRET") {
-		t.Fatalf("expected SERVICE_SECRET error, got %v", err)
+		testingInstance.Fatalf("expected SERVICE_SECRET error, got %v", err)
 	}
 	_, err = proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: "sekret",
 		OpenAIKey:     "",
-	}, newLogger(t))
+	}, newLogger(testingInstance))
 	if err == nil || !strings.Contains(err.Error(), "OPENAI_API_KEY") {
-		t.Fatalf("expected OPENAI_API_KEY error, got %v", err)
+		testingInstance.Fatalf("expected OPENAI_API_KEY error, got %v", err)
 	}
 
-	// With correct config, wrong key should 403.
-	proxy.HTTPClient, _ = makeHTTPClient(t, false)
+	proxy.HTTPClient, _ = makeHTTPClient(testingInstance, false)
 	proxy.SetModelsURL("https://mock.local/v1/models")
 	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	t.Cleanup(proxy.ResetModelsURL)
-	t.Cleanup(proxy.ResetResponsesURL)
+	testingInstance.Cleanup(proxy.ResetModelsURL)
+	testingInstance.Cleanup(proxy.ResetResponsesURL)
 
 	router, err := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: "sekret",
@@ -200,27 +203,27 @@ func TestIntegration_RejectsWrongKeyAndMissingSecrets(t *testing.T) {
 		LogLevel:      "debug",
 		WorkerCount:   1,
 		QueueSize:     4,
-	}, newLogger(t))
+	}, newLogger(testingInstance))
 	if err != nil {
-		t.Fatalf("BuildRouter failed: %v", err)
+		testingInstance.Fatalf("BuildRouter failed: %v", err)
 	}
-	srv := httptest.NewServer(router)
-	t.Cleanup(srv.Close)
+	server := httptest.NewServer(router)
+	testingInstance.Cleanup(server.Close)
 
-	u, _ := url.Parse(srv.URL)
-	q := u.Query()
-	q.Set("prompt", "ping")
-	q.Set("key", "wrong")
-	u.RawQuery = q.Encode()
+	requestURL, _ := url.Parse(server.URL)
+	queryValues := requestURL.Query()
+	queryValues.Set("prompt", "ping")
+	queryValues.Set("key", "wrong")
+	requestURL.RawQuery = queryValues.Encode()
 
-	res, err := http.Get(u.String())
-	if err != nil {
-		t.Fatalf("GET failed: %v", err)
+	httpResponse, requestError := http.Get(requestURL.String())
+	if requestError != nil {
+		testingInstance.Fatalf("GET failed: %v", requestError)
 	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusForbidden {
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode != http.StatusForbidden {
 		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, res.Body)
-		t.Fatalf("status=%d want=%d body=%q", res.StatusCode, http.StatusForbidden, buf.String())
+		_, _ = io.Copy(&buf, httpResponse.Body)
+		testingInstance.Fatalf("status=%d want=%d body=%q", httpResponse.StatusCode, http.StatusForbidden, buf.String())
 	}
 }

--- a/tests/integration/long_request_test.go
+++ b/tests/integration/long_request_test.go
@@ -32,7 +32,7 @@ const (
 func makeSlowHTTPClient(testingInstance *testing.T) *http.Client {
 	testingInstance.Helper()
 	return &http.Client{
-		Transport: rt(func(request *http.Request) (*http.Response, error) {
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
 			switch request.URL.String() {
 			case proxy.ModelsURL():
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(modelsListBody)), Header: make(http.Header)}, nil

--- a/tests/integration/request_timeout_test.go
+++ b/tests/integration/request_timeout_test.go
@@ -32,7 +32,7 @@ const (
 func makeTimeoutHTTPClient(testingInstance *testing.T) *http.Client {
 	testingInstance.Helper()
 	return &http.Client{
-		Transport: rt(func(request *http.Request) (*http.Response, error) {
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
 			switch request.URL.String() {
 			case proxy.ModelsURL():
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(timeoutModelsListBody)), Header: make(http.Header)}, nil


### PR DESCRIPTION
## Summary
- use descriptive request and response names across tests
- add documentation comments for test functions
- standardize custom round trippers with explicit names

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9c97ca6708327bf8b1500799bd228