### PR TITLE
refactor: use constants for response part types

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -64,6 +64,12 @@ const (
 	// responseTypeWebSearchCall identifies a web search tool call in the output array.
 	responseTypeWebSearchCall = "web_search_call"
 
+	// outputPartType identifies an output_text part in a content array.
+	outputPartType = "output_text"
+
+	// textPartType identifies a plain text part in a content array.
+	textPartType = "text"
+
 	// fallbackFinalAnswerFormat formats a message when the model does not provide a final answer.
 	fallbackFinalAnswerFormat = "Model did not provide a final answer. Last web search: \"%s\""
 

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -390,7 +390,7 @@ type searchAction struct {
 func joinParts(parts []contentPart) string {
 	var builder strings.Builder
 	for _, part := range parts {
-		if part.Type == "output_text" || part.Type == "text" {
+		if part.Type == outputPartType || part.Type == textPartType {
 			text := strings.TrimSpace(part.Text)
 			if text != constants.EmptyString {
 				if builder.Len() > 0 {


### PR DESCRIPTION
## Summary
- define constants for response part types
- reuse constants in joinParts

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbefd167388327815124edd93b03ff