### PR TITLE
Refactor response parsing with constants

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -48,6 +48,18 @@ const (
 
 	toolTypeWebSearch = "web_search"
 
+	// responseTypeMessage identifies a message output item in the upstream response.
+	responseTypeMessage = "message"
+
+	// responseRoleAssistant identifies the assistant role in output items.
+	responseRoleAssistant = "assistant"
+
+	// responseTypeWebSearchCall identifies a web search tool call in the output array.
+	responseTypeWebSearchCall = "web_search_call"
+
+	// fallbackFinalAnswerFormat formats a message when the model does not provide a final answer.
+	fallbackFinalAnswerFormat = "Model did not provide a final answer. Last web search: \"%s\""
+
 	keyRole = "role"
 	keyUser = "user"
 


### PR DESCRIPTION
## Summary
- define constants for message, assistant, web search call types, and fallback message format
- use new constants in OpenAI response parsing and rename loop index to `outputIndex`
- replace literal empty strings with `constants.EmptyString`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbdbf3c84c832797aeb19984382fa0