### PR TITLE
refactor: use external proxy tests

### DIFF
--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -20,6 +20,16 @@ type modelCapabilities struct {
 	supportsTemperature bool
 }
 
+// SupportsWebSearch reports whether the model allows web search.
+func (capabilities modelCapabilities) SupportsWebSearch() bool {
+	return capabilities.supportsWebSearch
+}
+
+// SupportsTemperature reports whether the model allows setting temperature.
+func (capabilities modelCapabilities) SupportsTemperature() bool {
+	return capabilities.supportsTemperature
+}
+
 // modelCapabilityPattern maps a model prefix to its capabilities.
 type modelCapabilityPattern struct {
 	prefix       string

--- a/internal/proxy/model_specs.go
+++ b/internal/proxy/model_specs.go
@@ -2,8 +2,8 @@ package proxy
 
 import "strings"
 
-// resolveModelSpecification returns capabilities using the shared capability table.
-func resolveModelSpecification(modelIdentifier string) modelCapabilities {
+// ResolveModelSpecification returns capabilities using the shared capability table.
+func ResolveModelSpecification(modelIdentifier string) modelCapabilities {
 	lower := strings.ToLower(strings.TrimSpace(modelIdentifier))
 	if capabilities, found := lookupModelCapabilities(lower); found {
 		return capabilities

--- a/internal/proxy/model_specs_test.go
+++ b/internal/proxy/model_specs_test.go
@@ -1,6 +1,17 @@
-package proxy
+package proxy_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/temirov/llm-proxy/internal/proxy"
+)
+
+const (
+	modelIdentifierGPT4o       = "gpt-4o"
+	modelIdentifierGPT5Mini    = "gpt-5-mini"
+	messageTemperatureMismatch = "model %s temperature=%v want=%v"
+	messageWebSearchMismatch   = "model %s webSearch=%v want=%v"
+)
 
 // TestResolveModelSpecification verifies that model capabilities come from the capability table.
 func TestResolveModelSpecification(testFramework *testing.T) {
@@ -9,16 +20,16 @@ func TestResolveModelSpecification(testFramework *testing.T) {
 		expectTemperature bool
 		expectWebSearch   bool
 	}{
-		{modelPrefixGPT4o, true, true},
-		{modelPrefixGPT5Mini, false, false},
+		{modelIdentifierGPT4o, true, true},
+		{modelIdentifierGPT5Mini, false, false},
 	}
 	for _, testCase := range testCases {
-		capabilities := resolveModelSpecification(testCase.modelIdentifier)
-		if capabilities.supportsTemperature != testCase.expectTemperature {
-			testFramework.Fatalf("model %s temperature=%v want=%v", testCase.modelIdentifier, capabilities.supportsTemperature, testCase.expectTemperature)
+		capabilities := proxy.ResolveModelSpecification(testCase.modelIdentifier)
+		if capabilities.SupportsTemperature() != testCase.expectTemperature {
+			testFramework.Fatalf(messageTemperatureMismatch, testCase.modelIdentifier, capabilities.SupportsTemperature(), testCase.expectTemperature)
 		}
-		if capabilities.supportsWebSearch != testCase.expectWebSearch {
-			testFramework.Fatalf("model %s webSearch=%v want=%v", testCase.modelIdentifier, capabilities.supportsWebSearch, testCase.expectWebSearch)
+		if capabilities.SupportsWebSearch() != testCase.expectWebSearch {
+			testFramework.Fatalf(messageWebSearchMismatch, testCase.modelIdentifier, capabilities.SupportsWebSearch(), testCase.expectWebSearch)
 		}
 	}
 }

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -25,6 +25,12 @@ var (
 	upstreamPollTimeout time.Duration
 )
 
+// UpstreamPollTimeout returns the current upstream poll timeout.
+func UpstreamPollTimeout() time.Duration { return upstreamPollTimeout }
+
+// SetUpstreamPollTimeout overrides the upstream poll timeout value.
+func SetUpstreamPollTimeout(newTimeout time.Duration) { upstreamPollTimeout = newTimeout }
+
 type responsesAPIShim struct {
 	Choices []struct {
 		Message struct {
@@ -41,17 +47,17 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 		{keyRole: keyUser, keyContent: userPrompt},
 	}
 
-	modelCapabilities := resolveModelSpecification(modelIdentifier)
+	modelCapabilities := ResolveModelSpecification(modelIdentifier)
 
 	requestPayload := map[string]any{
 		keyModel:           modelIdentifier,
 		keyInput:           messageList,
 		keyMaxOutputTokens: maxOutputTokens,
 	}
-	if modelCapabilities.supportsTemperature {
+	if modelCapabilities.SupportsTemperature() {
 		requestPayload[keyTemperature] = 0.7
 	}
-	if webSearchEnabled && modelCapabilities.supportsWebSearch {
+	if webSearchEnabled && modelCapabilities.SupportsWebSearch() {
 		requestPayload[keyTools] = []any{map[string]any{keyType: toolTypeWebSearch}}
 		requestPayload[keyToolChoice] = keyAuto
 	}


### PR DESCRIPTION
## Summary
- test proxy package via public API using `proxy_test`
- expose model spec and upstream timeout for external tests

## Testing
- `go test ./internal/proxy`


------
https://chatgpt.com/codex/tasks/task_e_68b9cdce873083278b726c982a43a819