### PR TITLE
test: refactor integration helpers

### DIFF
--- a/tests/integration/integration1_test.go
+++ b/tests/integration/integration1_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,63 +9,6 @@ import (
 	"github.com/temirov/llm-proxy/internal/proxy"
 	"go.uber.org/zap"
 )
-
-const (
-	integrationServiceSecret = "sekret"
-	integrationOpenAIKey     = "sk-test"
-	integrationModelsPath    = "/v1/models"
-	integrationResponsesPath = "/v1/responses"
-	integrationModelListBody = `{"object":"list","data":[{"id":"gpt-4.1","object":"model"}]}`
-	integrationOKBody        = "INTEGRATION_OK"
-	integrationSearchBody    = "SEARCH_OK"
-)
-
-// newOpenAIServer returns a stub OpenAI server yielding the provided body and optionally capturing requests.
-func newOpenAIServer(testingInstance *testing.T, responseText string, captureTarget *any) *httptest.Server {
-	testingInstance.Helper()
-	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
-		switch httpRequest.URL.Path {
-		case integrationModelsPath:
-			responseWriter.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(responseWriter, integrationModelListBody)
-		case integrationResponsesPath:
-			if captureTarget != nil {
-				body, _ := io.ReadAll(httpRequest.Body)
-				_ = json.Unmarshal(body, captureTarget)
-			}
-			responseWriter.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(responseWriter, `{"output_text":"`+responseText+`"}`)
-		default:
-			http.NotFound(responseWriter, httpRequest)
-		}
-	}))
-	return server
-}
-
-// newIntegrationServer builds the application server pointing at the stub OpenAI server.
-func newIntegrationServer(testingInstance *testing.T, openAIServer *httptest.Server) *httptest.Server {
-	testingInstance.Helper()
-	proxy.SetModelsURL(openAIServer.URL + integrationModelsPath)
-	proxy.SetResponsesURL(openAIServer.URL + integrationResponsesPath)
-	proxy.HTTPClient = openAIServer.Client()
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
-	logger, _ := zap.NewDevelopment()
-	testingInstance.Cleanup(func() { _ = logger.Sync() })
-	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: integrationServiceSecret,
-		OpenAIKey:     integrationOpenAIKey,
-		LogLevel:      logLevelDebug,
-		WorkerCount:   1,
-		QueueSize:     4,
-	}, logger.Sugar())
-	if buildRouterError != nil {
-		testingInstance.Fatalf("BuildRouter error: %v", buildRouterError)
-	}
-	server := httptest.NewServer(router)
-	testingInstance.Cleanup(server.Close)
-	return server
-}
 
 // newIntegrationServerWithTimeout builds the application server pointing at the stub OpenAI server with a configurable request timeout.
 func newIntegrationServerWithTimeout(testingInstance *testing.T, openAIServer *httptest.Server, requestTimeoutSeconds int) *httptest.Server {
@@ -87,7 +29,7 @@ func newIntegrationServerWithTimeout(testingInstance *testing.T, openAIServer *h
 		RequestTimeoutSeconds: requestTimeoutSeconds,
 	}, logger.Sugar())
 	if buildRouterError != nil {
-		testingInstance.Fatalf("BuildRouter error: %v", buildRouterError)
+		testingInstance.Fatalf(buildRouterErrorFormat, buildRouterError)
 	}
 	server := httptest.NewServer(router)
 	testingInstance.Cleanup(server.Close)
@@ -121,26 +63,26 @@ func TestProxyResponseDelivery(testingInstance *testing.T) {
 			}
 			httpResponse, requestError := http.Get(requestURL)
 			if requestError != nil {
-				subTest.Fatalf("request error: %v", requestError)
+				subTest.Fatalf(requestErrorFormat, requestError)
 			}
 			defer httpResponse.Body.Close()
 			if httpResponse.StatusCode != http.StatusOK {
 				responseBody, _ := io.ReadAll(httpResponse.Body)
-				subTest.Fatalf("status=%d body=%s", httpResponse.StatusCode, string(responseBody))
+				subTest.Fatalf(unexpectedStatusFormat, httpResponse.StatusCode, string(responseBody))
 			}
 			responseBytes, _ := io.ReadAll(httpResponse.Body)
 			if string(responseBytes) != testCase.body {
-				subTest.Fatalf("body=%q want=%q", string(responseBytes), testCase.body)
+				subTest.Fatalf(bodyMismatchFormat, string(responseBytes), testCase.body)
 			}
 			if testCase.checkTools {
 				capturedMap, _ := captured.(map[string]any)
 				tools, ok := capturedMap["tools"].([]any)
 				if !ok || len(tools) == 0 {
-					subTest.Fatalf("tools missing when web_search=1")
+					subTest.Fatalf(toolsMissingMessage)
 				}
 				first, _ := tools[0].(map[string]any)
 				if first["type"] != "web_search" {
-					subTest.Fatalf("tool type=%v want=web_search", first["type"])
+					subTest.Fatalf(toolTypeMismatchFormat, first["type"])
 				}
 			}
 		})

--- a/tests/integration/openai_malformed_json_test.go
+++ b/tests/integration/openai_malformed_json_test.go
@@ -9,12 +9,8 @@ import (
 )
 
 const (
-	// malformedJSONPayload is the body returned by the stubbed upstream to simulate invalid JSON.
 	malformedJSONPayload = "invalid"
-	// expectedErrorMessage is the error returned by the proxy when upstream JSON cannot be parsed.
 	expectedErrorMessage = "OpenAI API error"
-	// contentTypeJSON is the HTTP Content-Type header value for JSON payloads.
-	contentTypeJSON = "application/json"
 )
 
 // newMalformedOpenAIServer returns a stub OpenAI server emitting invalid JSON for the responses endpoint.
@@ -47,15 +43,15 @@ func TestOpenAIMalformedJSON(testingInstance *testing.T) {
 	requestURL.RawQuery = queryValues.Encode()
 	httpResponse, requestError := http.Get(requestURL.String())
 	if requestError != nil {
-		testingInstance.Fatalf("request error: %v", requestError)
+		testingInstance.Fatalf(requestErrorFormat, requestError)
 	}
 	defer httpResponse.Body.Close()
 	if httpResponse.StatusCode != http.StatusBadGateway {
 		responseBody, _ := io.ReadAll(httpResponse.Body)
-		testingInstance.Fatalf("status=%d body=%s", httpResponse.StatusCode, string(responseBody))
+		testingInstance.Fatalf(unexpectedStatusFormat, httpResponse.StatusCode, string(responseBody))
 	}
 	responseBytes, _ := io.ReadAll(httpResponse.Body)
 	if string(responseBytes) != expectedErrorMessage {
-		testingInstance.Fatalf("body=%q want=%q", string(responseBytes), expectedErrorMessage)
+		testingInstance.Fatalf(bodyMismatchFormat, string(responseBytes), expectedErrorMessage)
 	}
 }

--- a/tests/integration/test_helpers_test.go
+++ b/tests/integration/test_helpers_test.go
@@ -1,0 +1,181 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/temirov/llm-proxy/internal/proxy"
+	"go.uber.org/zap"
+)
+
+// Constants shared across integration tests.
+const (
+	// serviceSecretValue is the service secret used for test requests.
+	serviceSecretValue = "sekret"
+	// openAIKeyValue is the OpenAI API key used in tests.
+	openAIKeyValue = "sk-test"
+	// logLevelDebug represents the debug logging level.
+	logLevelDebug = "debug"
+	// mockModelsURL is the stub URL for the models endpoint.
+	mockModelsURL = "https://mock.local/v1/models"
+	// mockResponsesURL is the stub URL for the responses endpoint.
+	mockResponsesURL = "https://mock.local/v1/responses"
+	// promptQueryParameter is the name of the prompt query string parameter.
+	promptQueryParameter = "prompt"
+	// keyQueryParameter is the name of the service secret query string parameter.
+	keyQueryParameter = "key"
+	// promptValue is the prompt used for test requests.
+	promptValue = "ping"
+	// integrationServiceSecret is the service secret for OpenAI stub server tests.
+	integrationServiceSecret = serviceSecretValue
+	// integrationOpenAIKey is the OpenAI API key for the stub server tests.
+	integrationOpenAIKey = openAIKeyValue
+	// integrationModelsPath is the path for the models endpoint.
+	integrationModelsPath = "/v1/models"
+	// integrationResponsesPath is the path for the responses endpoint.
+	integrationResponsesPath = "/v1/responses"
+	// integrationModelListBody is the JSON body returned for model listing.
+	integrationModelListBody = `{"object":"list","data":[{"id":"gpt-4.1","object":"model"}]}`
+	// integrationOKBody is the plain response used in tests.
+	integrationOKBody = "INTEGRATION_OK"
+	// integrationSearchBody is the web search response used in tests.
+	integrationSearchBody = "SEARCH_OK"
+	// availableModelsBody is the JSON body returned by the stubbed models endpoint in HTTP client tests.
+	availableModelsBody = `{"data":[{"id":"gpt-4.1"},{"id":"gpt-5-mini"}]}`
+	// contentTypeJSON is the HTTP header value for JSON payloads.
+	contentTypeJSON = "application/json"
+	// buildRouterErrorFormat is the format string used when BuildRouter returns an error.
+	buildRouterErrorFormat = "BuildRouter error: %v"
+	// buildRouterFailedFormat is the format string used when BuildRouter fails in tests.
+	buildRouterFailedFormat = "BuildRouter failed: %v"
+	// unexpectedRequestFormat is the format string used when an unexpected request occurs.
+	unexpectedRequestFormat = "unexpected request to %s"
+	// requestErrorFormat is the format string used when a request fails.
+	requestErrorFormat = "request error: %v"
+	// unexpectedStatusFormat is the format string used when an unexpected HTTP status is returned.
+	unexpectedStatusFormat = "status=%d body=%s"
+	// bodyMismatchFormat reports differing response bodies.
+	bodyMismatchFormat = "body=%q want=%q"
+	// toolsMissingMessage reports missing tools in captured payloads.
+	toolsMissingMessage = "tools missing when web_search=1"
+	// toolsMissingFormat reports missing tools when the captured payload is included.
+	toolsMissingFormat = "tools missing in payload when web_search=1; captured=%v"
+	// toolTypeMismatchFormat reports an unexpected tool type.
+	toolTypeMismatchFormat = "tool type=%v want=web_search"
+	// expectedErrorFormat is used when a configuration error is expected.
+	expectedErrorFormat = "expected %s error, got %v"
+	// getFailedFormat reports HTTP GET request failures.
+	getFailedFormat = "GET failed: %v"
+	// statusWantFormat reports an unexpected HTTP status code.
+	statusWantFormat = "status=%d want=%d"
+	// statusWantBodyFormat reports unexpected status codes and response bodies.
+	statusWantBodyFormat = "status=%d want=%d body=%q"
+)
+
+// roundTripperFunc allows custom RoundTrip implementations for the HTTP client.
+type roundTripperFunc func(httpRequest *http.Request) (*http.Response, error)
+
+// RoundTrip executes the custom RoundTrip implementation.
+func (roundTripper roundTripperFunc) RoundTrip(httpRequest *http.Request) (*http.Response, error) {
+	return roundTripper(httpRequest)
+}
+
+// newOpenAIServer returns a stub OpenAI server yielding the provided body and optionally capturing requests.
+func newOpenAIServer(testingInstance *testing.T, responseText string, captureTarget *any) *httptest.Server {
+	testingInstance.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		switch httpRequest.URL.Path {
+		case integrationModelsPath:
+			responseWriter.Header().Set("Content-Type", contentTypeJSON)
+			_, _ = io.WriteString(responseWriter, integrationModelListBody)
+		case integrationResponsesPath:
+			if captureTarget != nil {
+				requestBytes, _ := io.ReadAll(httpRequest.Body)
+				_ = json.Unmarshal(requestBytes, captureTarget)
+			}
+			responseWriter.Header().Set("Content-Type", contentTypeJSON)
+			_, _ = io.WriteString(responseWriter, `{"output_text":"`+responseText+`"}`)
+		default:
+			http.NotFound(responseWriter, httpRequest)
+		}
+	}))
+	return server
+}
+
+// newIntegrationServer builds the application server pointing at the stub OpenAI server.
+func newIntegrationServer(testingInstance *testing.T, openAIServer *httptest.Server) *httptest.Server {
+	testingInstance.Helper()
+	proxy.SetModelsURL(openAIServer.URL + integrationModelsPath)
+	proxy.SetResponsesURL(openAIServer.URL + integrationResponsesPath)
+	proxy.HTTPClient = openAIServer.Client()
+	testingInstance.Cleanup(proxy.ResetModelsURL)
+	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	loggerInstance, _ := zap.NewDevelopment()
+	testingInstance.Cleanup(func() { _ = loggerInstance.Sync() })
+	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret: integrationServiceSecret,
+		OpenAIKey:     integrationOpenAIKey,
+		LogLevel:      logLevelDebug,
+		WorkerCount:   1,
+		QueueSize:     4,
+	}, loggerInstance.Sugar())
+	if buildRouterError != nil {
+		testingInstance.Fatalf(buildRouterErrorFormat, buildRouterError)
+	}
+	server := httptest.NewServer(router)
+	testingInstance.Cleanup(server.Close)
+	return server
+}
+
+// makeHTTPClient returns a stub HTTP client capturing payloads and returning canned responses.
+func makeHTTPClient(testingInstance *testing.T, wantWebSearch bool) (*http.Client, *map[string]any) {
+	testingInstance.Helper()
+	var captured map[string]any
+	return &http.Client{
+		Transport: roundTripperFunc(func(httpRequest *http.Request) (*http.Response, error) {
+			switch httpRequest.URL.String() {
+			case proxy.ModelsURL():
+				body := availableModelsBody
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+			case proxy.ResponsesURL():
+				if httpRequest.Body != nil {
+					requestBytes, _ := io.ReadAll(httpRequest.Body)
+					_ = json.Unmarshal(requestBytes, &captured)
+				}
+				text := integrationOKBody
+				if wantWebSearch {
+					text = integrationSearchBody
+				}
+				body := `{"output_text":"` + text + `"}`
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+			default:
+				testingInstance.Fatalf(unexpectedRequestFormat, httpRequest.URL.String())
+				return nil, nil
+			}
+		}),
+		Timeout: 5 * time.Second,
+	}, &captured
+}
+
+// newLogger constructs a development logger for tests.
+func newLogger(testingInstance *testing.T) *zap.SugaredLogger {
+	testingInstance.Helper()
+	loggerInstance, _ := zap.NewDevelopment()
+	testingInstance.Cleanup(func() { _ = loggerInstance.Sync() })
+	return loggerInstance.Sugar()
+}
+
+// configureProxy sets URLs and the HTTP client for proxy operations.
+func configureProxy(testingInstance *testing.T, client *http.Client) {
+	testingInstance.Helper()
+	proxy.HTTPClient = client
+	proxy.SetModelsURL(mockModelsURL)
+	proxy.SetResponsesURL(mockResponsesURL)
+	testingInstance.Cleanup(proxy.ResetModelsURL)
+	testingInstance.Cleanup(proxy.ResetResponsesURL)
+}


### PR DESCRIPTION
## Summary
- centralize integration test helpers and constants
- reuse shared helpers across integration tests to remove duplication

## Testing
- `go test ./...`
- `go test ./tests/integration -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ba198d83388327a51e1dfa5a086303