### PR TITLE
refactor: simplify model validator

### DIFF
--- a/internal/proxy/model_validator.go
+++ b/internal/proxy/model_validator.go
@@ -3,8 +3,6 @@ package proxy
 import (
 	"errors"
 	"fmt"
-
-	"go.uber.org/zap"
 )
 
 // errUnknownModelFormat specifies the format string for wrapping an unknown model error.
@@ -16,10 +14,8 @@ var ErrUnknownModel = errors.New(errorUnknownModel)
 // modelValidator validates model identifiers using the static payload schema table.
 type modelValidator struct{}
 
-// newModelValidator creates a modelValidator. The parameters are retained for signature compatibility.
-func newModelValidator(openAIKey string, structuredLogger *zap.SugaredLogger) (*modelValidator, error) {
-	_ = openAIKey
-	_ = structuredLogger
+// newModelValidator creates a modelValidator.
+func newModelValidator() (*modelValidator, error) {
 	return &modelValidator{}, nil
 }
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -39,7 +39,7 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 
 	configuration.ApplyTunables()
 
-	validator, validatorError := newModelValidator(configuration.OpenAIKey, structuredLogger)
+	validator, validatorError := newModelValidator()
 	if validatorError != nil {
 		return nil, validatorError
 	}


### PR DESCRIPTION
## Summary
- remove unused parameters from model validator
- update router to use streamlined model validator

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc76a58a848327b353ddd7e5d3acfe