### PR TITLE
Use constant for format query check

### DIFF
--- a/internal/proxy/formats.go
+++ b/internal/proxy/formats.go
@@ -13,7 +13,7 @@ import (
 
 // preferredMime determines the response MIME type using the format query parameter or the Accept header.
 func preferredMime(ginContext *gin.Context) string {
-	if explicitFormat := ginContext.Query(queryParameterFormat); explicitFormat != "" {
+	if explicitFormat := ginContext.Query(queryParameterFormat); explicitFormat != constants.EmptyString {
 		return strings.ToLower(strings.TrimSpace(explicitFormat))
 	}
 	return strings.ToLower(strings.TrimSpace(ginContext.GetHeader(headerAccept)))


### PR DESCRIPTION
## Summary
- use `constants.EmptyString` for explicit format comparison

## Testing
- `go fmt internal/proxy/formats.go`
- `go test ./internal/proxy`


------
https://chatgpt.com/codex/tasks/task_e_68bc81a8ad388327a28f3a067d3f43d5