### PR TITLE
refactor: centralize error messages

### DIFF
--- a/internal/apperrors/apperrors.go
+++ b/internal/apperrors/apperrors.go
@@ -1,8 +1,19 @@
+// Package apperrors provides shared application error values.
 package apperrors
 
 import "errors"
 
+const (
+	environmentVariableServiceSecret = "SERVICE_SECRET"
+	environmentVariableOpenAIAPIKey  = "OPENAI_API_KEY"
+	messageSuffixMustBeSet           = " must be set"
+	messageMissingServiceSecret      = environmentVariableServiceSecret + messageSuffixMustBeSet
+	messageMissingOpenAIKey          = environmentVariableOpenAIAPIKey + messageSuffixMustBeSet
+)
+
 var (
-	ErrMissingServiceSecret = errors.New("SERVICE_SECRET must be set")
-	ErrMissingOpenAIKey     = errors.New("OPENAI_API_KEY must be set")
+	// ErrMissingServiceSecret is returned when the SERVICE_SECRET environment variable is not defined.
+	ErrMissingServiceSecret = errors.New(messageMissingServiceSecret)
+	// ErrMissingOpenAIKey is returned when the OPENAI_API_KEY environment variable is not defined.
+	ErrMissingOpenAIKey = errors.New(messageMissingOpenAIKey)
 )


### PR DESCRIPTION
## Summary
- define constants for environment variables and error message text in apperrors
- document and construct exported errors using these constants

## Testing
- `go vet ./internal/apperrors`
- `go build ./internal/apperrors`


------
https://chatgpt.com/codex/tasks/task_e_68b9d52002008327a1583f2591ea6a61