### PR TITLE
Log and test malformed OpenAI JSON handling

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -79,11 +79,13 @@ const (
 	logFieldValue        = "value"
 	logFieldError        = "error"
 
-	logEventOpenAIRequestError            = "OpenAI request error"
-	logEventOpenAIResponse                = "OpenAI API response"
-	logEventOpenAIModelsList              = "OpenAI models list"
-	logEventOpenAIModelsListError         = "OpenAI models list error"
-	logEventOpenAIPollError               = "OpenAI poll error"
+	logEventOpenAIRequestError    = "OpenAI request error"
+	logEventOpenAIResponse        = "OpenAI API response"
+	logEventOpenAIModelsList      = "OpenAI models list"
+	logEventOpenAIModelsListError = "OpenAI models list error"
+	logEventOpenAIPollError       = "OpenAI poll error"
+	// logEventParseOpenAIResponseFailed indicates that parsing the OpenAI response failed.
+	logEventParseOpenAIResponseFailed     = "parse OpenAI response failed"
 	logEventForbiddenRequest              = "forbidden request"
 	logEventRequestReceived               = "request received"
 	logEventResponseSent                  = "response sent"

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -132,6 +132,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 
 	var decodedObject map[string]any
 	if unmarshalError := json.Unmarshal(responseBytes, &decodedObject); unmarshalError != nil {
+		structuredLogger.Errorw(logEventParseOpenAIResponseFailed, constants.LogFieldError, unmarshalError)
 		decodedObject = nil
 	}
 
@@ -220,6 +221,7 @@ func fetchResponseByID(contextToUse context.Context, openAIKey string, responseI
 
 	var decodedObject map[string]any
 	if unmarshalError := json.Unmarshal(responseBytes, &decodedObject); unmarshalError != nil {
+		structuredLogger.Errorw(logEventParseOpenAIResponseFailed, constants.LogFieldError, unmarshalError)
 		decodedObject = nil
 	}
 	responseStatus := strings.ToLower(getString(decodedObject, jsonFieldStatus))

--- a/tests/integration/openai_malformed_json_test.go
+++ b/tests/integration/openai_malformed_json_test.go
@@ -1,0 +1,61 @@
+package integration_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+const (
+	// malformedJSONPayload is the body returned by the stubbed upstream to simulate invalid JSON.
+	malformedJSONPayload = "invalid"
+	// expectedErrorMessage is the error returned by the proxy when upstream JSON cannot be parsed.
+	expectedErrorMessage = "OpenAI API error"
+	// contentTypeJSON is the HTTP Content-Type header value for JSON payloads.
+	contentTypeJSON = "application/json"
+)
+
+// newMalformedOpenAIServer returns a stub OpenAI server emitting invalid JSON for the responses endpoint.
+func newMalformedOpenAIServer(testingInstance *testing.T) *httptest.Server {
+	testingInstance.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		switch httpRequest.URL.Path {
+		case integrationModelsPath:
+			responseWriter.Header().Set("Content-Type", contentTypeJSON)
+			_, _ = io.WriteString(responseWriter, integrationModelListBody)
+		case integrationResponsesPath:
+			responseWriter.Header().Set("Content-Type", contentTypeJSON)
+			_, _ = io.WriteString(responseWriter, malformedJSONPayload)
+		default:
+			http.NotFound(responseWriter, httpRequest)
+		}
+	}))
+	return server
+}
+
+// TestOpenAIMalformedJSON verifies that the proxy returns a 502 error when the upstream responds with invalid JSON.
+func TestOpenAIMalformedJSON(testingInstance *testing.T) {
+	openAIServer := newMalformedOpenAIServer(testingInstance)
+	testingInstance.Cleanup(openAIServer.Close)
+	applicationServer := newIntegrationServer(testingInstance, openAIServer)
+	requestURL, _ := url.Parse(applicationServer.URL)
+	queryValues := requestURL.Query()
+	queryValues.Set(promptQueryParameter, promptValue)
+	queryValues.Set(keyQueryParameter, integrationServiceSecret)
+	requestURL.RawQuery = queryValues.Encode()
+	httpResponse, requestError := http.Get(requestURL.String())
+	if requestError != nil {
+		testingInstance.Fatalf("request error: %v", requestError)
+	}
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode != http.StatusBadGateway {
+		responseBody, _ := io.ReadAll(httpResponse.Body)
+		testingInstance.Fatalf("status=%d body=%s", httpResponse.StatusCode, string(responseBody))
+	}
+	responseBytes, _ := io.ReadAll(httpResponse.Body)
+	if string(responseBytes) != expectedErrorMessage {
+		testingInstance.Fatalf("body=%q want=%q", string(responseBytes), expectedErrorMessage)
+	}
+}


### PR DESCRIPTION
## Summary
- log OpenAI response parsing errors
- test malformed JSON response produces 502 and descriptive error

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9f55757b8832795b277312588ceda