### PR TITLE
refactor: introduce OpenAI client

### DIFF
--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -56,10 +56,11 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	}
 
 	taskQueue := make(chan requestTask, configuration.QueueSize)
+	openAIClient := NewOpenAIClient(HTTPClient, DefaultEndpoints, maxOutputTokens, UpstreamPollTimeout())
 	for workerIndex := 0; workerIndex < configuration.WorkerCount; workerIndex++ {
 		go func() {
 			for pending := range taskQueue {
-				text, requestError := openAIRequest(
+				text, requestError := openAIClient.openAIRequest(
 					configuration.OpenAIKey,
 					pending.model,
 					pending.prompt,


### PR DESCRIPTION
## Summary
- add `OpenAIClient` to manage endpoints, HTTP client, and tunables
- convert OpenAI request helpers to `OpenAIClient` methods
- update router to use `OpenAIClient`

## Testing
- `go test ./internal/proxy`


------
https://chatgpt.com/codex/tasks/task_e_68bc81ae8920832790d333dd22bae8b8