### PR TITLE
Add GPT-5 reasoning integration test

### DIFF
--- a/tests/integration/integration1_test.go
+++ b/tests/integration/integration1_test.go
@@ -4,10 +4,36 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/temirov/llm-proxy/internal/proxy"
 	"go.uber.org/zap"
+)
+
+const (
+	// toolsField identifies the tools request field.
+	toolsField = "tools"
+	// toolChoiceField identifies the tool_choice request field.
+	toolChoiceField = "tool_choice"
+	// reasoningField identifies the reasoning request field.
+	reasoningField = "reasoning"
+	// effortField identifies the effort field within the reasoning object.
+	effortField = "effort"
+	// typeField identifies the type field within a tool descriptor.
+	typeField = "type"
+	// toolChoiceAutoValue is the expected value of the tool_choice field when web search is enabled.
+	toolChoiceAutoValue = "auto"
+	// reasoningEffortMediumValue is the expected reasoning effort for GPT-5.
+	reasoningEffortMediumValue = "medium"
+	// toolTypeWebSearchValue is the expected tool type when web search is requested.
+	toolTypeWebSearchValue = "web_search"
+	// toolChoiceMismatchFormat reports an unexpected tool_choice value.
+	toolChoiceMismatchFormat = "tool_choice=%v want=%v"
+	// reasoningMissingFormat reports a missing reasoning field in the payload.
+	reasoningMissingFormat = "reasoning missing in payload: %v"
+	// reasoningEffortMismatchFormat reports an unexpected reasoning effort value.
+	reasoningEffortMismatchFormat = "reasoning effort=%v want=%v"
 )
 
 // newIntegrationServerWithTimeout builds the application server pointing at the stub OpenAI server with a configurable request timeout.
@@ -88,5 +114,52 @@ func TestProxyResponseDelivery(testingInstance *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestProxyGPT5WebSearchIncludesReasoning verifies that GPT-5 requests with web search
+// include tools, tool_choice, and reasoning fields.
+func TestProxyGPT5WebSearchIncludesReasoning(testingInstance *testing.T) {
+	var capturedPayload any
+	openAIServer := newOpenAIServer(testingInstance, integrationSearchBody, &capturedPayload)
+	testingInstance.Cleanup(openAIServer.Close)
+	applicationServer := newIntegrationServer(testingInstance, openAIServer)
+	requestURL, _ := url.Parse(applicationServer.URL)
+	queryValues := requestURL.Query()
+	queryValues.Set(promptQueryParameter, promptValue)
+	queryValues.Set(keyQueryParameter, integrationServiceSecret)
+	queryValues.Set(webSearchQueryParameter, "1")
+	queryValues.Set(adaptiveModelQueryParameter, proxy.ModelNameGPT5)
+	requestURL.RawQuery = queryValues.Encode()
+	httpResponse, requestError := http.Get(requestURL.String())
+	if requestError != nil {
+		testingInstance.Fatalf(requestErrorFormat, requestError)
+	}
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(httpResponse.Body)
+		testingInstance.Fatalf(unexpectedStatusFormat, httpResponse.StatusCode, string(responseBody))
+	}
+	_, _ = io.ReadAll(httpResponse.Body)
+	payloadMap, _ := capturedPayload.(map[string]any)
+	toolsValue, ok := payloadMap[toolsField].([]any)
+	if !ok || len(toolsValue) == 0 {
+		testingInstance.Fatalf(toolsMissingFormat, payloadMap)
+	}
+	firstTool, _ := toolsValue[0].(map[string]any)
+	if firstTool[typeField] != toolTypeWebSearchValue {
+		testingInstance.Fatalf(toolTypeMismatchFormat, firstTool[typeField])
+	}
+	toolChoiceValue, ok := payloadMap[toolChoiceField].(string)
+	if !ok || toolChoiceValue != toolChoiceAutoValue {
+		testingInstance.Fatalf(toolChoiceMismatchFormat, payloadMap[toolChoiceField], toolChoiceAutoValue)
+	}
+	reasoningValue, ok := payloadMap[reasoningField].(map[string]any)
+	if !ok {
+		testingInstance.Fatalf(reasoningMissingFormat, payloadMap)
+	}
+	effortValue, ok := reasoningValue[effortField].(string)
+	if !ok || effortValue != reasoningEffortMediumValue {
+		testingInstance.Fatalf(reasoningEffortMismatchFormat, reasoningValue[effortField], reasoningEffortMediumValue)
 	}
 }


### PR DESCRIPTION
## Summary
- add constants for request field and value assertions
- verify GPT-5 web-search request includes tools, tool_choice and reasoning

## Testing
- `go test ./tests/integration -run TestProxyGPT5WebSearchIncludesReasoning -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68bdcd3ecd60832791c0c000dc2da11f