### PR TITLE
refactor payload schema per model

### DIFF
--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -2,14 +2,10 @@ package proxy
 
 import "strings"
 
-// ModelPayloadSchema enumerates the request fields accepted by a model.
+// ModelPayloadSchema lists request fields allowed by a model.
 type ModelPayloadSchema struct {
-	// Temperature indicates whether the model accepts the temperature field.
-	Temperature bool
-	// Tools indicates whether the model accepts the tools field.
-	Tools bool
-	// ToolChoice indicates whether the model accepts the tool_choice field.
-	ToolChoice bool
+	// AllowedRequestFields enumerates JSON fields permitted in the request payload.
+	AllowedRequestFields []string
 }
 
 const (
@@ -27,15 +23,15 @@ const (
 
 var (
 	// SchemaGPT4oMini defines allowed payload fields for the GPT-4o-mini model.
-	SchemaGPT4oMini = ModelPayloadSchema{Temperature: true}
+	SchemaGPT4oMini = ModelPayloadSchema{AllowedRequestFields: []string{keyModel, keyInput, keyMaxOutputTokens, keyTemperature}}
 	// SchemaGPT4o defines allowed payload fields for the GPT-4o model.
-	SchemaGPT4o = ModelPayloadSchema{Temperature: true, Tools: true, ToolChoice: true}
+	SchemaGPT4o = ModelPayloadSchema{AllowedRequestFields: []string{keyModel, keyInput, keyMaxOutputTokens, keyTemperature, keyTools, keyToolChoice}}
 	// SchemaGPT41 defines allowed payload fields for the GPT-4.1 model.
-	SchemaGPT41 = ModelPayloadSchema{Temperature: true, Tools: true, ToolChoice: true}
+	SchemaGPT41 = ModelPayloadSchema{AllowedRequestFields: []string{keyModel, keyInput, keyMaxOutputTokens, keyTemperature, keyTools, keyToolChoice}}
 	// SchemaGPT5Mini defines allowed payload fields for the GPT-5-mini model.
-	SchemaGPT5Mini = ModelPayloadSchema{}
+	SchemaGPT5Mini = ModelPayloadSchema{AllowedRequestFields: []string{keyModel, keyInput, keyMaxOutputTokens}}
 	// SchemaGPT5 defines allowed payload fields for the GPT-5 model.
-	SchemaGPT5 = ModelPayloadSchema{Tools: true, ToolChoice: true}
+	SchemaGPT5 = ModelPayloadSchema{AllowedRequestFields: []string{keyModel, keyInput, keyMaxOutputTokens, keyTools, keyToolChoice}}
 )
 
 // modelPayloadSchemas associates model identifiers with their payload schemas.

--- a/internal/proxy/model_capabilities_test.go
+++ b/internal/proxy/model_capabilities_test.go
@@ -7,35 +7,43 @@ import (
 )
 
 const (
-	messageTemperatureMismatch = "model %s temperature=%v want=%v"
-	messageToolsMismatch       = "model %s tools=%v want=%v"
-	messageToolChoiceMismatch  = "model %s toolChoice=%v want=%v"
+	messageFieldsMismatch = "model %s fields=%v want=%v"
+	keyModel              = "model"
+	keyInput              = "input"
+	keyMaxOutputTokens    = "max_output_tokens"
+	keyTemperature        = "temperature"
+	keyTools              = "tools"
+	keyToolChoice         = "tool_choice"
 )
 
 // TestResolveModelPayloadSchema verifies that payload schemas are returned for every model.
 func TestResolveModelPayloadSchema(testFramework *testing.T) {
 	testCases := []struct {
-		modelIdentifier   string
-		expectTemperature bool
-		expectTools       bool
-		expectToolChoice  bool
+		modelIdentifier string
+		expectFields    []string
 	}{
-		{proxy.ModelNameGPT4oMini, true, false, false},
-		{proxy.ModelNameGPT4o, true, true, true},
-		{proxy.ModelNameGPT41, true, true, true},
-		{proxy.ModelNameGPT5Mini, false, false, false},
-		{proxy.ModelNameGPT5, false, true, true},
+		{proxy.ModelNameGPT4oMini, []string{keyModel, keyInput, keyMaxOutputTokens, keyTemperature}},
+		{proxy.ModelNameGPT4o, []string{keyModel, keyInput, keyMaxOutputTokens, keyTemperature, keyTools, keyToolChoice}},
+		{proxy.ModelNameGPT41, []string{keyModel, keyInput, keyMaxOutputTokens, keyTemperature, keyTools, keyToolChoice}},
+		{proxy.ModelNameGPT5Mini, []string{keyModel, keyInput, keyMaxOutputTokens}},
+		{proxy.ModelNameGPT5, []string{keyModel, keyInput, keyMaxOutputTokens, keyTools, keyToolChoice}},
 	}
 	for _, testCase := range testCases {
 		payloadSchema := proxy.ResolveModelPayloadSchema(testCase.modelIdentifier)
-		if payloadSchema.Temperature != testCase.expectTemperature {
-			testFramework.Fatalf(messageTemperatureMismatch, testCase.modelIdentifier, payloadSchema.Temperature, testCase.expectTemperature)
-		}
-		if payloadSchema.Tools != testCase.expectTools {
-			testFramework.Fatalf(messageToolsMismatch, testCase.modelIdentifier, payloadSchema.Tools, testCase.expectTools)
-		}
-		if payloadSchema.ToolChoice != testCase.expectToolChoice {
-			testFramework.Fatalf(messageToolChoiceMismatch, testCase.modelIdentifier, payloadSchema.ToolChoice, testCase.expectToolChoice)
+		if !equalSlices(payloadSchema.AllowedRequestFields, testCase.expectFields) {
+			testFramework.Fatalf(messageFieldsMismatch, testCase.modelIdentifier, payloadSchema.AllowedRequestFields, testCase.expectFields)
 		}
 	}
+}
+
+func equalSlices(first []string, second []string) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for index := range first {
+		if first[index] != second[index] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- define per-model payload fields in schema
- build OpenAI requests by filtering payload using model schema
- update tests for new schema representation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb76a2ac588327afd75f0208d9d0da