### PR TITLE
Add constant for OpenAI poll response logging

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -132,7 +132,9 @@ const (
 	logEventOpenAIModelsListError        = "OpenAI models list error"
 	logEventOpenAIModelCapabilitiesError = "OpenAI model capabilities error"
 	logEventOpenAIPollError              = "OpenAI poll error"
-	logEventOpenAIContinueError          = "OpenAI continue error"
+	// logEventOpenAIPollResponseBody records the body returned when polling OpenAI for a response.
+	logEventOpenAIPollResponseBody = "OpenAI poll response body"
+	logEventOpenAIContinueError    = "OpenAI continue error"
 	// logEventOpenAIInitialResponseBody records the body of the initial response from OpenAI.
 	logEventOpenAIInitialResponseBody = "OpenAI initial response body"
 	// logEventMissingFinalMessage indicates that the response completed without a final assistant message.

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -352,7 +352,7 @@ func fetchResponseByID(deadline time.Time, openAIKey string, responseIdentifier 
 	}
 
 	structuredLogger.Debugw(
-		"OpenAI poll response body",
+		logEventOpenAIPollResponseBody,
 		logFieldID, responseIdentifier,
 		logFieldResponseBody, string(responseBytes),
 	)


### PR DESCRIPTION
## Summary
- add `logEventOpenAIPollResponseBody` constant for logging OpenAI poll responses
- use the new constant when logging poll responses in the OpenAI client

## Testing
- `go test ./internal/proxy`


------
https://chatgpt.com/codex/tasks/task_e_68bc8196dbac8327aeee1ec50d254c9f