### PR TITLE
Use cancellable timers for queue and request timeouts

### DIFF
--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -110,6 +110,9 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 
 	statusCode, responseBytes, latencyMillis, requestError := performResponsesRequest(httpRequest, structuredLogger, logEventOpenAIRequestError)
 	if requestError != nil {
+		if errors.Is(requestError, context.DeadlineExceeded) {
+			return "", requestError
+		}
 		return "", errors.New(errorOpenAIRequest)
 	}
 
@@ -132,6 +135,9 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 		}
 		statusCode, responseBytes, latencyMillis, requestError = performResponsesRequest(retryRequest, structuredLogger, logEventOpenAIRequestError)
 		if requestError != nil {
+			if errors.Is(requestError, context.DeadlineExceeded) {
+				return "", requestError
+			}
 			return "", errors.New(errorOpenAIRequest)
 		}
 	}
@@ -156,6 +162,9 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 		}
 		statusCode, responseBytes, latencyMillis, requestError = performResponsesRequest(retryRequest, structuredLogger, logEventOpenAIRequestError)
 		if requestError != nil {
+			if errors.Is(requestError, context.DeadlineExceeded) {
+				return "", requestError
+			}
 			return "", errors.New(errorOpenAIRequest)
 		}
 	}
@@ -258,6 +267,9 @@ func fetchResponseByID(contextToUse context.Context, openAIKey string, responseI
 
 	_, responseBytes, _, requestError := performResponsesRequest(httpRequest, structuredLogger, logEventOpenAIPollError)
 	if requestError != nil {
+		if errors.Is(requestError, context.DeadlineExceeded) {
+			return "", false, requestError
+		}
 		return "", false, errors.New(errorOpenAIRequest)
 	}
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -140,6 +141,7 @@ func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validat
 		if deadlineFound {
 			enqueueDuration = time.Until(requestDeadline)
 		}
+		enqueueContext, enqueueCancel := context.WithTimeout(ginContext.Request.Context(), enqueueDuration)
 		select {
 		case taskQueue <- requestTask{
 			prompt:           userPrompt,
@@ -148,13 +150,17 @@ func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validat
 			webSearchEnabled: webSearchEnabled,
 			reply:            replyChannel,
 		}:
-		case <-time.After(enqueueDuration):
+			enqueueCancel()
+		case <-enqueueContext.Done():
+			enqueueCancel()
 			ginContext.String(http.StatusServiceUnavailable, errorQueueFull)
 			return
 		}
 
+		requestContext, requestCancel := context.WithTimeout(ginContext.Request.Context(), requestTimeout)
 		select {
 		case outcome := <-replyChannel:
+			requestCancel()
 			if outcome.requestError != nil {
 				if errors.Is(outcome.requestError, ErrUnknownModel) {
 					ginContext.String(http.StatusBadRequest, outcome.requestError.Error())
@@ -166,7 +172,8 @@ func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validat
 			mime := preferredMime(ginContext)
 			formattedBody, contentType := formatResponse(outcome.text, mime, userPrompt, structuredLogger)
 			ginContext.Data(http.StatusOK, contentType, []byte(formattedBody))
-		case <-time.After(requestTimeout):
+		case <-requestContext.Done():
+			requestCancel()
 			ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
 		}
 	}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -164,6 +164,8 @@ func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validat
 			if outcome.requestError != nil {
 				if errors.Is(outcome.requestError, ErrUnknownModel) {
 					ginContext.String(http.StatusBadRequest, outcome.requestError.Error())
+				} else if errors.Is(outcome.requestError, context.DeadlineExceeded) {
+					ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
 				} else {
 					ginContext.String(http.StatusBadGateway, outcome.requestError.Error())
 				}


### PR DESCRIPTION
## Summary
- avoid goroutine leaks by replacing `time.After` with `context.WithTimeout` for enqueue and request timeouts

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba00c815888327986a989320d409c2