### PR TITLE
feat: publish changelog with docker releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
+    env:
+      CHANGELOG_FILE: CHANGELOG.md
+      RELEASE_NOTES_FILE: release_notes.md
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -36,3 +39,18 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:latest
+      - name: Extract release notes
+        run: |
+          release_tag="${{ github.ref_name }}"
+          awk -v tag="$release_tag" '
+            $0 ~ "^## \\[" tag "\\]" {flag=1; next}
+            flag && /^## \\[/ {flag=0}
+            flag
+          ' "$CHANGELOG_FILE" > "$RELEASE_NOTES_FILE"
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Release ${{ github.ref_name }}"
+          body_path: ${{ env.RELEASE_NOTES_FILE }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 *.iml
 .env
+release_notes.md


### PR DESCRIPTION
## Summary
- publish changelog entries during docker releases
- ignore generated release notes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bcaf379de4832780500658263cbe09