### PR TITLE
chore: remove unused key constants

### DIFF
--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -72,12 +72,6 @@ const (
 	// fallbackFinalAnswerFormat formats a message when the model does not provide a final answer.
 	fallbackFinalAnswerFormat = "Model did not provide a final answer. Last web search: \"%s\""
 
-	keyRole = "role"
-	keyUser = "user"
-
-	keySystem             = "system"
-	keyAssistant          = "assistant"
-	keyContent            = "content"
 	keyModel              = "model"
 	keyInput              = "input"
 	keyTemperature        = "temperature"


### PR DESCRIPTION
## Summary
- remove unused key constants from proxy constants

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bca5739c888327bd710c4479cb3bfa