### PR TITLE
docs: clarify HTTP abstraction types

### DIFF
--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -52,4 +52,5 @@ func validateConfig(config Configuration) error {
 
 var requestTimeout = 30 * time.Second
 
+// ErrUpstreamIncomplete indicates that the upstream provider returned an incomplete response before the poll deadline.
 var ErrUpstreamIncomplete = errors.New("OpenAI API error (incomplete response)")

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -15,11 +15,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// HTTPDoer executes HTTP requests, allowing the proxy to abstract the underlying HTTP client.
 type HTTPDoer interface {
 	Do(httpRequest *http.Request) (*http.Response, error)
 }
 
 var (
+	// HTTPClient is the default HTTPDoer implementation that delegates to http.DefaultClient.
 	HTTPClient          HTTPDoer = http.DefaultClient
 	maxOutputTokens              = DefaultMaxOutputTokens
 	upstreamPollTimeout time.Duration


### PR DESCRIPTION
## Summary
- Document HTTPDoer and HTTPClient to describe their HTTP abstraction roles
- Explain ErrUpstreamIncomplete to clarify upstream polling behavior

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9cdd6d8fc8327a5a396fe828be898