### PR TITLE
refactor integration tests into table-driven cases

### DIFF
--- a/tests/integration/integration2_test.go
+++ b/tests/integration/integration2_test.go
@@ -16,47 +16,40 @@ import (
 	"go.uber.org/zap"
 )
 
-// roundTripperFunc stubs both /models and /responses.
+const (
+	availableModelsBody     = `{"data":[{"id":"gpt-4.1"},{"id":"gpt-5-mini"}]}`
+	webSearchQueryParameter = "web_search"
+)
+
+// roundTripperFunc stubs both models and responses endpoints.
 type roundTripperFunc func(httpRequest *http.Request) (*http.Response, error)
 
 func (roundTripper roundTripperFunc) RoundTrip(httpRequest *http.Request) (*http.Response, error) {
 	return roundTripper(httpRequest)
 }
 
+// makeHTTPClient returns a stub HTTP client capturing payloads and returning canned responses.
 func makeHTTPClient(testingInstance *testing.T, wantWebSearch bool) (*http.Client, *map[string]any) {
 	testingInstance.Helper()
 	var captured map[string]any
-
 	return &http.Client{
 		Transport: roundTripperFunc(func(httpRequest *http.Request) (*http.Response, error) {
 			switch httpRequest.URL.String() {
 			case proxy.ModelsURL():
-				// Return known models so validator passes for tests using gpt-4.1 and gpt-5-mini.
-				body := `{"data":[{"id":"gpt-4.1"},{"id":"gpt-5-mini"}]}`
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(body)),
-					Header:     make(http.Header),
-				}, nil
+				body := availableModelsBody
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
 			case proxy.ResponsesURL():
-				// Capture JSON payload to assert tools presence.
 				if httpRequest.Body != nil {
 					buf, _ := io.ReadAll(httpRequest.Body)
 					_ = json.Unmarshal(buf, &captured)
 				}
-				// Different body based on whether caller asked for search.
-				text := "INTEGRATION_OK"
+				text := integrationOKBody
 				if wantWebSearch {
-					text = "SEARCH_OK"
+					text = integrationSearchBody
 				}
 				body := `{"output_text":"` + text + `"}`
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(body)),
-					Header:     make(http.Header),
-				}, nil
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
 			default:
-				// If an unexpected URL is hit, fail loudly.
 				testingInstance.Fatalf("unexpected request to %s", httpRequest.URL.String())
 				return nil, nil
 			}
@@ -65,6 +58,7 @@ func makeHTTPClient(testingInstance *testing.T, wantWebSearch bool) (*http.Clien
 	}, &captured
 }
 
+// newLogger constructs a development logger for tests.
 func newLogger(testingInstance *testing.T) *zap.SugaredLogger {
 	testingInstance.Helper()
 	l, _ := zap.NewDevelopment()
@@ -72,158 +66,137 @@ func newLogger(testingInstance *testing.T) *zap.SugaredLogger {
 	return l.Sugar()
 }
 
-// TestIntegration_ResponseDelivered_Plain validates basic response delivery without web search.
-func TestIntegration_ResponseDelivered_Plain(testingInstance *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	proxy.HTTPClient, _ = makeHTTPClient(testingInstance, false)
-	proxy.SetModelsURL("https://mock.local/v1/models")
-	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
-
-	router, err := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: "sekret",
-		OpenAIKey:     "sk-test",
-		LogLevel:      "debug",
-		WorkerCount:   1,
-		QueueSize:     8,
-	}, newLogger(testingInstance))
-	if err != nil {
-		testingInstance.Fatalf("BuildRouter failed: %v", err)
-	}
-
-	server := httptest.NewServer(router)
-	testingInstance.Cleanup(server.Close)
-
-	requestURL, _ := url.Parse(server.URL)
-	queryValues := requestURL.Query()
-	queryValues.Set("prompt", "ping")
-	queryValues.Set("key", "sekret")
-	requestURL.RawQuery = queryValues.Encode()
-
-	httpResponse, requestError := http.Get(requestURL.String())
-	if requestError != nil {
-		testingInstance.Fatalf("GET failed: %v", requestError)
-	}
-	defer httpResponse.Body.Close()
-	if httpResponse.StatusCode != http.StatusOK {
-		testingInstance.Fatalf("status=%d want=%d", httpResponse.StatusCode, http.StatusOK)
-	}
-	responseBytes, _ := io.ReadAll(httpResponse.Body)
-	if string(responseBytes) != "INTEGRATION_OK" {
-		testingInstance.Fatalf("body=%q want=%q", string(responseBytes), "INTEGRATION_OK")
-	}
-}
-
-// TestIntegration_WebSearch_SendsTool confirms that web search requests include the correct tool in the payload.
-func TestIntegration_WebSearch_SendsTool(testingInstance *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	client, captured := makeHTTPClient(testingInstance, true)
+// configureProxy sets URLs and the HTTP client for proxy operations.
+func configureProxy(testingInstance *testing.T, client *http.Client) {
+	testingInstance.Helper()
 	proxy.HTTPClient = client
-	proxy.SetModelsURL("https://mock.local/v1/models")
-	proxy.SetResponsesURL("https://mock.local/v1/responses")
+	proxy.SetModelsURL(mockModelsURL)
+	proxy.SetResponsesURL(mockResponsesURL)
 	testingInstance.Cleanup(proxy.ResetModelsURL)
 	testingInstance.Cleanup(proxy.ResetResponsesURL)
+}
 
-	router, err := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: "sekret",
-		OpenAIKey:     "sk-test",
-		LogLevel:      "debug",
-		WorkerCount:   1,
-		QueueSize:     8,
-	}, newLogger(testingInstance))
-	if err != nil {
-		testingInstance.Fatalf("BuildRouter failed: %v", err)
+// TestClientResponseDelivery validates responses with and without web search.
+func TestClientResponseDelivery(testingInstance *testing.T) {
+	gin.SetMode(gin.TestMode)
+	testCases := []struct {
+		name       string
+		webSearch  bool
+		expected   string
+		checkTools bool
+	}{
+		{name: "plain", webSearch: false, expected: integrationOKBody},
+		{name: "web_search", webSearch: true, expected: integrationSearchBody, checkTools: true},
 	}
-
-	server := httptest.NewServer(router)
-	testingInstance.Cleanup(server.Close)
-
-	requestURL, _ := url.Parse(server.URL)
-	queryValues := requestURL.Query()
-	queryValues.Set("prompt", "ping")
-	queryValues.Set("key", "sekret")
-	queryValues.Set("web_search", "1")
-	requestURL.RawQuery = queryValues.Encode()
-
-	httpResponse, requestError := http.Get(requestURL.String())
-	if requestError != nil {
-		testingInstance.Fatalf("GET failed: %v", requestError)
-	}
-	defer httpResponse.Body.Close()
-	if httpResponse.StatusCode != http.StatusOK {
-		testingInstance.Fatalf("status=%d want=%d", httpResponse.StatusCode, http.StatusOK)
-	}
-	responseBytes, _ := io.ReadAll(httpResponse.Body)
-	if string(responseBytes) != "SEARCH_OK" {
-		testingInstance.Fatalf("body=%q want=%q", string(responseBytes), "SEARCH_OK")
-	}
-
-	// Assert tool was sent.
-	tools, ok := (*captured)["tools"].([]any)
-	if !ok || len(tools) == 0 {
-		testingInstance.Fatalf("tools missing in payload when web_search=1; captured=%v", *captured)
-	}
-	first, _ := tools[0].(map[string]any)
-	if first["type"] != "web_search" {
-		testingInstance.Fatalf("tool type=%v want=web_search", first["type"])
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			client, captured := makeHTTPClient(subTest, testCase.webSearch)
+			configureProxy(subTest, client)
+			router, err := proxy.BuildRouter(proxy.Configuration{
+				ServiceSecret: serviceSecretValue,
+				OpenAIKey:     openAIKeyValue,
+				LogLevel:      "debug",
+				WorkerCount:   1,
+				QueueSize:     8,
+			}, newLogger(subTest))
+			if err != nil {
+				subTest.Fatalf("BuildRouter failed: %v", err)
+			}
+			server := httptest.NewServer(router)
+			subTest.Cleanup(server.Close)
+			requestURL, _ := url.Parse(server.URL)
+			queryValues := requestURL.Query()
+			queryValues.Set(promptQueryParameter, promptValue)
+			queryValues.Set(keyQueryParameter, serviceSecretValue)
+			if testCase.webSearch {
+				queryValues.Set(webSearchQueryParameter, "1")
+			}
+			requestURL.RawQuery = queryValues.Encode()
+			httpResponse, requestError := http.Get(requestURL.String())
+			if requestError != nil {
+				subTest.Fatalf("GET failed: %v", requestError)
+			}
+			defer httpResponse.Body.Close()
+			if httpResponse.StatusCode != http.StatusOK {
+				subTest.Fatalf("status=%d want=%d", httpResponse.StatusCode, http.StatusOK)
+			}
+			responseBytes, _ := io.ReadAll(httpResponse.Body)
+			if string(responseBytes) != testCase.expected {
+				subTest.Fatalf("body=%q want=%q", string(responseBytes), testCase.expected)
+			}
+			if testCase.checkTools {
+				tools, ok := (*captured)["tools"].([]any)
+				if !ok || len(tools) == 0 {
+					subTest.Fatalf("tools missing in payload when web_search=1; captured=%v", *captured)
+				}
+				first, _ := tools[0].(map[string]any)
+				if first["type"] != "web_search" {
+					subTest.Fatalf("tool type=%v want=web_search", first["type"])
+				}
+			}
+		})
 	}
 }
 
-// TestIntegration_RejectsWrongKeyAndMissingSecrets ensures that configuration errors and wrong API keys are handled correctly.
-func TestIntegration_RejectsWrongKeyAndMissingSecrets(testingInstance *testing.T) {
+// TestIntegrationConfiguration covers configuration errors and wrong API keys.
+func TestIntegrationConfiguration(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
-
-	_, err := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: "",
-		OpenAIKey:     "sk-test",
-	}, newLogger(testingInstance))
-	if err == nil || !strings.Contains(err.Error(), "SERVICE_SECRET") {
-		testingInstance.Fatalf("expected SERVICE_SECRET error, got %v", err)
+	testCases := []struct {
+		name           string
+		config         proxy.Configuration
+		requestKey     string
+		expectedStatus int
+		expectError    string
+	}{
+		{
+			name:        "missing_service_secret",
+			config:      proxy.Configuration{ServiceSecret: "", OpenAIKey: openAIKeyValue},
+			expectError: "SERVICE_SECRET",
+		},
+		{
+			name:        "missing_openai_key",
+			config:      proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: ""},
+			expectError: "OPENAI_API_KEY",
+		},
+		{
+			name:           "wrong_key",
+			config:         proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 4},
+			requestKey:     "wrong",
+			expectedStatus: http.StatusForbidden,
+		},
 	}
-	_, err = proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: "sekret",
-		OpenAIKey:     "",
-	}, newLogger(testingInstance))
-	if err == nil || !strings.Contains(err.Error(), "OPENAI_API_KEY") {
-		testingInstance.Fatalf("expected OPENAI_API_KEY error, got %v", err)
-	}
-
-	proxy.HTTPClient, _ = makeHTTPClient(testingInstance, false)
-	proxy.SetModelsURL("https://mock.local/v1/models")
-	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
-
-	router, err := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: "sekret",
-		OpenAIKey:     "sk-test",
-		LogLevel:      "debug",
-		WorkerCount:   1,
-		QueueSize:     4,
-	}, newLogger(testingInstance))
-	if err != nil {
-		testingInstance.Fatalf("BuildRouter failed: %v", err)
-	}
-	server := httptest.NewServer(router)
-	testingInstance.Cleanup(server.Close)
-
-	requestURL, _ := url.Parse(server.URL)
-	queryValues := requestURL.Query()
-	queryValues.Set("prompt", "ping")
-	queryValues.Set("key", "wrong")
-	requestURL.RawQuery = queryValues.Encode()
-
-	httpResponse, requestError := http.Get(requestURL.String())
-	if requestError != nil {
-		testingInstance.Fatalf("GET failed: %v", requestError)
-	}
-	defer httpResponse.Body.Close()
-	if httpResponse.StatusCode != http.StatusForbidden {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, httpResponse.Body)
-		testingInstance.Fatalf("status=%d want=%d body=%q", httpResponse.StatusCode, http.StatusForbidden, buf.String())
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			if testCase.expectError != "" {
+				_, err := proxy.BuildRouter(testCase.config, newLogger(subTest))
+				if err == nil || !strings.Contains(err.Error(), testCase.expectError) {
+					subTest.Fatalf("expected %s error, got %v", testCase.expectError, err)
+				}
+				return
+			}
+			client, _ := makeHTTPClient(subTest, false)
+			configureProxy(subTest, client)
+			router, err := proxy.BuildRouter(testCase.config, newLogger(subTest))
+			if err != nil {
+				subTest.Fatalf("BuildRouter failed: %v", err)
+			}
+			server := httptest.NewServer(router)
+			subTest.Cleanup(server.Close)
+			requestURL, _ := url.Parse(server.URL)
+			queryValues := requestURL.Query()
+			queryValues.Set(promptQueryParameter, promptValue)
+			queryValues.Set(keyQueryParameter, testCase.requestKey)
+			requestURL.RawQuery = queryValues.Encode()
+			httpResponse, requestError := http.Get(requestURL.String())
+			if requestError != nil {
+				subTest.Fatalf("GET failed: %v", requestError)
+			}
+			defer httpResponse.Body.Close()
+			if httpResponse.StatusCode != testCase.expectedStatus {
+				var buf bytes.Buffer
+				_, _ = io.Copy(&buf, httpResponse.Body)
+				subTest.Fatalf("status=%d want=%d body=%q", httpResponse.StatusCode, testCase.expectedStatus, buf.String())
+			}
+		})
 	}
 }

--- a/tests/integration/integration_models_test.go
+++ b/tests/integration/integration_models_test.go
@@ -12,58 +12,53 @@ import (
 	"github.com/temirov/llm-proxy/internal/proxy"
 )
 
-// TestIntegration_ModelSpec_SuppressesTemperatureAndTools_ForMini verifies that certain fields are suppressed for mini models.
-func TestIntegration_ModelSpec_SuppressesTemperatureAndTools_ForMini(testingInstance *testing.T) {
+// TestIntegrationModelSpecSuppression verifies that certain fields are suppressed for mini models.
+func TestIntegrationModelSpecSuppression(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
-
-	client, captured := makeHTTPClient(testingInstance, true)
-	proxy.HTTPClient = client
-	proxy.SetModelsURL("https://mock.local/v1/models")
-	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
-
-	router, err := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: "sekret",
-		OpenAIKey:     "sk-test",
-		LogLevel:      "debug",
-		WorkerCount:   1,
-		QueueSize:     8,
-	}, newLogger(testingInstance))
-	if err != nil {
-		testingInstance.Fatalf("BuildRouter failed: %v", err)
+	testCases := []struct{ name string }{{name: "gpt_5_mini"}}
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			client, captured := makeHTTPClient(subTest, true)
+			configureProxy(subTest, client)
+			router, err := proxy.BuildRouter(proxy.Configuration{
+				ServiceSecret: serviceSecretValue,
+				OpenAIKey:     openAIKeyValue,
+				LogLevel:      "debug",
+				WorkerCount:   1,
+				QueueSize:     8,
+			}, newLogger(subTest))
+			if err != nil {
+				subTest.Fatalf("BuildRouter failed: %v", err)
+			}
+			server := httptest.NewServer(router)
+			subTest.Cleanup(server.Close)
+			requestURL, _ := url.Parse(server.URL)
+			queryValues := requestURL.Query()
+			queryValues.Set(promptQueryParameter, promptValue)
+			queryValues.Set(keyQueryParameter, serviceSecretValue)
+			queryValues.Set(webSearchQueryParameter, "1")
+			queryValues.Set(adaptiveModelQueryParameter, "gpt-5-mini")
+			requestURL.RawQuery = queryValues.Encode()
+			httpResponse, requestError := http.Get(requestURL.String())
+			if requestError != nil {
+				subTest.Fatalf("GET failed: %v", requestError)
+			}
+			defer httpResponse.Body.Close()
+			_, _ = io.ReadAll(httpResponse.Body)
+			payload := *captured
+			if _, ok := payload["temperature"]; ok {
+				subTest.Fatalf("temperature must be omitted for gpt-5-mini, got: %v", payload["temperature"])
+			}
+			if _, ok := payload["tools"]; ok {
+				subTest.Fatalf("tools must be omitted for gpt-5-mini, got: %v", payload["tools"])
+			}
+			if _, hasInput := payload["input"]; !hasInput {
+				subTest.Fatalf("input must be present for responses API")
+			}
+			if _, hasMessages := payload["messages"]; hasMessages {
+				subTest.Fatalf("messages must not be present for responses API payload")
+			}
+			time.Sleep(10 * time.Millisecond)
+		})
 	}
-
-	server := httptest.NewServer(router)
-	testingInstance.Cleanup(server.Close)
-
-	requestURL, _ := url.Parse(server.URL)
-	queryValues := requestURL.Query()
-	queryValues.Set("prompt", "ping")
-	queryValues.Set("key", "sekret")
-	queryValues.Set("web_search", "1")
-	queryValues.Set("model", "gpt-5-mini")
-	requestURL.RawQuery = queryValues.Encode()
-
-	httpResponse, requestError := http.Get(requestURL.String())
-	if requestError != nil {
-		testingInstance.Fatalf("GET failed: %v", requestError)
-	}
-	defer httpResponse.Body.Close()
-	_, _ = io.ReadAll(httpResponse.Body)
-
-	payload := *captured
-	if _, ok := payload["temperature"]; ok {
-		testingInstance.Fatalf("temperature must be omitted for gpt-5-mini, got: %v", payload["temperature"])
-	}
-	if _, ok := payload["tools"]; ok {
-		testingInstance.Fatalf("tools must be omitted for gpt-5-mini, got: %v", payload["tools"])
-	}
-	if _, hasInput := payload["input"]; !hasInput {
-		testingInstance.Fatalf("input must be present for responses API")
-	}
-	if _, hasMessages := payload["messages"]; hasMessages {
-		testingInstance.Fatalf("messages must not be present for responses API payload")
-	}
-	time.Sleep(10 * time.Millisecond)
 }


### PR DESCRIPTION
## Summary
- consolidate integration tests into table-driven `[]struct` cases
- extract shared helpers for proxy configuration and OpenAI stubs
- streamline setup/teardown across integration suite

## Testing
- `go test ./tests/integration`


------
https://chatgpt.com/codex/tasks/task_e_68b9ce080a9c8327b88758d42f741d7c