### PR TITLE
refactor: clarify handler parameters in tests

### DIFF
--- a/internal/proxy/response_shapes_e2e_test.go
+++ b/internal/proxy/response_shapes_e2e_test.go
@@ -24,14 +24,14 @@ func withStubbedProxy(t *testing.T, initialResponse, finalResponse string) http.
 	t.Helper()
 	const jobID = "resp_test_123"
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.Method == http.MethodPost {
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		if httpRequest.Method == http.MethodPost {
 			// Return the initial response, which might be the job ID or the full response.
-			_, _ = w.Write([]byte(initialResponse))
-		} else if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, jobID) {
+			_, _ = responseWriter.Write([]byte(initialResponse))
+		} else if httpRequest.Method == http.MethodGet && strings.HasSuffix(httpRequest.URL.Path, jobID) {
 			// Return the final response on poll.
-			_, _ = w.Write([]byte(finalResponse))
+			_, _ = responseWriter.Write([]byte(finalResponse))
 		}
 	}))
 	t.Cleanup(server.Close)

--- a/internal/proxy/test_helpers_test.go
+++ b/internal/proxy/test_helpers_test.go
@@ -21,26 +21,26 @@ const (
 // NewSessionMockServer creates a reusable httptest.Server that correctly
 // simulates the multi-step session flow for the Responses API.
 func NewSessionMockServer(finalResponseJSON string) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		// 1. Handle the initial POST to create the session.
-		if r.Method == http.MethodPost && r.URL.Path == "/" {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"id": "%s", "status": "queued"}`, TestJobID)))
+		if httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/" {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(`{"id": "%s", "status": "queued"}`, TestJobID)))
 			return
 		}
 		// 2. Handle the subsequent GET to poll the session.
-		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, TestJobID) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(finalResponseJSON))
+		if httpRequest.Method == http.MethodGet && strings.HasSuffix(httpRequest.URL.Path, TestJobID) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(finalResponseJSON))
 			return
 		}
 		// 3. Handle a "continue" POST if a test requires it.
-		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/continue") {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"status": "in_progress"}`)) // Acknowledge the continue request
+		if httpRequest.Method == http.MethodPost && strings.HasSuffix(httpRequest.URL.Path, "/continue") {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"status": "in_progress"}`)) // Acknowledge the continue request
 			return
 		}
-		http.NotFound(w, r)
+		http.NotFound(responseWriter, httpRequest)
 	}))
 }
 


### PR DESCRIPTION
## Summary
- use descriptive `responseWriter` and `httpRequest` parameter names in test handlers

## Testing
- `go run golang.org/x/tools/cmd/goimports@latest -w internal/proxy/test_helpers_test.go internal/proxy/response_shapes_e2e_test.go`
- `go test ./...` *(fails: command hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bca57d36b4832790e12f47f33761b3