### PR TITLE
Handle environment load errors

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,12 +2,23 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/subosito/gotenv"
+)
+
+const (
+	// environmentLoadErrorMessage is printed when environment variables cannot be loaded.
+	environmentLoadErrorMessage = "failed to load environment variables: %v\n"
 )
 
 // main is the entry point for llm-proxy.
 func main() {
-	_ = gotenv.Load()
+	environmentLoadError := gotenv.Load()
+	if environmentLoadError != nil {
+		fmt.Fprintf(os.Stderr, environmentLoadErrorMessage, environmentLoadError)
+	}
 
 	Execute()
 }


### PR DESCRIPTION
## Summary
- log environment loading failures to stderr instead of silently ignoring them

## Testing
- `go fmt cmd/cli/main.go`
- `go test ./...` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9dde49e48327960cf426ac3f5cc5