### PR TITLE
test: add table-driven chat handler tests

### DIFF
--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -1,50 +1,106 @@
-package proxy
+package proxy_test
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
-	"github.com/gin-gonic/gin"
+	"github.com/temirov/llm-proxy/internal/proxy"
 	"go.uber.org/zap"
 )
 
-// Test string constants.
 const (
-	promptValue             = "hello"
-	modelIdentifierValue    = "gpt-4o"
-	systemPromptValue       = "system"
-	requestQueryFormat      = "/?prompt=%s&model=%s"
-	messageUnexpectedStatus = "status=%d want=%d"
+	// promptValue holds the prompt sent in requests.
+	promptValue = "hello"
+	// knownModelValue identifies a valid model recognized by the validator.
+	knownModelValue = "gpt-4o"
+	// unknownModelValue identifies a model absent from the validator.
+	unknownModelValue = "unknown-model"
+	// systemPromptValue provides the system prompt used by the router.
+	systemPromptValue = "system"
+	// routerServiceSecret is the expected client key.
+	routerServiceSecret = "sekret"
+	// routerOpenAIKey is a stub API key.
+	routerOpenAIKey = "sk-test"
+	// modelsListJSON is the canned response listing supported models.
+	modelsListJSON = "{\"data\":[{\"id\":\"gpt-4o\"}]}"
+	// responsesBodyJSON is the canned response returned by the responses API.
+	responsesBodyJSON = "{\"output\":[{\"content\":[{\"text\":\"ok\"}]}]}"
+	// requestPathTemplate formats the request path with prompt, model, and key.
+	requestPathTemplate = "/?prompt=%s&model=%s&key=%s"
+	// errorFormatBuildRouter formats BuildRouter errors.
+	errorFormatBuildRouter = "BuildRouter error: %v"
+	// errorFormatUnexpectedStatus formats unexpected HTTP status errors.
+	errorFormatUnexpectedStatus = "status=%d want=%d"
 )
 
-// TestChatHandlerReturnsBadRequestForUnknownModel verifies that chatHandler returns HTTP 400 when the model is unknown.
-func TestChatHandlerReturnsBadRequestForUnknownModel(testFramework *testing.T) {
-	validator := &modelValidator{
-		models: map[string]struct{}{modelIdentifierValue: {}},
-		expiry: time.Now().Add(time.Hour),
+// chatHandlerScenario defines a single test scenario for model validation.
+type chatHandlerScenario struct {
+	scenarioName       string
+	modelIdentifier    string
+	expectedStatusCode int
+}
+
+// TestChatHandlerValidatesModel verifies that the chat handler returns appropriate status codes for valid and invalid model identifiers.
+func TestChatHandlerValidatesModel(testingInstance *testing.T) {
+	testScenarios := []chatHandlerScenario{
+		{
+			scenarioName:       "unknown model returns bad request",
+			modelIdentifier:    unknownModelValue,
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			scenarioName:       "known model returns ok",
+			modelIdentifier:    knownModelValue,
+			expectedStatusCode: http.StatusOK,
+		},
 	}
 
-	taskQueue := make(chan requestTask, 1)
-	go func() {
-		pendingTask := <-taskQueue
-		pendingTask.reply <- result{requestError: fmt.Errorf("%w: %s", ErrUnknownModel, pendingTask.model)}
-	}()
+	for _, currentScenario := range testScenarios {
+		testingInstance.Run(currentScenario.scenarioName, func(subTest *testing.T) {
+			modelsServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+				io.WriteString(responseWriter, modelsListJSON)
+			}))
+			subTest.Cleanup(modelsServer.Close)
 
-	loggerInstance, _ := zap.NewDevelopment()
-	defer loggerInstance.Sync()
+			responsesServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+				io.WriteString(responseWriter, responsesBodyJSON)
+			}))
+			subTest.Cleanup(responsesServer.Close)
 
-	handler := chatHandler(taskQueue, systemPromptValue, validator, loggerInstance.Sugar())
+			proxy.SetModelsURL(modelsServer.URL)
+			proxy.SetResponsesURL(responsesServer.URL)
+			proxy.HTTPClient = http.DefaultClient
+			subTest.Cleanup(proxy.ResetModelsURL)
+			subTest.Cleanup(proxy.ResetResponsesURL)
+			subTest.Cleanup(func() { proxy.HTTPClient = http.DefaultClient })
 
-	responseRecorder := httptest.NewRecorder()
-	ginContext, _ := gin.CreateTestContext(responseRecorder)
-	ginContext.Request = httptest.NewRequest(http.MethodGet, fmt.Sprintf(requestQueryFormat, promptValue, modelIdentifierValue), nil)
+			loggerInstance, _ := zap.NewDevelopment()
+			defer loggerInstance.Sync()
 
-	handler(ginContext)
+			builtRouter, buildRouterError := proxy.BuildRouter(proxy.Configuration{
+				ServiceSecret: routerServiceSecret,
+				OpenAIKey:     routerOpenAIKey,
+				LogLevel:      proxy.LogLevelDebug,
+				SystemPrompt:  systemPromptValue,
+				WorkerCount:   1,
+				QueueSize:     1,
+			}, loggerInstance.Sugar())
+			if buildRouterError != nil {
+				subTest.Fatalf(errorFormatBuildRouter, buildRouterError)
+			}
 
-	if responseRecorder.Code != http.StatusBadRequest {
-		testFramework.Fatalf(messageUnexpectedStatus, responseRecorder.Code, http.StatusBadRequest)
+			responseRecorder := httptest.NewRecorder()
+			requestPath := fmt.Sprintf(requestPathTemplate, promptValue, currentScenario.modelIdentifier, routerServiceSecret)
+			request := httptest.NewRequest(http.MethodGet, requestPath, nil)
+
+			builtRouter.ServeHTTP(responseRecorder, request)
+
+			if responseRecorder.Code != currentScenario.expectedStatusCode {
+				subTest.Fatalf(errorFormatUnexpectedStatus, responseRecorder.Code, currentScenario.expectedStatusCode)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- convert router tests to use the `proxy_test` package
- cover valid and invalid model scenarios with a table-driven test
- stub proxy package interactions via explicit imports

## Testing
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68ba0e9939b08327aef98f6fdc2bd96a