### PR TITLE
Handle environment variable loading errors

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,12 +2,23 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/subosito/gotenv"
+)
+
+const (
+	// messageEnvironmentLoadFailed is printed when environment variables fail to load.
+	messageEnvironmentLoadFailed = "failed to load environment variables: %v\n"
 )
 
 // main is the entry point for llm-proxy.
 func main() {
-	_ = gotenv.Load()
+	environmentLoadError := gotenv.Load()
+	if environmentLoadError != nil {
+		fmt.Fprintf(os.Stderr, messageEnvironmentLoadFailed, environmentLoadError)
+	}
 
 	Execute()
 }


### PR DESCRIPTION
## Summary
- log `.env` loading errors to stderr

## Testing
- `go fmt cmd/cli/main.go`
- `go test ./...`
- `go test ./tests/...`


------
https://chatgpt.com/codex/tasks/task_e_68bc819cc3e48327abe125fcac4b5b21