### PR TITLE
test: replace log level strings with constant

### DIFF
--- a/tests/integration/high_load_queue_test.go
+++ b/tests/integration/high_load_queue_test.go
@@ -21,7 +21,7 @@ func TestIntegrationHighLoadQueue(testingInstance *testing.T) {
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: serviceSecretValue,
 		OpenAIKey:     openAIKeyValue,
-		LogLevel:      "debug",
+		LogLevel:      logLevelDebug,
 		WorkerCount:   1,
 		QueueSize:     proxy.DefaultQueueSize,
 	}, newLogger(testingInstance))

--- a/tests/integration/integration1_test.go
+++ b/tests/integration/integration1_test.go
@@ -56,7 +56,7 @@ func newIntegrationServer(testingInstance *testing.T, openAIServer *httptest.Ser
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: integrationServiceSecret,
 		OpenAIKey:     integrationOpenAIKey,
-		LogLevel:      "debug",
+		LogLevel:      logLevelDebug,
 		WorkerCount:   1,
 		QueueSize:     4,
 	}, logger.Sugar())
@@ -81,7 +81,7 @@ func newIntegrationServerWithTimeout(testingInstance *testing.T, openAIServer *h
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret:         integrationServiceSecret,
 		OpenAIKey:             integrationOpenAIKey,
-		LogLevel:              "debug",
+		LogLevel:              logLevelDebug,
 		WorkerCount:           1,
 		QueueSize:             4,
 		RequestTimeoutSeconds: requestTimeoutSeconds,

--- a/tests/integration/integration2_test.go
+++ b/tests/integration/integration2_test.go
@@ -95,7 +95,7 @@ func TestClientResponseDelivery(testingInstance *testing.T) {
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 				ServiceSecret: serviceSecretValue,
 				OpenAIKey:     openAIKeyValue,
-				LogLevel:      "debug",
+				LogLevel:      logLevelDebug,
 				WorkerCount:   1,
 				QueueSize:     8,
 			}, newLogger(subTest))
@@ -160,7 +160,7 @@ func TestIntegrationConfiguration(testingInstance *testing.T) {
 		},
 		{
 			name:           "wrong_key",
-			config:         proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 4},
+			config:         proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 4},
 			requestKey:     "wrong",
 			expectedStatus: http.StatusForbidden,
 		},

--- a/tests/integration/integration_adaptive_test.go
+++ b/tests/integration/integration_adaptive_test.go
@@ -82,7 +82,7 @@ func newAdaptiveRouter(testingInstance *testing.T, mode string) *gin.Engine {
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: serviceSecretValue,
 		OpenAIKey:     openAIKeyValue,
-		LogLevel:      "debug",
+		LogLevel:      logLevelDebug,
 		WorkerCount:   1,
 		QueueSize:     8,
 	}, logger.Sugar())

--- a/tests/integration/integration_models_test.go
+++ b/tests/integration/integration_models_test.go
@@ -23,7 +23,7 @@ func TestIntegrationModelSpecSuppression(testingInstance *testing.T) {
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 				ServiceSecret: serviceSecretValue,
 				OpenAIKey:     openAIKeyValue,
-				LogLevel:      "debug",
+				LogLevel:      logLevelDebug,
 				WorkerCount:   1,
 				QueueSize:     8,
 			}, newLogger(subTest))

--- a/tests/integration/long_request_test.go
+++ b/tests/integration/long_request_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 const (
-	serviceSecretValue           = "sekret"
-	openAIKeyValue               = "sk-test"
+	serviceSecretValue = "sekret"
+	openAIKeyValue     = "sk-test"
+	// logLevelDebug is the logging level used in integration tests.
+	logLevelDebug                = "debug"
 	mockModelsURL                = "https://mock.local/v1/models"
 	mockResponsesURL             = "https://mock.local/v1/responses"
 	modelsListBody               = `{"data":[{"id":"gpt-4.1"}]}`
@@ -55,7 +57,7 @@ func TestIntegrationResponseDeliveredAfterDelay(testingInstance *testing.T) {
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			configureProxy(subTest, makeSlowHTTPClient(subTest))
-			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: requestTimeoutSecondsDefault}, newLogger(subTest))
+			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: requestTimeoutSecondsDefault}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf("BuildRouter failed: %v", buildError)
 			}

--- a/tests/integration/missing_prompt_test.go
+++ b/tests/integration/missing_prompt_test.go
@@ -18,7 +18,7 @@ func TestRequestWithoutPromptReturnsMissingPromptError(testingInstance *testing.
 	gin.SetMode(gin.TestMode)
 	client, _ := makeHTTPClient(testingInstance, false)
 	configureProxy(testingInstance, client)
-	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 8}, newLogger(testingInstance))
+	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8}, newLogger(testingInstance))
 	if buildError != nil {
 		testingInstance.Fatalf("BuildRouter failed: %v", buildError)
 	}

--- a/tests/integration/request_timeout_test.go
+++ b/tests/integration/request_timeout_test.go
@@ -51,7 +51,7 @@ func TestIntegrationUpstreamRequestTimeoutTriggersGatewayTimeout(testingInstance
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			configureProxy(subTest, makeTimeoutHTTPClient(subTest))
-			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: timeoutRequestTimeout}, newLogger(subTest))
+			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: timeoutRequestTimeout}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf("BuildRouter failed: %v", buildError)
 			}

--- a/tests/integration/web_search_unsupported_test.go
+++ b/tests/integration/web_search_unsupported_test.go
@@ -45,7 +45,7 @@ func TestIntegrationWebSearchUnsupportedModelReturnsBadRequest(testingInstance *
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			client := makeWebSearchRejectingHTTPClient(subTest)
 			configureProxy(subTest, client)
-			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 8}, newLogger(subTest))
+			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf("BuildRouter failed: %v", buildError)
 			}


### PR DESCRIPTION
## Summary
- add reusable `logLevelDebug` test constant
- use `logLevelDebug` in integration tests instead of repeating the string literal

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba145c74988327a44b10dec21fe637