### PR TITLE
Refactor model capability tests for clarity

### DIFF
--- a/internal/proxy/model_capabilities_test.go
+++ b/internal/proxy/model_capabilities_test.go
@@ -1,11 +1,20 @@
 package proxy_test
 
 import (
-	"encoding/json"
-	"strings"
-	"testing"
+        "encoding/json"
+        "strings"
+        "testing"
 
-	"github.com/temirov/llm-proxy/internal/proxy"
+        "github.com/temirov/llm-proxy/internal/proxy"
+)
+
+const (
+        marshalPayloadErrorFormat           = "Failed to marshal payload: %v"
+        temperatureFieldPresenceMismatch    = "Mismatch in 'temperature' field presence. Got: %s, Want presence: %v"
+        toolsFieldPresenceMismatch          = "Mismatch in 'tools' field presence. Got: %s, Want presence: %v"
+        toolChoiceFieldPresenceMismatch     = "Mismatch in 'tool_choice' field presence. Got: %s, Want presence: %v"
+        modelFieldsMismatchFormat           = "model %s fields=%v want=%v"
+        promptValue                         = "hello"
 )
 
 // TestResolveModelPayloadSchema verifies that payload schemas are returned for every model.
@@ -21,23 +30,21 @@ func TestResolveModelPayloadSchema(testFramework *testing.T) {
 		{proxy.ModelNameGPT5, []string{"model", "input", "max_output_tokens", "tools", "tool_choice", "reasoning"}},
 	}
 	for _, testCase := range testCases {
-		payloadSchema := proxy.ResolveModelPayloadSchema(testCase.modelIdentifier)
-		if !equalSlices(payloadSchema.AllowedRequestFields, testCase.expectFields) {
-			testFramework.Fatalf("model %s fields=%v want=%v", testCase.modelIdentifier, payloadSchema.AllowedRequestFields, testCase.expectFields)
-		}
-	}
+                payloadSchema := proxy.ResolveModelPayloadSchema(testCase.modelIdentifier)
+                if !equalSlices(payloadSchema.AllowedRequestFields, testCase.expectFields) {
+                        testFramework.Fatalf(modelFieldsMismatchFormat, testCase.modelIdentifier, payloadSchema.AllowedRequestFields, testCase.expectFields)
+                }
+        }
 }
 
 // TestBuildRequestPayload verifies the correct payload structure is built for each model.
-func TestBuildRequestPayload(t *testing.T) {
-	const prompt = "hello"
-
-	testCases := []struct {
-		name              string
-		modelIdentifier   string
-		webSearchEnabled  bool
-		expectTemperature bool
-		expectTools       bool
+func TestBuildRequestPayload(testFramework *testing.T) {
+        testCases := []struct {
+                name              string
+                modelIdentifier   string
+                webSearchEnabled  bool
+                expectTemperature bool
+                expectTools       bool
 	}{
 		{
 			name:              "GPT-5 with web search",
@@ -76,28 +83,29 @@ func TestBuildRequestPayload(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			payload := proxy.BuildRequestPayload(testCase.modelIdentifier, prompt, testCase.webSearchEnabled)
-			payloadBytes, err := json.Marshal(payload)
-			if err != nil {
-				t.Fatalf("Failed to marshal payload: %v", err)
-			}
-			payloadJSON := string(payloadBytes)
+        for _, testCase := range testCases {
+                testFramework.Run(testCase.name, func(subTestFramework *testing.T) {
+                        payload := proxy.BuildRequestPayload(testCase.modelIdentifier, promptValue, testCase.webSearchEnabled)
+                        payloadBytes, marshalError := json.Marshal(payload)
+                        if marshalError != nil {
+                                subTestFramework.Fatalf(marshalPayloadErrorFormat, marshalError)
+                        }
+                        payloadJSON := string(payloadBytes)
 
-			if testCase.expectTemperature != strings.Contains(payloadJSON, `"temperature"`) {
-				t.Errorf("Mismatch in 'temperature' field presence. Got: %s, Want presence: %v", payloadJSON, testCase.expectTemperature)
-			}
-			if testCase.expectTools != strings.Contains(payloadJSON, `"tools"`) {
-				t.Errorf("Mismatch in 'tools' field presence. Got: %s, Want presence: %v", payloadJSON, testCase.expectTools)
-			}
-			if testCase.expectTools != strings.Contains(payloadJSON, `"tool_choice"`) {
-				t.Errorf("Mismatch in 'tool_choice' field presence. Got: %s, Want presence: %v", payloadJSON, testCase.expectTools)
-			}
-		})
-	}
+                        if testCase.expectTemperature != strings.Contains(payloadJSON, `"temperature"`) {
+                                subTestFramework.Errorf(temperatureFieldPresenceMismatch, payloadJSON, testCase.expectTemperature)
+                        }
+                        if testCase.expectTools != strings.Contains(payloadJSON, `"tools"`) {
+                                subTestFramework.Errorf(toolsFieldPresenceMismatch, payloadJSON, testCase.expectTools)
+                        }
+                        if testCase.expectTools != strings.Contains(payloadJSON, `"tool_choice"`) {
+                                subTestFramework.Errorf(toolChoiceFieldPresenceMismatch, payloadJSON, testCase.expectTools)
+                        }
+                })
+        }
 }
 
+// equalSlices reports whether two string slices contain identical elements in order.
 func equalSlices(first []string, second []string) bool {
 	if len(first) != len(second) {
 		return false


### PR DESCRIPTION
## Summary
- replace short test variables with descriptive identifiers
- add constants for shared strings in model capabilities tests
- document helper functions and subtests for clarity

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc76abcc3c8327b59f8bd8433fcb32