### PR TITLE
test: add coverage for utils helpers

### DIFF
--- a/internal/utils/fingerprint_test.go
+++ b/internal/utils/fingerprint_test.go
@@ -1,0 +1,39 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/temirov/llm-proxy/internal/utils"
+)
+
+const (
+	secretEmpty         = ""
+	secretABC           = "abc"
+	secretLLMProxy      = "llm-proxy"
+	fingerprintEmpty    = "e3b0c442"
+	fingerprintABC      = "ba7816bf"
+	fingerprintLLMProxy = "c30d6864"
+)
+
+type fingerprintTestDefinition struct {
+	testName      string
+	secretValue   string
+	expectedValue string
+}
+
+// TestFingerprint_OutputMatchesExpected verifies that Fingerprint returns the expected values for a variety of inputs.
+func TestFingerprint_OutputMatchesExpected(testingInstance *testing.T) {
+	testCases := []fingerprintTestDefinition{
+		{testName: "empty string", secretValue: secretEmpty, expectedValue: fingerprintEmpty},
+		{testName: "short string", secretValue: secretABC, expectedValue: fingerprintABC},
+		{testName: "longer string", secretValue: secretLLMProxy, expectedValue: fingerprintLLMProxy},
+	}
+	for _, currentTestCase := range testCases {
+		testingInstance.Run(currentTestCase.testName, func(nestedTestingInstance *testing.T) {
+			actualFingerprint := utils.Fingerprint(currentTestCase.secretValue)
+			if actualFingerprint != currentTestCase.expectedValue {
+				nestedTestingInstance.Fatalf("fingerprint=%s expected=%s", actualFingerprint, currentTestCase.expectedValue)
+			}
+		})
+	}
+}

--- a/internal/utils/http_test.go
+++ b/internal/utils/http_test.go
@@ -1,0 +1,65 @@
+package utils_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/temirov/llm-proxy/internal/utils"
+)
+
+const (
+	httpMethodGet      = "GET"
+	requestURLExample  = "http://example.com"
+	headerNameExample  = "X-Test-Header"
+	headerValueExample = "header-value"
+	invalidRequestURL  = "://bad-url"
+	bodyContent        = "body"
+)
+
+type buildHTTPRequestTestDefinition struct {
+	testName            string
+	method              string
+	requestURL          string
+	headers             map[string]string
+	expectError         bool
+	expectedHeaderValue string
+}
+
+// TestBuildHTTPRequestWithHeaders_ConstructsRequests verifies that BuildHTTPRequestWithHeaders creates requests and applies headers.
+func TestBuildHTTPRequestWithHeaders_ConstructsRequests(testingInstance *testing.T) {
+	testCases := []buildHTTPRequestTestDefinition{
+		{
+			testName:            "valid request",
+			method:              httpMethodGet,
+			requestURL:          requestURLExample,
+			headers:             map[string]string{headerNameExample: headerValueExample},
+			expectError:         false,
+			expectedHeaderValue: headerValueExample,
+		},
+		{
+			testName:    "invalid url",
+			method:      httpMethodGet,
+			requestURL:  invalidRequestURL,
+			headers:     map[string]string{},
+			expectError: true,
+		},
+	}
+	for _, currentTestCase := range testCases {
+		testingInstance.Run(currentTestCase.testName, func(nestedTestingInstance *testing.T) {
+			httpRequest, buildRequestError := utils.BuildHTTPRequestWithHeaders(currentTestCase.method, currentTestCase.requestURL, bytes.NewBufferString(bodyContent), currentTestCase.headers)
+			if currentTestCase.expectError {
+				if buildRequestError == nil {
+					nestedTestingInstance.Fatalf("expected error but got none")
+				}
+				return
+			}
+			if buildRequestError != nil {
+				nestedTestingInstance.Fatalf("unexpected error: %v", buildRequestError)
+			}
+			headerValue := httpRequest.Header.Get(headerNameExample)
+			if headerValue != currentTestCase.expectedHeaderValue {
+				nestedTestingInstance.Fatalf("header value=%s expected=%s", headerValue, currentTestCase.expectedHeaderValue)
+			}
+		})
+	}
+}

--- a/internal/utils/strings_test.go
+++ b/internal/utils/strings_test.go
@@ -1,0 +1,67 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/temirov/llm-proxy/internal/utils"
+)
+
+const (
+	emptyStringValue      = ""
+	whitespaceStringValue = " \t\n"
+	wordStringValue       = "hello"
+	spacedWordStringValue = "  hello  "
+	valueFoobar           = "foobar"
+	prefixFoo             = "foo"
+	prefixFooUppercase    = "FOO"
+	prefixBar             = "bar"
+	prefixBaz             = "baz"
+)
+
+type isBlankTestDefinition struct {
+	testName      string
+	inputValue    string
+	expectedValue bool
+}
+
+// TestIsBlank_IdentifiesBlankStrings verifies that IsBlank correctly identifies blank strings.
+func TestIsBlank_IdentifiesBlankStrings(testingInstance *testing.T) {
+	testCases := []isBlankTestDefinition{
+		{testName: "empty string", inputValue: emptyStringValue, expectedValue: true},
+		{testName: "whitespace string", inputValue: whitespaceStringValue, expectedValue: true},
+		{testName: "word string", inputValue: wordStringValue, expectedValue: false},
+		{testName: "spaced word string", inputValue: spacedWordStringValue, expectedValue: false},
+	}
+	for _, currentTestCase := range testCases {
+		testingInstance.Run(currentTestCase.testName, func(nestedTestingInstance *testing.T) {
+			actualBlank := utils.IsBlank(currentTestCase.inputValue)
+			if actualBlank != currentTestCase.expectedValue {
+				nestedTestingInstance.Fatalf("blank=%v expected=%v", actualBlank, currentTestCase.expectedValue)
+			}
+		})
+	}
+}
+
+type hasAnyPrefixTestDefinition struct {
+	testName      string
+	value         string
+	prefixes      []string
+	expectedValue bool
+}
+
+// TestHasAnyPrefix_DetectsPrefixes verifies that HasAnyPrefix detects matching prefixes in a case-insensitive manner.
+func TestHasAnyPrefix_DetectsPrefixes(testingInstance *testing.T) {
+	testCases := []hasAnyPrefixTestDefinition{
+		{testName: "direct match", value: valueFoobar, prefixes: []string{prefixFoo}, expectedValue: true},
+		{testName: "case insensitive match", value: valueFoobar, prefixes: []string{prefixFooUppercase}, expectedValue: true},
+		{testName: "multiple prefixes no match", value: valueFoobar, prefixes: []string{prefixBar, prefixBaz}, expectedValue: false},
+	}
+	for _, currentTestCase := range testCases {
+		testingInstance.Run(currentTestCase.testName, func(nestedTestingInstance *testing.T) {
+			actualHasPrefix := utils.HasAnyPrefix(currentTestCase.value, currentTestCase.prefixes...)
+			if actualHasPrefix != currentTestCase.expectedValue {
+				nestedTestingInstance.Fatalf("hasPrefix=%v expected=%v", actualHasPrefix, currentTestCase.expectedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven tests for Fingerprint
- cover string helper functions
- verify BuildHTTPRequestWithHeaders behavior

## Testing
- `go test ./internal/utils -run Test -count=1`
- `go test ./...` *(fails: terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0ed5edb0832797b8c8af19086991