### PR TITLE
chore: remove unused proxy constants

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -65,12 +65,6 @@ const (
 	// fallbackFinalAnswerFormat formats a message when the model does not provide a final answer.
 	fallbackFinalAnswerFormat = "Model did not provide a final answer. Last web search: \"%s\""
 
-	keyRole = "role"
-	keyUser = "user"
-
-	keySystem          = "system"
-	keyAssistant       = "assistant"
-	keyContent         = "content"
 	keyModel           = "model"
 	keyInput           = "input"
 	keyTemperature     = "temperature"


### PR DESCRIPTION
## Summary
- remove unused message role constants

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbe0168b288327a13f4c2fd72bc601