### PR TITLE
Omit temperature for gpt-5 and add integration test

### DIFF
--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -19,7 +19,7 @@ const (
 	ModelNameGPT41 = "gpt-4.1"
 	// ModelNameGPT5Mini identifies the GPT-5-mini model.
 	ModelNameGPT5Mini = "gpt-5-mini"
-	// ModelNameGPT5 identifies the GPT-5 model.
+	// ModelNameGPT5 identifies the GPT-5 model which does not accept the temperature field.
 	ModelNameGPT5 = "gpt-5"
 )
 
@@ -28,7 +28,7 @@ var modelSpecifications = map[string]ModelSpecification{
 	ModelNameGPT4o:     {SupportsTemperature: true, SupportsWebSearch: true},
 	ModelNameGPT41:     {SupportsTemperature: true, SupportsWebSearch: true},
 	ModelNameGPT5Mini:  {},
-	ModelNameGPT5:      {SupportsTemperature: true, SupportsWebSearch: true},
+	ModelNameGPT5:      {SupportsTemperature: false, SupportsWebSearch: true},
 }
 
 // ResolveModelSpecification returns the specification for a model or an empty specification when unknown.

--- a/tests/integration/test_helpers_test.go
+++ b/tests/integration/test_helpers_test.go
@@ -46,7 +46,7 @@ const (
 	// integrationSearchBody is the web search response used in tests.
 	integrationSearchBody = "SEARCH_OK"
 	// availableModelsBody is the JSON body returned by the stubbed models endpoint in HTTP client tests.
-	availableModelsBody = `{"data":[{"id":"` + proxy.ModelNameGPT41 + `"},{"id":"` + proxy.ModelNameGPT5Mini + `"}]}`
+	availableModelsBody = `{"data":[{"id":"` + proxy.ModelNameGPT41 + `"},{"id":"` + proxy.ModelNameGPT5Mini + `"},{"id":"` + proxy.ModelNameGPT5 + `"}]}`
 	// contentTypeJSON is the HTTP header value for JSON payloads.
 	contentTypeJSON = "application/json"
 	// buildRouterErrorFormat is the format string used when BuildRouter returns an error.
@@ -65,6 +65,10 @@ const (
 	toolsMissingMessage = "tools missing when web_search=1"
 	// toolsMissingFormat reports missing tools when the captured payload is included.
 	toolsMissingFormat = "tools missing in payload when web_search=1; captured=%v"
+	// toolsOmittedFormat reports an unexpected tools field for models without tool support.
+	toolsOmittedFormat = "tools must be omitted for %s, got: %v"
+	// temperatureOmittedFormat reports a temperature field when it should be omitted.
+	temperatureOmittedFormat = "temperature must be omitted for %s, got: %v"
 	// toolTypeMismatchFormat reports an unexpected tool type.
 	toolTypeMismatchFormat = "tool type=%v want=web_search"
 	// metadataTemperatureTools provides model metadata allowing temperature and tools.


### PR DESCRIPTION
## Summary
- disable temperature support for `gpt-5`
- document that `gpt-5` ignores the temperature field
- add integration test ensuring `gpt-5` omits temperature and keeps web search tools

## Testing
- `go test ./tests/integration -run 'TestIntegrationModelSpecSuppression|TestIntegrationGPT5TemperatureSuppression' -count=1`
- `go test ./...` *(fails: signal: interrupt after ~30s)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f788a008327915acef241068cc9