### PR TITLE
Refactor proxy to eliminate global state and isolate endpoints

### DIFF
--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/temirov/llm-proxy/internal/apperrors"
 	"github.com/temirov/llm-proxy/internal/constants"
@@ -36,6 +35,7 @@ type Configuration struct {
 	RequestTimeoutSeconds      int
 	UpstreamPollTimeoutSeconds int
 	MaxOutputTokens            int
+	Endpoints                  *Endpoints
 }
 
 // validateConfig confirms required settings are present.
@@ -49,12 +49,10 @@ func validateConfig(config Configuration) error {
 	return nil
 }
 
-var requestTimeout = 30 * time.Second
-
 // ErrUpstreamIncomplete indicates that the upstream provider returned an incomplete response before the poll deadline.
 var ErrUpstreamIncomplete = errors.New(errorUpstreamIncomplete)
 
-// ApplyTunables ensures tunable configuration values have sensible defaults and updates package-level parameters.
+// ApplyTunables ensures tunable configuration values have sensible defaults.
 func (configuration *Configuration) ApplyTunables() {
 	if configuration.RequestTimeoutSeconds <= 0 {
 		configuration.RequestTimeoutSeconds = DefaultRequestTimeoutSeconds
@@ -65,7 +63,4 @@ func (configuration *Configuration) ApplyTunables() {
 	if configuration.MaxOutputTokens <= 0 {
 		configuration.MaxOutputTokens = DefaultMaxOutputTokens
 	}
-	requestTimeout = time.Duration(configuration.RequestTimeoutSeconds) * time.Second
-	SetUpstreamPollTimeout(time.Duration(configuration.UpstreamPollTimeoutSeconds) * time.Second)
-	maxOutputTokens = configuration.MaxOutputTokens
 }

--- a/internal/proxy/endpoints.go
+++ b/internal/proxy/endpoints.go
@@ -1,53 +1,65 @@
 package proxy
 
+import "sync"
+
 const (
 	defaultResponsesURL = "https://api.openai.com/v1/responses"
 	defaultModelsURL    = "https://api.openai.com/v1/models"
 )
 
-// Endpoints holds the URLs for the OpenAI responses and models endpoints.
+// Endpoints provides concurrency-safe access to OpenAI endpoint URLs.
 type Endpoints struct {
-	ResponsesURL string
-	ModelsURL    string
+	accessMutex  sync.RWMutex
+	responsesURL string
+	modelsURL    string
 }
 
-// NewEndpoints returns an Endpoints instance initialized with default URLs.
+// NewEndpoints creates an Endpoints instance initialized with default URLs.
 func NewEndpoints() *Endpoints {
 	return &Endpoints{
-		ResponsesURL: defaultResponsesURL,
-		ModelsURL:    defaultModelsURL,
+		responsesURL: defaultResponsesURL,
+		modelsURL:    defaultModelsURL,
 	}
 }
 
-// DefaultEndpoints provides the endpoint URLs used by the proxy.
-var DefaultEndpoints = NewEndpoints()
-
 // GetResponsesURL returns the URL used for the OpenAI responses endpoint.
 func (endpointConfiguration *Endpoints) GetResponsesURL() string {
-	return endpointConfiguration.ResponsesURL
+	endpointConfiguration.accessMutex.RLock()
+	defer endpointConfiguration.accessMutex.RUnlock()
+	return endpointConfiguration.responsesURL
 }
 
 // SetResponsesURL sets the URL for the OpenAI responses endpoint.
 func (endpointConfiguration *Endpoints) SetResponsesURL(newURL string) {
-	endpointConfiguration.ResponsesURL = newURL
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.responsesURL = newURL
 }
 
 // ResetResponsesURL resets the responses endpoint to the default.
 func (endpointConfiguration *Endpoints) ResetResponsesURL() {
-	endpointConfiguration.ResponsesURL = defaultResponsesURL
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.responsesURL = defaultResponsesURL
 }
 
 // GetModelsURL returns the URL used for the OpenAI models endpoint.
 func (endpointConfiguration *Endpoints) GetModelsURL() string {
-	return endpointConfiguration.ModelsURL
+	endpointConfiguration.accessMutex.RLock()
+	defer endpointConfiguration.accessMutex.RUnlock()
+	return endpointConfiguration.modelsURL
 }
 
 // SetModelsURL sets the URL for the OpenAI models endpoint.
 func (endpointConfiguration *Endpoints) SetModelsURL(newURL string) {
-	endpointConfiguration.ModelsURL = newURL
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.modelsURL = newURL
 }
 
 // ResetModelsURL resets the models endpoint to the default.
 func (endpointConfiguration *Endpoints) ResetModelsURL() {
-	endpointConfiguration.ModelsURL = defaultModelsURL
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.modelsURL = defaultModelsURL
 }

--- a/internal/proxy/endpoints_parallel_test.go
+++ b/internal/proxy/endpoints_parallel_test.go
@@ -1,0 +1,32 @@
+package proxy_test
+
+import (
+	"testing"
+
+	"github.com/temirov/llm-proxy/internal/proxy"
+)
+
+const (
+	firstResponsesURL  = "https://one.local/v1/responses"
+	secondResponsesURL = "https://two.local/v1/responses"
+)
+
+// TestEndpointsIsolation verifies that endpoint instances remain independent when used in parallel tests.
+func TestEndpointsIsolation(testingInstance *testing.T) {
+	testingInstance.Run("first", func(subTest *testing.T) {
+		subTest.Parallel()
+		endpoints := proxy.NewEndpoints()
+		endpoints.SetResponsesURL(firstResponsesURL)
+		if endpoints.GetResponsesURL() != firstResponsesURL {
+			subTest.Fatalf("responsesURL=%s want=%s", endpoints.GetResponsesURL(), firstResponsesURL)
+		}
+	})
+	testingInstance.Run("second", func(subTest *testing.T) {
+		subTest.Parallel()
+		endpoints := proxy.NewEndpoints()
+		endpoints.SetResponsesURL(secondResponsesURL)
+		if endpoints.GetResponsesURL() != secondResponsesURL {
+			subTest.Fatalf("responsesURL=%s want=%s", endpoints.GetResponsesURL(), secondResponsesURL)
+		}
+	})
+}

--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -54,11 +54,11 @@ type Tool struct {
 }
 
 // BuildRequestPayload selects the correct struct for the given model and returns it.
-func BuildRequestPayload(modelIdentifier string, combinedPrompt string, webSearchEnabled bool) any {
+func BuildRequestPayload(modelIdentifier string, combinedPrompt string, webSearchEnabled bool, maxTokens int) any {
 	base := requestPayloadBase{
 		Model:           modelIdentifier,
 		Input:           combinedPrompt,
-		MaxOutputTokens: maxOutputTokens,
+		MaxOutputTokens: maxTokens,
 	}
 
 	// Declaratively choose the payload structure based on the model.

--- a/internal/proxy/model_capabilities_test.go
+++ b/internal/proxy/model_capabilities_test.go
@@ -85,7 +85,7 @@ func TestBuildRequestPayload(testFramework *testing.T) {
 
 	for _, testCase := range testCases {
 		testFramework.Run(testCase.name, func(subTestFramework *testing.T) {
-			payload := proxy.BuildRequestPayload(testCase.modelIdentifier, promptValue, testCase.webSearchEnabled)
+			payload := proxy.BuildRequestPayload(testCase.modelIdentifier, promptValue, testCase.webSearchEnabled, proxy.DefaultMaxOutputTokens)
 			payloadBytes, marshalError := json.Marshal(payload)
 			if marshalError != nil {
 				subTestFramework.Fatalf(marshalPayloadErrorFormat, marshalError)

--- a/internal/proxy/poll_timeout_test.go
+++ b/internal/proxy/poll_timeout_test.go
@@ -2,36 +2,17 @@ package proxy_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/temirov/llm-proxy/internal/proxy"
-	"go.uber.org/zap"
 )
 
-// TestBuildRouterAppliesDefaultUpstreamPollTimeout verifies that BuildRouter sets the
-// upstream poll timeout to the default value when the configuration omits it.
-func TestBuildRouterAppliesDefaultUpstreamPollTimeout(testFramework *testing.T) {
-	loggerInstance, _ := zap.NewDevelopment()
-	defer func() { _ = loggerInstance.Sync() }()
+const messageUnexpectedPollTimeout = "upstreamPollTimeoutSeconds=%d want=%d"
 
-	previousPollTimeout := proxy.UpstreamPollTimeout()
-	defer proxy.SetUpstreamPollTimeout(previousPollTimeout)
-
-	_, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
-		OpenAIKey:                  TestAPIKey,
-		LogLevel:                   proxy.LogLevelDebug,
-		WorkerCount:                1,
-		QueueSize:                  1,
-		UpstreamPollTimeoutSeconds: 0, // Explicitly set to 0 to test default behavior
-	}, loggerInstance.Sugar())
-
-	if buildRouterError != nil {
-		testFramework.Fatalf(messageBuildRouterError, buildRouterError)
-	}
-
-	expectedDuration := time.Duration(proxy.DefaultUpstreamPollTimeoutSeconds) * time.Second
-	if proxy.UpstreamPollTimeout() != expectedDuration {
-		testFramework.Fatalf(messageUnexpectedPollTimeout, proxy.UpstreamPollTimeout(), expectedDuration)
+// TestApplyTunablesSetsDefaultUpstreamPollTimeout verifies the default poll timeout is applied.
+func TestApplyTunablesSetsDefaultUpstreamPollTimeout(testingInstance *testing.T) {
+	configuration := proxy.Configuration{}
+	configuration.ApplyTunables()
+	if configuration.UpstreamPollTimeoutSeconds != proxy.DefaultUpstreamPollTimeoutSeconds {
+		testingInstance.Fatalf(messageUnexpectedPollTimeout, configuration.UpstreamPollTimeoutSeconds, proxy.DefaultUpstreamPollTimeoutSeconds)
 	}
 }

--- a/internal/proxy/response_shapes_e2e_test.go
+++ b/internal/proxy/response_shapes_e2e_test.go
@@ -36,8 +36,8 @@ func withStubbedProxy(t *testing.T, initialResponse, finalResponse string) http.
 	}))
 	t.Cleanup(server.Close)
 
-	proxy.DefaultEndpoints.SetResponsesURL(server.URL)
-	t.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(server.URL)
 
 	logger, _ := zap.NewDevelopment()
 	t.Cleanup(func() { _ = logger.Sync() })
@@ -49,6 +49,7 @@ func withStubbedProxy(t *testing.T, initialResponse, finalResponse string) http.
 		QueueSize:                  1,
 		RequestTimeoutSeconds:      TestTimeout,
 		UpstreamPollTimeoutSeconds: TestTimeout,
+		Endpoints:                  endpoints,
 	}, logger.Sugar())
 	if err != nil {
 		t.Fatalf("BuildRouter error: %v", err)

--- a/internal/proxy/test_helpers_test.go
+++ b/internal/proxy/test_helpers_test.go
@@ -14,9 +14,8 @@ import (
 
 // Test constants used across the entire test suite for this package.
 const (
-	TestJobID                    = "resp_test_12345"
-	messageBuildRouterError      = "BuildRouter error: %v"
-	messageUnexpectedPollTimeout = "upstreamPollTimeout=%v want=%v"
+	TestJobID               = "resp_test_12345"
+	messageBuildRouterError = "BuildRouter error: %v"
 )
 
 // NewSessionMockServer creates a reusable httptest.Server that correctly
@@ -48,8 +47,8 @@ func NewSessionMockServer(finalResponseJSON string) *httptest.Server {
 // NewTestRouter creates a pre-configured router for integration tests.
 func NewTestRouter(t *testing.T, serverURL string) *gin.Engine {
 	t.Helper()
-	proxy.DefaultEndpoints.SetResponsesURL(serverURL)
-	t.Cleanup(func() { proxy.DefaultEndpoints.ResetResponsesURL() })
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(serverURL)
 
 	logger, _ := zap.NewDevelopment()
 	t.Cleanup(func() { _ = logger.Sync() })
@@ -62,6 +61,7 @@ func NewTestRouter(t *testing.T, serverURL string) *gin.Engine {
 		QueueSize:                  1,
 		RequestTimeoutSeconds:      TestTimeout,
 		UpstreamPollTimeoutSeconds: TestTimeout,
+		Endpoints:                  endpoints,
 	}, logger.Sugar())
 	if err != nil {
 		t.Fatalf("BuildRouter error: %v", err)

--- a/tests/integration/integration_models_test.go
+++ b/tests/integration/integration_models_test.go
@@ -21,14 +21,16 @@ func TestIntegrationModelSpecSuppression(testingInstance *testing.T) {
 	}{{name: "gpt_5_mini", model: proxy.ModelNameGPT5Mini}}
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
-			client, captured := makeHTTPClient(subTest, true)
-			configureProxy(subTest, client)
+			endpoints := proxy.NewEndpoints()
+			client, captured := makeHTTPClient(subTest, true, endpoints)
+			configureProxy(subTest, client, endpoints)
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 				ServiceSecret: serviceSecretValue,
 				OpenAIKey:     openAIKeyValue,
 				LogLevel:      logLevelDebug,
 				WorkerCount:   1,
 				QueueSize:     8,
+				Endpoints:     endpoints,
 			}, newLogger(subTest))
 			if buildRouterError != nil {
 				subTest.Fatalf(buildRouterFailedFormat, buildRouterError)
@@ -69,14 +71,16 @@ func TestIntegrationModelSpecSuppression(testingInstance *testing.T) {
 // TestIntegrationGPT5TemperatureSuppression verifies that temperature is omitted and tools retained for GPT-5.
 func TestIntegrationGPT5TemperatureSuppression(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
-	client, captured := makeHTTPClient(testingInstance, true)
-	configureProxy(testingInstance, client)
+	endpoints := proxy.NewEndpoints()
+	client, captured := makeHTTPClient(testingInstance, true, endpoints)
+	configureProxy(testingInstance, client, endpoints)
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret: serviceSecretValue,
 		OpenAIKey:     openAIKeyValue,
 		LogLevel:      logLevelDebug,
 		WorkerCount:   1,
 		QueueSize:     8,
+		Endpoints:     endpoints,
 	}, newLogger(testingInstance))
 	if buildRouterError != nil {
 		testingInstance.Fatalf(buildRouterFailedFormat, buildRouterError)

--- a/tests/integration/missing_prompt_test.go
+++ b/tests/integration/missing_prompt_test.go
@@ -16,9 +16,10 @@ const missingPromptErrorMessage = "missing prompt parameter"
 // TestRequestWithoutPromptReturnsMissingPromptError ensures that a request lacking the prompt query parameter yields a 400 status with the missing prompt error message.
 func TestRequestWithoutPromptReturnsMissingPromptError(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
-	client, _ := makeHTTPClient(testingInstance, false)
-	configureProxy(testingInstance, client)
-	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8}, newLogger(testingInstance))
+	endpoints := proxy.NewEndpoints()
+	client, _ := makeHTTPClient(testingInstance, false, endpoints)
+	configureProxy(testingInstance, client, endpoints)
+	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, Endpoints: endpoints}, newLogger(testingInstance))
 	if buildError != nil {
 		testingInstance.Fatalf("BuildRouter failed: %v", buildError)
 	}


### PR DESCRIPTION
## Summary
- guard endpoint URLs behind a concurrency-safe `Endpoints` type and inject through configuration
- remove mutable global configuration in router and OpenAI client
- isolate tests from shared state and restore HTTP clients

## Testing
- `go test ./...` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9d955f5c8327821a79d4f4b956fe