### PR TITLE
refactor: reuse root path constant

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -12,6 +12,9 @@ const (
 	headerAccept              = "Accept"
 	headerAuthorizationPrefix = "Bearer "
 
+	// rootPath defines the HTTP path for the root endpoint.
+	rootPath = "/"
+
 	queryParameterPrompt       = "prompt"
 	queryParameterKey          = "key"
 	queryParameterModel        = "model"

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -85,7 +85,7 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	}
 
 	router.Use(gin.Recovery(), secretMiddleware(configuration.ServiceSecret, structuredLogger))
-	router.GET("/", chatHandler(taskQueue, configuration.SystemPrompt, validator, structuredLogger))
+	router.GET(rootPath, chatHandler(taskQueue, configuration.SystemPrompt, validator, structuredLogger))
 	return router, nil
 }
 


### PR DESCRIPTION
## Summary
- define rootPath constant for the API root endpoint
- use rootPath constant in router setup

## Testing
- `go fmt internal/proxy/constants.go internal/proxy/router.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbdc1456d0832782025f5d5468b161