### PR TITLE
refactor: define upstream incomplete error constant

### DIFF
--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -53,4 +53,4 @@ func validateConfig(config Configuration) error {
 var requestTimeout = 30 * time.Second
 
 // ErrUpstreamIncomplete indicates that the upstream provider returned an incomplete response before the poll deadline.
-var ErrUpstreamIncomplete = errors.New("OpenAI API error (incomplete response)")
+var ErrUpstreamIncomplete = errors.New(errorUpstreamIncomplete)

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -29,13 +29,15 @@ const (
 
 	errorMissingPrompt = "missing prompt parameter"
 	// errorMissingClientKey indicates that the key query parameter is missing.
-	errorMissingClientKey      = "missing client key"
-	errorRequestTimedOut       = "request timed out"
-	errorRequestBuild          = "request build error"
-	errorOpenAIRequest         = "OpenAI request error"
-	errorOpenAIAPI             = "OpenAI API error"
-	errorOpenAIAPINoText       = "OpenAI API error (no text)"
-	errorOpenAIFailedStatus    = "OpenAI API error (failed status)"
+	errorMissingClientKey   = "missing client key"
+	errorRequestTimedOut    = "request timed out"
+	errorRequestBuild       = "request build error"
+	errorOpenAIRequest      = "OpenAI request error"
+	errorOpenAIAPI          = "OpenAI API error"
+	errorOpenAIAPINoText    = "OpenAI API error (no text)"
+	errorOpenAIFailedStatus = "OpenAI API error (failed status)"
+	// errorUpstreamIncomplete indicates that the upstream provider returned an incomplete response.
+	errorUpstreamIncomplete    = "OpenAI API error (incomplete response)"
 	errorOpenAIModelValidation = "OpenAI model validation error"
 	// errorUnknownModel indicates that a model identifier is not recognized.
 	errorUnknownModel                = "unknown model"


### PR DESCRIPTION
## Summary
- add `errorUpstreamIncomplete` constant
- reference new constant when creating `ErrUpstreamIncomplete`

## Testing
- `go test ./...` *(fails: command hung, manual interrupt)*
- `go test ./internal/proxy -run Test -count=1` *(fails: command hung, manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0ec110e4832785c3392791d4b902