### PR TITLE
propagate marshal and build errors

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -34,7 +34,6 @@ const (
 	// errorMissingClientKey indicates that the key query parameter is missing.
 	errorMissingClientKey   = "unknown client key"
 	errorRequestTimedOut    = "request timed out"
-	errorRequestBuild       = "request build error"
 	errorOpenAIRequest      = "OpenAI request error"
 	errorOpenAIAPI          = "OpenAI API error"
 	errorOpenAIAPINoText    = "OpenAI API error (no text)"

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -81,7 +81,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 	payloadBytes, marshalError := json.Marshal(payload)
 	if marshalError != nil {
 		structuredLogger.Errorw(logEventMarshalRequestPayload, constants.LogFieldError, marshalError)
-		return constants.EmptyString, errors.New(errorRequestBuild)
+		return constants.EmptyString, marshalError
 	}
 
 	requestContext, cancelRequest := context.WithTimeout(context.Background(), requestTimeout)
@@ -89,7 +89,7 @@ func openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, 
 	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodPost, DefaultEndpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
 	if buildError != nil {
 		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
-		return constants.EmptyString, errors.New(errorRequestBuild)
+		return constants.EmptyString, buildError
 	}
 
 	statusCode, responseBytes, latencyMillis, requestError := performResponsesRequest(httpRequest, structuredLogger, logEventOpenAIRequestError)


### PR DESCRIPTION
## Summary
- return JSON marshal errors instead of masking them
- surface HTTP request build errors to callers
- drop unused error constant

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbefc5c6188327b4ee80f1341bcb1a