### PR TITLE
Use byte-level checks and logging in OpenAI proxy

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -74,6 +74,8 @@ const (
 	logFieldHTTPStatus   = "http_status"
 	logFieldAPIStatus    = "api_status"
 	logFieldResponseText = "response_text"
+	// logFieldResponseBody captures the raw body returned by the upstream API.
+	logFieldResponseBody = "response_body"
 	logFieldMethod       = "method"
 	logFieldPath         = "path"
 	logFieldClientIP     = "client_ip"


### PR DESCRIPTION
## Summary
- detect unsupported temperature and tools parameters using byte comparisons
- log upstream response bodies without string conversion
- expose `response_body` log field

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9fc87f4d0832789b48f157690917c