### PR TITLE
Optimize secret comparison

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -82,6 +82,8 @@ const (
 	logFieldStatus       = "status"
 	logFieldValue        = "value"
 	logFieldError        = "error"
+	// logFieldExpectedFingerprint identifies the fingerprint of the expected client key.
+	logFieldExpectedFingerprint = "expected_fingerprint"
 
 	logEventOpenAIRequestError    = "OpenAI request error"
 	logEventOpenAIResponse        = "OpenAI API response"


### PR DESCRIPTION
## Summary
- Pre-compute shared secret bytes and fingerprint in middleware
- Compare secrets as byte slices to avoid repeated allocations
- Add log field constant for expected secret fingerprint

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68ba055efd008327a1264d005503e10a