### PR TITLE
Handle JSON marshalling errors in synthesis continuation

### DIFF
--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -299,7 +299,11 @@ func (client *OpenAIClient) startSynthesisContinuation(openAIKey string, previou
 			keyVerbosity: verbosityLow,
 		},
 	}
-	payloadBytes, _ := json.Marshal(payload)
+	payloadBytes, marshalError := json.Marshal(payload)
+	if marshalError != nil {
+		structuredLogger.Errorw(logEventMarshalRequestPayload, constants.LogFieldError, marshalError)
+		return constants.EmptyString, marshalError
+	}
 
 	requestContext, cancelRequest := context.WithTimeout(context.Background(), client.requestTimeout)
 	defer cancelRequest()


### PR DESCRIPTION
## Summary
- Capture and log JSON marshalling errors in `startSynthesisContinuation`
- Return marshalling error to caller and avoid using invalid payload bytes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bca57741e88327b60d6da9ab60472e