### PR TITLE
doc: describe request task and result types

### DIFF
--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -14,11 +14,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// result holds the outcome returned by a worker, including the text response
+// and any error encountered during the OpenAI request.
 type result struct {
 	text         string
 	requestError error
 }
 
+// requestTask carries all details needed to process a user request in the
+// worker queue.
 type requestTask struct {
 	prompt           string
 	systemPrompt     string


### PR DESCRIPTION
## Summary
- document result type
- document requestTask type

## Testing
- `go vet ./internal/proxy`


------
https://chatgpt.com/codex/tasks/task_e_68bbf57fca4c8327aa0bf3a2e963d1b0