### PR TITLE
chore: remove unused allowed request fields constant

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -96,11 +96,10 @@ const (
 	textFormatType        = "text"
 	verbosityLow          = "low"
 
-	jsonFieldID                   = "id"
-	jsonFieldStatus               = "status"
-	jsonFieldOutputText           = "output_text"
-	jsonFieldResponse             = "response"
-	jsonFieldAllowedRequestFields = "allowed_request_fields"
+	jsonFieldID         = "id"
+	jsonFieldStatus     = "status"
+	jsonFieldOutputText = "output_text"
+	jsonFieldResponse   = "response"
 
 	statusCompleted = "completed"
 	statusSucceeded = "succeeded"


### PR DESCRIPTION
## Summary
- remove jsonFieldAllowedRequestFields constant from proxy constants

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc769b88ac83278329d21c77d3457d