### PR TITLE
refactor: replace string literals with constants

### DIFF
--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/temirov/llm-proxy/internal/apperrors"
+	"github.com/temirov/llm-proxy/internal/constants"
 )
 
 const (
@@ -39,10 +40,10 @@ type Configuration struct {
 
 // validateConfig confirms required settings are present.
 func validateConfig(config Configuration) error {
-	if strings.TrimSpace(config.ServiceSecret) == "" {
+	if strings.TrimSpace(config.ServiceSecret) == constants.EmptyString {
 		return apperrors.ErrMissingServiceSecret
 	}
-	if strings.TrimSpace(config.OpenAIKey) == "" {
+	if strings.TrimSpace(config.OpenAIKey) == constants.EmptyString {
 		return apperrors.ErrMissingOpenAIKey
 	}
 	return nil

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -102,18 +102,18 @@ func Serve(configuration Configuration, structuredLogger *zap.SugaredLogger) err
 func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validator *modelValidator, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
 		userPrompt := ginContext.Query(queryParameterPrompt)
-		if userPrompt == "" {
+		if userPrompt == constants.EmptyString {
 			ginContext.String(http.StatusBadRequest, errorMissingPrompt)
 			return
 		}
 
 		systemPrompt := ginContext.Query(queryParameterSystemPrompt)
-		if systemPrompt == "" {
+		if systemPrompt == constants.EmptyString {
 			systemPrompt = defaultSystemPrompt
 		}
 
 		modelIdentifier := ginContext.Query(queryParameterModel)
-		if modelIdentifier == "" {
+		if modelIdentifier == constants.EmptyString {
 			modelIdentifier = DefaultModel
 		}
 		if verificationError := validator.Verify(modelIdentifier); verificationError != nil {
@@ -123,7 +123,7 @@ func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validat
 
 		webSearchQuery := strings.TrimSpace(ginContext.Query(queryParameterWebSearch))
 		webSearchEnabled := false
-		if webSearchQuery != "" {
+		if webSearchQuery != constants.EmptyString {
 			parsedWebSearch, parseError := strconv.ParseBool(webSearchQuery)
 			if parseError != nil {
 				structuredLogger.Warnw(

--- a/internal/utils/fingerprint_test.go
+++ b/internal/utils/fingerprint_test.go
@@ -3,11 +3,12 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/temirov/llm-proxy/internal/constants"
 	"github.com/temirov/llm-proxy/internal/utils"
 )
 
 const (
-	secretEmpty         = ""
+	secretEmpty         = constants.EmptyString
 	secretABC           = "abc"
 	secretLLMProxy      = "llm-proxy"
 	fingerprintEmpty    = "e3b0c442"

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -8,7 +8,7 @@ import (
 
 // IsBlank reports whether a string is empty or whitespace-only.
 func IsBlank(value string) bool {
-	return strings.TrimSpace(value) == ""
+	return strings.TrimSpace(value) == constants.EmptyString
 }
 
 // HasAnyPrefix reports whether value starts with any of the given prefixes (case-insensitive).

--- a/internal/utils/strings_test.go
+++ b/internal/utils/strings_test.go
@@ -3,11 +3,12 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/temirov/llm-proxy/internal/constants"
 	"github.com/temirov/llm-proxy/internal/utils"
 )
 
 const (
-	emptyStringValue      = ""
+	emptyStringValue      = constants.EmptyString
 	whitespaceStringValue = " \t\n"
 	wordStringValue       = "hello"
 	spacedWordStringValue = "  hello  "

--- a/tests/integration/integration2_test.go
+++ b/tests/integration/integration2_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/temirov/llm-proxy/internal/constants"
 	"github.com/temirov/llm-proxy/internal/proxy"
 )
 
@@ -89,12 +90,12 @@ func TestIntegrationConfiguration(testingInstance *testing.T) {
 	}{
 		{
 			name:        "missing_service_secret",
-			config:      proxy.Configuration{ServiceSecret: "", OpenAIKey: openAIKeyValue},
+			config:      proxy.Configuration{ServiceSecret: constants.EmptyString, OpenAIKey: openAIKeyValue},
 			expectError: "SERVICE_SECRET",
 		},
 		{
 			name:        "missing_openai_key",
-			config:      proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: ""},
+			config:      proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: constants.EmptyString},
 			expectError: "OPENAI_API_KEY",
 		},
 		{
@@ -106,7 +107,7 @@ func TestIntegrationConfiguration(testingInstance *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
-			if testCase.expectError != "" {
+			if testCase.expectError != constants.EmptyString {
 				_, buildRouterError := proxy.BuildRouter(testCase.config, newLogger(subTest))
 				if buildRouterError == nil || !strings.Contains(buildRouterError.Error(), testCase.expectError) {
 					subTest.Fatalf(expectedErrorFormat, testCase.expectError, buildRouterError)


### PR DESCRIPTION
## Summary
- reuse constants.EmptyString in string utilities and proxy code
- ensure proxy configuration validation avoids direct string literals
- update tests to rely on shared string constants

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbe0104ed483278070e2fcbdd0ad9a