### PR TITLE
chore: initialize issues.md planning context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md
+
+## llm-proxy
+
+llm-proxy repository managed through ISSUES.md workflow. See README.md for details
+
+## Document Roles
+
+- AGENTS.md: Read-only workflow + behavior playbook maintained by leads. Agents never edit it during implementation cycles.
+- ISSUES.md: Log of newly discovered requests and changes. Each entry records what changed or what was discovered.
+- PLAN.md: Working plan for one concrete change/issue; ephemeral and replaced per change.
+
+### Document Precedence
+
+- `POLICY.md` defines binding validation, error-handling, and “confident programming” rules.
+- `AGENTS.md` (this file) defines repo-wide workflow, testing philosophy, and agent behavior; stack-specific AGENTS.* guides refine these rules for each technology.
+- `AGENTS.*.md` files never contradict `AGENTS.md` or `POLICY.md`; if guidance appears inconsistent, defer to `POLICY.md` first, then `AGENTS.md`, and treat the stack guide as a refinement.
+
+### Issue Status Terms
+
+- Resolved: Completed and verified; no further action (`[x]`).
+- Unresolved: Needs decision and/or implementation (`[ ]`).
+- Blocked: Requires an external dependency or policy decision (`[!]`); must include a `Blocked:` explanation in the issue body.
+
+### Validation & Confidence Policy
+
+All rules for validation, error handling, invariants, and “confident programming” (no defensive checks, edge-only validation, smart constructors, CI gates) are defined in POLICY.md. Treat that document as binding; this file does not restate them.
+
+### Build & Test Commands
+
+- Use the repository `Makefile` for local automation. Invoke `make test`, `make lint`, `make ci`, or other documented targets instead of running ad-hoc tool commands.
+- `make test` runs the canonical test suite for the active stack.
+- `make lint` enforces linting rules before code review.
+- `make ci` mirrors the GitHub Actions workflow and should pass locally before opening a PR.
+
+### Tooling Workflow (Tests, Lint, Format)
+
+- In ISSUES Managing Director execution runs, branch prep, completion checks, push, and PR creation are handled by the execution chain.
+- Agents should not duplicate those chain-owned steps unless the active issue explicitly asks for manual investigation output.
+
+## Workflow
+
+Operational playbook for working in this repository. Use it to coordinate planning, execution, and delivery. Code style, stack-specific rules, and tooling details remain in the AGENTS* documents; this section focuses purely on day-to-day process.
+
+### Authoritative References
+
+- `AGENTS.md` + per-stack guides for coding standards.
+- `POLICY.md` for validation/confident-programming rules.
+- `AGENTS.GIT.md` for Git/GitHub workflow.
+- `AGENTS.DOCKER.md` for container expectations.
+- `docs/` for adjacent documentation: third-party library notes, integration docs/runbooks, and API/contract references. Agents MUST search/check `docs/` whenever changing behavior or touching an integration.
+- `README.md`, `PRD.md`, and `ARCHITECTURE.md` for product context.
+
+### Workflow Overview
+
+1. Read `AGENTS.md` (plus relevant stack guides) before touching code.
+   Also scan `docs/` for integration runbooks and third-party library guidance relevant to the active issue.
+2. Review the backlog in `ISSUES.md`; work sequentially through BugFixes, Improvements, Maintenance, then Features. Planning is reserved for future work; do not implement Planning items.
+3. For the active issue, read `PLANNING.md` and create `PLAN.md` (ignored by git) with bullet steps. Keep it updated and delete/rewrite it for the next issue.
+4. Implement the requested change, keeping to stack-specific standards. Limit edits to necessary files plus issue-document updates when required.
+5. Do not manually create/switch branches, run completion-gate command chains, commit/push, or open PRs as part of routine execution; the execution chain does this automatically.
+6. Run local commands only when the issue explicitly asks for investigation/debugging evidence.
+7. Report what changed and any blockers; the execution chain finalizes git/check/PR steps.
+
+### Completion Gate (Non-negotiable)
+
+For agent executions launched by ISSUES Managing Director, completion is controlled by the execution chain. The agent-side completion condition is:
+1) Requested file/documentation changes are implemented.
+2) Any required issue status/notes updates are made.
+3) Blockers are reported clearly when present.
+
+### Testing & Tooling
+
+- Use `Makefile` targets (`make test`, `make lint`, `make ci`) when local diagnostics are explicitly needed.
+- Do not run full completion-gate suites as routine finish steps; the execution chain runs completion checks automatically.
+- Run stack-specific formatters only when the issue requires local validation output or explicit formatting changes.
+
+### Git & Release Flow
+
+- `master` is production. Execution branches use taxonomy prefixes (`feature/`, `improvement/`, `bugfix/`, `maintenance/`, `blocked/`) outlined in `AGENTS.GIT.md`.
+- Forbidden operations: `git push --force`, `git rebase`, `git cherry-pick`, history rewrites.
+- Do not manually run branch creation/push/PR commands during standard agent execution; those are execution-chain responsibilities.
+
+### Output Requirements
+
+- Always follow AGENTS* rules; do not restate them in PRs.
+- Begin every implementation with an up-to-date `PLAN.md`.
+- Do not touch `AGENTS.md` during normal work; treat it as read-only guidance.
+- `ISSUES.md` tracks issue status; mark items `[x]` with a concise resolution note once tests pass.
+- `PLAN.md` must remain untracked. If it enters git history, remove it via `timeout -k 350s -s SIGKILL 350s git filter-repo --path PLAN.md --invert-paths` before continuing.
+- Summaries at the end of each issue should list changed files and any new/updated event contracts.
+
+### Pre-Finish Checklist
+
+1. `PLAN.md` reflects the final state for the active issue.
+2. `ISSUES.md` entry is marked `[x]` with the resolution note.
+3. Requested implementation and documentation updates are complete.
+4. Any blockers are documented with concrete failure context.
+5. Provide a short summary plus next steps in the CLI output before moving to the next issue.
+
+If any checklist item is incomplete, do not claim completion. Complete the missing step(s) first.
+
+### Action Items Reminder
+
+- Read guiding docs (`README.md`, `PRD.md`, `docs/`, `AGENTS*`, `AGENTS.md`, `ARCHITECTURE.md`) before planning.
+- Keep working sequentially through the backlog—never parallelize issues.
+- Add missing issues to `ISSUES.md` if you discover new work while investigating; plan and resolve them in order.
+
+### Testing Philosophy
+
+- Testing follows an **inverted test pyramid**: heavy bias to high-value black-box integration and end-to-end tests that exercise external public APIs.
+- We **strive for (approximately) 100% test coverage**, with CI enforcing an agreed threshold. If coverage drops, add scenarios at the public entry points; do not chase coverage with isolated unit tests.
+- For CLI and backend services, tests compile or run the real program/CLI entrypoints or run the service and call real HTTP endpoints, capture exit codes and output (stdout/stderr, files, side effects), and assert observable results—not internal functions.
+- For web/UI, tests run the app and backing web server, drive flows through the browser, and assert against the rendered page, DOM state, events, and other user-visible behavior.
+- Unit tests are generally discouraged and may be prohibited by your stack guide. Only use unit tests when the relevant stack guide explicitly allows them (for example, `AGENTS.PY.md`), keep them as narrow guardrails for pure, deterministic helpers, and never use them as a substitute for black-box coverage or to pad coverage numbers.
+
+## Tech Stack Guides
+
+Stack-specific instructions now live in dedicated files. Apply the relevant guide alongside the shared policies above.
+
+- Front-End (Browser ES Modules with Alpine.js): `AGENTS.FRONTEND.md`
+- Backend (Go): `AGENTS.GO.md`
+- Backend (Python): `AGENTS.PY.md`
+- Docker and containerization: `AGENTS.DOCKER.md`
+- Git and version control workflow: `AGENTS.GIT.md`

--- a/issues.md/AGENTS.DOCKER.md
+++ b/issues.md/AGENTS.DOCKER.md
@@ -1,0 +1,27 @@
+# AGENTS.DOCKER.md
+
+## Scope
+
+Docker build standards for the repository. Follow AGENTS.md for shared documentation policies, validation rules, and workflow expectations.
+
+## Docker Guidelines
+
+### Base User
+
+- Containers must run as `root`. Do not create or switch to non-root users inside Docker images.
+
+### Build Strategy
+
+- Always use multi-stage Dockerfiles: compile or package artifacts in an initial stage, then copy only the required outputs into a lean runtime stage.
+- Avoid elaborate build steps when an existing base image that already contains the needed tooling or dependencies can be used. Prefer composing from purpose-built images over scripting complex setups inside Dockerfiles.
+- Provide curated Dockerfile and docker-compose YAML samples (development and production variants) for each service so contributors consistently follow approved patterns.
+- Development Dockerfiles must build artifacts directly so they can exercise uncommitted or unmerged changes before they land on main.
+- Production Dockerfiles must always pull the newest base image before layering repo artifacts to ensure dependencies stay current.
+
+### Go Builds In Containers
+
+- When building Go binaries in Docker, set `CGO_ENABLED=0`. Enable CGO only when absolutely required and document the justification in the Dockerfile.
+
+### Environment Configuration
+
+- All environment configuration for a service must reside in a single `.env.<service>` file shared by both development and production Docker workflows. Do not scatter env variables across multiple files or inline them inside Dockerfiles/compose YAML.

--- a/issues.md/AGENTS.FRONTEND.md
+++ b/issues.md/AGENTS.FRONTEND.md
@@ -1,0 +1,132 @@
+# AGENTS.FRONTEND.md
+
+## Scope
+
+Guidelines for building the browser front end with semantic web components, Alpine.js, and vanilla CSS. Follow AGENTS.md for shared workflow and POLICY.md for validation rules.
+
+## Front-End Philosophy
+
+### Semantic Web Components
+
+- Author interfaces with semantic HTML or lightweight custom elements that mirror the domain (e.g., `<note-card>`, `<history-panel>`). Avoid anonymous `<div>` stacks.
+- Keep markup declarative: structure communicates intent and lifecycle; avoid imperative DOM creation when semantics suffice.
+- Encapsulate visual states with attributes or data-* flags that Alpine can toggle, keeping templates readable.
+
+### Alpine-Driven Behavior
+
+- Alpine factories (`function NoteCard() { return { ... } }`) own component behavior. Bind them via `x-data` on the semantic wrapper element.
+- Co-locate Alpine directives (`x-bind`, `x-on`, `x-show`, etc.) with the markup they affect. The template should read like a specification of behavior.
+- Business logic belongs inside Alpine stores/factories or pure helpers in `js/core` and `js/utils`. Templates only orchestrate declared behaviors.
+- Prefer Alpine events over manual DOM APIs. Dispatch intent-specific events (`$dispatch('note:saved', payload)`) from child components and listen inside parent scope.
+
+### Declarative Flow
+
+- Local state lives inside each component; introduce shared stores only when multiple semantic components must coordinate.
+- Treat events as the communication boundary between components. Avoid `.window` listeners unless no other scope fits.
+- Eliminate dead code, unused imports, or duplicate logic. Extract shared behaviors into helpers or Alpine factories reused via composition.
+
+## Component Authoring
+
+### Naming & Identifiers
+
+- No single-letter or non-descriptive names.
+- `camelCase` for variables/functions, `PascalCase` for Alpine factories or classes, `SCREAMING_SNAKE_CASE` for constants.
+- Event handler functions describe intent (`handleSpinButtonClick`, not `onClick`).
+
+### Template Semantics
+
+- Start each component with a semantic wrapper element or custom element name.
+- Use attributes (e.g., `data-state="loading"`) or CSS classes driven by Alpine to reflect business state; do not hardcode styling logic inside JavaScript.
+- Keep markup tidy: avoid deeply nested anonymous wrappers, and prefer slot-like child elements for content sections.
+
+### Strings & Enums
+
+- All user-facing strings belong in `js/constants.js`.
+- Freeze enum-like objects with `Object.freeze` or use symbols.
+- Map keys must be named constants, never ad-hoc strings.
+
+### State & Events
+
+- `x-data` owns localized state. Do not mutate imports or global objects.
+- Shared state goes through `Alpine.store` only when multiple components truly require it.
+- Use `$dispatch`/`$listen` for cross-component communication and keep events scoped to component boundaries where possible.
+- Notifications/modals must respond to explicit events; they never self-open.
+
+## Structure & Dependencies
+
+### Code Organization
+
+- ES modules everywhere (`type="module"`). Enable strict mode implicitly through modules.
+- Pure transforms in helpers; Alpine factories for stateful UI behavior.
+- Directory layout:
+
+  ```
+  /assets/{css,img,audio}
+  /data/*.json
+  /js/
+    constants.js
+    types.d.js
+    utils/
+    core/
+    ui/
+    app.js
+  index.html
+  ```
+
+- DOM logic lives in `js/ui/`; domain logic in `js/core/`; reusable helpers in `js/utils/`.
+- Do not mutate imported bindings or function parameters.
+
+### Dependencies & Versions
+
+- CDN dependencies only; no bundlers.
+- Alpine.js: `3.13.5` from `https://cdn.jsdelivr.net/npm/alpinejs@3.13.5/dist/module.esm.js`
+- Google Identity Services: `https://accounts.google.com/gsi/client`
+- Loopaware widget: `https://loopaware.mprlab.com/widget.js`
+
+## Testing & Quality
+
+- Testing follows an **inverted test pyramid**: Playwright-driven black-box integration/end-to-end tests are the primary mechanism and should drive coverage toward (approximately) 100%, with CI enforcing an agreed threshold.
+- Playwright is the standard browser automation framework; Puppeteer and other harnesses are not allowed.
+- For user-visible behavior, tests MUST exercise the real deployed code path through the browser (no bypassing Alpine wiring or DOM behavior).
+- Integration tests only; unit tests are prohibited.
+- Perform semantic testing of component visibility, accessibility, and behavior through Playwright scenarios.
+- `make test` runs the Playwright harness headless (it may delegate to package scripts).
+- When you have many scenarios, table-drive Playwright cases (data sets) to cover permutations.
+- Black-box tests only: assert observable behavior and events, not internal DOM wiring.
+
+## Documentation & Refactors
+
+- Every public function and Alpine factory includes JSDoc and `// @ts-check` at the top of each module.
+- `types.d.js` stores shared typedefs (e.g., `Note`, `NoteClassification`).
+- Each domain module receives a `doc.md` or `README.md` explaining its responsibilities.
+- Plan refactors with bullet plans and split files larger than ~300–400 lines.
+- `app.js` remains the composition root: registers stores, components, and bridges events.
+
+## Error Handling & Logging
+
+- Throw `Error` objects—not strings—and catch errors at user entry points (button actions, init routines).
+- Use `js/utils/logging.js` for logging; no stray `console.log`.
+
+## Performance & UX
+
+- Use Alpine `.debounce` modifiers for inputs.
+- Batch DOM writes with `requestAnimationFrame`.
+- Lazy-initialize heavy components (editors, charts) on first intersection/interaction.
+- Cache selectors, avoid forced reflows, and keep animations asynchronous (no blocking waits).
+
+## Linting & Formatting
+
+- Run lint/format via the repo `Makefile` targets (prefer `make lint` / `make fmt` / `make ci`). If ESLint runs in Docker, the Makefile target should encapsulate that so contributors do not need ad-hoc commands.
+- Prettier runs only when explicitly requested; never on save.
+- Enforced rules include `no-unused-vars`, `no-implicit-globals`, `no-var`, `prefer-const`, `eqeqeq`, and `no-magic-numbers` (allowed: -1, 0, 1, 100, 360).
+
+## Data > Logic
+
+- Validate static JSON catalogs during boot.
+- Treat validated data as trustworthy; fail fast if validation fails.
+
+## Security & Boundaries
+
+- No `eval` or inline `onclick`.
+- CSP is optional but recommended; only Google Analytics may remain inline per policy.
+- All external network calls go through `js/core/backendClient.js` or `js/core/classifier.js`. UI layers never call `fetch` directly.

--- a/issues.md/AGENTS.GIT.md
+++ b/issues.md/AGENTS.GIT.md
@@ -1,0 +1,80 @@
+# AGENTS.GIT.md
+
+## Scope
+
+Git and GitHub conventions for this repository. Use these rules whenever you create branches, commit, or open pull requests. Process-oriented steps (planning, test sequencing, etc.) live in `AGENTS.md` (Workflow section); this document focuses purely on version control hygiene.
+
+In ISSUES Managing Director execution runs, branch preparation, commit, checks, push, and PR creation are handled by the execution chain. Agents should not duplicate those operations unless an issue explicitly requests manual git intervention.
+
+## Branch Strategy
+
+- `master` is the only production branch; there is no `main`.
+- Work proceeds as a forward-only chain: branch from the latest issue branch rather than repeatedly branching off `master`, so history forms a linear sequence of completed issues.
+- Only fast-forward or merge commits that advance history are allowed. Never rewrite or reset existing commits.
+
+## Branch Naming
+
+- For manual workflows outside the execution chain, create a branch before editing files. Use taxonomy prefixes `feature/`, `improvement/`, `bugfix/`, `maintenance/`, or `blocked/`.
+- Follow the pattern `<prefix>/<ISSUE-ID>-short-description`, e.g., `bugfix/B042-editor-duplicate-preview`.
+- Keep names concise enough for GitHub limits while remaining descriptive.
+- Reserve `blocked/<issue-id>` branches for work that cannot progress; the blocking reason must be documented in `ISSUES.md`.
+
+## Commits & History
+
+- Each issue typically concludes with a single commit capturing the tests and implementation for that issue. If additional fixes are needed, append new commits—do not amend or reorder history.
+- Never use `git push --force`, `git rebase`, or `git cherry-pick`. History is append-only.
+- Do not use `git revert` to rewrite history; address mistakes by authoring a new forward commit.
+- If a mistake occurs, fix it with a new commit on top of the existing branch.
+- Commit messages must be descriptive (e.g., “Fix B042 editor preview duplication”) so reviewers understand the change at a glance.
+- Do not commit or push changes unless the relevant tests, linters, and formatters have been run and are passing on the current branch, as required by `AGENTS.md` (Workflow section) (blocked work must be explicitly documented in `ISSUES.md`).
+
+## Tracking & Remotes
+
+- Push only to the `origin` remote.
+- First push for a branch must establish upstream tracking (see Command Examples).
+- Do not rename remote branches or create alternate remotes for the same work.
+- Keep local branches aligned with their tracked remote counterpart; fetch/rebase equivalents are prohibited, so merge the tracked branch if needed to resolve conflicts.
+
+## Pull Requests & GitHub
+
+- For manual workflows outside the execution chain, open pull requests via the GitHub CLI (see Command Examples). Reserve the GitHub UI only for viewing existing PRs or reviews.
+- PRs are chained: target the previously opened issue branch so reviewers can follow the sequential history. Only the first PR in a sequence targets `master`.
+- PR descriptions should reference the issue ID, summarize the change, and include PLAN.md content if required by process docs.
+- Keep PRs scoped to a single issue branch. If multiple issues are in flight, each must have its own branch and PR.
+- Continuous Integration (CI) runs on GitHub Actions; rely on it for acceptance tests and release validation. Local checks remain mandatory, but CI is the authoritative gate before merge.
+- Releases and deployment artifacts originate from GitHub workflows; keep branch histories clean to ensure deterministic CI results.
+
+## File Tracking & Ignore Rules
+
+- `PLAN.md` is intentionally ignored in `.gitignore`; ensure it never appears in commits. If it does, remove it with `timeout -k 350s -s SIGKILL 350s git filter-repo --path PLAN.md --invert-paths` before proceeding.
+- Treat generated artifacts (build output, coverage reports, etc.) as untracked unless explicitly added to `.gitignore`.
+
+## Conflict Resolution
+
+- Resolve merge conflicts locally by editing files and committing the resolution; never use force pushes or rebases to “fix” conflicts.
+- If conflicts arise because an earlier branch landed upstream, merge the updated upstream branch into your branch and continue forward.
+
+## Blocking Branches
+
+- After three documented attempts on a branch without resolution, convert the branch to `blocked/<issue-id>`, commit the current state, push it, and document the status in `ISSUES.md`.
+- Future work resumes from the last successful (non-blocked) branch tip.
+
+## Command Examples
+
+Use these standard commands when working with Git and GitHub in this repo:
+
+```sh
+# Start from the latest branch tip
+timeout -k 30s -s SIGKILL 30s git checkout bugfix/B041-editor-spam
+timeout -k 30s -s SIGKILL 30s git checkout -b bugfix/B042-editor-preview
+
+# Stage and commit work
+timeout -k 30s -s SIGKILL 30s git add path/to/files
+timeout -k 30s -s SIGKILL 30s git commit -m "Fix B042 editor preview duplication"
+
+# Push and open a PR
+timeout -k 30s -s SIGKILL 30s git push -u origin bugfix/B042-editor-preview
+timeout -k 30s -s SIGKILL 30s gh pr create --base master --head bugfix/B042-editor-preview --fill
+```
+
+CI builds and release artifacts are produced by GitHub Actions workflows in `.github/workflows/`. Refer to those YAML files for additional build examples and replicate the same steps locally when needed.

--- a/issues.md/AGENTS.GO.md
+++ b/issues.md/AGENTS.GO.md
@@ -1,0 +1,158 @@
+# AGENTS.GO.md
+
+## Scope
+
+Backend guidance for Go code. Follow AGENTS.md for repo-wide policies, documentation rules, and workflow expectations.
+
+## Backend (Go Language)
+
+### Core Principles
+
+- Reuse existing code first; extend or adapt before writing new code.
+- Generalize existing implementations instead of duplicating them.
+- Favor data structures (maps, registries, tables) over branching logic.
+- Use composition, interfaces, and method sets (“object-oriented Go”).
+- Depend on interfaces; return concrete types.
+- Group behavior on receiver types with cohesive methods.
+- Inject all external effects (I/O, network, time, randomness, OS).
+- No hidden globals for behavior.
+- Treat inputs as immutable; return new values instead of mutating.
+- Separate pure logic from effectful layers.
+- Keep units small and composable.
+- Minimal public API surface.
+- Provide only the best solution — no alternatives.
+
+---
+
+### Deliverables (for automation)
+
+- Only changed files.
+- No diffs, snippets, or examples.
+- Must compile cleanly.
+- Must pass `make ci` (or, at minimum, `make fmt`, `make lint`, and `make test`).
+- `make lint` MUST run `go vet`, `staticcheck`, and `ineffassign`.
+
+---
+
+### Code Style
+
+- No single-letter identifiers.
+- Long, descriptive names for all identifiers.
+- No inline comments.
+- Only GoDoc for modules and exported identifiers.
+- No repeated inline string literals — lift to constants.
+- Return `error`; wrap with `%w` or `errors.Join`.
+- No panics in library code.
+- Use zap for logging; no `fmt.Println`.
+- Prefer channels and contexts over shared mutable state.
+- Guard critical sections explicitly.
+
+---
+
+### Project Structure
+
+- `cmd/` for CLI entrypoints.
+- `internal/` for private packages.
+- `pkg/` for reusable libraries.
+- No package cycles.
+- Respect existing layout and naming.
+
+---
+
+### Configuration & CLI
+
+- Use Viper + Cobra.
+- Flags optional when provided via config/env.
+- Validate config in `PreRunE`.
+- Read secrets from environment.
+
+---
+
+### Dependencies (Approved)
+
+- Core: `spf13/viper`, `spf13/cobra`, `uber/zap`.
+- HTTP: `gin-gonic/gin`, `gin-contrib/cors`.
+- Data: `gorm.io/gorm`, `gorm.io/driver/postgres`, `jackc/pgx/v5`.
+- Auth/Validation: `golang-jwt/jwt/v5`, `go-playground/validator/v10`.
+- Testing: `stretchr/testify`.
+- Optional: `joho/godotenv`, `prometheus/client_golang`, `robfig/cron/v3`.
+- Prefer standard library whenever possible.
+
+---
+
+### Testing
+
+- Testing follows an **inverted test pyramid**: heavy bias to black-box integration and end-to-end tests.
+- Cover behavior through real entry points (HTTP endpoints, CLI commands, public APIs) and exercise the real deployed code path (routing/middleware/etc).
+- Integration tests only; unit tests are prohibited.
+- Use `t.TempDir()` for temporary dirs; no filesystem pollution.
+- When you have many scenarios, table-drive them inside an integration test harness (subtests) while still exercising real entry points.
+- Coverage should trend toward (approximately) 100% via integration/end-to-end scenarios through public entry points, with CI enforcing an agreed threshold.
+
+---
+
+### Web/UI
+
+- Use Gin for routing.
+- Middleware for CORS, auth, logging.
+- Vanilla CSS; no Bootstrap.
+- Header fixed top; footer fixed bottom using CSS utilities.
+
+---
+
+### Performance & Reliability
+
+- Measure before optimizing.
+- Favor clarity first, optimize after.
+- Use maps and indexes for hot paths.
+- Always propagate `context.Context`.
+- Backoff/retry as data-driven config.
+
+---
+
+### Security
+
+- Secrets from env.
+- Never log secrets or PII.
+- Validate all inputs.
+- Principle of least privilege.
+- CSP-friendly ES modules. Allowed third-party scripts: Google Analytics snippet, Google Identity Services, Loopaware widget. When CSP is enabled, inline scripts must be limited to GA config or guarded by nonce/hash.
+
+#### CSP Template (optional; use when enabling CSP)
+
+- HTTP header (preferred):
+  - `Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://accounts.google.com https://www.googletagmanager.com https://loopaware.mprlab.com 'nonce-<nonce-value>'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' https://llm-proxy.mprlab.com http://localhost:8080; font-src 'self' data:; frame-src https://accounts.google.com; base-uri 'self'; form-action 'self';`
+- Meta tag (static hosting):
+  - `<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://accounts.google.com https://www.googletagmanager.com https://loopaware.mprlab.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' https://llm-proxy.mprlab.com http://localhost:8080; font-src 'self' data:; frame-src https://accounts.google.com; base-uri 'self'; form-action 'self';">`
+- Replace `connect-src` endpoints when running against different backends or proxies. Prefer nonces over `'unsafe-inline'` where a server can inject them.
+- When using a local LLM proxy on a non-default port (e.g., `http://localhost:8081`), include it in `connect-src`.
+
+### Containerization
+
+- Follow `AGENTS.DOCKER.md` for Dockerfile requirements and runtime expectations.
+- Container builds must default to multi-stage Dockerfiles with root as the sole user.
+- Set `CGO_ENABLED=0` (`CGOENABLED=false`) for Go binaries built in Docker. Enable CGO only when absolutely necessary and document the rationale.
+
+### Assistant Workflow
+
+- Read repo and scan existing code.
+- Plan reuse and extension.
+- Replace branching with data tables where appropriate.
+- Implement minimal, cohesive types.
+- Inject dependencies.
+- Prove behavior via black-box integration/end-to-end tests through public entry points.
+
+---
+
+### Review Checklist
+
+- [ ] Reused/extended existing code.
+- [ ] Replaced branching with data structures where appropriate.
+- [ ] Minimal, cohesive public API.
+- [ ] All side effects injected.
+- [ ] No single-letter identifiers.
+- [ ] Constants used for repeated strings.
+- [ ] zap logging; contextual errors.
+- [ ] Config via Viper; validated in `PreRunE`.
+- [ ] Black-box integration/end-to-end coverage through public entry points; no filesystem pollution.
+- [ ] `make fmt`, `make lint`, `make test` (or `make ci`) pass.

--- a/issues.md/AGENTS.PY.md
+++ b/issues.md/AGENTS.PY.md
@@ -1,0 +1,79 @@
+# AGENTS.PY.md
+
+## Scope
+
+Backend guidance for Python code. Follow AGENTS.md for repo-wide policies, documentation rules, and workflow expectations.
+
+## Backend (Python)
+
+### Core Principles
+
+- Reuse existing modules first; extend or adapt before writing new code.
+- Generalize existing implementations rather than duplicating logic.
+- Favor **data-driven** solutions (maps, registries, configuration) over imperative branching.
+- Encapsulate domain rules in **dataclasses** or dedicated classes with clear invariants.
+- Keep functions small, pure, and composable; separate logic from I/O.
+- Inject all external dependencies (files, network, randomness, time). No hidden globals.
+- Treat inputs as immutable; always return new values instead of mutating.
+- Minimal public API surface; expose only one clear solution.
+- For validation, error handling, and invariants, follow **POLICY.md (Confident Programming)**.
+
+---
+
+### Code Style
+
+- Descriptive identifiers only; no single-letter names.
+- Use `@dataclass(frozen=True)` for immutable domain types.
+- Validation happens in `__post_init__` or via Pydantic (if already in use).
+- Raise `ValueError` subclasses for domain validation errors.
+- Lift repeated string literals to constants.
+- Module docstrings and class/function docstrings required; no inline comments.
+- Use type hints everywhere; keep strict type checking and run it via the repo `Makefile` (for example, `make lint`).
+- Logging through standard `logging` module; no stray `print`.
+
+---
+
+### Project Structure
+
+- `app/` or `src/` as top-level application package.
+- `domain/` for core business objects and invariants.
+- `infrastructure/` for DB, network, and OS integration.
+- `services/` for orchestration logic using domain + infra.
+
+---
+
+### Configuration & CLI
+
+- Use `argparse` or `typer` for CLI.
+- Read configuration from environment or `.env` files.
+- Validate configuration up front (edge validation).
+
+---
+
+### Dependencies
+
+- Prefer standard library; third-party libraries require explicit approval.
+- Allowed: `dataclasses`, `typing`, `pydantic` (optional), `pytest`, `mypy`.
+
+---
+
+### Testing
+
+- Follows the repo-wide **Testing Philosophy** in `AGENTS.md`: inverted test pyramid, coverage driven by black-box integration/end-to-end scenarios through public entry points and trending toward (approximately) 100% with an agreed CI threshold; unit tests are discouraged and allowed only as narrow guardrails.
+- Use `pytest` for black-box integration/end-to-end tests; parameterize cases to cover scenario matrices without drifting into unit-test-only coverage.
+- Isolate side effects with fixtures.
+- Use `tmp_path` for filesystem operations (no pollution).
+- Black-box: test only public API contracts.
+- CI gate: `make lint` (mypy/pyright) and `make test` (pytest), or `make ci` when available.
+
+---
+
+### Review Checklist
+
+- [ ] Reused/extended existing code.
+- [ ] Domain objects created via smart constructors or dataclasses with invariants.
+- [ ] No duplicated validation inside core.
+- [ ] Constants used for repeated strings.
+- [ ] Clear type hints, no single-letter identifiers.
+- [ ] Config validated at startup.
+- [ ] `make lint` and `make test` (or `make ci`) passing.

--- a/issues.md/AGENTS.md
+++ b/issues.md/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md
+
+## llm-proxy
+
+llm-proxy repository managed through ISSUES.md workflow. See README.md for details
+
+## Document Roles
+
+- AGENTS.md: Read-only workflow + behavior playbook maintained by leads. Agents never edit it during implementation cycles.
+- ISSUES.md: Log of newly discovered requests and changes. Each entry records what changed or what was discovered.
+- PLAN.md: Working plan for one concrete change/issue; ephemeral and replaced per change.
+
+### Document Precedence
+
+- `POLICY.md` defines binding validation, error-handling, and “confident programming” rules.
+- `AGENTS.md` (this file) defines repo-wide workflow, testing philosophy, and agent behavior; stack-specific AGENTS.* guides refine these rules for each technology.
+- `AGENTS.*.md` files never contradict `AGENTS.md` or `POLICY.md`; if guidance appears inconsistent, defer to `POLICY.md` first, then `AGENTS.md`, and treat the stack guide as a refinement.
+
+### Issue Status Terms
+
+- Resolved: Completed and verified; no further action (`[x]`).
+- Unresolved: Needs decision and/or implementation (`[ ]`).
+- Blocked: Requires an external dependency or policy decision (`[!]`); must include a `Blocked:` explanation in the issue body.
+
+### Validation & Confidence Policy
+
+All rules for validation, error handling, invariants, and “confident programming” (no defensive checks, edge-only validation, smart constructors, CI gates) are defined in POLICY.md. Treat that document as binding; this file does not restate them.
+
+### Build & Test Commands
+
+- Use the repository `Makefile` for local automation. Invoke `make test`, `make lint`, `make ci`, or other documented targets instead of running ad-hoc tool commands.
+- `make test` runs the canonical test suite for the active stack.
+- `make lint` enforces linting rules before code review.
+- `make ci` mirrors the GitHub Actions workflow and should pass locally before opening a PR.
+
+### Tooling Workflow (Tests, Lint, Format)
+
+- In ISSUES Managing Director execution runs, branch prep, completion checks, push, and PR creation are handled by the execution chain.
+- Agents should not duplicate those chain-owned steps unless the active issue explicitly asks for manual investigation output.
+
+## Workflow
+
+Operational playbook for working in this repository. Use it to coordinate planning, execution, and delivery. Code style, stack-specific rules, and tooling details remain in the AGENTS* documents; this section focuses purely on day-to-day process.
+
+### Authoritative References
+
+- `AGENTS.md` + per-stack guides for coding standards.
+- `POLICY.md` for validation/confident-programming rules.
+- `AGENTS.GIT.md` for Git/GitHub workflow.
+- `AGENTS.DOCKER.md` for container expectations.
+- `docs/` for adjacent documentation: third-party library notes, integration docs/runbooks, and API/contract references. Agents MUST search/check `docs/` whenever changing behavior or touching an integration.
+- `README.md`, `PRD.md`, and `ARCHITECTURE.md` for product context.
+
+### Workflow Overview
+
+1. Read `AGENTS.md` (plus relevant stack guides) before touching code.
+   Also scan `docs/` for integration runbooks and third-party library guidance relevant to the active issue.
+2. Review the backlog in `ISSUES.md`; work sequentially through BugFixes, Improvements, Maintenance, then Features. Planning is reserved for future work; do not implement Planning items.
+3. For the active issue, read `PLANNING.md` and create `PLAN.md` (ignored by git) with bullet steps. Keep it updated and delete/rewrite it for the next issue.
+4. Implement the requested change, keeping to stack-specific standards. Limit edits to necessary files plus issue-document updates when required.
+5. Do not manually create/switch branches, run completion-gate command chains, commit/push, or open PRs as part of routine execution; the execution chain does this automatically.
+6. Run local commands only when the issue explicitly asks for investigation/debugging evidence.
+7. Report what changed and any blockers; the execution chain finalizes git/check/PR steps.
+
+### Completion Gate (Non-negotiable)
+
+For agent executions launched by ISSUES Managing Director, completion is controlled by the execution chain. The agent-side completion condition is:
+1) Requested file/documentation changes are implemented.
+2) Any required issue status/notes updates are made.
+3) Blockers are reported clearly when present.
+
+### Testing & Tooling
+
+- Use `Makefile` targets (`make test`, `make lint`, `make ci`) when local diagnostics are explicitly needed.
+- Do not run full completion-gate suites as routine finish steps; the execution chain runs completion checks automatically.
+- Run stack-specific formatters only when the issue requires local validation output or explicit formatting changes.
+
+### Git & Release Flow
+
+- `master` is production. Execution branches use taxonomy prefixes (`feature/`, `improvement/`, `bugfix/`, `maintenance/`, `blocked/`) outlined in `AGENTS.GIT.md`.
+- Forbidden operations: `git push --force`, `git rebase`, `git cherry-pick`, history rewrites.
+- Do not manually run branch creation/push/PR commands during standard agent execution; those are execution-chain responsibilities.
+
+### Output Requirements
+
+- Always follow AGENTS* rules; do not restate them in PRs.
+- Begin every implementation with an up-to-date `PLAN.md`.
+- Do not touch `AGENTS.md` during normal work; treat it as read-only guidance.
+- `ISSUES.md` tracks issue status; mark items `[x]` with a concise resolution note once tests pass.
+- `PLAN.md` must remain untracked. If it enters git history, remove it via `timeout -k 350s -s SIGKILL 350s git filter-repo --path PLAN.md --invert-paths` before continuing.
+- Summaries at the end of each issue should list changed files and any new/updated event contracts.
+
+### Pre-Finish Checklist
+
+1. `PLAN.md` reflects the final state for the active issue.
+2. `ISSUES.md` entry is marked `[x]` with the resolution note.
+3. Requested implementation and documentation updates are complete.
+4. Any blockers are documented with concrete failure context.
+5. Provide a short summary plus next steps in the CLI output before moving to the next issue.
+
+If any checklist item is incomplete, do not claim completion. Complete the missing step(s) first.
+
+### Action Items Reminder
+
+- Read guiding docs (`README.md`, `PRD.md`, `docs/`, `AGENTS*`, `AGENTS.md`, `ARCHITECTURE.md`) before planning.
+- Keep working sequentially through the backlog—never parallelize issues.
+- Add missing issues to `ISSUES.md` if you discover new work while investigating; plan and resolve them in order.
+
+### Testing Philosophy
+
+- Testing follows an **inverted test pyramid**: heavy bias to high-value black-box integration and end-to-end tests that exercise external public APIs.
+- We **strive for (approximately) 100% test coverage**, with CI enforcing an agreed threshold. If coverage drops, add scenarios at the public entry points; do not chase coverage with isolated unit tests.
+- For CLI and backend services, tests compile or run the real program/CLI entrypoints or run the service and call real HTTP endpoints, capture exit codes and output (stdout/stderr, files, side effects), and assert observable results—not internal functions.
+- For web/UI, tests run the app and backing web server, drive flows through the browser, and assert against the rendered page, DOM state, events, and other user-visible behavior.
+- Unit tests are generally discouraged and may be prohibited by your stack guide. Only use unit tests when the relevant stack guide explicitly allows them (for example, `AGENTS.PY.md`), keep them as narrow guardrails for pure, deterministic helpers, and never use them as a substitute for black-box coverage or to pad coverage numbers.
+
+## Tech Stack Guides
+
+Stack-specific instructions now live in dedicated files. Apply the relevant guide alongside the shared policies above.
+
+- Front-End (Browser ES Modules with Alpine.js): `AGENTS.FRONTEND.md`
+- Backend (Go): `AGENTS.GO.md`
+- Backend (Python): `AGENTS.PY.md`
+- Docker and containerization: `AGENTS.DOCKER.md`
+- Git and version control workflow: `AGENTS.GIT.md`

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -1,0 +1,34 @@
+# ISSUES
+
+Working backlog for this repository. Keep it current and small. Use @issues-md-format.md for the canonical format.
+
+- Status markers: `[ ]` open, `[!]` blocked (must include a `Blocked:` line), `[x]` closed.
+- Hygiene: once a closed issue's consequences are reflected in code/tests and in user-facing docs, remove the entry from this file. Git history remains the record. (Recurring runbooks below are the exception: keep them open.)
+
+## BugFixes
+
+## Improvements
+
+## Maintenance
+
+### Recurring (runbooks; keep open)
+
+These entries are always-available procedures. Keep them `[ ]` so they remain runnable; when you run one, update a short `Last run:` line in the body (and optionally link the PR/commit).
+
+- [ ] [M400] (P2) Backlog housekeeping
+  1. Validate `issues.md/ISSUES.md` matches `issues-md-format.md`.
+  2. Confirm user-facing consequences of recently closed work are documented (README/ARCHITECTURE/PRD).
+  3. Prune closed entries once documented.
+  4. Merge duplicates and delete irrelevant issues.
+
+- [ ] [M401] (P2) Polish open issues
+  1. For each open issue, add missing context (dependencies, repro steps, acceptance criteria, and test expectations).
+  2. Ensure each issue has a clear priority and concrete deliverables.
+
+- [ ] [M402] (P2) Architecture and policy review
+  1. Review the codebase against POLICY.md and stack guides.
+  2. Record findings as new Maintenance issues (or close as "no action" if already covered).
+
+## Features
+
+## Planning

--- a/issues.md/PLANNING.md
+++ b/issues.md/PLANNING.md
@@ -1,0 +1,44 @@
+You are a very strong reasoner and planner. Use these critical instructions to structure your plans, thoughts, and responses.
+
+Before taking any action (either tool calls *or* responses to the user), you must proactively, methodically, and independently plan and reason about:
+
+1. Logical dependencies and constraints: Analyze the intended action against the following factors. Resolve conflicts in order of importance:
+    1.1) Policy-based rules, mandatory prerequisites, and constraints.
+    1.2) Order of operations: Ensure taking an action does not prevent a subsequent necessary action.
+     1.2.1) The user may request actions in a random order, but you may need to reorder operations to maximize successful completion of the task.
+    1.3) Other prerequisites (information and/or actions needed).
+    1.4) Explicit user constraints or preferences.
+
+2. Risk assessment: What are the consequences of taking the action? Will the new state cause any future issues?
+    2.1) For exploratory tasks (like searches), missing *optional* parameters is a LOW risk.
+    **Prefer calling the tool with the available information over asking the user, unless** your *Rule 1* (Logical Dependencies) reasoning determines that optional information is required for a later step in your plan.
+
+3. Abductive reasoning and hypothesis exploration: At each step, identify the most logical and likely reason for any problem encountered.
+    3.1) Look beyond immediate or obvious causes. The most likely reason may not be the simplest and may require deeper inference.
+    3.2) Hypotheses may require additional research. Each hypothesis may take multiple steps to test.
+    3.3) Prioritize hypotheses based on likelihood, but do not discard less likely ones prematurely. A low-probability event may still be the root cause.
+
+4. Outcome evaluation and adaptability: Does the previous observation require any changes to your plan?
+    4.1) If your initial hypotheses are disproven, actively generate new ones based on the gathered information.
+
+5. Information availability: Incorporate all applicable and alternative sources of information, including:
+    5.1) Using available tools and their capabilities
+    5.2) All policies, rules, checklists, and constraints
+    5.3) Previous observations and conversation history
+    5.4) Information only available by asking the user
+
+6. Precision and Grounding: Ensure your reasoning is extremely precise and relevant to each exact ongoing situation.
+    6.1) Verify your claims by quoting the exact applicable information (including policies) when referring to them.
+
+7. Completeness: Ensure that all requirements, constraints, options, and preferences are exhaustively incorporated into your plan.
+    7.1) Resolve conflicts using the order of importance in #1.
+    7.2) Avoid premature conclusions: There may be multiple relevant options for a given situation.
+     7.2.1) To check for whether an option is relevant, reason about all information sources from #5.
+     7.2.2) You may need to consult the user to even know whether something is applicable. Do not assume it is not applicable without checking.
+    7.3) Review applicable sources of information from #5 to confirm which are relevant to the current state.
+
+8. Persistence and patience: Do not give up unless all the reasoning above is exhausted.
+    8.1) Don't be dissuaded by time taken or user frustration.
+    8.2) This persistence must be intelligent: On *transient* errors (e.g. please try again), you *must* retry **unless an explicit retry limit (e.g., max x tries) has been reached**. If such a limit is hit, you *must* stop. On *other* errors, you must change your strategy or arguments, not repeat the same failed call.
+
+9. Inhibit your response: only take an action after all the above reasoning is completed. Once you’ve taken an action, you cannot take it back.

--- a/issues.md/POLICY.md
+++ b/issues.md/POLICY.md
@@ -1,0 +1,224 @@
+# Confident Programming (Binding Policy for Agents)
+
+## 0) One-page summary (operator rules)
+
+- Validate **only at edges** (I/O, HTTP, CLI, DB adapters). Core assumes valid domain objects.
+- **Make illegal states unrepresentable** via types and smart constructors.
+- **Fail fast** (dev) and **wrap errors with context** at boundaries (prod).
+- **Narrow interfaces**: accept domain types, not loose primitives, when a domain type exists.
+- **No duplicate checks** in core; once validated, don’t re-validate.
+- Tests target **contracts/invariants**, not defensive branches.
+- **Inverted test pyramid (integration-first)**: Bias hard toward black-box integration and end-to-end tests that exercise the real code path through public entry points (HTTP endpoints, CLI commands, browser flows).
+- **Integration tests only (default)**: Unit tests are prohibited for Go and Front-End/JS work. Python may allow narrow unit tests only when explicitly permitted by `AGENTS.PY.md`, and never as a substitute for black-box coverage of user-visible behavior.
+- We **strive for (approximately) 100% test coverage** achieved via those black-box integration/end-to-end suites, with CI enforcing an agreed threshold. If coverage drops, add scenarios at the public entry points.
+
+---
+
+## A. Hard rules (agent MUST follow)
+
+1. Edge-only validation; core **assumes** valid domain objects.
+2. All domain entities created via **smart constructors**; exporting “zero-but-invalid” is **forbidden**.
+3. **No duplicated validation** inside core modules—remove it when found.
+4. **Narrow interfaces**: functions accept domain types (not `string`, `any`, bare `float64`, etc., when a domain type exists).
+5. Errors are **explicit and contextual**. Choices:
+
+   - **Dev**: assert/panic for impossible states.
+   - **Prod boundary**: **wrap** with operation + subject + stable code.
+
+6. **No silent fallbacks** or “best-effort” paths unless a product requirement is cited in the commit.
+
+---
+
+## B. Invariants & contracts (declare per module)
+
+- **Preconditions**: truth required at entry.
+- **Postconditions**: guarantees on success.
+- **Invariants**: properties that can never be false for the type/module.
+- Each constructor MUST reject invalid state with a **typed/explicit** error.
+
+---
+
+## C. Language targets (agent MUST implement)
+
+### Go
+
+- Smart constructors returning `(Type, error)`; **no exported invalid zero-values**.
+- Typed/sentinel errors; wrap using `fmt.Errorf("%w: context", ErrX)`.
+- CI gates MUST pass via the repository `Makefile` targets (prefer `make ci`): `make lint` MUST run `go vet`, `staticcheck`, and `ineffassign`, and `make test` MUST run `go test`.
+
+### Python
+
+- `@dataclass(frozen=True)` or **Pydantic if already present**.
+- Validate in `__post_init__` (or Pydantic validators); raise `ValueError` subclasses.
+- CI gates MUST pass via the repository `Makefile` targets (prefer `make ci`): `make lint` MUST run `mypy --strict` (or `pyright` equivalent), and `make test` MUST run `pytest`.
+
+### JavaScript (vanilla ESM + JSDoc; no build step)
+
+- `// @ts-check` at top of every new/edited file.
+- JSDoc typedefs; factory functions **throw** on invalid input.
+- CI gates MUST pass via the repository `Makefile` targets (prefer `make ci`): `make lint` and/or `make test` MUST run `tsc --noEmit` (type-checking only) for edited files.
+
+---
+
+## D. Prohibited patterns (auto-reject)
+
+- Adding unit tests in Go or Front-End/JS work.
+- Using unit tests as product-correctness coverage for externally observable behavior. If a behavior is user-visible, it must be covered via a black-box integration/end-to-end test through a public entry point (even if a stack allows narrow unit tests for pure helpers).
+- Tests that claim product correctness but bypass the real entry point (HTTP routing/middleware, CLI entrypoint, browser flow) as the only validation.
+- Exporting partially initialized/invalid structs/classes.
+- Swallowing errors (`catch {}` with no action; `if err == nil { /* ignore */ }`).
+- Re-validating a domain object already built by a smart constructor.
+- Adding "best-effort" fallback without a cited product requirement.
+- Boolean/flag parameters that conflate behaviors when a sum-type or distinct API is clearer.
+
+---
+
+## E. Agent patching protocol (order of operations)
+
+1. **Introduce or reuse** a domain type before changing service logic.
+2. **Move validation** from core into the nearest edge (handler/CLI/repo adapter).
+3. Replace ambiguous flags with **sum-type** style (Go: newtype + constants; Python/JS: literal unions).
+4. **Wrap errors** with operation + subject + stable code; do not couple core to HTTP/log formatting.
+5. **Delete redundant checks**; note removal in commit message: “removed interior validation (edge-validated)”.
+
+---
+
+## F. CI gates (must wire or respect)
+
+- **Go:** `make lint` (must run `go vet`, `staticcheck`, `ineffassign`) and `make test` (or `make ci`).
+- **Python:** `make lint` (mypy/pyright) and `make test` (pytest), as wired in the repository.
+- **JS:** `make lint` and/or `make test` must include `tsc --noEmit` for edited files, with `// @ts-check` present in edited modules.
+- **Coverage:** CI MUST enforce a coverage gate aligned with the repo-wide testing philosophy in `AGENTS.md`—integration/black-box suites should drive effective coverage toward (approximately) 100% for code under test, and CI should fail when coverage drops below the agreed threshold.
+
+> Failing any gate = patch is not acceptable.
+
+---
+
+## G. PR template checks (agent MUST tick)
+
+- [ ] Validation moved to edges; core free of re-checks
+- [ ] Domain types created/extended via smart constructors
+- [ ] Errors wrapped with operation + subject + stable code
+- [ ] No zero-but-invalid exports
+- [ ] Language CI gates pass (Go/Py/JS as applicable)
+
+---
+
+## H. Agent self-check rubric (0/1 each; **must score 6/6**)
+
+1. All external inputs validated **exactly once** at edges.
+2. All core function params are **domain types**, not loose primitives.
+3. No defensive re-checks remain inside core.
+4. Every constructor rejects invalid state with a typed/explicit error.
+5. Every error path includes **operation + subject + stable code**.
+6. CI gates configured or confirmed passing for edited languages.
+
+If score < 6, agent MUST continue patching until score = 6.
+
+---
+
+## I. Minimal boilerplate the agent MAY reuse
+
+### Go
+
+```go
+package domain
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrInvalidExample = errors.New("invalid_example")
+
+type ExampleID string
+
+func NewExampleID(rawInput string) (ExampleID, error) {
+	if rawInput == "" {
+		return "", fmt.Errorf("%w: empty id", ErrInvalidExample)
+	}
+	return ExampleID(rawInput), nil
+}
+```
+
+### Python
+
+```python
+from dataclasses import dataclass
+
+class InvalidExample(ValueError):
+    pass
+
+@dataclass(frozen=True)
+class ExampleId:
+    value: str
+    def __post_init__(self) -> None:
+        if not self.value:
+            raise InvalidExample("empty id")
+```
+
+### JavaScript (ESM + JSDoc)
+
+/_ @ts-check _/
+
+```js
+/**
+ * @typedef {{ value: string }} ExampleId
+ */
+
+/**
+ * @param {string} rawInput
+ * @returns {ExampleId}
+ */
+export function createExampleId(rawInput) {
+  const normalized = String(rawInput).trim();
+  if (!normalized) throw new Error("invalid_example: empty id");
+  return { value: normalized };
+}
+```
+
+---
+
+## J. Commit message template (agent MUST use)
+
+```
+feat(domain): introduce {DomainType} smart constructor; move validation to edge
+
+- add {DomainType} with invariants: {list}
+- adapt handlers/adapters to construct at edges
+- remove interior defensive checks (validated once at boundary)
+- wrap errors with operation+subject+stable code (e.g., user.create.invalid_email)
+- CI: `make fmt`, `make lint`, `make test` (or `make ci`) passing
+```
+
+---
+
+## K. Example edge→core flow (reference)
+
+1. **Edge** (HTTP/CLI/Repo): parse → validate → construct domain types.
+2. **Core** (services/domain): operate only on domain types; no re-validation.
+3. **Boundary**: map domain/infra errors to stable codes and user-facing messages.
+
+---
+
+### Notes for agents
+
+- Prefer **static guarantees** over runtime checks.
+- If you must catch and continue, include a **product requirement citation** and justification.
+- Do not introduce new dependencies unless an existing project standard already includes them.
+
+---
+
+### CI snippets
+
+Run the repo's CI gates via `make` (preferred) and always prefix commands with `timeout`:
+
+```sh
+# Full suite (preferred when available)
+timeout -k 350s -s SIGKILL 350s make ci
+
+# Per-target (when you need to isolate failures)
+timeout -k 30s -s SIGKILL 30s make fmt
+timeout -k 30s -s SIGKILL 30s make lint
+timeout -k 350s -s SIGKILL 350s make test
+```

--- a/issues.md/issues-md-format.md
+++ b/issues.md/issues-md-format.md
@@ -1,0 +1,79 @@
+# ISSUES.md Format
+
+This document describes the canonical ISSUES.md layout and the section-aware identifier scheme.
+
+## Structure
+
+- The file starts with a title line (for example, `# ISSUES`),
+  followed by optional guidance text.
+- Issues are grouped under level-2 headings (`## ...`).
+- Optional subheadings (`### ...`) may be used within a section for organization (for example, "Recurring"), but IDs must still match the parent section.
+- Sections are:
+  - BugFixes
+  - Improvements
+  - Maintenance
+  - Features
+  - Planning
+
+Section headings should not include numeric ranges; the section name alone is
+the category.
+
+## Issue entries
+
+Each issue entry is a single list item with this shape:
+
+```text
+- [ ] [B042] (P1) {I007} Short title
+```
+
+Rules:
+
+- `[ ]` means open (unresolved), `[!]` means blocked (unresolved), `[x]` means closed (resolved).
+- The external ID is required.
+- Priority and dependencies are optional and appear immediately after the ID.
+- The title is required.
+- Blocked issues (`[!]`) MUST include a short explanation in the body (at minimum one indented line starting with `Blocked:`).
+
+## Identifiers
+
+Format: `<SectionLetter><SequenceNumber>` with no repo prefix.
+
+Section letters:
+
+- B = BugFixes
+- I = Improvements
+- M = Maintenance
+- F = Features
+- P = Planning
+
+Identifiers must match the section they appear in. Numbers increment
+independently per section. Use three digits (`001`-`999`) per section; after a
+section reaches its max (example: after B999), the next auto-number wraps to
+B001.
+Legacy repo-prefixed identifiers (for example `IM-###`) are invalid.
+
+## Priority and dependencies
+
+- Priority uses `(P0)` through `(P2)` immediately after the ID.
+- Dependencies use `{ID,ID}` with comma-separated IDs.
+
+## Body text
+
+- To attach a body on the same line, separate the title and body with a space,
+  an em dash (U+2014), and a space.
+- Additional body lines may follow on subsequent lines; indent by two spaces
+  to keep them attached to the issue.
+- Fenced code blocks are allowed in the body; indent them by two spaces as well.
+
+## Example
+
+```text
+# ISSUES
+
+## BugFixes
+- [!] [B042] (P0) Fix crash on startup
+  Blocked: waiting on upstream API credentials.
+  ```bash
+  timeout -k 30s -s SIGKILL 30s make test
+  ```
+```


### PR DESCRIPTION
## Summary

Initialize issues.md planning context for `llm-proxy`.

- seed issues.md templates
- create root AGENTS.md from context templates
- replace template placeholders with repository values
