### PR TITLE
Introduce model payload schemas for OpenAI requests

### DIFF
--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -2,12 +2,14 @@ package proxy
 
 import "strings"
 
-// ModelSpecification describes the features supported by a model.
-type ModelSpecification struct {
-	// SupportsTemperature indicates whether the model accepts the temperature field.
-	SupportsTemperature bool
-	// SupportsWebSearch indicates whether the model supports web search tools.
-	SupportsWebSearch bool
+// ModelPayloadSchema enumerates the request fields accepted by a model.
+type ModelPayloadSchema struct {
+	// Temperature indicates whether the model accepts the temperature field.
+	Temperature bool
+	// Tools indicates whether the model accepts the tools field.
+	Tools bool
+	// ToolChoice indicates whether the model accepts the tool_choice field.
+	ToolChoice bool
 }
 
 const (
@@ -23,19 +25,33 @@ const (
 	ModelNameGPT5 = "gpt-5"
 )
 
-var modelSpecifications = map[string]ModelSpecification{
-	ModelNameGPT4oMini: {SupportsTemperature: true},
-	ModelNameGPT4o:     {SupportsTemperature: true, SupportsWebSearch: true},
-	ModelNameGPT41:     {SupportsTemperature: true, SupportsWebSearch: true},
-	ModelNameGPT5Mini:  {},
-	ModelNameGPT5:      {SupportsTemperature: false, SupportsWebSearch: true},
+var (
+	// SchemaGPT4oMini defines allowed payload fields for the GPT-4o-mini model.
+	SchemaGPT4oMini = ModelPayloadSchema{Temperature: true}
+	// SchemaGPT4o defines allowed payload fields for the GPT-4o model.
+	SchemaGPT4o = ModelPayloadSchema{Temperature: true, Tools: true, ToolChoice: true}
+	// SchemaGPT41 defines allowed payload fields for the GPT-4.1 model.
+	SchemaGPT41 = ModelPayloadSchema{Temperature: true, Tools: true, ToolChoice: true}
+	// SchemaGPT5Mini defines allowed payload fields for the GPT-5-mini model.
+	SchemaGPT5Mini = ModelPayloadSchema{}
+	// SchemaGPT5 defines allowed payload fields for the GPT-5 model.
+	SchemaGPT5 = ModelPayloadSchema{Tools: true, ToolChoice: true}
+)
+
+// modelPayloadSchemas associates model identifiers with their payload schemas.
+var modelPayloadSchemas = map[string]ModelPayloadSchema{
+	ModelNameGPT4oMini: SchemaGPT4oMini,
+	ModelNameGPT4o:     SchemaGPT4o,
+	ModelNameGPT41:     SchemaGPT41,
+	ModelNameGPT5Mini:  SchemaGPT5Mini,
+	ModelNameGPT5:      SchemaGPT5,
 }
 
-// ResolveModelSpecification returns the specification for a model or an empty specification when unknown.
-func ResolveModelSpecification(modelIdentifier string) ModelSpecification {
+// ResolveModelPayloadSchema returns the schema for a model or an empty schema when unknown.
+func ResolveModelPayloadSchema(modelIdentifier string) ModelPayloadSchema {
 	normalized := strings.ToLower(strings.TrimSpace(modelIdentifier))
-	if spec, found := modelSpecifications[normalized]; found {
-		return spec
+	if schema, found := modelPayloadSchemas[normalized]; found {
+		return schema
 	}
-	return ModelSpecification{}
+	return ModelPayloadSchema{}
 }

--- a/internal/proxy/model_capabilities_test.go
+++ b/internal/proxy/model_capabilities_test.go
@@ -8,26 +8,42 @@ import (
 
 const (
 	messageTemperatureMismatch = "model %s temperature=%v want=%v"
-	messageWebSearchMismatch   = "model %s webSearch=%v want=%v"
+	messageToolsMismatch       = "model %s tools=%v want=%v"
+	messageToolChoiceMismatch  = "model %s toolChoice=%v want=%v"
 )
 
-// TestResolveModelSpecification verifies that model capabilities come from the capability table.
-func TestResolveModelSpecification(testFramework *testing.T) {
+// TestResolveModelPayloadSchema verifies that payload schemas are returned for every model.
+func TestResolveModelPayloadSchema(testFramework *testing.T) {
 	testCases := []struct {
 		modelIdentifier   string
 		expectTemperature bool
-		expectWebSearch   bool
+		expectTools       bool
+		expectToolChoice  bool
 	}{
-		{proxy.ModelNameGPT4o, true, true},
-		{proxy.ModelNameGPT5Mini, false, false},
+		{proxy.ModelNameGPT4oMini, true, false, false},
+		{proxy.ModelNameGPT4o, true, true, true},
+		{proxy.ModelNameGPT41, true, true, true},
+		{proxy.ModelNameGPT5Mini, false, false, false},
+		{proxy.ModelNameGPT5, false, true, true},
 	}
 	for _, testCase := range testCases {
-		capabilities := proxy.ResolveModelSpecification(testCase.modelIdentifier)
-		if capabilities.SupportsTemperature != testCase.expectTemperature {
-			testFramework.Fatalf(messageTemperatureMismatch, testCase.modelIdentifier, capabilities.SupportsTemperature, testCase.expectTemperature)
+		payloadSchema := proxy.ResolveModelPayloadSchema(testCase.modelIdentifier)
+		if payloadSchema.Temperature != testCase.expectTemperature {
+			testFramework.Fatalf(messageTemperatureMismatch, testCase.modelIdentifier, payloadSchema.Temperature, testCase.expectTemperature)
 		}
-		if capabilities.SupportsWebSearch != testCase.expectWebSearch {
-			testFramework.Fatalf(messageWebSearchMismatch, testCase.modelIdentifier, capabilities.SupportsWebSearch, testCase.expectWebSearch)
+		if payloadSchema.Tools != testCase.expectTools {
+			testFramework.Fatalf(messageToolsMismatch, testCase.modelIdentifier, payloadSchema.Tools, testCase.expectTools)
 		}
+		if payloadSchema.ToolChoice != testCase.expectToolChoice {
+			testFramework.Fatalf(messageToolChoiceMismatch, testCase.modelIdentifier, payloadSchema.ToolChoice, testCase.expectToolChoice)
+		}
+	}
+}
+
+// TestResolveModelPayloadSchemaUnknown verifies that unknown models return an empty schema.
+func TestResolveModelPayloadSchemaUnknown(testFramework *testing.T) {
+	unknownSchema := proxy.ResolveModelPayloadSchema("unknown-model")
+	if unknownSchema != (proxy.ModelPayloadSchema{}) {
+		testFramework.Fatalf("unknown model returned non-empty schema")
 	}
 }

--- a/internal/proxy/model_validator.go
+++ b/internal/proxy/model_validator.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 )
@@ -10,7 +11,7 @@ import (
 // ErrUnknownModel is returned when a model identifier is not recognized.
 var ErrUnknownModel = errors.New(errorUnknownModel)
 
-// modelValidator validates model identifiers using the static specification table.
+// modelValidator validates model identifiers using the static payload schema table.
 type modelValidator struct{}
 
 // newModelValidator creates a modelValidator. The parameters are retained for signature compatibility.
@@ -20,9 +21,10 @@ func newModelValidator(openAIKey string, structuredLogger *zap.SugaredLogger) (*
 	return &modelValidator{}, nil
 }
 
-// Verify checks whether the provided model identifier is known.
+// Verify checks whether the provided model identifier is known after normalization.
 func (validator *modelValidator) Verify(modelIdentifier string) error {
-	if _, known := modelSpecifications[modelIdentifier]; !known {
+	normalized := strings.ToLower(strings.TrimSpace(modelIdentifier))
+	if _, known := modelPayloadSchemas[normalized]; !known {
 		return fmt.Errorf("%w: %s", ErrUnknownModel, modelIdentifier)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- define `ModelPayloadSchema` and per-model schema variables
- refactor OpenAI request builder to honor payload schemas without default temperature
- normalize model validation and test unknown models

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb51d204e88327bcd5ad74dfe1d724