### PR TITLE
refactor: use constants for synthesis continuation

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -81,6 +81,15 @@ const (
 	keyReasoning       = "reasoning"
 	keyAuto            = "auto"
 
+	// keyPreviousResponseID identifies the prior response in a continuation request.
+	keyPreviousResponseID = "previous_response_id"
+	// keyText identifies a text format hint in request payloads.
+	keyText = "text"
+	// keyFormat indicates the desired format for a text hint.
+	keyFormat = "format"
+	// keyVerbosity specifies the verbosity level for a text hint.
+	keyVerbosity = "verbosity"
+
 	jsonFieldID                   = "id"
 	jsonFieldStatus               = "status"
 	jsonFieldOutputText           = "output_text"

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -267,18 +267,17 @@ func startSynthesisContinuation(openAIKey string, previousResponseID string, mod
 	}
 
 	payload := map[string]any{
-		"model":                modelIdentifier,
-		"previous_response_id": previousResponseID,
-		"tool_choice":          "none", // forbid more tool calls; force synthesis
-		"input":                instruction,
-		"max_output_tokens":    outTokens,
-		"reasoning": map[string]any{
+		keyModel:              modelIdentifier,
+		keyPreviousResponseID: previousResponseID,
+		keyToolChoice:         "none",
+		keyInput:              instruction,
+		keyMaxOutputTokens:    outTokens,
+		keyReasoning: map[string]any{
 			"effort": "minimal",
 		},
-		// (Optional) You can also include a text format hint; harmless if ignored by the API.
-		"text": map[string]any{
-			"format":    map[string]any{"type": "text"},
-			"verbosity": "low",
+		keyText: map[string]any{
+			keyFormat:    map[string]any{keyType: "text"},
+			keyVerbosity: "low",
 		},
 	}
 	payloadBytes, _ := json.Marshal(payload)


### PR DESCRIPTION
## Summary
- add key constants for previous response, text hints, format, and verbosity
- use constants in `startSynthesisContinuation` payload

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbe03da3408327821eaf42e1f49c7c