### PR TITLE
feat: apply tunables as configuration method

### DIFF
--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -52,3 +52,19 @@ var requestTimeout = 30 * time.Second
 
 // ErrUpstreamIncomplete indicates that the upstream provider returned an incomplete response before the poll deadline.
 var ErrUpstreamIncomplete = errors.New(errorUpstreamIncomplete)
+
+// ApplyTunables ensures tunable configuration values have sensible defaults and updates package-level parameters.
+func (configuration *Configuration) ApplyTunables() {
+	if configuration.RequestTimeoutSeconds <= 0 {
+		configuration.RequestTimeoutSeconds = DefaultRequestTimeoutSeconds
+	}
+	if configuration.UpstreamPollTimeoutSeconds <= 0 {
+		configuration.UpstreamPollTimeoutSeconds = DefaultUpstreamPollTimeoutSeconds
+	}
+	if configuration.MaxOutputTokens <= 0 {
+		configuration.MaxOutputTokens = DefaultMaxOutputTokens
+	}
+	requestTimeout = time.Duration(configuration.RequestTimeoutSeconds) * time.Second
+	SetUpstreamPollTimeout(time.Duration(configuration.UpstreamPollTimeoutSeconds) * time.Second)
+	maxOutputTokens = configuration.MaxOutputTokens
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -27,29 +27,13 @@ type requestTask struct {
 	reply            chan result
 }
 
-// normalizeAndApplyTunables ensures configuration tunables have sensible defaults and updates package-level variables.
-func normalizeAndApplyTunables(configuration *Configuration) {
-	if configuration.RequestTimeoutSeconds <= 0 {
-		configuration.RequestTimeoutSeconds = DefaultRequestTimeoutSeconds
-	}
-	if configuration.UpstreamPollTimeoutSeconds <= 0 {
-		configuration.UpstreamPollTimeoutSeconds = DefaultUpstreamPollTimeoutSeconds
-	}
-	if configuration.MaxOutputTokens <= 0 {
-		configuration.MaxOutputTokens = DefaultMaxOutputTokens
-	}
-	requestTimeout = time.Duration(configuration.RequestTimeoutSeconds) * time.Second
-	upstreamPollTimeout = time.Duration(configuration.UpstreamPollTimeoutSeconds) * time.Second
-	maxOutputTokens = configuration.MaxOutputTokens
-}
-
 // BuildRouter constructs the HTTP router used by the proxy. configuration supplies queue sizes, worker counts, timeout values, API credentials and other settings. structuredLogger records structured log messages during routing.
 func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogger) (*gin.Engine, error) {
 	if validationError := validateConfig(configuration); validationError != nil {
 		return nil, validationError
 	}
 
-	normalizeAndApplyTunables(&configuration)
+	configuration.ApplyTunables()
 
 	validator, validatorError := newModelValidator(configuration.OpenAIKey, structuredLogger)
 	if validatorError != nil {


### PR DESCRIPTION
## Summary
- move tunable normalization into `Configuration.ApplyTunables`
- use `ApplyTunables` when building the router

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbe057e79c83278e4c9f8a48527c07