### PR TITLE
Return error when client key missing

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -27,7 +27,9 @@ const (
 	mimeTextCSV         = "text/csv"
 	mimeTextPlain       = "text/plain; charset=utf-8"
 
-	errorMissingPrompt         = "missing prompt parameter"
+	errorMissingPrompt = "missing prompt parameter"
+	// errorMissingClientKey indicates that the key query parameter is missing.
+	errorMissingClientKey      = "missing client key"
 	errorRequestTimedOut       = "request timed out"
 	errorRequestBuild          = "request build error"
 	errorOpenAIRequest         = "OpenAI request error"

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -61,7 +61,8 @@ func secretMiddleware(sharedSecret string, structuredLogger *zap.SugaredLogger) 
 				logEventForbiddenRequest,
 				"expected_fingerprint", utils.Fingerprint(normalizedSecret),
 			)
-			ginContext.AbortWithStatus(http.StatusForbidden)
+			ginContext.String(http.StatusForbidden, errorMissingClientKey)
+			ginContext.Abort()
 			return
 		}
 		ginContext.Next()

--- a/tests/integration/missing_key_test.go
+++ b/tests/integration/missing_key_test.go
@@ -1,0 +1,37 @@
+package integration_test
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+const (
+	// missingKeyErrorBody is the expected response when the key query parameter is absent.
+	missingKeyErrorBody = "missing client key"
+)
+
+// TestMissingClientKeyReturnsForbidden verifies that a request without a key is rejected.
+func TestMissingClientKeyReturnsForbidden(testingInstance *testing.T) {
+	openAIServer := newOpenAIServer(testingInstance, integrationOKBody, nil)
+	testingInstance.Cleanup(openAIServer.Close)
+	applicationServer := newIntegrationServer(testingInstance, openAIServer)
+	requestURL, _ := url.Parse(applicationServer.URL)
+	queryValues := requestURL.Query()
+	queryValues.Set(promptQueryParameter, promptValue)
+	requestURL.RawQuery = queryValues.Encode()
+	httpResponse, requestError := http.Get(requestURL.String())
+	if requestError != nil {
+		testingInstance.Fatalf("request error: %v", requestError)
+	}
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode != http.StatusForbidden {
+		responseBody, _ := io.ReadAll(httpResponse.Body)
+		testingInstance.Fatalf("status=%d body=%s", httpResponse.StatusCode, string(responseBody))
+	}
+	responseBytes, _ := io.ReadAll(httpResponse.Body)
+	if string(responseBytes) != missingKeyErrorBody {
+		testingInstance.Fatalf("body=%q want=%q", string(responseBytes), missingKeyErrorBody)
+	}
+}


### PR DESCRIPTION
## Summary
- add explicit error when secret key query parameter is absent
- return missing client key error instead of bare status code
- test forbidden response when key is omitted

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9f490dcfc8327ae11d4def195a279