### PR TITLE
refactor: centralize OpenAI log event strings

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -96,13 +96,19 @@ const (
 	// logFieldExpectedFingerprint identifies the fingerprint of the expected client key.
 	logFieldExpectedFingerprint = "expected_fingerprint"
 
-	logEventOpenAIRequestError            = "OpenAI request error"
-	logEventOpenAIResponse                = "OpenAI API response"
-	logEventOpenAIModelsList              = "OpenAI models list"
-	logEventOpenAIModelsListError         = "OpenAI models list error"
-	logEventOpenAIModelCapabilitiesError  = "OpenAI model capabilities error"
-	logEventOpenAIPollError               = "OpenAI poll error"
-	logEventOpenAIContinueError           = "OpenAI continue error"
+	logEventOpenAIRequestError           = "OpenAI request error"
+	logEventOpenAIResponse               = "OpenAI API response"
+	logEventOpenAIModelsList             = "OpenAI models list"
+	logEventOpenAIModelsListError        = "OpenAI models list error"
+	logEventOpenAIModelCapabilitiesError = "OpenAI model capabilities error"
+	logEventOpenAIPollError              = "OpenAI poll error"
+	logEventOpenAIContinueError          = "OpenAI continue error"
+	// logEventOpenAIInitialResponseBody records the body of the initial response from OpenAI.
+	logEventOpenAIInitialResponseBody = "OpenAI initial response body"
+	// logEventMissingFinalMessage indicates that the response completed without a final assistant message.
+	logEventMissingFinalMessage = "response is 'completed' but lacks final message; starting synthesis continuation"
+	// logEventRetryingSynthesis reports a retry of synthesis due to an empty initial attempt.
+	logEventRetryingSynthesis             = "first synthesis continuation yielded no text; retrying once with stricter settings"
 	logEventParseOpenAIResponseFailed     = "parse OpenAI response failed"
 	logEventForbiddenRequest              = "forbidden request"
 	logEventRequestReceived               = "request received"

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -95,7 +95,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 		return constants.EmptyString, errors.New(errorOpenAIRequest)
 	}
 
-	structuredLogger.Debugw("OpenAI initial response body", logFieldResponseBody, string(responseBytes))
+	structuredLogger.Debugw(logEventOpenAIInitialResponseBody, logFieldResponseBody, string(responseBytes))
 
 	var decodedObject map[string]any
 	_ = json.Unmarshal(responseBytes, &decodedObject)
@@ -132,7 +132,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 	if isTerminalStatus && apiStatus == statusCompleted && !hasFinalMessage(responseBytes) {
 		// Tool phase finished without a final assistant message.
 		forcedSynthesis = true
-		structuredLogger.Debugw("response is 'completed' but lacks final message; starting synthesis continuation")
+		structuredLogger.Debugw(logEventMissingFinalMessage)
 	}
 
 	// If the state is non-terminal OR we must force a synthesis continuation, proceed accordingly.
@@ -180,7 +180,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 
 		// --- Fallback: one more synthesis continuation if still no text ---
 		if forcedSynthesis {
-			structuredLogger.Debugw("first synthesis continuation yielded no text; retrying once with stricter settings")
+			structuredLogger.Debugw(logEventRetryingSynthesis)
 			newID, synthErr := startSynthesisContinuation(openAIKey, targetResponseID, modelIdentifier, structuredLogger /*retryOrdinal=*/, 1)
 			if synthErr != nil {
 				structuredLogger.Errorw(


### PR DESCRIPTION
## Summary
- add constants for OpenAI log events
- replace inline log messages with constants

## Testing
- `go fmt internal/proxy/constants.go internal/proxy/openai.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbdbebd52c8327a31f84392b857b70