### PR TITLE
Refactor OpenAI endpoints into struct

### DIFF
--- a/internal/proxy/endpoints.go
+++ b/internal/proxy/endpoints.go
@@ -5,25 +5,49 @@ const (
 	defaultModelsURL    = "https://api.openai.com/v1/models"
 )
 
-var (
-	responsesURL = defaultResponsesURL
-	modelsURL    = defaultModelsURL
-)
+// Endpoints holds the URLs for the OpenAI responses and models endpoints.
+type Endpoints struct {
+	ResponsesURL string
+	ModelsURL    string
+}
 
-// ResponsesURL returns the URL used for the OpenAI responses endpoint.
-func ResponsesURL() string { return responsesURL }
+// NewEndpoints returns an Endpoints instance initialized with default URLs.
+func NewEndpoints() *Endpoints {
+	return &Endpoints{
+		ResponsesURL: defaultResponsesURL,
+		ModelsURL:    defaultModelsURL,
+	}
+}
+
+// DefaultEndpoints provides the endpoint URLs used by the proxy.
+var DefaultEndpoints = NewEndpoints()
+
+// GetResponsesURL returns the URL used for the OpenAI responses endpoint.
+func (endpointConfiguration *Endpoints) GetResponsesURL() string {
+	return endpointConfiguration.ResponsesURL
+}
 
 // SetResponsesURL sets the URL for the OpenAI responses endpoint.
-func SetResponsesURL(newURL string) { responsesURL = newURL }
+func (endpointConfiguration *Endpoints) SetResponsesURL(newURL string) {
+	endpointConfiguration.ResponsesURL = newURL
+}
 
 // ResetResponsesURL resets the responses endpoint to the default.
-func ResetResponsesURL() { responsesURL = defaultResponsesURL }
+func (endpointConfiguration *Endpoints) ResetResponsesURL() {
+	endpointConfiguration.ResponsesURL = defaultResponsesURL
+}
 
-// ModelsURL returns the URL used for the OpenAI models endpoint.
-func ModelsURL() string { return modelsURL }
+// GetModelsURL returns the URL used for the OpenAI models endpoint.
+func (endpointConfiguration *Endpoints) GetModelsURL() string {
+	return endpointConfiguration.ModelsURL
+}
 
 // SetModelsURL sets the URL for the OpenAI models endpoint.
-func SetModelsURL(newURL string) { modelsURL = newURL }
+func (endpointConfiguration *Endpoints) SetModelsURL(newURL string) {
+	endpointConfiguration.ModelsURL = newURL
+}
 
 // ResetModelsURL resets the models endpoint to the default.
-func ResetModelsURL() { modelsURL = defaultModelsURL }
+func (endpointConfiguration *Endpoints) ResetModelsURL() {
+	endpointConfiguration.ModelsURL = defaultModelsURL
+}

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -81,7 +81,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 
 	requestContext, cancelRequest := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancelRequest()
-	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodPost, ResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
+	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodPost, DefaultEndpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
 	if buildError != nil {
 		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
 		return constants.EmptyString, errors.New(errorRequestBuild)
@@ -218,7 +218,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 
 // continueResponse signals to the API that a response session should proceed (legacy non-terminal case).
 func continueResponse(openAIKey string, responseIdentifier string, structuredLogger *zap.SugaredLogger) error {
-	resourceURL := ResponsesURL() + "/" + responseIdentifier + "/continue"
+	resourceURL := DefaultEndpoints.GetResponsesURL() + "/" + responseIdentifier + "/continue"
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 
@@ -285,7 +285,7 @@ func startSynthesisContinuation(openAIKey string, previousResponseID string, mod
 
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
-	req, buildErr := buildAuthorizedJSONRequest(ctx, http.MethodPost, ResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
+	req, buildErr := buildAuthorizedJSONRequest(ctx, http.MethodPost, DefaultEndpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
 	if buildErr != nil {
 		return "", buildErr
 	}
@@ -332,7 +332,7 @@ func pollResponseUntilDone(openAIKey string, responseIdentifier string, structur
 
 // fetchResponseByID retrieves a response by identifier and reports whether the response is complete.
 func fetchResponseByID(deadline time.Time, openAIKey string, responseIdentifier string, structuredLogger *zap.SugaredLogger) (string, bool, error) {
-	resourceURL := ResponsesURL() + "/" + responseIdentifier
+	resourceURL := DefaultEndpoints.GetResponsesURL() + "/" + responseIdentifier
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 

--- a/internal/proxy/response_shapes_e2e_test.go
+++ b/internal/proxy/response_shapes_e2e_test.go
@@ -36,8 +36,8 @@ func withStubbedProxy(t *testing.T, initialResponse, finalResponse string) http.
 	}))
 	t.Cleanup(server.Close)
 
-	proxy.SetResponsesURL(server.URL)
-	t.Cleanup(proxy.ResetResponsesURL)
+	proxy.DefaultEndpoints.SetResponsesURL(server.URL)
+	t.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 
 	logger, _ := zap.NewDevelopment()
 	t.Cleanup(func() { _ = logger.Sync() })

--- a/internal/proxy/test_helpers_test.go
+++ b/internal/proxy/test_helpers_test.go
@@ -48,8 +48,8 @@ func NewSessionMockServer(finalResponseJSON string) *httptest.Server {
 // NewTestRouter creates a pre-configured router for integration tests.
 func NewTestRouter(t *testing.T, serverURL string) *gin.Engine {
 	t.Helper()
-	proxy.SetResponsesURL(serverURL)
-	t.Cleanup(proxy.ResetResponsesURL)
+	proxy.DefaultEndpoints.SetResponsesURL(serverURL)
+	t.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 
 	logger, _ := zap.NewDevelopment()
 	t.Cleanup(func() { _ = logger.Sync() })

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -38,9 +38,9 @@ func TestIntegration_TemperatureNotAllowed_OmitsParameter(testingInstance *testi
 	}))
 	defer openAIServer.Close()
 
-	proxy.SetResponsesURL(openAIServer.URL + "/v1/responses")
+	proxy.DefaultEndpoints.SetResponsesURL(openAIServer.URL + "/v1/responses")
 	proxy.HTTPClient = openAIServer.Client()
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 
 	logger, _ := zap.NewDevelopment()
 	defer logger.Sync()
@@ -96,9 +96,9 @@ func TestIntegration_ToolsNotAllowed_OmitsParameters(testingInstance *testing.T)
 	}))
 	defer openAIServer.Close()
 
-	proxy.SetResponsesURL(openAIServer.URL + "/v1/responses")
+	proxy.DefaultEndpoints.SetResponsesURL(openAIServer.URL + "/v1/responses")
 	proxy.HTTPClient = openAIServer.Client()
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 
 	logger, _ := zap.NewDevelopment()
 	defer logger.Sync()

--- a/tests/integration/integration1_test.go
+++ b/tests/integration/integration1_test.go
@@ -13,11 +13,11 @@ import (
 // newIntegrationServerWithTimeout builds the application server pointing at the stub OpenAI server with a configurable request timeout.
 func newIntegrationServerWithTimeout(testingInstance *testing.T, openAIServer *httptest.Server, requestTimeoutSeconds int) *httptest.Server {
 	testingInstance.Helper()
-	proxy.SetModelsURL(openAIServer.URL + integrationModelsPath)
-	proxy.SetResponsesURL(openAIServer.URL + integrationResponsesPath)
+	proxy.DefaultEndpoints.SetModelsURL(openAIServer.URL + integrationModelsPath)
+	proxy.DefaultEndpoints.SetResponsesURL(openAIServer.URL + integrationResponsesPath)
 	proxy.HTTPClient = openAIServer.Client()
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetModelsURL() })
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 	logger, _ := zap.NewDevelopment()
 	testingInstance.Cleanup(func() { _ = logger.Sync() })
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{

--- a/tests/integration/integration_adaptive_test.go
+++ b/tests/integration/integration_adaptive_test.go
@@ -35,12 +35,12 @@ func newAdaptiveClient(testingInstance *testing.T, mode string) *http.Client {
 	return &http.Client{
 		Transport: adaptiveRoundTripper(func(httpRequest *http.Request) (*http.Response, error) {
 			switch {
-			case httpRequest.URL.String() == proxy.ModelsURL():
+			case httpRequest.URL.String() == proxy.DefaultEndpoints.GetModelsURL():
 				body := `{"data":[{"id":"` + proxy.ModelNameGPT5Mini + `"}]}`
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
-			case strings.HasPrefix(httpRequest.URL.String(), proxy.ModelsURL()+"/"):
+			case strings.HasPrefix(httpRequest.URL.String(), proxy.DefaultEndpoints.GetModelsURL()+"/"):
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(metadataEmpty)), Header: make(http.Header)}, nil
-			case httpRequest.URL.String() == proxy.ResponsesURL():
+			case httpRequest.URL.String() == proxy.DefaultEndpoints.GetResponsesURL():
 				buf, _ := io.ReadAll(httpRequest.Body)
 				httpRequest.Body.Close()
 				payload := string(buf)
@@ -75,10 +75,10 @@ func newAdaptiveRouter(testingInstance *testing.T, mode string) *gin.Engine {
 	testingInstance.Helper()
 	gin.SetMode(gin.TestMode)
 	proxy.HTTPClient = newAdaptiveClient(testingInstance, mode)
-	proxy.SetModelsURL(mockModelsURL)
-	proxy.SetResponsesURL(mockResponsesURL)
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	proxy.DefaultEndpoints.SetModelsURL(mockModelsURL)
+	proxy.DefaultEndpoints.SetResponsesURL(mockResponsesURL)
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetModelsURL() })
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 	logger, _ := zap.NewDevelopment()
 	testingInstance.Cleanup(func() { _ = logger.Sync() })
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{

--- a/tests/integration/long_request_test.go
+++ b/tests/integration/long_request_test.go
@@ -27,11 +27,11 @@ func makeSlowHTTPClient(testingInstance *testing.T) *http.Client {
 	return &http.Client{
 		Transport: roundTripperFunc(func(httpRequest *http.Request) (*http.Response, error) {
 			switch {
-			case httpRequest.URL.String() == proxy.ModelsURL():
+			case httpRequest.URL.String() == proxy.DefaultEndpoints.GetModelsURL():
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(modelsListBody)), Header: make(http.Header)}, nil
-			case strings.HasPrefix(httpRequest.URL.String(), proxy.ModelsURL()+"/"):
+			case strings.HasPrefix(httpRequest.URL.String(), proxy.DefaultEndpoints.GetModelsURL()+"/"):
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(metadataTemperatureTools)), Header: make(http.Header)}, nil
-			case httpRequest.URL.String() == proxy.ResponsesURL():
+			case httpRequest.URL.String() == proxy.DefaultEndpoints.GetResponsesURL():
 				time.Sleep(responseDelay)
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"output_text":"` + expectedResponseBody + `"}`)), Header: make(http.Header)}, nil
 			default:

--- a/tests/integration/request_timeout_test.go
+++ b/tests/integration/request_timeout_test.go
@@ -26,11 +26,11 @@ func makeTimeoutHTTPClient(testingInstance *testing.T) *http.Client {
 	return &http.Client{
 		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
 			switch {
-			case request.URL.String() == proxy.ModelsURL():
+			case request.URL.String() == proxy.DefaultEndpoints.GetModelsURL():
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(modelsListBody)), Header: make(http.Header)}, nil
-			case strings.HasPrefix(request.URL.String(), proxy.ModelsURL()+"/"):
+			case strings.HasPrefix(request.URL.String(), proxy.DefaultEndpoints.GetModelsURL()+"/"):
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(metadataTemperatureTools)), Header: make(http.Header)}, nil
-			case request.URL.String() == proxy.ResponsesURL():
+			case request.URL.String() == proxy.DefaultEndpoints.GetResponsesURL():
 				select {
 				case <-request.Context().Done():
 					return nil, request.Context().Err()

--- a/tests/llm-proxy/serve_test.go
+++ b/tests/llm-proxy/serve_test.go
@@ -29,13 +29,13 @@ func newRouterWithStubbedOpenAI(testingInstance *testing.T, modelsBody, response
 	proxy.HTTPClient = &http.Client{
 		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
 			switch request.URL.String() {
-			case proxy.ModelsURL():
+			case proxy.DefaultEndpoints.GetModelsURL():
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(modelsBody)),
 					Header:     make(http.Header),
 				}, nil
-			case proxy.ResponsesURL():
+			case proxy.DefaultEndpoints.GetResponsesURL():
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(responsesBody)),
@@ -72,10 +72,10 @@ func newRouterWithStubbedOpenAI(testingInstance *testing.T, modelsBody, response
 func TestEndpoint_Empty200TreatedAsError(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	proxy.SetModelsURL("https://mock.local/v1/models")
-	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	proxy.DefaultEndpoints.SetModelsURL("https://mock.local/v1/models")
+	proxy.DefaultEndpoints.SetResponsesURL("https://mock.local/v1/responses")
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetModelsURL() })
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 
 	router := newRouterWithStubbedOpenAI(
 		testingInstance,
@@ -105,10 +105,10 @@ func TestEndpoint_Empty200TreatedAsError(testingInstance *testing.T) {
 func TestEndpoint_RespectsAcceptHeaderCSV(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	proxy.SetModelsURL("https://mock.local/v1/models")
-	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	proxy.DefaultEndpoints.SetModelsURL("https://mock.local/v1/models")
+	proxy.DefaultEndpoints.SetResponsesURL("https://mock.local/v1/responses")
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetModelsURL() })
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 
 	router := newRouterWithStubbedOpenAI(
 		testingInstance,
@@ -143,10 +143,10 @@ func TestEndpoint_RespectsAcceptHeaderCSV(testingInstance *testing.T) {
 func TestEndpoint_ReturnsServiceUnavailableWhenQueueFull(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	proxy.SetModelsURL("https://mock.local/v1/models")
-	proxy.SetResponsesURL("https://mock.local/v1/responses")
-	testingInstance.Cleanup(proxy.ResetModelsURL)
-	testingInstance.Cleanup(proxy.ResetResponsesURL)
+	proxy.DefaultEndpoints.SetModelsURL("https://mock.local/v1/models")
+	proxy.DefaultEndpoints.SetResponsesURL("https://mock.local/v1/responses")
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetModelsURL() })
+	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
 
 	router := newRouterWithStubbedOpenAI(
 		testingInstance,


### PR DESCRIPTION
## Summary
- encapsulate OpenAI URLs in an `Endpoints` struct with defaults
- replace package-level getters and setters with `Endpoints` methods
- update tests to configure endpoints via an `Endpoints` instance

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbdc38623c8327b80a8d2042d17b24