### PR TITLE
Reuse exponential backoff

### DIFF
--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -393,7 +393,8 @@ func performResponsesRequest(httpRequest *http.Request, structuredLogger *zap.Su
 		}
 		return nil
 	}
-	retryStrategy := backoff.NewExponentialBackOff()
+	retryStrategy := utils.AcquireExponentialBackoff()
+	defer utils.ReleaseExponentialBackoff(retryStrategy)
 	retryError := backoff.Retry(operation, backoff.WithContext(retryStrategy, httpRequest.Context()))
 	return statusCode, responseBytes, latencyMillis, retryError
 }


### PR DESCRIPTION
## Summary
- reuse pooled exponential backoff instead of allocating per request
- reset and return backoff instances to the pool

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba053f6f848327baf5e1be3487ce27