### PR TITLE
Add authenticated /dictate endpoint for audio transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # LLM Proxy
 
 LLM Proxy is a lightweight HTTP service that forwards user prompts to the
-OpenAI **Responses API**. It exposes a single endpoint that requires a shared
-secret and is intended to simplify integrating language model responses into
-other services without embedding API credentials in each client.
+OpenAI **Responses API** and **audio transcriptions API**. It exposes protected
+HTTP endpoints that require a shared secret and simplify integrating provider
+capabilities without embedding API credentials in each client.
 
 ## Features
 
-- Minimal HTTP server that accepts `GET /?prompt=...&key=...` requests
+- Minimal HTTP server that accepts:
+  - `GET /?prompt=...&key=...` for LLM responses
+  - `POST /dictate?key=...` for audio transcription
 - Choose the **OpenAI model** per request via `model=...` (default: `gpt-4.1`)
+- Choose the dictation model per request via `model=...` on `/dictate` (default: `gpt-4o-mini-transcribe`)
 - Optional per-request **web search** via `web_search=1|true|yes`
 - Optional logging at `debug` or `info` levels
 - Forwards requests to the OpenAI API using your existing API key
@@ -28,6 +31,8 @@ variables:
 | `--system_prompt` / `SYSTEM_PROMPT`   | Optional system prompt text                         |
 | `--workers` / `GPT_WORKERS`           | Number of worker goroutines (default `4`)           |
 | `--queue_size` / `GPT_QUEUE_SIZE`     | Request queue size (default `100`)                  |
+| `--dictation_model` / `GPT_DICTATION_MODEL` | Default model for `/dictate` when query model is not provided (default `gpt-4o-mini-transcribe`) |
+| `--max_input_audio_bytes` / `GPT_MAX_INPUT_AUDIO_BYTES` | Max accepted upload size for `/dictate` (default `26214400`) |
 
 > **Note:** Web search is **per request**, enabled by adding `web_search=1` to your query.
 
@@ -88,6 +93,22 @@ curl --get \
   "http://localhost:8080/"
 ```
 
+### Dictation request
+
+```shell
+curl -X POST \
+  -F "audio=@./recording.webm" \
+  "http://localhost:8080/dictate?key=mysecret"
+```
+
+Optional model override:
+
+```shell
+curl -X POST \
+  -F "audio=@./recording.webm" \
+  "http://localhost:8080/dictate?key=mysecret&model=gpt-4o-mini-transcribe"
+```
+
 ### Response formats
 
 You can request alternative formats using either the `format` query parameter or
@@ -102,6 +123,8 @@ If no supported value is provided, `text/plain` is returned.
 
 ## Endpoint
 
+### LLM endpoint
+
 ```
 GET /
   ?prompt=STRING            # required
@@ -109,6 +132,22 @@ GET /
   &model=MODEL_NAME         # optional; defaults to gpt-4.1
   &web_search=1|true|yes    # optional; enables OpenAI web_search tool
   &format=CONTENT_TYPE      # optional; or use Accept header
+```
+
+### Dictation endpoint
+
+```
+POST /dictate
+  ?key=SERVICE_SECRET       # required
+  &model=MODEL_NAME         # optional; defaults to gpt-4o-mini-transcribe
+Content-Type: multipart/form-data
+  audio=<file>              # required (alias: file)
+```
+
+Success response:
+
+```json
+{ "text": "..." }
 ```
 
 Supported models include any listed in `/v1/models` from the OpenAI API
@@ -128,7 +167,7 @@ Not all models support tools; for **web search**, use `gpt-4o`, `gpt-4.1`, or `g
 ### Status codes
 
 * `200 OK` – success
-* `400 Bad Request` – missing required parameters or unknown model
+* `400 Bad Request` – missing/invalid parameters or invalid multipart audio form
 * `403 Forbidden` – missing or invalid `key`
 * `504 Gateway Timeout` – upstream request timed out
 * `502 Bad Gateway` – OpenAI API returned an error
@@ -137,6 +176,10 @@ Not all models support tools; for **web search**, use `gpt-4o`, `gpt-4.1`, or `g
 
 * All requests must include the shared secret via `key=...`.
 * Do not expose this service to the public internet without appropriate network controls.
+
+## Implementation Plans
+
+Current scoped implementation plans are tracked under `docs/implementation/`.
 
 ## Releasing
 

--- a/cmd/cli/configuration_helpers.go
+++ b/cmd/cli/configuration_helpers.go
@@ -32,6 +32,18 @@ func populateIntConfiguration(command *cobra.Command, flagName, configurationKey
 	}
 }
 
+// populateInt64Configuration resolves an int64 value from command flags, environment variables and defaults.
+// flagName specifies the CLI flag, configurationKey maps to the viper key, destination receives the result,
+// and defaultValue replaces non-positive values.
+func populateInt64Configuration(command *cobra.Command, flagName, configurationKey string, destination *int64, defaultValue int64) {
+	if !command.Flags().Changed(flagName) {
+		*destination = viper.GetInt64(configurationKey)
+	}
+	if *destination <= 0 {
+		*destination = defaultValue
+	}
+}
+
 // identityTransformer returns the supplied value unchanged.
 func identityTransformer(value string) string {
 	return value

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -27,6 +27,8 @@ const (
 	keyRequestTimeoutSeconds      = "request_timeout_seconds"
 	keyUpstreamPollTimeoutSeconds = "upstream_poll_timeout_seconds"
 	keyMaxOutputTokens            = "max_output_tokens"
+	keyDictationModel             = "dictation_model"
+	keyMaxInputAudioBytes         = "max_input_audio_bytes"
 
 	flagOpenAIAPIKey        = keyOpenAIAPIKey
 	flagServiceSecret       = keyServiceSecret
@@ -38,6 +40,8 @@ const (
 	flagRequestTimeout      = "request_timeout"
 	flagUpstreamPollTimeout = "upstream_poll_timeout"
 	flagMaxOutputTokens     = keyMaxOutputTokens
+	flagDictationModel      = keyDictationModel
+	flagMaxInputAudioBytes  = keyMaxInputAudioBytes
 
 	envOpenAIAPIKey               = "OPENAI_API_KEY"
 	envServiceSecret              = "SERVICE_SECRET"
@@ -49,6 +53,8 @@ const (
 	envRequestTimeoutSeconds      = "GPT_REQUEST_TIMEOUT_SECONDS"
 	envUpstreamPollTimeoutSeconds = "GPT_UPSTREAM_POLL_TIMEOUT_SECONDS"
 	envMaxOutputTokens            = "GPT_MAX_OUTPUT_TOKENS"
+	envDictationModel             = "GPT_DICTATION_MODEL"
+	envMaxInputAudioBytes         = "GPT_MAX_INPUT_AUDIO_BYTES"
 
 	quoteCharacters = "\"'"
 )
@@ -76,7 +82,7 @@ const (
 
 	// rootCmdLong provides a detailed description of the root command.
 	// Additional commands should define their long description using a constant following this pattern.
-	rootCmdLong = "Accepts GET /?prompt=…&key=SECRET and forwards to OpenAI."
+	rootCmdLong = "Accepts GET / for prompts and POST /dictate for audio transcription; forwards to OpenAI."
 
 	// rootCmdExample demonstrates how to use the root command.
 	// Additional commands should define their usage examples using a constant following this pattern.
@@ -109,6 +115,8 @@ var rootCmd = &cobra.Command{
 		populateIntConfiguration(command, flagRequestTimeout, keyRequestTimeoutSeconds, &config.RequestTimeoutSeconds, proxy.DefaultRequestTimeoutSeconds)
 		populateIntConfiguration(command, flagUpstreamPollTimeout, keyUpstreamPollTimeoutSeconds, &config.UpstreamPollTimeoutSeconds, proxy.DefaultUpstreamPollTimeoutSeconds)
 		populateIntConfiguration(command, flagMaxOutputTokens, keyMaxOutputTokens, &config.MaxOutputTokens, proxy.DefaultMaxOutputTokens)
+		populateStringConfiguration(command, flagDictationModel, keyDictationModel, &config.DictationModel, proxy.DefaultDictationModel, trimSpacesAndQuotes)
+		populateInt64Configuration(command, flagMaxInputAudioBytes, keyMaxInputAudioBytes, &config.MaxInputAudioBytes, proxy.DefaultMaxInputAudioBytes)
 
 		var logger *zap.Logger
 		var loggerError error
@@ -174,6 +182,12 @@ func bindOrDie() error {
 	}
 	if bindError := viper.BindEnv(keyMaxOutputTokens, envMaxOutputTokens); bindError != nil {
 		bindingErrors = append(bindingErrors, keyMaxOutputTokens+":"+bindError.Error())
+	}
+	if bindError := viper.BindEnv(keyDictationModel, envDictationModel); bindError != nil {
+		bindingErrors = append(bindingErrors, keyDictationModel+":"+bindError.Error())
+	}
+	if bindError := viper.BindEnv(keyMaxInputAudioBytes, envMaxInputAudioBytes); bindError != nil {
+		bindingErrors = append(bindingErrors, keyMaxInputAudioBytes+":"+bindError.Error())
 	}
 	if len(bindingErrors) > 0 {
 		return errors.New(strings.Join(bindingErrors, bindingErrorSeparator))
@@ -248,6 +262,18 @@ func init() {
 		flagMaxOutputTokens,
 		0,
 		"maximum output tokens (env: "+envMaxOutputTokens+")",
+	)
+	rootCmd.Flags().StringVar(
+		&config.DictationModel,
+		flagDictationModel,
+		"",
+		"default model for /dictate when query model is not provided (env: "+envDictationModel+")",
+	)
+	rootCmd.Flags().Int64Var(
+		&config.MaxInputAudioBytes,
+		flagMaxInputAudioBytes,
+		0,
+		"maximum accepted audio payload size for /dictate in bytes (env: "+envMaxInputAudioBytes+")",
 	)
 
 	if flagBindError := viper.BindPFlags(rootCmd.Flags()); flagBindError != nil {

--- a/docs/implementation/dictation-endpoint-plan.md
+++ b/docs/implementation/dictation-endpoint-plan.md
@@ -1,0 +1,50 @@
+# Dictation Endpoint Plan (`/dictate`)
+
+Issue: `ISSUES.md` -> `WB-001` (workspace-local tracker)
+
+## Goal
+Provide an authenticated audio-transcription endpoint in `llm-proxy` so downstream apps can route dictation through proxy infrastructure instead of calling OpenAI directly.
+
+## Target API Contract
+- `POST /dictate?key=SERVICE_SECRET[&model=MODEL_ID]`
+- `Content-Type: multipart/form-data`
+- request audio part name: `audio` (alias `file` for compatibility)
+- success response: JSON `{ "text": "..." }`
+
+## Implementation Path
+1. Add constants/config in `internal/proxy`:
+   - default transcriptions URL (`https://api.openai.com/v1/audio/transcriptions`)
+   - default dictation model (`gpt-4o-mini-transcribe`)
+   - max input audio bytes (configurable)
+2. Extend endpoint configuration in `internal/proxy/endpoints.go`:
+   - add getter/setter/reset for transcriptions URL (parallel to responses/models)
+3. Add transcription client flow in `internal/proxy/openai.go` (or `openai_dictation.go`):
+   - build multipart upstream request (`model`, `file`)
+   - set bearer auth from `OpenAIKey`
+   - parse upstream payload (`text`, `transcript`, `output_text` fallback)
+   - normalize and return trimmed text
+4. Extend router in `internal/proxy/router.go`:
+   - register `POST /dictate` route
+   - reuse `secretMiddleware` (query `key`)
+   - enforce multipart/size limits and missing-file validation
+   - return proxy-mapped status codes (`400`, `502`, `504`)
+5. Update README endpoint docs and curl examples for `/dictate`.
+
+## Test Plan
+- Unit tests:
+  - route method/validation/missing audio
+  - transcription parser shape fallbacks
+  - upstream status and read/parse failure handling
+- Integration tests:
+  - successful `/dictate` proxy call
+  - model override via query
+  - shared-secret enforcement for `/dictate`
+
+Run repository test command (per CI workflow): `go test ./...`
+
+## Repo Management Notes
+- Testing workflow in `.github/workflows/test.yml` runs `go test ./...` on PRs.
+- Release process in `README.md` requires:
+  1. update `CHANGELOG.md`
+  2. tag `vX.Y.Z`
+  3. push branch and tag (release workflow publishes binaries and release notes).

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -21,6 +21,8 @@ const (
 	DefaultRequestTimeoutSeconds      = 180 // overall app-side request timeout
 	DefaultUpstreamPollTimeoutSeconds = 60  // poll budget after "incomplete"
 	DefaultMaxOutputTokens            = 1024
+	DefaultDictationModel             = "gpt-4o-mini-transcribe"
+	DefaultMaxInputAudioBytes         = 25 * 1024 * 1024
 )
 
 // Configuration holds runtime settings.
@@ -35,6 +37,8 @@ type Configuration struct {
 	RequestTimeoutSeconds      int
 	UpstreamPollTimeoutSeconds int
 	MaxOutputTokens            int
+	DictationModel             string
+	MaxInputAudioBytes         int64
 	Endpoints                  *Endpoints
 }
 
@@ -62,5 +66,11 @@ func (configuration *Configuration) ApplyTunables() {
 	}
 	if configuration.MaxOutputTokens <= 0 {
 		configuration.MaxOutputTokens = DefaultMaxOutputTokens
+	}
+	if strings.TrimSpace(configuration.DictationModel) == constants.EmptyString {
+		configuration.DictationModel = DefaultDictationModel
+	}
+	if configuration.MaxInputAudioBytes <= 0 {
+		configuration.MaxInputAudioBytes = DefaultMaxInputAudioBytes
 	}
 }

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -14,6 +14,8 @@ const (
 
 	// rootPath defines the HTTP path for the root endpoint.
 	rootPath = "/"
+	// dictatePath defines the HTTP path for audio transcription requests.
+	dictatePath = "/dictate"
 
 	queryParameterPrompt       = "prompt"
 	queryParameterKey          = "key"
@@ -21,6 +23,9 @@ const (
 	queryParameterWebSearch    = "web_search"
 	queryParameterSystemPrompt = "system_prompt"
 	queryParameterFormat       = "format"
+
+	formFieldAudio = "audio"
+	formFieldFile  = "file"
 
 	redactedPlaceholder = "***REDACTED***"
 
@@ -39,6 +44,8 @@ const (
 	errorOpenAIAPINoText    = "OpenAI API error (no text)"
 	errorOpenAIFailedStatus = "OpenAI API error (failed status)"
 	errorOpenAIContinue     = "OpenAI API continue error"
+	errorInvalidAudioForm   = "invalid audio form"
+	errorMissingAudioFile   = "missing audio file"
 	// errorUpstreamIncomplete indicates that the upstream provider returned an incomplete response.
 	errorUpstreamIncomplete    = "OpenAI API error (incomplete response)"
 	errorOpenAIModelValidation = "OpenAI model validation error"

--- a/internal/proxy/dictate_handler_test.go
+++ b/internal/proxy/dictate_handler_test.go
@@ -1,0 +1,279 @@
+package proxy_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/temirov/llm-proxy/internal/proxy"
+	"go.uber.org/zap"
+)
+
+const (
+	testAudioPayload = "fake-audio-binary"
+)
+
+func newDictationRouter(t *testing.T, transcriptionsURL string, requestTimeoutSeconds int) *gin.Engine {
+	t.Helper()
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetTranscriptionsURL(transcriptionsURL)
+
+	logger, _ := zap.NewDevelopment()
+	t.Cleanup(func() { _ = logger.Sync() })
+
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		LogLevel:                   proxy.LogLevelDebug,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      requestTimeoutSeconds,
+		UpstreamPollTimeoutSeconds: requestTimeoutSeconds,
+		DictationModel:             proxy.DefaultDictationModel,
+		MaxInputAudioBytes:         1024 * 1024,
+		Endpoints:                  endpoints,
+	}, logger.Sugar())
+	if buildError != nil {
+		t.Fatalf("BuildRouter error: %v", buildError)
+	}
+	return router
+}
+
+func buildMultipartAudioRequest(t *testing.T, formFieldName string) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	filePart, createError := writer.CreateFormFile(formFieldName, "recording.webm")
+	if createError != nil {
+		t.Fatalf("CreateFormFile error: %v", createError)
+	}
+	if _, copyError := io.Copy(filePart, strings.NewReader(testAudioPayload)); copyError != nil {
+		t.Fatalf("Copy error: %v", copyError)
+	}
+	if closeError := writer.Close(); closeError != nil {
+		t.Fatalf("Close writer error: %v", closeError)
+	}
+	return body, writer.FormDataContentType()
+}
+
+func decodeTextResponse(t *testing.T, responseBody []byte) string {
+	t.Helper()
+	var payload map[string]string
+	if decodeError := json.Unmarshal(responseBody, &payload); decodeError != nil {
+		t.Fatalf("decode response error: %v body=%s", decodeError, string(responseBody))
+	}
+	return payload["text"]
+}
+
+func TestDictateHandlerSuccessWithAudioField(t *testing.T) {
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Fatalf("method=%s want=%s", request.Method, http.MethodPost)
+		}
+		if authorizationHeader := request.Header.Get("Authorization"); authorizationHeader != "Bearer "+TestAPIKey {
+			t.Fatalf("authorization=%q want=%q", authorizationHeader, "Bearer "+TestAPIKey)
+		}
+		if parseError := request.ParseMultipartForm(1024 * 1024); parseError != nil {
+			t.Fatalf("ParseMultipartForm error: %v", parseError)
+		}
+		if model := request.FormValue("model"); model != proxy.DefaultDictationModel {
+			t.Fatalf("model=%q want=%q", model, proxy.DefaultDictationModel)
+		}
+		file, _, fileError := request.FormFile("file")
+		if fileError != nil {
+			t.Fatalf("FormFile(file) error: %v", fileError)
+		}
+		defer file.Close()
+		rawAudio, readError := io.ReadAll(file)
+		if readError != nil {
+			t.Fatalf("ReadAll(file) error: %v", readError)
+		}
+		if string(rawAudio) != testAudioPayload {
+			t.Fatalf("audio payload mismatch got=%q want=%q", string(rawAudio), testAudioPayload)
+		}
+
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"text":"transcribed audio"}`))
+	}))
+	defer upstreamServer.Close()
+
+	router := newDictationRouter(t, upstreamServer.URL, TestTimeout)
+	body, contentType := buildMultipartAudioRequest(t, "audio")
+	request := httptest.NewRequest(http.MethodPost, "/dictate?key="+TestSecret, body)
+	request.Header.Set("Content-Type", contentType)
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusOK, responseRecorder.Body.String())
+	}
+	if responseText := decodeTextResponse(t, responseRecorder.Body.Bytes()); responseText != "transcribed audio" {
+		t.Fatalf("text=%q want=%q", responseText, "transcribed audio")
+	}
+}
+
+func TestDictateHandlerAcceptsFileAlias(t *testing.T) {
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if parseError := request.ParseMultipartForm(1024 * 1024); parseError != nil {
+			t.Fatalf("ParseMultipartForm error: %v", parseError)
+		}
+		if model := request.FormValue("model"); model != proxy.DefaultDictationModel {
+			t.Fatalf("model=%q want=%q", model, proxy.DefaultDictationModel)
+		}
+		if _, _, fileError := request.FormFile("file"); fileError != nil {
+			t.Fatalf("FormFile(file) error: %v", fileError)
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"text":"ok from alias"}`))
+	}))
+	defer upstreamServer.Close()
+
+	router := newDictationRouter(t, upstreamServer.URL, TestTimeout)
+	body, contentType := buildMultipartAudioRequest(t, "file")
+	request := httptest.NewRequest(http.MethodPost, "/dictate?key="+TestSecret, body)
+	request.Header.Set("Content-Type", contentType)
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusOK, responseRecorder.Body.String())
+	}
+	if responseText := decodeTextResponse(t, responseRecorder.Body.Bytes()); responseText != "ok from alias" {
+		t.Fatalf("text=%q want=%q", responseText, "ok from alias")
+	}
+}
+
+func TestDictateHandlerSupportsModelOverride(t *testing.T) {
+	const modelOverride = "gpt-4o-transcribe"
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if parseError := request.ParseMultipartForm(1024 * 1024); parseError != nil {
+			t.Fatalf("ParseMultipartForm error: %v", parseError)
+		}
+		if model := request.FormValue("model"); model != modelOverride {
+			t.Fatalf("model=%q want=%q", model, modelOverride)
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"text":"model override ok"}`))
+	}))
+	defer upstreamServer.Close()
+
+	router := newDictationRouter(t, upstreamServer.URL, TestTimeout)
+	body, contentType := buildMultipartAudioRequest(t, "audio")
+
+	query := url.Values{}
+	query.Set("key", TestSecret)
+	query.Set("model", modelOverride)
+	request := httptest.NewRequest(http.MethodPost, "/dictate?"+query.Encode(), body)
+	request.Header.Set("Content-Type", contentType)
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusOK, responseRecorder.Body.String())
+	}
+	if responseText := decodeTextResponse(t, responseRecorder.Body.Bytes()); responseText != "model override ok" {
+		t.Fatalf("text=%q want=%q", responseText, "model override ok")
+	}
+}
+
+func TestDictateHandlerValidationAndAuth(t *testing.T) {
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"text":"should-not-be-used"}`))
+	}))
+	defer upstreamServer.Close()
+
+	router := newDictationRouter(t, upstreamServer.URL, TestTimeout)
+
+	t.Run("missing key is forbidden", func(subTest *testing.T) {
+		body, contentType := buildMultipartAudioRequest(subTest, "audio")
+		request := httptest.NewRequest(http.MethodPost, "/dictate", body)
+		request.Header.Set("Content-Type", contentType)
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusForbidden {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusForbidden, responseRecorder.Body.String())
+		}
+	})
+
+	t.Run("invalid multipart form returns bad request", func(subTest *testing.T) {
+		request := httptest.NewRequest(http.MethodPost, "/dictate?key="+TestSecret, strings.NewReader("not-multipart"))
+		request.Header.Set("Content-Type", "text/plain")
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusBadRequest {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusBadRequest, responseRecorder.Body.String())
+		}
+	})
+
+	t.Run("multipart without audio returns bad request", func(subTest *testing.T) {
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		if writeError := writer.WriteField("note", "missing audio"); writeError != nil {
+			subTest.Fatalf("WriteField error: %v", writeError)
+		}
+		if closeError := writer.Close(); closeError != nil {
+			subTest.Fatalf("Close writer error: %v", closeError)
+		}
+
+		request := httptest.NewRequest(http.MethodPost, "/dictate?key="+TestSecret, body)
+		request.Header.Set("Content-Type", writer.FormDataContentType())
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusBadRequest {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusBadRequest, responseRecorder.Body.String())
+		}
+	})
+}
+
+func TestDictateHandlerUpstreamFailures(t *testing.T) {
+	t.Run("upstream non-2xx returns bad gateway", func(subTest *testing.T) {
+		upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+			responseWriter.WriteHeader(http.StatusInternalServerError)
+			_, _ = responseWriter.Write([]byte(`{"error":"upstream failed"}`))
+		}))
+		defer upstreamServer.Close()
+
+		router := newDictationRouter(subTest, upstreamServer.URL, TestTimeout)
+		body, contentType := buildMultipartAudioRequest(subTest, "audio")
+		request := httptest.NewRequest(http.MethodPost, "/dictate?key="+TestSecret, body)
+		request.Header.Set("Content-Type", contentType)
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+
+		if responseRecorder.Code != http.StatusBadGateway {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusBadGateway, responseRecorder.Body.String())
+		}
+	})
+
+	t.Run("upstream timeout returns gateway timeout", func(subTest *testing.T) {
+		upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+			time.Sleep(1500 * time.Millisecond)
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"text":"late"}`))
+		}))
+		defer upstreamServer.Close()
+
+		router := newDictationRouter(subTest, upstreamServer.URL, 1)
+		body, contentType := buildMultipartAudioRequest(subTest, "audio")
+		request := httptest.NewRequest(http.MethodPost, "/dictate?key="+TestSecret, body)
+		request.Header.Set("Content-Type", contentType)
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+
+		if responseRecorder.Code != http.StatusGatewayTimeout {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusGatewayTimeout, responseRecorder.Body.String())
+		}
+	})
+}

--- a/internal/proxy/endpoints.go
+++ b/internal/proxy/endpoints.go
@@ -3,22 +3,25 @@ package proxy
 import "sync"
 
 const (
-	defaultResponsesURL = "https://api.openai.com/v1/responses"
-	defaultModelsURL    = "https://api.openai.com/v1/models"
+	defaultResponsesURL      = "https://api.openai.com/v1/responses"
+	defaultModelsURL         = "https://api.openai.com/v1/models"
+	defaultTranscriptionsURL = "https://api.openai.com/v1/audio/transcriptions"
 )
 
 // Endpoints provides concurrency-safe access to OpenAI endpoint URLs.
 type Endpoints struct {
-	accessMutex  sync.RWMutex
-	responsesURL string
-	modelsURL    string
+	accessMutex       sync.RWMutex
+	responsesURL      string
+	modelsURL         string
+	transcriptionsURL string
 }
 
 // NewEndpoints creates an Endpoints instance initialized with default URLs.
 func NewEndpoints() *Endpoints {
 	return &Endpoints{
-		responsesURL: defaultResponsesURL,
-		modelsURL:    defaultModelsURL,
+		responsesURL:      defaultResponsesURL,
+		modelsURL:         defaultModelsURL,
+		transcriptionsURL: defaultTranscriptionsURL,
 	}
 }
 
@@ -62,4 +65,25 @@ func (endpointConfiguration *Endpoints) ResetModelsURL() {
 	endpointConfiguration.accessMutex.Lock()
 	defer endpointConfiguration.accessMutex.Unlock()
 	endpointConfiguration.modelsURL = defaultModelsURL
+}
+
+// GetTranscriptionsURL returns the URL used for the OpenAI audio transcriptions endpoint.
+func (endpointConfiguration *Endpoints) GetTranscriptionsURL() string {
+	endpointConfiguration.accessMutex.RLock()
+	defer endpointConfiguration.accessMutex.RUnlock()
+	return endpointConfiguration.transcriptionsURL
+}
+
+// SetTranscriptionsURL sets the URL for the OpenAI audio transcriptions endpoint.
+func (endpointConfiguration *Endpoints) SetTranscriptionsURL(newURL string) {
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.transcriptionsURL = newURL
+}
+
+// ResetTranscriptionsURL resets the transcriptions endpoint to the default.
+func (endpointConfiguration *Endpoints) ResetTranscriptionsURL() {
+	endpointConfiguration.accessMutex.Lock()
+	defer endpointConfiguration.accessMutex.Unlock()
+	endpointConfiguration.transcriptionsURL = defaultTranscriptionsURL
 }

--- a/internal/proxy/endpoints_parallel_test.go
+++ b/internal/proxy/endpoints_parallel_test.go
@@ -9,6 +9,8 @@ import (
 const (
 	firstResponsesURL  = "https://one.local/v1/responses"
 	secondResponsesURL = "https://two.local/v1/responses"
+	firstDictateURL    = "https://one.local/v1/audio/transcriptions"
+	secondDictateURL   = "https://two.local/v1/audio/transcriptions"
 )
 
 // TestEndpointsIsolation verifies that endpoint instances remain independent when used in parallel tests.
@@ -17,16 +19,24 @@ func TestEndpointsIsolation(testingInstance *testing.T) {
 		subTest.Parallel()
 		endpoints := proxy.NewEndpoints()
 		endpoints.SetResponsesURL(firstResponsesURL)
+		endpoints.SetTranscriptionsURL(firstDictateURL)
 		if endpoints.GetResponsesURL() != firstResponsesURL {
 			subTest.Fatalf("responsesURL=%s want=%s", endpoints.GetResponsesURL(), firstResponsesURL)
+		}
+		if endpoints.GetTranscriptionsURL() != firstDictateURL {
+			subTest.Fatalf("transcriptionsURL=%s want=%s", endpoints.GetTranscriptionsURL(), firstDictateURL)
 		}
 	})
 	testingInstance.Run("second", func(subTest *testing.T) {
 		subTest.Parallel()
 		endpoints := proxy.NewEndpoints()
 		endpoints.SetResponsesURL(secondResponsesURL)
+		endpoints.SetTranscriptionsURL(secondDictateURL)
 		if endpoints.GetResponsesURL() != secondResponsesURL {
 			subTest.Fatalf("responsesURL=%s want=%s", endpoints.GetResponsesURL(), secondResponsesURL)
+		}
+		if endpoints.GetTranscriptionsURL() != secondDictateURL {
+			subTest.Fatalf("transcriptionsURL=%s want=%s", endpoints.GetTranscriptionsURL(), secondDictateURL)
 		}
 	})
 }

--- a/internal/proxy/openai_dictation.go
+++ b/internal/proxy/openai_dictation.go
@@ -1,0 +1,111 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/temirov/llm-proxy/internal/constants"
+	"github.com/temirov/llm-proxy/internal/utils"
+	"go.uber.org/zap"
+)
+
+type transcriptionResponse struct {
+	Text       string `json:"text"`
+	Transcript string `json:"transcript"`
+	OutputText string `json:"output_text"`
+}
+
+func (client *OpenAIClient) transcribeAudio(openAIKey string, modelIdentifier string, fileName string, audioReader io.Reader, structuredLogger *zap.SugaredLogger) (string, error) {
+	modelIdentifier = strings.TrimSpace(modelIdentifier)
+	if modelIdentifier == constants.EmptyString {
+		modelIdentifier = DefaultDictationModel
+	}
+	fileName = strings.TrimSpace(fileName)
+	if fileName == constants.EmptyString {
+		fileName = "audio.webm"
+	}
+
+	payloadBuffer := &bytes.Buffer{}
+	multipartWriter := multipart.NewWriter(payloadBuffer)
+
+	if writeError := multipartWriter.WriteField(keyModel, modelIdentifier); writeError != nil {
+		return constants.EmptyString, writeError
+	}
+
+	filePart, createFileError := multipartWriter.CreateFormFile(formFieldFile, fileName)
+	if createFileError != nil {
+		return constants.EmptyString, createFileError
+	}
+	if _, copyError := io.Copy(filePart, audioReader); copyError != nil {
+		return constants.EmptyString, copyError
+	}
+
+	if closeWriterError := multipartWriter.Close(); closeWriterError != nil {
+		return constants.EmptyString, closeWriterError
+	}
+
+	requestContext, cancelRequest := context.WithTimeout(context.Background(), client.requestTimeout)
+	defer cancelRequest()
+
+	requestBody := bytes.NewReader(payloadBuffer.Bytes())
+	httpRequest, buildError := http.NewRequestWithContext(requestContext, http.MethodPost, client.endpoints.GetTranscriptionsURL(), requestBody)
+	if buildError != nil {
+		return constants.EmptyString, buildError
+	}
+	httpRequest.Header.Set(headerAuthorization, headerAuthorizationPrefix+openAIKey)
+	httpRequest.Header.Set(headerContentType, multipartWriter.FormDataContentType())
+	httpRequest.Header.Set(headerAccept, mimeApplicationJSON)
+
+	statusCode, responseBytes, _, requestError := client.performTranscriptionsRequest(httpRequest, structuredLogger)
+	if requestError != nil {
+		if errors.Is(requestError, context.DeadlineExceeded) {
+			return constants.EmptyString, requestError
+		}
+		return constants.EmptyString, errors.New(errorOpenAIRequest)
+	}
+
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return constants.EmptyString, fmt.Errorf("%s: status=%d", errorOpenAIAPI, statusCode)
+	}
+
+	transcribedText, parseError := parseTranscriptionText(responseBytes)
+	if parseError != nil {
+		return constants.EmptyString, parseError
+	}
+	return transcribedText, nil
+}
+
+func parseTranscriptionText(rawPayload []byte) (string, error) {
+	trimmedPayload := strings.TrimSpace(string(rawPayload))
+	if trimmedPayload == constants.EmptyString {
+		return constants.EmptyString, errors.New(errorOpenAIAPINoText)
+	}
+
+	if strings.HasPrefix(trimmedPayload, "{") {
+		var response transcriptionResponse
+		if unmarshalError := json.Unmarshal(rawPayload, &response); unmarshalError != nil {
+			return constants.EmptyString, unmarshalError
+		}
+
+		for _, candidate := range []string{response.Text, response.Transcript, response.OutputText} {
+			trimmedCandidate := strings.TrimSpace(candidate)
+			if trimmedCandidate != constants.EmptyString {
+				return trimmedCandidate, nil
+			}
+		}
+		return constants.EmptyString, errors.New(errorOpenAIAPINoText)
+	}
+
+	return trimmedPayload, nil
+}
+
+func (client *OpenAIClient) performTranscriptionsRequest(httpRequest *http.Request, structuredLogger *zap.SugaredLogger) (int, []byte, int64, error) {
+	return utils.PerformHTTPRequest(client.httpClient.Do, httpRequest, structuredLogger, logEventOpenAIRequestError)
+}

--- a/internal/proxy/openai_dictation_test.go
+++ b/internal/proxy/openai_dictation_test.go
@@ -1,0 +1,66 @@
+package proxy
+
+import "testing"
+
+func TestParseTranscriptionText(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		wantText    string
+		wantFailure bool
+	}{
+		{
+			name:     "uses text field",
+			input:    `{"text":"hello from text"}`,
+			wantText: "hello from text",
+		},
+		{
+			name:     "falls back to transcript field",
+			input:    `{"transcript":"hello from transcript"}`,
+			wantText: "hello from transcript",
+		},
+		{
+			name:     "falls back to output_text field",
+			input:    `{"output_text":"hello from output_text"}`,
+			wantText: "hello from output_text",
+		},
+		{
+			name:        "returns error for invalid json object payload",
+			input:       `{"text":`,
+			wantFailure: true,
+		},
+		{
+			name:        "returns error for json without transcript fields",
+			input:       `{"status":"ok"}`,
+			wantFailure: true,
+		},
+		{
+			name:     "returns plain text payload when response is not json",
+			input:    "plain transcription",
+			wantText: "plain transcription",
+		},
+		{
+			name:        "returns error for blank payload",
+			input:       "   ",
+			wantFailure: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			text, parseError := parseTranscriptionText([]byte(testCase.input))
+			if testCase.wantFailure {
+				if parseError == nil {
+					subTest.Fatalf("parseError=nil want non-nil")
+				}
+				return
+			}
+			if parseError != nil {
+				subTest.Fatalf("unexpected parseError: %v", parseError)
+			}
+			if text != testCase.wantText {
+				subTest.Fatalf("text=%q want=%q", text, testCase.wantText)
+			}
+		})
+	}
+}

--- a/internal/proxy/poll_timeout_test.go
+++ b/internal/proxy/poll_timeout_test.go
@@ -16,3 +16,14 @@ func TestApplyTunablesSetsDefaultUpstreamPollTimeout(testingInstance *testing.T)
 		testingInstance.Fatalf(messageUnexpectedPollTimeout, configuration.UpstreamPollTimeoutSeconds, proxy.DefaultUpstreamPollTimeoutSeconds)
 	}
 }
+
+func TestApplyTunablesSetsDefaultDictationConfiguration(testingInstance *testing.T) {
+	configuration := proxy.Configuration{}
+	configuration.ApplyTunables()
+	if configuration.DictationModel != proxy.DefaultDictationModel {
+		testingInstance.Fatalf("dictationModel=%q want=%q", configuration.DictationModel, proxy.DefaultDictationModel)
+	}
+	if configuration.MaxInputAudioBytes != proxy.DefaultMaxInputAudioBytes {
+		testingInstance.Fatalf("maxInputAudioBytes=%d want=%d", configuration.MaxInputAudioBytes, proxy.DefaultMaxInputAudioBytes)
+	}
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -80,6 +80,7 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 
 	router.Use(gin.Recovery(), secretMiddleware(configuration.ServiceSecret, structuredLogger))
 	router.GET(rootPath, chatHandler(taskQueue, configuration.SystemPrompt, validator, requestTimeout, structuredLogger))
+	router.POST(dictatePath, dictateHandler(openAIClient, configuration.OpenAIKey, configuration.DictationModel, configuration.MaxInputAudioBytes, structuredLogger))
 	return router, nil
 }
 
@@ -173,5 +174,50 @@ func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validat
 			requestCancel()
 			ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
 		}
+	}
+}
+
+func dictateHandler(openAIClient *OpenAIClient, openAIKey string, defaultModel string, maxInputAudioBytes int64, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+	return func(ginContext *gin.Context) {
+		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxInputAudioBytes+2*1024*1024)
+		if parseError := ginContext.Request.ParseMultipartForm(maxInputAudioBytes); parseError != nil {
+			ginContext.String(http.StatusBadRequest, errorInvalidAudioForm)
+			return
+		}
+
+		audioFile, header, fileError := ginContext.Request.FormFile(formFieldAudio)
+		if fileError != nil {
+			audioFile, header, fileError = ginContext.Request.FormFile(formFieldFile)
+			if fileError != nil {
+				ginContext.String(http.StatusBadRequest, errorMissingAudioFile)
+				return
+			}
+		}
+		defer audioFile.Close()
+
+		fileName := "audio.webm"
+		if header != nil {
+			trimmedFileName := strings.TrimSpace(header.Filename)
+			if trimmedFileName != constants.EmptyString {
+				fileName = trimmedFileName
+			}
+		}
+
+		modelIdentifier := strings.TrimSpace(ginContext.Query(queryParameterModel))
+		if modelIdentifier == constants.EmptyString {
+			modelIdentifier = defaultModel
+		}
+
+		transcribedText, requestError := openAIClient.transcribeAudio(openAIKey, modelIdentifier, fileName, audioFile, structuredLogger)
+		if requestError != nil {
+			if errors.Is(requestError, context.DeadlineExceeded) {
+				ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
+				return
+			}
+			ginContext.String(http.StatusBadGateway, requestError.Error())
+			return
+		}
+
+		ginContext.JSON(http.StatusOK, gin.H{keyText: transcribedText})
 	}
 }


### PR DESCRIPTION
## Summary
- add authenticated `POST /dictate` endpoint that accepts multipart audio and returns normalized JSON `{ "text": "..." }`
- route dictation through OpenAI transcriptions endpoint via new proxy client flow
- add configurable dictation defaults (`dictation_model`, `max_input_audio_bytes`) via config, CLI flags, and env vars
- extend endpoint registry with transcriptions URL getters/setters
- document `/dictate` usage and configuration in README

## Testing
- `go test ./...`
