### PR TITLE
Refactor missing key integration test to table-driven cases

### DIFF
--- a/tests/integration/missing_key_test.go
+++ b/tests/integration/missing_key_test.go
@@ -10,28 +10,61 @@ import (
 const (
 	// missingKeyErrorBody is the expected response when the key query parameter is absent.
 	missingKeyErrorBody = "unknown client key"
+	// testCaseWithoutKeyName identifies the scenario lacking the key query parameter.
+	testCaseWithoutKeyName = "without_key_query_parameter"
+	// testCaseWithKeyName identifies the scenario including the key query parameter.
+	testCaseWithKeyName = "with_key_query_parameter"
 )
 
-// TestMissingClientKeyReturnsForbidden verifies that a request without a key is rejected.
-func TestMissingClientKeyReturnsForbidden(testingInstance *testing.T) {
-	openAIServer := newOpenAIServer(testingInstance, integrationOKBody, nil)
-	testingInstance.Cleanup(openAIServer.Close)
-	applicationServer := newIntegrationServer(testingInstance, openAIServer)
-	requestURL, _ := url.Parse(applicationServer.URL)
-	queryValues := requestURL.Query()
-	queryValues.Set(promptQueryParameter, promptValue)
-	requestURL.RawQuery = queryValues.Encode()
-	httpResponse, requestError := http.Get(requestURL.String())
-	if requestError != nil {
-		testingInstance.Fatalf("request error: %v", requestError)
+// missingKeyTestCase defines the inputs and expectations for key parameter handling scenarios.
+type missingKeyTestCase struct {
+	name           string
+	includeKey     bool
+	expectedStatus int
+	expectedBody   string
+}
+
+// TestClientKeyHandling verifies responses for requests with and without the key query parameter.
+func TestClientKeyHandling(testingInstance *testing.T) {
+	testCases := []missingKeyTestCase{
+		{
+			name:           testCaseWithoutKeyName,
+			includeKey:     false,
+			expectedStatus: http.StatusForbidden,
+			expectedBody:   missingKeyErrorBody,
+		},
+		{
+			name:           testCaseWithKeyName,
+			includeKey:     true,
+			expectedStatus: http.StatusOK,
+			expectedBody:   integrationOKBody,
+		},
 	}
-	defer httpResponse.Body.Close()
-	if httpResponse.StatusCode != http.StatusForbidden {
-		responseBody, _ := io.ReadAll(httpResponse.Body)
-		testingInstance.Fatalf("status=%d body=%s", httpResponse.StatusCode, string(responseBody))
-	}
-	responseBytes, _ := io.ReadAll(httpResponse.Body)
-	if string(responseBytes) != missingKeyErrorBody {
-		testingInstance.Fatalf("body=%q want=%q", string(responseBytes), missingKeyErrorBody)
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			openAIServer := newOpenAIServer(subTest, integrationOKBody, nil)
+			subTest.Cleanup(openAIServer.Close)
+			applicationServer := newIntegrationServer(subTest, openAIServer)
+			requestURL, _ := url.Parse(applicationServer.URL)
+			queryValues := requestURL.Query()
+			queryValues.Set(promptQueryParameter, promptValue)
+			if testCase.includeKey {
+				queryValues.Set(keyQueryParameter, integrationServiceSecret)
+			}
+			requestURL.RawQuery = queryValues.Encode()
+			httpResponse, requestError := http.Get(requestURL.String())
+			if requestError != nil {
+				subTest.Fatalf(requestErrorFormat, requestError)
+			}
+			defer httpResponse.Body.Close()
+			if httpResponse.StatusCode != testCase.expectedStatus {
+				responseBody, _ := io.ReadAll(httpResponse.Body)
+				subTest.Fatalf(unexpectedStatusFormat, httpResponse.StatusCode, string(responseBody))
+			}
+			responseBytes, _ := io.ReadAll(httpResponse.Body)
+			if string(responseBytes) != testCase.expectedBody {
+				subTest.Fatalf(bodyMismatchFormat, string(responseBytes), testCase.expectedBody)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- expand missing key integration test to table-driven scenarios for requests with and without key parameter
- assert expected HTTP status and body for each case

## Testing
- `go test ./tests/integration`


------
https://chatgpt.com/codex/tasks/task_e_68bbf56fbd108327b1fb3f997d97f25a