### PR TITLE
refactor: centralize integration test helpers

### DIFF
--- a/tests/integration/high_load_queue_test.go
+++ b/tests/integration/high_load_queue_test.go
@@ -21,7 +21,7 @@ func TestIntegrationHighLoadQueue(testingInstance *testing.T) {
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: serviceSecretValue,
 		OpenAIKey:     openAIKeyValue,
-		LogLevel:      "debug",
+		LogLevel:      logLevelDebug,
 		WorkerCount:   1,
 		QueueSize:     proxy.DefaultQueueSize,
 	}, newLogger(testingInstance))

--- a/tests/integration/integration_adaptive_test.go
+++ b/tests/integration/integration_adaptive_test.go
@@ -82,7 +82,7 @@ func newAdaptiveRouter(testingInstance *testing.T, mode string) *gin.Engine {
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: serviceSecretValue,
 		OpenAIKey:     openAIKeyValue,
-		LogLevel:      "debug",
+		LogLevel:      logLevelDebug,
 		WorkerCount:   1,
 		QueueSize:     8,
 	}, logger.Sugar())

--- a/tests/integration/integration_models_test.go
+++ b/tests/integration/integration_models_test.go
@@ -23,7 +23,7 @@ func TestIntegrationModelSpecSuppression(testingInstance *testing.T) {
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 				ServiceSecret: serviceSecretValue,
 				OpenAIKey:     openAIKeyValue,
-				LogLevel:      "debug",
+				LogLevel:      logLevelDebug,
 				WorkerCount:   1,
 				QueueSize:     8,
 			}, newLogger(subTest))

--- a/tests/integration/long_request_test.go
+++ b/tests/integration/long_request_test.go
@@ -14,15 +14,8 @@ import (
 )
 
 const (
-	serviceSecretValue           = "sekret"
-	openAIKeyValue               = "sk-test"
-	mockModelsURL                = "https://mock.local/v1/models"
-	mockResponsesURL             = "https://mock.local/v1/responses"
 	modelsListBody               = `{"data":[{"id":"gpt-4.1"}]}`
 	expectedResponseBody         = "SLOW_OK"
-	promptQueryParameter         = "prompt"
-	keyQueryParameter            = "key"
-	promptValue                  = "ping"
 	responseDelay                = 31 * time.Second
 	httpClientTimeout            = responseDelay + 5*time.Second
 	requestTimeoutSecondsDefault = 40
@@ -55,7 +48,7 @@ func TestIntegrationResponseDeliveredAfterDelay(testingInstance *testing.T) {
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			configureProxy(subTest, makeSlowHTTPClient(subTest))
-			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: requestTimeoutSecondsDefault}, newLogger(subTest))
+			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: requestTimeoutSecondsDefault}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf("BuildRouter failed: %v", buildError)
 			}

--- a/tests/integration/missing_prompt_test.go
+++ b/tests/integration/missing_prompt_test.go
@@ -18,7 +18,7 @@ func TestRequestWithoutPromptReturnsMissingPromptError(testingInstance *testing.
 	gin.SetMode(gin.TestMode)
 	client, _ := makeHTTPClient(testingInstance, false)
 	configureProxy(testingInstance, client)
-	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 8}, newLogger(testingInstance))
+	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8}, newLogger(testingInstance))
 	if buildError != nil {
 		testingInstance.Fatalf("BuildRouter failed: %v", buildError)
 	}

--- a/tests/integration/openai_5xx_retry_test.go
+++ b/tests/integration/openai_5xx_retry_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 const (
-	contentTypeHeaderKey = "Content-Type"
-	mimeApplicationJSON  = "application/json"
 	minimumExpectedCalls = 2
 )
 
@@ -18,10 +16,10 @@ func TestOpenAIResponsesRetries(testingInstance *testing.T) {
 	responsesAPICallCount := 0
 	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		switch httpRequest.URL.Path {
-		case integrationModelsPath:
-			responseWriter.Header().Set(contentTypeHeaderKey, mimeApplicationJSON)
-			_, _ = io.WriteString(responseWriter, integrationModelListBody)
-		case integrationResponsesPath:
+		case modelsPath:
+			responseWriter.Header().Set(headerContentTypeKey, mimeTypeApplicationJSON)
+			_, _ = io.WriteString(responseWriter, modelListBody)
+		case responsesPath:
 			responsesAPICallCount++
 			responseWriter.WriteHeader(http.StatusInternalServerError)
 		default:
@@ -31,7 +29,7 @@ func TestOpenAIResponsesRetries(testingInstance *testing.T) {
 	testingInstance.Cleanup(openAIServer.Close)
 
 	applicationServer := newIntegrationServerWithTimeout(testingInstance, openAIServer, 4)
-	requestURL := applicationServer.URL + "?prompt=ping&key=" + integrationServiceSecret
+	requestURL := applicationServer.URL + "?prompt=ping&key=" + serviceSecretValue
 	httpResponse, requestError := http.Get(requestURL)
 	if requestError != nil {
 		testingInstance.Fatalf("request error: %v", requestError)

--- a/tests/integration/openai_malformed_json_test.go
+++ b/tests/integration/openai_malformed_json_test.go
@@ -13,8 +13,6 @@ const (
 	malformedJSONPayload = "invalid"
 	// expectedErrorMessage is the error returned by the proxy when upstream JSON cannot be parsed.
 	expectedErrorMessage = "OpenAI API error"
-	// contentTypeJSON is the HTTP Content-Type header value for JSON payloads.
-	contentTypeJSON = "application/json"
 )
 
 // newMalformedOpenAIServer returns a stub OpenAI server emitting invalid JSON for the responses endpoint.
@@ -22,11 +20,11 @@ func newMalformedOpenAIServer(testingInstance *testing.T) *httptest.Server {
 	testingInstance.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		switch httpRequest.URL.Path {
-		case integrationModelsPath:
-			responseWriter.Header().Set("Content-Type", contentTypeJSON)
-			_, _ = io.WriteString(responseWriter, integrationModelListBody)
-		case integrationResponsesPath:
-			responseWriter.Header().Set("Content-Type", contentTypeJSON)
+		case modelsPath:
+			responseWriter.Header().Set(headerContentTypeKey, mimeTypeApplicationJSON)
+			_, _ = io.WriteString(responseWriter, modelListBody)
+		case responsesPath:
+			responseWriter.Header().Set(headerContentTypeKey, mimeTypeApplicationJSON)
 			_, _ = io.WriteString(responseWriter, malformedJSONPayload)
 		default:
 			http.NotFound(responseWriter, httpRequest)
@@ -43,7 +41,7 @@ func TestOpenAIMalformedJSON(testingInstance *testing.T) {
 	requestURL, _ := url.Parse(applicationServer.URL)
 	queryValues := requestURL.Query()
 	queryValues.Set(promptQueryParameter, promptValue)
-	queryValues.Set(keyQueryParameter, integrationServiceSecret)
+	queryValues.Set(keyQueryParameter, serviceSecretValue)
 	requestURL.RawQuery = queryValues.Encode()
 	httpResponse, requestError := http.Get(requestURL.String())
 	if requestError != nil {

--- a/tests/integration/request_timeout_test.go
+++ b/tests/integration/request_timeout_test.go
@@ -51,7 +51,7 @@ func TestIntegrationUpstreamRequestTimeoutTriggersGatewayTimeout(testingInstance
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			configureProxy(subTest, makeTimeoutHTTPClient(subTest))
-			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: timeoutRequestTimeout}, newLogger(subTest))
+			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: timeoutRequestTimeout}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf("BuildRouter failed: %v", buildError)
 			}

--- a/tests/integration/test_helpers_test.go
+++ b/tests/integration/test_helpers_test.go
@@ -1,0 +1,156 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/temirov/llm-proxy/internal/proxy"
+	"go.uber.org/zap"
+)
+
+const (
+	serviceSecretValue      = "sekret"
+	openAIKeyValue          = "sk-test"
+	mockModelsURL           = "https://mock.local/v1/models"
+	mockResponsesURL        = "https://mock.local/v1/responses"
+	modelsPath              = "/v1/models"
+	responsesPath           = "/v1/responses"
+	modelListBody           = `{"object":"list","data":[{"id":"gpt-4.1","object":"model"}]}`
+	availableModelsBody     = `{"data":[{"id":"gpt-4.1"},{"id":"gpt-5-mini"}]}`
+	integrationOKBody       = "INTEGRATION_OK"
+	integrationSearchBody   = "SEARCH_OK"
+	headerContentTypeKey    = "Content-Type"
+	mimeTypeApplicationJSON = "application/json"
+	logLevelDebug           = "debug"
+	promptQueryParameter    = "prompt"
+	keyQueryParameter       = "key"
+	promptValue             = "ping"
+)
+
+type roundTripperFunc func(httpRequest *http.Request) (*http.Response, error)
+
+func (roundTripper roundTripperFunc) RoundTrip(httpRequest *http.Request) (*http.Response, error) {
+	return roundTripper(httpRequest)
+}
+
+// newOpenAIServer returns a stub OpenAI server yielding the provided body and optionally capturing requests.
+func newOpenAIServer(testingInstance *testing.T, responseText string, captureTarget *any) *httptest.Server {
+	testingInstance.Helper()
+	handler := http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		switch httpRequest.URL.Path {
+		case modelsPath:
+			responseWriter.Header().Set(headerContentTypeKey, mimeTypeApplicationJSON)
+			_, _ = io.WriteString(responseWriter, modelListBody)
+		case responsesPath:
+			if captureTarget != nil {
+				body, _ := io.ReadAll(httpRequest.Body)
+				_ = json.Unmarshal(body, captureTarget)
+			}
+			responseWriter.Header().Set(headerContentTypeKey, mimeTypeApplicationJSON)
+			_, _ = io.WriteString(responseWriter, `{"output_text":"`+responseText+`"}`)
+		default:
+			http.NotFound(responseWriter, httpRequest)
+		}
+	})
+	return httptest.NewServer(handler)
+}
+
+// newIntegrationServer builds the application server pointing at the provided OpenAI server.
+func newIntegrationServer(testingInstance *testing.T, openAIServer *httptest.Server) *httptest.Server {
+	testingInstance.Helper()
+	proxy.SetModelsURL(openAIServer.URL + modelsPath)
+	proxy.SetResponsesURL(openAIServer.URL + responsesPath)
+	proxy.HTTPClient = openAIServer.Client()
+	testingInstance.Cleanup(proxy.ResetModelsURL)
+	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret: serviceSecretValue,
+		OpenAIKey:     openAIKeyValue,
+		LogLevel:      logLevelDebug,
+		WorkerCount:   1,
+		QueueSize:     4,
+	}, newLogger(testingInstance))
+	if buildRouterError != nil {
+		testingInstance.Fatalf("BuildRouter error: %v", buildRouterError)
+	}
+	server := httptest.NewServer(router)
+	testingInstance.Cleanup(server.Close)
+	return server
+}
+
+// newIntegrationServerWithTimeout builds the application server with a configurable request timeout.
+func newIntegrationServerWithTimeout(testingInstance *testing.T, openAIServer *httptest.Server, requestTimeoutSeconds int) *httptest.Server {
+	testingInstance.Helper()
+	proxy.SetModelsURL(openAIServer.URL + modelsPath)
+	proxy.SetResponsesURL(openAIServer.URL + responsesPath)
+	proxy.HTTPClient = openAIServer.Client()
+	testingInstance.Cleanup(proxy.ResetModelsURL)
+	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:         serviceSecretValue,
+		OpenAIKey:             openAIKeyValue,
+		LogLevel:              logLevelDebug,
+		WorkerCount:           1,
+		QueueSize:             4,
+		RequestTimeoutSeconds: requestTimeoutSeconds,
+	}, newLogger(testingInstance))
+	if buildRouterError != nil {
+		testingInstance.Fatalf("BuildRouter error: %v", buildRouterError)
+	}
+	server := httptest.NewServer(router)
+	testingInstance.Cleanup(server.Close)
+	return server
+}
+
+// makeHTTPClient returns a stub HTTP client capturing payloads and returning canned responses.
+func makeHTTPClient(testingInstance *testing.T, wantWebSearch bool) (*http.Client, *map[string]any) {
+	testingInstance.Helper()
+	var captured map[string]any
+	client := &http.Client{
+		Transport: roundTripperFunc(func(httpRequest *http.Request) (*http.Response, error) {
+			switch httpRequest.URL.String() {
+			case proxy.ModelsURL():
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(availableModelsBody)), Header: make(http.Header)}, nil
+			case proxy.ResponsesURL():
+				if httpRequest.Body != nil {
+					buf, _ := io.ReadAll(httpRequest.Body)
+					_ = json.Unmarshal(buf, &captured)
+				}
+				text := integrationOKBody
+				if wantWebSearch {
+					text = integrationSearchBody
+				}
+				body := `{"output_text":"` + text + `"}`
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+			default:
+				testingInstance.Fatalf("unexpected request to %s", httpRequest.URL.String())
+				return nil, nil
+			}
+		}),
+		Timeout: 5 * time.Second,
+	}
+	return client, &captured
+}
+
+// configureProxy sets URLs and the HTTP client for proxy operations.
+func configureProxy(testingInstance *testing.T, client *http.Client) {
+	testingInstance.Helper()
+	proxy.HTTPClient = client
+	proxy.SetModelsURL(mockModelsURL)
+	proxy.SetResponsesURL(mockResponsesURL)
+	testingInstance.Cleanup(proxy.ResetModelsURL)
+	testingInstance.Cleanup(proxy.ResetResponsesURL)
+}
+
+// newLogger constructs a development logger for tests.
+func newLogger(testingInstance *testing.T) *zap.SugaredLogger {
+	testingInstance.Helper()
+	logger, _ := zap.NewDevelopment()
+	testingInstance.Cleanup(func() { _ = logger.Sync() })
+	return logger.Sugar()
+}

--- a/tests/integration/web_search_unsupported_test.go
+++ b/tests/integration/web_search_unsupported_test.go
@@ -45,7 +45,7 @@ func TestIntegrationWebSearchUnsupportedModelReturnsBadRequest(testingInstance *
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			client := makeWebSearchRejectingHTTPClient(subTest)
 			configureProxy(subTest, client)
-			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: "debug", WorkerCount: 1, QueueSize: 8}, newLogger(subTest))
+			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf("BuildRouter failed: %v", buildError)
 			}


### PR DESCRIPTION
## Summary
- consolidate shared helpers for integration tests
- refactor integration tests to use common helpers and constants

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba1450d410832787cafe672cf5f582