### PR TITLE
refactor: rename test instances in router tests

### DIFF
--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -16,38 +16,51 @@ type chatHandlerScenario struct {
 	expectedStatusCode int
 }
 
+const (
+	// finalResponse is the JSON payload returned by the session mock server.
+	finalResponse = `{"status":"completed", "output":[{"type":"message", "role":"assistant", "content":[{"type":"text","text":"ok"}]}]}`
+	// requestPathPattern formats the request path for the chat handler tests.
+	requestPathPattern = "/?prompt=%s&model=%s&key=%s"
+	// scenarioUnknownModelBadRequest describes the behavior when an unknown model is requested.
+	scenarioUnknownModelBadRequest = "unknown model returns bad request"
+	// scenarioKnownModelOK describes the behavior when a known model is requested.
+	scenarioKnownModelOK = "known model returns ok"
+	// unknownModelIdentifier is a model name not recognized by the proxy.
+	unknownModelIdentifier = "unknown-model"
+	// statusFormat formats the mismatch status code error message.
+	statusFormat = "status=%d want=%d"
+)
+
 // TestChatHandlerValidatesModel verifies model validation and a successful request flow.
-func TestChatHandlerValidatesModel(t *testing.T) {
-	// Corrected to use "text" to match the parser's expectation.
-	const finalResponse = `{"status":"completed", "output":[{"type":"message", "role":"assistant", "content":[{"type":"text","text":"ok"}]}]}`
+func TestChatHandlerValidatesModel(testingInstance *testing.T) {
 
 	testScenarios := []chatHandlerScenario{
 		{
-			scenarioName:       "unknown model returns bad request",
-			modelIdentifier:    "unknown-model",
+			scenarioName:       scenarioUnknownModelBadRequest,
+			modelIdentifier:    unknownModelIdentifier,
 			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
-			scenarioName:       "known model returns ok",
+			scenarioName:       scenarioKnownModelOK,
 			modelIdentifier:    proxy.ModelNameGPT4o,
 			expectedStatusCode: http.StatusOK,
 		},
 	}
 
 	for _, testScenario := range testScenarios {
-		t.Run(testScenario.scenarioName, func(t *testing.T) {
+		testingInstance.Run(testScenario.scenarioName, func(subTestInstance *testing.T) {
 			mockServer := NewSessionMockServer(finalResponse)
 			defer mockServer.Close()
-			router := NewTestRouter(t, mockServer.URL)
+			router := NewTestRouter(subTestInstance, mockServer.URL)
 
-			requestPath := fmt.Sprintf("/?prompt=%s&model=%s&key=%s", TestPrompt, testScenario.modelIdentifier, TestSecret)
+			requestPath := fmt.Sprintf(requestPathPattern, TestPrompt, testScenario.modelIdentifier, TestSecret)
 			request := httptest.NewRequest(http.MethodGet, requestPath, nil)
 			responseRecorder := httptest.NewRecorder()
 
 			router.ServeHTTP(responseRecorder, request)
 
 			if responseRecorder.Code != testScenario.expectedStatusCode {
-				t.Fatalf("status=%d want=%d", responseRecorder.Code, testScenario.expectedStatusCode)
+				subTestInstance.Fatalf(statusFormat, responseRecorder.Code, testScenario.expectedStatusCode)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- use descriptive testing instance names in router tests
- centralize string constants for mock responses and paths

## Testing
- `go test ./internal/proxy`

------
https://chatgpt.com/codex/tasks/task_e_68bc818d6ff0832792c8e6f42be0bd84