### PR TITLE
refactor: encapsulate endpoint configuration

### DIFF
--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -36,6 +36,8 @@ type Configuration struct {
 	RequestTimeoutSeconds      int
 	UpstreamPollTimeoutSeconds int
 	MaxOutputTokens            int
+	// Endpoints defines the URLs for upstream API requests.
+	Endpoints *Endpoints
 }
 
 // validateConfig confirms required settings are present.

--- a/internal/proxy/endpoints.go
+++ b/internal/proxy/endpoints.go
@@ -1,53 +1,67 @@
 package proxy
 
+import "sync"
+
 const (
 	defaultResponsesURL = "https://api.openai.com/v1/responses"
 	defaultModelsURL    = "https://api.openai.com/v1/models"
 )
 
 // Endpoints holds the URLs for the OpenAI responses and models endpoints.
+// Access to the URLs is guarded by a read–write mutex to ensure safe
+// concurrent reads and writes.
 type Endpoints struct {
-	ResponsesURL string
-	ModelsURL    string
+	responsesURL string
+	modelsURL    string
+	accessMutex  sync.RWMutex
 }
 
 // NewEndpoints returns an Endpoints instance initialized with default URLs.
 func NewEndpoints() *Endpoints {
 	return &Endpoints{
-		ResponsesURL: defaultResponsesURL,
-		ModelsURL:    defaultModelsURL,
+		responsesURL: defaultResponsesURL,
+		modelsURL:    defaultModelsURL,
 	}
 }
 
-// DefaultEndpoints provides the endpoint URLs used by the proxy.
-var DefaultEndpoints = NewEndpoints()
-
 // GetResponsesURL returns the URL used for the OpenAI responses endpoint.
 func (endpointConfiguration *Endpoints) GetResponsesURL() string {
-	return endpointConfiguration.ResponsesURL
+	endpointConfiguration.accessMutex.RLock()
+	defer endpointConfiguration.accessMutex.RUnlock()
+	return endpointConfiguration.responsesURL
 }
 
 // SetResponsesURL sets the URL for the OpenAI responses endpoint.
 func (endpointConfiguration *Endpoints) SetResponsesURL(newURL string) {
-	endpointConfiguration.ResponsesURL = newURL
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.responsesURL = newURL
 }
 
 // ResetResponsesURL resets the responses endpoint to the default.
 func (endpointConfiguration *Endpoints) ResetResponsesURL() {
-	endpointConfiguration.ResponsesURL = defaultResponsesURL
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.responsesURL = defaultResponsesURL
 }
 
 // GetModelsURL returns the URL used for the OpenAI models endpoint.
 func (endpointConfiguration *Endpoints) GetModelsURL() string {
-	return endpointConfiguration.ModelsURL
+	endpointConfiguration.accessMutex.RLock()
+	defer endpointConfiguration.accessMutex.RUnlock()
+	return endpointConfiguration.modelsURL
 }
 
 // SetModelsURL sets the URL for the OpenAI models endpoint.
 func (endpointConfiguration *Endpoints) SetModelsURL(newURL string) {
-	endpointConfiguration.ModelsURL = newURL
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.modelsURL = newURL
 }
 
 // ResetModelsURL resets the models endpoint to the default.
 func (endpointConfiguration *Endpoints) ResetModelsURL() {
-	endpointConfiguration.ModelsURL = defaultModelsURL
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.modelsURL = defaultModelsURL
 }

--- a/internal/proxy/response_shapes_e2e_test.go
+++ b/internal/proxy/response_shapes_e2e_test.go
@@ -36,8 +36,10 @@ func withStubbedProxy(t *testing.T, initialResponse, finalResponse string) http.
 	}))
 	t.Cleanup(server.Close)
 
-	proxy.DefaultEndpoints.SetResponsesURL(server.URL)
-	t.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
+	endpointConfiguration := proxy.NewEndpoints()
+	endpointConfiguration.SetResponsesURL(server.URL)
+	proxy.HTTPClient = server.Client()
+	t.Cleanup(func() { proxy.HTTPClient = http.DefaultClient })
 
 	logger, _ := zap.NewDevelopment()
 	t.Cleanup(func() { _ = logger.Sync() })
@@ -49,6 +51,7 @@ func withStubbedProxy(t *testing.T, initialResponse, finalResponse string) http.
 		QueueSize:                  1,
 		RequestTimeoutSeconds:      TestTimeout,
 		UpstreamPollTimeoutSeconds: TestTimeout,
+		Endpoints:                  endpointConfiguration,
 	}, logger.Sugar())
 	if err != nil {
 		t.Fatalf("BuildRouter error: %v", err)

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -38,6 +38,9 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	}
 
 	configuration.ApplyTunables()
+	if configuration.Endpoints == nil {
+		configuration.Endpoints = NewEndpoints()
+	}
 
 	validator, validatorError := newModelValidator()
 	if validatorError != nil {
@@ -60,6 +63,7 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 		go func() {
 			for pending := range taskQueue {
 				text, requestError := openAIRequest(
+					configuration.Endpoints,
 					configuration.OpenAIKey,
 					pending.model,
 					pending.prompt,

--- a/internal/proxy/test_helpers_test.go
+++ b/internal/proxy/test_helpers_test.go
@@ -48,8 +48,8 @@ func NewSessionMockServer(finalResponseJSON string) *httptest.Server {
 // NewTestRouter creates a pre-configured router for integration tests.
 func NewTestRouter(t *testing.T, serverURL string) *gin.Engine {
 	t.Helper()
-	proxy.DefaultEndpoints.SetResponsesURL(serverURL)
-	t.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
+	endpointConfiguration := proxy.NewEndpoints()
+	endpointConfiguration.SetResponsesURL(serverURL)
 
 	logger, _ := zap.NewDevelopment()
 	t.Cleanup(func() { _ = logger.Sync() })
@@ -62,6 +62,7 @@ func NewTestRouter(t *testing.T, serverURL string) *gin.Engine {
 		QueueSize:                  1,
 		RequestTimeoutSeconds:      TestTimeout,
 		UpstreamPollTimeoutSeconds: TestTimeout,
+		Endpoints:                  endpointConfiguration,
 	}, logger.Sugar())
 	if err != nil {
 		t.Fatalf("BuildRouter error: %v", err)

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -69,9 +69,10 @@ func TestIntegration_OmitsDisallowedParameters(testingInstance *testing.T) {
 			}))
 			defer openAIServer.Close()
 
-			proxy.DefaultEndpoints.SetResponsesURL(openAIServer.URL + openAIResponsesPath)
+			endpointConfiguration := proxy.NewEndpoints()
+			endpointConfiguration.SetResponsesURL(openAIServer.URL + openAIResponsesPath)
 			proxy.HTTPClient = openAIServer.Client()
-			subTestInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
+			subTestInstance.Cleanup(func() { proxy.HTTPClient = http.DefaultClient })
 
 			logger, _ := zap.NewDevelopment()
 			defer logger.Sync()
@@ -82,6 +83,7 @@ func TestIntegration_OmitsDisallowedParameters(testingInstance *testing.T) {
 				LogLevel:      logLevel,
 				WorkerCount:   1,
 				QueueSize:     4,
+				Endpoints:     endpointConfiguration,
 			}, logger.Sugar())
 			if buildRouterError != nil {
 				subTestInstance.Fatalf("BuildRouter error: %v", buildRouterError)

--- a/tests/integration/integration1_test.go
+++ b/tests/integration/integration1_test.go
@@ -13,11 +13,11 @@ import (
 // newIntegrationServerWithTimeout builds the application server pointing at the stub OpenAI server with a configurable request timeout.
 func newIntegrationServerWithTimeout(testingInstance *testing.T, openAIServer *httptest.Server, requestTimeoutSeconds int) *httptest.Server {
 	testingInstance.Helper()
-	proxy.DefaultEndpoints.SetModelsURL(openAIServer.URL + integrationModelsPath)
-	proxy.DefaultEndpoints.SetResponsesURL(openAIServer.URL + integrationResponsesPath)
+	endpointConfiguration := proxy.NewEndpoints()
+	endpointConfiguration.SetModelsURL(openAIServer.URL + integrationModelsPath)
+	endpointConfiguration.SetResponsesURL(openAIServer.URL + integrationResponsesPath)
 	proxy.HTTPClient = openAIServer.Client()
-	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetModelsURL() })
-	testingInstance.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
+	testingInstance.Cleanup(func() { proxy.HTTPClient = http.DefaultClient })
 	logger, _ := zap.NewDevelopment()
 	testingInstance.Cleanup(func() { _ = logger.Sync() })
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
@@ -27,6 +27,7 @@ func newIntegrationServerWithTimeout(testingInstance *testing.T, openAIServer *h
 		WorkerCount:           1,
 		QueueSize:             4,
 		RequestTimeoutSeconds: requestTimeoutSeconds,
+		Endpoints:             endpointConfiguration,
 	}, logger.Sugar())
 	if buildRouterError != nil {
 		testingInstance.Fatalf(buildRouterErrorFormat, buildRouterError)

--- a/tests/integration/integration2_test.go
+++ b/tests/integration/integration2_test.go
@@ -31,13 +31,14 @@ func TestClientResponseDelivery(testingInstance *testing.T) {
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			client, captured := makeHTTPClient(subTest, testCase.webSearch)
-			configureProxy(subTest, client)
+			endpointConfiguration := configureProxy(subTest, client)
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 				ServiceSecret: serviceSecretValue,
 				OpenAIKey:     openAIKeyValue,
 				LogLevel:      logLevelDebug,
 				WorkerCount:   1,
 				QueueSize:     8,
+				Endpoints:     endpointConfiguration,
 			}, newLogger(subTest))
 			if buildRouterError != nil {
 				subTest.Fatalf(buildRouterFailedFormat, buildRouterError)
@@ -115,7 +116,8 @@ func TestIntegrationConfiguration(testingInstance *testing.T) {
 				return
 			}
 			client, _ := makeHTTPClient(subTest, false)
-			configureProxy(subTest, client)
+			endpointConfiguration := configureProxy(subTest, client)
+			testCase.config.Endpoints = endpointConfiguration
 			router, buildRouterError := proxy.BuildRouter(testCase.config, newLogger(subTest))
 			if buildRouterError != nil {
 				subTest.Fatalf(buildRouterFailedFormat, buildRouterError)

--- a/tests/integration/integration_models_test.go
+++ b/tests/integration/integration_models_test.go
@@ -22,13 +22,14 @@ func TestIntegrationModelSpecSuppression(testingInstance *testing.T) {
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			client, captured := makeHTTPClient(subTest, true)
-			configureProxy(subTest, client)
+			endpointConfiguration := configureProxy(subTest, client)
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 				ServiceSecret: serviceSecretValue,
 				OpenAIKey:     openAIKeyValue,
 				LogLevel:      logLevelDebug,
 				WorkerCount:   1,
 				QueueSize:     8,
+				Endpoints:     endpointConfiguration,
 			}, newLogger(subTest))
 			if buildRouterError != nil {
 				subTest.Fatalf(buildRouterFailedFormat, buildRouterError)
@@ -70,13 +71,14 @@ func TestIntegrationModelSpecSuppression(testingInstance *testing.T) {
 func TestIntegrationGPT5TemperatureSuppression(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 	client, captured := makeHTTPClient(testingInstance, true)
-	configureProxy(testingInstance, client)
+	endpointConfiguration := configureProxy(testingInstance, client)
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: serviceSecretValue,
 		OpenAIKey:     openAIKeyValue,
 		LogLevel:      logLevelDebug,
 		WorkerCount:   1,
 		QueueSize:     8,
+		Endpoints:     endpointConfiguration,
 	}, newLogger(testingInstance))
 	if buildRouterError != nil {
 		testingInstance.Fatalf(buildRouterFailedFormat, buildRouterError)

--- a/tests/integration/missing_prompt_test.go
+++ b/tests/integration/missing_prompt_test.go
@@ -17,8 +17,8 @@ const missingPromptErrorMessage = "missing prompt parameter"
 func TestRequestWithoutPromptReturnsMissingPromptError(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 	client, _ := makeHTTPClient(testingInstance, false)
-	configureProxy(testingInstance, client)
-	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8}, newLogger(testingInstance))
+	endpointConfiguration := configureProxy(testingInstance, client)
+	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, Endpoints: endpointConfiguration}, newLogger(testingInstance))
 	if buildError != nil {
 		testingInstance.Fatalf("BuildRouter failed: %v", buildError)
 	}


### PR DESCRIPTION
## Summary
- protect endpoint URLs behind a mutex-protected `Endpoints` type
- pass `Endpoints` through configuration and router to remove global state
- update tests to supply isolated endpoint configurations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68bc8342ba74832786ee7e260c64a8b2