### PR TITLE
Use descriptive log level variable name in BuildRouter

### DIFF
--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -59,7 +59,7 @@ func BuildRouter(config Configuration, structuredLogger *zap.SugaredLogger) (*gi
 	}
 
 	router := gin.New()
-	if lvl := strings.ToLower(config.LogLevel); lvl == LogLevelInfo || lvl == LogLevelDebug {
+	if normalizedLogLevel := strings.ToLower(config.LogLevel); normalizedLogLevel == LogLevelInfo || normalizedLogLevel == LogLevelDebug {
 		router.Use(requestResponseLogger(structuredLogger))
 	}
 


### PR DESCRIPTION
## Summary
- replace temporary variable `lvl` with descriptive `normalizedLogLevel` within `BuildRouter`

## Testing
- `go test ./...` *(fails: command produced no output and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0ea1f39c832795610f22a3e6afdf