### PR TITLE
refactor: use constants for error log field

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,6 +1,9 @@
 package constants
 
 const (
+	// LogFieldError identifies the structured log field name for an error.
+	LogFieldError = "err"
+
 	// LogFieldLatencyMilliseconds identifies the structured log field name for latency in milliseconds.
 	LogFieldLatencyMilliseconds = "latency_ms"
 

--- a/internal/proxy/model_validator.go
+++ b/internal/proxy/model_validator.go
@@ -44,7 +44,13 @@ func (validator *modelValidator) refresh() error {
 	httpResponse, httpError := HTTPClient.Do(httpRequest)
 	latencyMillis := time.Since(startTime).Milliseconds()
 	if httpError != nil {
-		validator.logger.Errorw(logEventOpenAIModelsListError, "err", httpError, constants.LogFieldLatencyMilliseconds, latencyMillis)
+		validator.logger.Errorw(
+			logEventOpenAIModelsListError,
+			constants.LogFieldError,
+			httpError,
+			constants.LogFieldLatencyMilliseconds,
+			latencyMillis,
+		)
 		return httpError
 	}
 	defer httpResponse.Body.Close()

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -38,7 +38,7 @@ func PerformHTTPRequest(do func(*http.Request) (*http.Response, error), httpRequ
 		response, httpError := do(httpRequest)
 		if httpError != nil {
 			if structuredLogger != nil {
-				structuredLogger.Errorw(logEventOnTransportError, "err", httpError)
+				structuredLogger.Errorw(logEventOnTransportError, constants.LogFieldError, httpError)
 			}
 			return httpError
 		}
@@ -51,7 +51,13 @@ func PerformHTTPRequest(do func(*http.Request) (*http.Response, error), httpRequ
 	latencyMillis := time.Since(startTime).Milliseconds()
 	if retryError != nil {
 		if structuredLogger != nil {
-			structuredLogger.Errorw(logEventOnTransportError, "err", retryError, constants.LogFieldLatencyMilliseconds, latencyMillis)
+			structuredLogger.Errorw(
+				logEventOnTransportError,
+				constants.LogFieldError,
+				retryError,
+				constants.LogFieldLatencyMilliseconds,
+				latencyMillis,
+			)
 		}
 		return 0, nil, latencyMillis, retryError
 	}
@@ -60,7 +66,7 @@ func PerformHTTPRequest(do func(*http.Request) (*http.Response, error), httpRequ
 	responseBytes, readError := io.ReadAll(httpResponse.Body)
 	if readError != nil {
 		if structuredLogger != nil {
-			structuredLogger.Errorw(constants.LogEventReadResponseBodyFailed, "err", readError)
+			structuredLogger.Errorw(constants.LogEventReadResponseBodyFailed, constants.LogFieldError, readError)
 		}
 		return httpResponse.StatusCode, nil, latencyMillis, readError
 	}


### PR DESCRIPTION
## Summary
- add `LogFieldError` constant for structured error logging
- replace string literal `"err"` with `constants.LogFieldError`

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9cdf2d4948327ab65dd13daf22890