### PR TITLE
refactor: describe root command constants

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -63,6 +63,21 @@ const (
 
 var config proxy.Configuration
 
+const (
+	// rootCmdShort provides a brief description of the root command.
+	// Additional commands should define their short description using a constant following this pattern.
+	rootCmdShort = "Tiny HTTP proxy for ChatGPT"
+
+	// rootCmdLong provides a detailed description of the root command.
+	// Additional commands should define their long description using a constant following this pattern.
+	rootCmdLong = "Accepts GET /?prompt=…&key=SECRET and forwards to OpenAI."
+
+	// rootCmdExample demonstrates how to use the root command.
+	// Additional commands should define their usage examples using a constant following this pattern.
+	rootCmdExample = `llm-proxy --service_secret=mysecret --openai_api_key=sk-xxxxx --log_level=debug
+SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy`
+)
+
 // Execute runs the command-line interface.
 func Execute() {
 	rootCmd.SilenceUsage = false
@@ -73,11 +88,10 @@ func Execute() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "llm-proxy",
-	Short: "Tiny HTTP proxy for ChatGPT",
-	Long:  "Accepts GET /?prompt=…&key=SECRET and forwards to OpenAI.",
-	Example: `llm-proxy --service_secret=mysecret --openai_api_key=sk-xxxxx --log_level=debug
-SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy`,
+	Use:     "llm-proxy",
+	Short:   rootCmdShort,
+	Long:    rootCmdLong,
+	Example: rootCmdExample,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !cmd.Flags().Changed(flagServiceSecret) {
 			config.ServiceSecret = strings.TrimSpace(strings.Trim(viper.GetString(keyServiceSecret), quoteCharacters))


### PR DESCRIPTION
## Summary
- declare constants for root command descriptions
- reference the constants when building the command

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbe06031f48327a953b61229c1efb5