### PR TITLE
refactor: remove redundant log field error constant

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -87,7 +87,6 @@ const (
 	logFieldClientIP     = "client_ip"
 	logFieldStatus       = "status"
 	logFieldValue        = "value"
-	logFieldError        = "error"
 	// logFieldParameter identifies the request parameter related to a log entry.
 	logFieldParameter = "parameter"
 	// logFieldID identifies the response identifier logged for traceability.


### PR DESCRIPTION
## Summary
- remove unused `logFieldError` constant from proxy package and use shared `constants.LogFieldError`

## Testing
- `go test ./...` *(fails: process hangs in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68bbdbc2538083279832d42d05c0875c