### PR TITLE
refactor: use constants for synthesis continuation

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -50,6 +50,10 @@ const (
 	errorQueueFull = "request queue full"
 
 	toolTypeWebSearch = "web_search"
+	// toolChoiceNone instructs the upstream model not to invoke any tools.
+	toolChoiceNone = "none"
+	// reasoningEffortMinimal denotes a minimal reasoning effort level.
+	reasoningEffortMinimal = "minimal"
 	// reasoningEffortMedium denotes a medium reasoning effort level.
 	reasoningEffortMedium = "medium"
 
@@ -80,6 +84,21 @@ const (
 	keyToolChoice      = "tool_choice"
 	keyReasoning       = "reasoning"
 	keyAuto            = "auto"
+	// keyEffort identifies the reasoning effort field in request payloads.
+	keyEffort = "effort"
+
+	// keyPreviousResponseID identifies the prior response in a continuation request.
+	keyPreviousResponseID = "previous_response_id"
+	// keyText identifies a text format hint in request payloads.
+	keyText = "text"
+	// keyFormat indicates the desired format for a text hint.
+	keyFormat = "format"
+	// keyVerbosity specifies the verbosity level for a text hint.
+	keyVerbosity = "verbosity"
+	// typeText identifies plain text formatting.
+	typeText = "text"
+	// verbosityLow specifies a low verbosity setting.
+	verbosityLow = "low"
 
 	jsonFieldID                   = "id"
 	jsonFieldStatus               = "status"

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -267,18 +267,17 @@ func startSynthesisContinuation(openAIKey string, previousResponseID string, mod
 	}
 
 	payload := map[string]any{
-		"model":                modelIdentifier,
-		"previous_response_id": previousResponseID,
-		"tool_choice":          "none", // forbid more tool calls; force synthesis
-		"input":                instruction,
-		"max_output_tokens":    outTokens,
-		"reasoning": map[string]any{
-			"effort": "minimal",
+		keyModel:              modelIdentifier,
+		keyPreviousResponseID: previousResponseID,
+		keyToolChoice:         toolChoiceNone,
+		keyInput:              instruction,
+		keyMaxOutputTokens:    outTokens,
+		keyReasoning: map[string]any{
+			keyEffort: reasoningEffortMinimal,
 		},
-		// (Optional) You can also include a text format hint; harmless if ignored by the API.
-		"text": map[string]any{
-			"format":    map[string]any{"type": "text"},
-			"verbosity": "low",
+		keyText: map[string]any{
+			keyFormat:    map[string]any{keyType: typeText},
+			keyVerbosity: verbosityLow,
 		},
 	}
 	payloadBytes, _ := json.Marshal(payload)


### PR DESCRIPTION
## Summary
- add request constants for tool selection, reasoning effort, and text formatting
- build continuation payload with key constants instead of string literals

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbe03da3408327821eaf42e1f49c7c