### PR TITLE
centralize OpenAI log field names

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -82,6 +82,10 @@ const (
 	logFieldStatus       = "status"
 	logFieldValue        = "value"
 	logFieldError        = "error"
+	// logFieldParameter identifies the request parameter related to a log entry.
+	logFieldParameter = "parameter"
+	// logFieldID identifies the response identifier logged for traceability.
+	logFieldID = "id"
 	// logFieldExpectedFingerprint identifies the fingerprint of the expected client key.
 	logFieldExpectedFingerprint = "expected_fingerprint"
 

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -121,7 +121,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 	if statusCode >= http.StatusBadRequest &&
 		bytes.Contains(responseBytes, []byte(unsupportedTemperatureParameterToken)) &&
 		requestPayload.Temperature != nil {
-		structuredLogger.Infow(logEventRetryingWithoutParam, "parameter", keyTemperature)
+		structuredLogger.Infow(logEventRetryingWithoutParam, logFieldParameter, keyTemperature)
 		requestPayload.Temperature = nil
 		retryPayloadBytes, marshalRetryError := json.Marshal(requestPayload)
 		if marshalRetryError != nil {
@@ -147,7 +147,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 	if statusCode >= http.StatusBadRequest &&
 		bytes.Contains(responseBytes, []byte(unsupportedToolsParameterToken)) &&
 		len(requestPayload.Tools) > 0 {
-		structuredLogger.Infow(logEventRetryingWithoutParam, "parameter", keyTools)
+		structuredLogger.Infow(logEventRetryingWithoutParam, logFieldParameter, keyTools)
 		requestPayload.Tools = nil
 		requestPayload.ToolChoice = ""
 		retryPayloadBytes, marshalRetryError := json.Marshal(requestPayload)
@@ -203,7 +203,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 		if pollError != nil {
 			structuredLogger.Errorw(
 				logEventOpenAIPollError,
-				"id",
+				logFieldID,
 				responseIdentifier,
 				constants.LogFieldError,
 				pollError,


### PR DESCRIPTION
## Summary
- add `logFieldParameter` and `logFieldID` constants for proxy logging
- use new log field constants in OpenAI request logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba0eb907088327b1822349d985348f