### PR TITLE
refactor: extract unknown model error format constant

### DIFF
--- a/internal/proxy/model_validator.go
+++ b/internal/proxy/model_validator.go
@@ -7,6 +7,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// errUnknownModelFormat specifies the format string for wrapping an unknown model error.
+const errUnknownModelFormat = "%w: %s"
+
 // ErrUnknownModel is returned when a model identifier is not recognized.
 var ErrUnknownModel = errors.New(errorUnknownModel)
 
@@ -23,7 +26,7 @@ func newModelValidator(openAIKey string, structuredLogger *zap.SugaredLogger) (*
 // Verify checks whether the provided model identifier is known.
 func (validator *modelValidator) Verify(modelIdentifier string) error {
 	if _, known := modelPayloadSchemas[modelIdentifier]; !known {
-		return fmt.Errorf("%w: %s", ErrUnknownModel, modelIdentifier)
+		return fmt.Errorf(errUnknownModelFormat, ErrUnknownModel, modelIdentifier)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- centralize unknown model error format
- reference constant when building error

## Testing
- `go fmt internal/proxy/model_validator.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbdc047e5c8327bfaa9341ff8d2ba7