### PR TITLE
Improve model support and add JSON POST chat payload handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,13 @@ jobs:
             exit 1
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to registry
         uses: docker/login-action@v2
@@ -55,6 +60,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,24 @@ jobs:
       contents: write
       packages: write
     env:
+      GO_VERSION: '1.24'
       CHANGELOG_FILE: CHANGELOG.md
       RELEASE_NOTES_FILE: release_notes.md
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Go lint tools
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install github.com/gordonklaus/ineffassign@latest
+
+      - name: Run CI
+        run: timeout -k 350s -s SIGKILL 350s make ci
 
       - name: Validate changelog and extract release notes
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,21 +6,34 @@ on:
       - master
     types:
       - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     paths:
       - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - 'scripts/**'
+      - '.github/workflows/test.yml'
+      - '.github/workflows/release.yml'
+      - 'Dockerfile'
 
 env:
   GO_VERSION: '1.24'
-  TEST_COMMAND: go test ./...
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Run tests
-        run: ${{ env.TEST_COMMAND }}
+      - name: Install Go lint tools
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install github.com/gordonklaus/ineffassign@latest
+      - name: Run CI
+        run: timeout -k 350s -s SIGKILL 350s make ci

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 !AGENTS.md
 !.mprl/
 !.mprl/**
+!Makefile
+!scripts/
+!scripts/**

--- a/.mprl/ISSUES.md
+++ b/.mprl/ISSUES.md
@@ -47,8 +47,14 @@ Working backlog for this repository. Keep it current and small. Use @issues-md-f
 
 ## Maintenance
 
+- [x] [M001] (P1) Standardize repository automation targets.
+  ### Summary
+  Add the standard repo-local `make ci`, `make release`, `make publish`, and `make deploy` entrypoints used by deployed MPR services.
+  
+  ### Resolution
+  Added a Makefile, release/publish/deploy scripts, GitHub workflow alignment for `make ci`, and README documentation. `make deploy` delegates to the sibling `mprlab-gateway` checkout because `llm-proxy` is gateway-colocated.
+
 ## Features
 
 ## Planning
 *do not implement yet*
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 # Build stage (Debian-based Go image)
-FROM golang:1.24-bullseye AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-bullseye AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /app
 
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o llm-proxy ./cmd/cli
+RUN CGO_ENABLED=0 GOOS="${TARGETOS:-$(go env GOOS)}" GOARCH="${TARGETARCH:-$(go env GOARCH)}" go build -o llm-proxy ./cmd/cli
 
 # Runtime stage
 FROM debian:bullseye-slim

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+SHELL := /bin/bash
+
+GO ?= go
+GOFMT ?= gofmt
+STATICCHECK ?= staticcheck
+INEFFASSIGN ?= ineffassign
+BIN_DIR ?= bin
+BINARY_NAME ?= llm-proxy
+PUBLISH_ARGS ?=
+RELEASE_ARGS ?=
+DEPLOY_ARGS ?=
+PUBLISH_PLATFORMS ?= linux/amd64,linux/arm64
+DOCKER_IMAGE ?= ghcr.io/tyemirov/llm-proxy
+PUBLISH_REMOTE ?= origin
+PUBLISH_BRANCH ?= master
+GATEWAY_DIR ?=
+GATEWAY_DEPLOY_TARGET ?= deploy-gateway
+
+GO_SOURCES := $(shell find . -name '*.go' -not -path './vendor/*')
+
+.PHONY: fmt check-format lint test build clean ci release publish deploy
+
+fmt:
+	$(GOFMT) -w $(GO_SOURCES)
+
+check-format:
+	@formatted="$$($(GOFMT) -l $(GO_SOURCES))"; \
+	if [ -n "$$formatted" ]; then \
+		echo "Go files require formatting:"; \
+		echo "$$formatted"; \
+		exit 1; \
+	fi
+
+lint:
+	@command -v $(STATICCHECK) >/dev/null 2>&1 || { echo "staticcheck is required (install via go install honnef.co/go/tools/cmd/staticcheck@latest)"; exit 1; }
+	@command -v $(INEFFASSIGN) >/dev/null 2>&1 || { echo "ineffassign is required (install via go install github.com/gordonklaus/ineffassign@latest)"; exit 1; }
+	$(GO) vet ./...
+	$(STATICCHECK) ./...
+	$(INEFFASSIGN) ./...
+
+test:
+	$(GO) test ./...
+
+build:
+	mkdir -p $(BIN_DIR)
+	CGO_ENABLED=0 $(GO) build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/cli
+
+clean:
+	rm -rf $(BIN_DIR)
+
+ci: check-format lint test
+
+release:
+	@./scripts/release.sh $(RELEASE_ARGS)
+
+publish:
+	@DOCKER_IMAGE="$(DOCKER_IMAGE)" PUBLISH_PLATFORMS="$(PUBLISH_PLATFORMS)" PUBLISH_REMOTE="$(PUBLISH_REMOTE)" PUBLISH_BRANCH="$(PUBLISH_BRANCH)" ./scripts/publish.sh $(PUBLISH_ARGS)
+
+deploy:
+	@GATEWAY_DIR="$(GATEWAY_DIR)" DOCKER_IMAGE="$(DOCKER_IMAGE)" GATEWAY_DEPLOY_TARGET="$(GATEWAY_DEPLOY_TARGET)" ./scripts/deploy.sh $(DEPLOY_ARGS)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx \
   ./llm-proxy --port=8080 --log_level=info
 ```
 
+## Local Automation
+
+This repository exposes the standard local targets used by MPR app repos:
+
+| Command | Purpose |
+|---------|---------|
+| `make ci` | Run format checks, Go lint (`go vet`, `staticcheck`, `ineffassign`), and the Go test suite. |
+| `make release` | Cut a `v*` release from `master`, update `CHANGELOG.md` when needed, and push the release tag. |
+| `make publish` | Validate the release source and publish `ghcr.io/tyemirov/llm-proxy:<tag>` plus `:latest`. |
+| `make deploy` | Verify the published image and deploy through the sibling `../mprlab-gateway` checkout. |
+
+`llm-proxy` is a gateway-local service in `mprlab-gateway`, so `make deploy`
+defaults to the gateway `deploy-gateway` target. Override the checkout or target
+with `GATEWAY_DIR=/path/to/mprlab-gateway` or
+`GATEWAY_DEPLOY_TARGET=<target>`.
+
 ## Usage
 
 ### Basic request (default model, no web search)
@@ -238,20 +254,15 @@ the selected integration profile or deployment docs, not in this README.
 
 ## Releasing
 
-To publish a new version:
+Use `make release` from a clean, up-to-date `master` branch. It runs `make ci`,
+updates `CHANGELOG.md` if the selected version is missing, creates the release
+commit when needed, and pushes the `v*` tag. Tags that begin with `v` trigger
+the release workflow, which builds and publishes the Docker image and uses the
+matching changelog section as release notes.
 
-1. Update `CHANGELOG.md` with a new section describing the release.
-2. Commit the change.
-3. Tag the commit and push both the branch and tag:
-
-   ```bash
-   git tag vX.Y.Z
-   git push origin master
-   git push origin vX.Y.Z
-   ```
-
-Tags that begin with `v` trigger the release workflow, which builds binaries and uses the matching changelog section as
-release notes.
+Use `make publish` only when you need to publish the release image manually.
+Use `make deploy` after the release image is published and `:latest` points at
+the same digest as the release tag.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ variables:
 | `--system_prompt` / `SYSTEM_PROMPT`   | Optional system prompt text                         |
 | `--workers` / `GPT_WORKERS`           | Number of worker goroutines (default `4`)           |
 | `--queue_size` / `GPT_QUEUE_SIZE`     | Request queue size (default `100`)                  |
+| `--max_prompt_bytes` / `GPT_MAX_PROMPT_BYTES` | Max accepted JSON body size for `POST /` prompts (default `4194304`) |
 | `--dictation_model` / `GPT_DICTATION_MODEL` | Default model for `/dictate` when query model is not provided (default `gpt-4o-mini-transcribe`) |
 | `--max_input_audio_bytes` / `GPT_MAX_INPUT_AUDIO_BYTES` | Max accepted upload size for `/dictate` (default `26214400`) |
 
@@ -61,6 +62,31 @@ curl --get \
   --data-urlencode "key=mysecret" \
   "http://localhost:8080/"
 ```
+
+### Large text request
+
+Use `POST /` with a JSON body when the prompt is too large for a URL query
+parameter. Authentication still uses the `key` query parameter, which is the
+proxy `SERVICE_SECRET`. Do not send `OPENAI_API_KEY` or any upstream provider
+secret in the request body; the proxy reads its OpenAI key from server-side
+configuration. The JSON body is capped by `--max_prompt_bytes` /
+`GPT_MAX_PROMPT_BYTES`.
+
+```shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  --data '{"prompt":"большой русский текст...","model":"gpt-5.5","web_search":false,"system_prompt":"optional"}' \
+  "http://localhost:8080/?key=mysecret"
+```
+
+JSON body fields:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `prompt` | Yes | none | Full text to send to the LLM. Use this body field for large or non-ASCII prompts. |
+| `model` | No | `gpt-4.1` | OpenAI model identifier from the supported LLM model list. |
+| `web_search` | No | `false` | Enables the OpenAI web search tool when the selected model supports it. |
+| `system_prompt` | No | configured `SYSTEM_PROMPT` | Per-request system prompt override. |
 
 ### Choose a model
 
@@ -134,6 +160,23 @@ GET /
   &format=CONTENT_TYPE      # optional; or use Accept header
 ```
 
+```
+POST /
+  ?key=SERVICE_SECRET       # required
+  &format=CONTENT_TYPE      # optional; or use Accept header
+Content-Type: application/json
+{
+  "prompt": "STRING",       # required
+  "model": "MODEL_NAME",    # optional; defaults to gpt-4.1
+  "web_search": false,      # optional; defaults to false
+  "system_prompt": "STRING" # optional; defaults to configured system prompt
+}
+```
+
+The POST JSON body carries only LLM request parameters. The client shared
+secret remains in the `key` query parameter, and the upstream OpenAI API key is
+never accepted from client requests.
+
 ### Dictation endpoint
 
 ```
@@ -150,36 +193,48 @@ Success response:
 { "text": "..." }
 ```
 
-Supported models include any listed in `/v1/models` from the OpenAI API
-(e.g. `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`).
-Not all models support tools; for **web search**, use `gpt-4o`, `gpt-4.1`, or `gpt-5`.
+Supported LLM endpoint models are listed below. The `/dictate` endpoint passes
+its `model` parameter through to OpenAI's audio transcriptions API.
+Not all models support tools; use a model marked `Yes` below for **web search**.
 
 ### Model capabilities
 
-| Model         | Provider | Web Search |
-|---------------|----------|------------|
-| `gpt-4.1`     | OpenAI   | Yes        |
-| `gpt-4o`      | OpenAI   | Yes        |
-| `gpt-4o-mini` | OpenAI   | No         |
-| `gpt-5`       | OpenAI   | Yes        |
-| `gpt-5-mini`  | OpenAI   | No         |
+| Model                     | Provider | Web Search |
+|---------------------------|----------|------------|
+| `gpt-4.1`                 | OpenAI   | Yes        |
+| `gpt-4o`                  | OpenAI   | Yes        |
+| `gpt-4o-mini`             | OpenAI   | No         |
+| `gpt-5`                   | OpenAI   | Yes        |
+| `gpt-5-mini`              | OpenAI   | No         |
+| `gpt-5.5`                 | OpenAI   | Yes        |
+| `gpt-5.5-pro`             | OpenAI   | Yes        |
 
 ### Status codes
 
 * `200 OK` – success
 * `400 Bad Request` – missing/invalid parameters or invalid multipart audio form
 * `403 Forbidden` – missing or invalid `key`
+* `413 Payload Too Large` – JSON prompt body exceeds `max_prompt_bytes`
 * `504 Gateway Timeout` – upstream request timed out
 * `502 Bad Gateway` – OpenAI API returned an error
 
 ## Security
 
 * All requests must include the shared secret via `key=...`.
+* Client requests must not include the OpenAI API key; configure it on the server with `OPENAI_API_KEY`.
 * Do not expose this service to the public internet without appropriate network controls.
 
 ## Implementation Plans
 
 Current scoped implementation plans are tracked under `docs/implementation/`.
+
+## MPR Integration Verification
+
+For Marco Polo Research Lab integration workflows, use the Codex
+`mpr-integration` skill when a change needs contract/profile/task-based
+black-box verification against an MPR app or fixture. Keep app-specific
+hostnames, cookie names, ports, OAuth callbacks, and environment literals in
+the selected integration profile or deployment docs, not in this README.
 
 ## Releasing
 

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -27,6 +27,7 @@ const (
 	keyRequestTimeoutSeconds      = "request_timeout_seconds"
 	keyUpstreamPollTimeoutSeconds = "upstream_poll_timeout_seconds"
 	keyMaxOutputTokens            = "max_output_tokens"
+	keyMaxPromptBytes             = "max_prompt_bytes"
 	keyDictationModel             = "dictation_model"
 	keyMaxInputAudioBytes         = "max_input_audio_bytes"
 
@@ -40,6 +41,7 @@ const (
 	flagRequestTimeout      = "request_timeout"
 	flagUpstreamPollTimeout = "upstream_poll_timeout"
 	flagMaxOutputTokens     = keyMaxOutputTokens
+	flagMaxPromptBytes      = keyMaxPromptBytes
 	flagDictationModel      = keyDictationModel
 	flagMaxInputAudioBytes  = keyMaxInputAudioBytes
 
@@ -53,6 +55,7 @@ const (
 	envRequestTimeoutSeconds      = "GPT_REQUEST_TIMEOUT_SECONDS"
 	envUpstreamPollTimeoutSeconds = "GPT_UPSTREAM_POLL_TIMEOUT_SECONDS"
 	envMaxOutputTokens            = "GPT_MAX_OUTPUT_TOKENS"
+	envMaxPromptBytes             = "GPT_MAX_PROMPT_BYTES"
 	envDictationModel             = "GPT_DICTATION_MODEL"
 	envMaxInputAudioBytes         = "GPT_MAX_INPUT_AUDIO_BYTES"
 
@@ -82,7 +85,7 @@ const (
 
 	// rootCmdLong provides a detailed description of the root command.
 	// Additional commands should define their long description using a constant following this pattern.
-	rootCmdLong = "Accepts GET / for prompts and POST /dictate for audio transcription; forwards to OpenAI."
+	rootCmdLong = "Accepts GET / and JSON POST / for prompts and POST /dictate for audio transcription; forwards to OpenAI."
 
 	// rootCmdExample demonstrates how to use the root command.
 	// Additional commands should define their usage examples using a constant following this pattern.
@@ -115,6 +118,7 @@ var rootCmd = &cobra.Command{
 		populateIntConfiguration(command, flagRequestTimeout, keyRequestTimeoutSeconds, &config.RequestTimeoutSeconds, proxy.DefaultRequestTimeoutSeconds)
 		populateIntConfiguration(command, flagUpstreamPollTimeout, keyUpstreamPollTimeoutSeconds, &config.UpstreamPollTimeoutSeconds, proxy.DefaultUpstreamPollTimeoutSeconds)
 		populateIntConfiguration(command, flagMaxOutputTokens, keyMaxOutputTokens, &config.MaxOutputTokens, proxy.DefaultMaxOutputTokens)
+		populateInt64Configuration(command, flagMaxPromptBytes, keyMaxPromptBytes, &config.MaxPromptBytes, proxy.DefaultMaxPromptBytes)
 		populateStringConfiguration(command, flagDictationModel, keyDictationModel, &config.DictationModel, proxy.DefaultDictationModel, trimSpacesAndQuotes)
 		populateInt64Configuration(command, flagMaxInputAudioBytes, keyMaxInputAudioBytes, &config.MaxInputAudioBytes, proxy.DefaultMaxInputAudioBytes)
 
@@ -182,6 +186,9 @@ func bindOrDie() error {
 	}
 	if bindError := viper.BindEnv(keyMaxOutputTokens, envMaxOutputTokens); bindError != nil {
 		bindingErrors = append(bindingErrors, keyMaxOutputTokens+":"+bindError.Error())
+	}
+	if bindError := viper.BindEnv(keyMaxPromptBytes, envMaxPromptBytes); bindError != nil {
+		bindingErrors = append(bindingErrors, keyMaxPromptBytes+":"+bindError.Error())
 	}
 	if bindError := viper.BindEnv(keyDictationModel, envDictationModel); bindError != nil {
 		bindingErrors = append(bindingErrors, keyDictationModel+":"+bindError.Error())
@@ -262,6 +269,12 @@ func init() {
 		flagMaxOutputTokens,
 		0,
 		"maximum output tokens (env: "+envMaxOutputTokens+")",
+	)
+	rootCmd.Flags().Int64Var(
+		&config.MaxPromptBytes,
+		flagMaxPromptBytes,
+		0,
+		"maximum accepted JSON prompt payload size for POST / in bytes (env: "+envMaxPromptBytes+")",
 	)
 	rootCmd.Flags().StringVar(
 		&config.DictationModel,

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -21,8 +21,10 @@ const (
 	DefaultRequestTimeoutSeconds      = 180 // overall app-side request timeout
 	DefaultUpstreamPollTimeoutSeconds = 60  // poll budget after "incomplete"
 	DefaultMaxOutputTokens            = 1024
-	DefaultDictationModel             = "gpt-4o-mini-transcribe"
-	DefaultMaxInputAudioBytes         = 25 * 1024 * 1024
+	// DefaultMaxPromptBytes limits JSON LLM request bodies accepted by POST /.
+	DefaultMaxPromptBytes     = 4 * 1024 * 1024
+	DefaultDictationModel     = "gpt-4o-mini-transcribe"
+	DefaultMaxInputAudioBytes = 25 * 1024 * 1024
 )
 
 // Configuration holds runtime settings.
@@ -37,6 +39,7 @@ type Configuration struct {
 	RequestTimeoutSeconds      int
 	UpstreamPollTimeoutSeconds int
 	MaxOutputTokens            int
+	MaxPromptBytes             int64
 	DictationModel             string
 	MaxInputAudioBytes         int64
 	Endpoints                  *Endpoints
@@ -66,6 +69,9 @@ func (configuration *Configuration) ApplyTunables() {
 	}
 	if configuration.MaxOutputTokens <= 0 {
 		configuration.MaxOutputTokens = DefaultMaxOutputTokens
+	}
+	if configuration.MaxPromptBytes <= 0 {
+		configuration.MaxPromptBytes = DefaultMaxPromptBytes
 	}
 	if strings.TrimSpace(configuration.DictationModel) == constants.EmptyString {
 		configuration.DictationModel = DefaultDictationModel

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -35,7 +35,9 @@ const (
 	mimeTextCSV         = "text/csv"
 	mimeTextPlain       = "text/plain; charset=utf-8"
 
-	errorMissingPrompt = "missing prompt parameter"
+	errorMissingPrompt         = "missing prompt parameter"
+	errorInvalidJSONRequest    = "invalid JSON request"
+	errorPromptPayloadTooLarge = "prompt payload too large"
 	// errorMissingClientKey indicates that the key query parameter is missing.
 	errorMissingClientKey   = "unknown client key"
 	errorRequestTimedOut    = "request timed out"

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -121,8 +121,6 @@ const (
 	logFieldClientIP     = "client_ip"
 	logFieldStatus       = "status"
 	logFieldValue        = "value"
-	// logFieldParameter identifies the request parameter related to a log entry.
-	logFieldParameter = "parameter"
 	// logFieldID identifies the response identifier logged for traceability.
 	logFieldID = "id"
 

--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -72,7 +72,7 @@ func BuildRequestPayload(modelIdentifier string, combinedPrompt string, webSearc
 			payload.ToolChoice = keyAuto
 		}
 		return payload
-	case ModelNameGPT5:
+	case ModelNameGPT5, ModelNameGPT55, ModelNameGPT55Pro:
 		payload := requestPayloadWithTools{requestPayloadBase: base}
 		if webSearchEnabled {
 			payload.Tools = []Tool{{Type: toolTypeWebSearch}}
@@ -120,6 +120,10 @@ const (
 	ModelNameGPT5Mini = "gpt-5-mini"
 	// ModelNameGPT5 identifies the GPT-5 model which does not accept the temperature field.
 	ModelNameGPT5 = "gpt-5"
+	// ModelNameGPT55 identifies the GPT-5.5 model which does not accept the temperature field.
+	ModelNameGPT55 = "gpt-5.5"
+	// ModelNameGPT55Pro identifies the GPT-5.5 pro model which does not accept the temperature field.
+	ModelNameGPT55Pro = "gpt-5.5-pro"
 )
 
 var (
@@ -133,6 +137,8 @@ var (
 	SchemaGPT5Mini = ModelPayloadSchema{AllowedRequestFields: []string{keyModel, keyInput, keyMaxOutputTokens}}
 	// SchemaGPT5 defines allowed payload fields for the GPT-5 model.
 	SchemaGPT5 = ModelPayloadSchema{AllowedRequestFields: []string{keyModel, keyInput, keyMaxOutputTokens, keyTools, keyToolChoice, keyReasoning}}
+	// SchemaGPT55 defines allowed payload fields for GPT-5.5 family models.
+	SchemaGPT55 = SchemaGPT5
 )
 
 // modelPayloadSchemas associates model identifiers with their payload schemas.
@@ -142,6 +148,8 @@ var modelPayloadSchemas = map[string]ModelPayloadSchema{
 	ModelNameGPT41:     SchemaGPT41,
 	ModelNameGPT5Mini:  SchemaGPT5Mini,
 	ModelNameGPT5:      SchemaGPT5,
+	ModelNameGPT55:     SchemaGPT55,
+	ModelNameGPT55Pro:  SchemaGPT55,
 }
 
 // ResolveModelPayloadSchema returns the schema for a model or an empty schema when unknown.

--- a/internal/proxy/model_capabilities_test.go
+++ b/internal/proxy/model_capabilities_test.go
@@ -30,6 +30,8 @@ func TestResolveModelPayloadSchema(testFramework *testing.T) {
 		{proxy.ModelNameGPT41, []string{"model", "input", "max_output_tokens", "temperature", "tools", "tool_choice"}},
 		{proxy.ModelNameGPT5Mini, []string{"model", "input", "max_output_tokens"}},
 		{proxy.ModelNameGPT5, []string{"model", "input", "max_output_tokens", "tools", "tool_choice", "reasoning"}},
+		{proxy.ModelNameGPT55, []string{"model", "input", "max_output_tokens", "tools", "tool_choice", "reasoning"}},
+		{proxy.ModelNameGPT55Pro, []string{"model", "input", "max_output_tokens", "tools", "tool_choice", "reasoning"}},
 	}
 	for _, testCase := range testCases {
 		payloadSchema := proxy.ResolveModelPayloadSchema(testCase.modelIdentifier)
@@ -64,6 +66,22 @@ func TestBuildRequestPayload(testFramework *testing.T) {
 			expectTemperature: false,
 			expectTools:       false,
 			expectReasoning:   false,
+		},
+		{
+			name:              "GPT-5.5 with web search",
+			modelIdentifier:   proxy.ModelNameGPT55,
+			webSearchEnabled:  true,
+			expectTemperature: false,
+			expectTools:       true,
+			expectReasoning:   true,
+		},
+		{
+			name:              "GPT-5.5 pro with web search",
+			modelIdentifier:   proxy.ModelNameGPT55Pro,
+			webSearchEnabled:  true,
+			expectTemperature: false,
+			expectTools:       true,
+			expectReasoning:   true,
 		},
 		{
 			name:              "GPT-4o with web search",

--- a/internal/proxy/poll_timeout_test.go
+++ b/internal/proxy/poll_timeout_test.go
@@ -27,3 +27,11 @@ func TestApplyTunablesSetsDefaultDictationConfiguration(testingInstance *testing
 		testingInstance.Fatalf("maxInputAudioBytes=%d want=%d", configuration.MaxInputAudioBytes, proxy.DefaultMaxInputAudioBytes)
 	}
 }
+
+func TestApplyTunablesSetsDefaultPromptPayloadLimit(testingInstance *testing.T) {
+	configuration := proxy.Configuration{}
+	configuration.ApplyTunables()
+	if configuration.MaxPromptBytes != proxy.DefaultMaxPromptBytes {
+		testingInstance.Fatalf("maxPromptBytes=%d want=%d", configuration.MaxPromptBytes, proxy.DefaultMaxPromptBytes)
+	}
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -29,6 +30,23 @@ type requestTask struct {
 	model            string
 	webSearchEnabled bool
 	reply            chan result
+}
+
+// chatRequestPayload is the JSON contract for POST / LLM requests.
+// Client authentication stays outside this body on the key query parameter; OpenAI credentials are loaded from server configuration.
+type chatRequestPayload struct {
+	Prompt       string `json:"prompt"`
+	Model        string `json:"model"`
+	WebSearch    bool   `json:"web_search"`
+	SystemPrompt string `json:"system_prompt"`
+}
+
+// chatRequestParameters is the normalized request shape shared by GET and POST handlers after edge validation.
+type chatRequestParameters struct {
+	prompt           string
+	systemPrompt     string
+	modelIdentifier  string
+	webSearchEnabled bool
 }
 
 // BuildRouter constructs the HTTP router used by the proxy. configuration supplies queue sizes, worker counts, timeout values, API credentials and other settings. structuredLogger records structured log messages during routing.
@@ -80,6 +98,7 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 
 	router.Use(gin.Recovery(), secretMiddleware(configuration.ServiceSecret, structuredLogger))
 	router.GET(rootPath, chatHandler(taskQueue, configuration.SystemPrompt, validator, requestTimeout, structuredLogger))
+	router.POST(rootPath, chatJSONHandler(taskQueue, configuration.SystemPrompt, validator, requestTimeout, configuration.MaxPromptBytes, structuredLogger))
 	router.POST(dictatePath, dictateHandler(openAIClient, configuration.OpenAIKey, configuration.DictationModel, configuration.MaxInputAudioBytes, structuredLogger))
 	return router, nil
 }
@@ -93,87 +112,154 @@ func Serve(configuration Configuration, structuredLogger *zap.SugaredLogger) err
 	return router.Run(fmt.Sprintf(":%d", configuration.Port))
 }
 
-// chatHandler returns a handler that forwards requests to the task queue.
+// chatHandler returns a handler that forwards query-string requests to the task queue.
 func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, validator *modelValidator, requestTimeout time.Duration, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
-		userPrompt := ginContext.Query(queryParameterPrompt)
-		if userPrompt == constants.EmptyString {
-			ginContext.String(http.StatusBadRequest, errorMissingPrompt)
+		chatRequest, ok := chatRequestFromQuery(ginContext, defaultSystemPrompt, validator, structuredLogger)
+		if !ok {
 			return
 		}
+		submitChatRequest(ginContext, taskQueue, chatRequest, requestTimeout, structuredLogger)
+	}
+}
 
-		systemPrompt := ginContext.Query(queryParameterSystemPrompt)
-		if systemPrompt == constants.EmptyString {
-			systemPrompt = defaultSystemPrompt
-		}
-
-		modelIdentifier := ginContext.Query(queryParameterModel)
-		if modelIdentifier == constants.EmptyString {
-			modelIdentifier = DefaultModel
-		}
-		if verificationError := validator.Verify(modelIdentifier); verificationError != nil {
-			ginContext.String(http.StatusBadRequest, verificationError.Error())
-			return
-		}
-
-		webSearchQuery := strings.TrimSpace(ginContext.Query(queryParameterWebSearch))
-		webSearchEnabled := false
-		if webSearchQuery != constants.EmptyString {
-			parsedWebSearch, parseError := strconv.ParseBool(webSearchQuery)
-			if parseError != nil {
-				structuredLogger.Warnw(
-					logEventParseWebSearchParameterFailed,
-					logFieldValue, webSearchQuery,
-					constants.LogFieldError, parseError,
-				)
-			} else {
-				webSearchEnabled = parsedWebSearch
-			}
-		}
-
-		replyChannel := make(chan result, 1)
-		requestDeadline, deadlineFound := ginContext.Request.Context().Deadline()
-		enqueueDuration := requestTimeout
-		if deadlineFound {
-			enqueueDuration = time.Until(requestDeadline)
-		}
-		enqueueContext, enqueueCancel := context.WithTimeout(ginContext.Request.Context(), enqueueDuration)
-		select {
-		case taskQueue <- requestTask{
-			prompt:           userPrompt,
-			systemPrompt:     systemPrompt,
-			model:            modelIdentifier,
-			webSearchEnabled: webSearchEnabled,
-			reply:            replyChannel,
-		}:
-			enqueueCancel()
-		case <-enqueueContext.Done():
-			enqueueCancel()
-			ginContext.String(http.StatusServiceUnavailable, errorQueueFull)
-			return
-		}
-
-		requestContext, requestCancel := context.WithTimeout(ginContext.Request.Context(), requestTimeout)
-		select {
-		case outcome := <-replyChannel:
-			requestCancel()
-			if outcome.requestError != nil {
-				if errors.Is(outcome.requestError, ErrUnknownModel) {
-					ginContext.String(http.StatusBadRequest, outcome.requestError.Error())
-				} else if errors.Is(outcome.requestError, context.DeadlineExceeded) {
-					ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
-				} else {
-					ginContext.String(http.StatusBadGateway, outcome.requestError.Error())
-				}
+// chatJSONHandler accepts large prompt bodies while preserving the same model validation, queueing, and response formatting used by GET /.
+func chatJSONHandler(taskQueue chan requestTask, defaultSystemPrompt string, validator *modelValidator, requestTimeout time.Duration, maxPromptBytes int64, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+	return func(ginContext *gin.Context) {
+		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxPromptBytes)
+		var payload chatRequestPayload
+		if decodeError := json.NewDecoder(ginContext.Request.Body).Decode(&payload); decodeError != nil {
+			var maxBytesError *http.MaxBytesError
+			if errors.As(decodeError, &maxBytesError) {
+				ginContext.String(http.StatusRequestEntityTooLarge, errorPromptPayloadTooLarge)
 				return
 			}
-			mime := preferredMime(ginContext)
-			formattedBody, contentType := formatResponse(outcome.text, mime, userPrompt, structuredLogger)
-			ginContext.Data(http.StatusOK, contentType, []byte(formattedBody))
-		case <-requestContext.Done():
-			requestCancel()
-			ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
+			ginContext.String(http.StatusBadRequest, errorInvalidJSONRequest)
+			return
 		}
+
+		chatRequest, validationMessage, ok := chatRequestFromPayload(payload, defaultSystemPrompt, validator)
+		if !ok {
+			ginContext.String(http.StatusBadRequest, validationMessage)
+			return
+		}
+		submitChatRequest(ginContext, taskQueue, chatRequest, requestTimeout, structuredLogger)
+	}
+}
+
+func chatRequestFromQuery(ginContext *gin.Context, defaultSystemPrompt string, validator *modelValidator, structuredLogger *zap.SugaredLogger) (chatRequestParameters, bool) {
+	userPrompt := ginContext.Query(queryParameterPrompt)
+	if userPrompt == constants.EmptyString {
+		ginContext.String(http.StatusBadRequest, errorMissingPrompt)
+		return chatRequestParameters{}, false
+	}
+
+	systemPrompt := ginContext.Query(queryParameterSystemPrompt)
+	if systemPrompt == constants.EmptyString {
+		systemPrompt = defaultSystemPrompt
+	}
+
+	modelIdentifier := ginContext.Query(queryParameterModel)
+	if modelIdentifier == constants.EmptyString {
+		modelIdentifier = DefaultModel
+	}
+	if verificationError := validator.Verify(modelIdentifier); verificationError != nil {
+		ginContext.String(http.StatusBadRequest, verificationError.Error())
+		return chatRequestParameters{}, false
+	}
+
+	webSearchQuery := strings.TrimSpace(ginContext.Query(queryParameterWebSearch))
+	webSearchEnabled := false
+	if webSearchQuery != constants.EmptyString {
+		parsedWebSearch, parseError := strconv.ParseBool(webSearchQuery)
+		if parseError != nil {
+			structuredLogger.Warnw(
+				logEventParseWebSearchParameterFailed,
+				logFieldValue, webSearchQuery,
+				constants.LogFieldError, parseError,
+			)
+		} else {
+			webSearchEnabled = parsedWebSearch
+		}
+	}
+
+	return chatRequestParameters{
+		prompt:           userPrompt,
+		systemPrompt:     systemPrompt,
+		modelIdentifier:  modelIdentifier,
+		webSearchEnabled: webSearchEnabled,
+	}, true
+}
+
+func chatRequestFromPayload(payload chatRequestPayload, defaultSystemPrompt string, validator *modelValidator) (chatRequestParameters, string, bool) {
+	if payload.Prompt == constants.EmptyString {
+		return chatRequestParameters{}, errorMissingPrompt, false
+	}
+
+	systemPrompt := payload.SystemPrompt
+	if systemPrompt == constants.EmptyString {
+		systemPrompt = defaultSystemPrompt
+	}
+
+	modelIdentifier := payload.Model
+	if modelIdentifier == constants.EmptyString {
+		modelIdentifier = DefaultModel
+	}
+	if verificationError := validator.Verify(modelIdentifier); verificationError != nil {
+		return chatRequestParameters{}, verificationError.Error(), false
+	}
+
+	return chatRequestParameters{
+		prompt:           payload.Prompt,
+		systemPrompt:     systemPrompt,
+		modelIdentifier:  modelIdentifier,
+		webSearchEnabled: payload.WebSearch,
+	}, constants.EmptyString, true
+}
+
+func submitChatRequest(ginContext *gin.Context, taskQueue chan requestTask, chatRequest chatRequestParameters, requestTimeout time.Duration, structuredLogger *zap.SugaredLogger) {
+	replyChannel := make(chan result, 1)
+	requestDeadline, deadlineFound := ginContext.Request.Context().Deadline()
+	enqueueDuration := requestTimeout
+	if deadlineFound {
+		enqueueDuration = time.Until(requestDeadline)
+	}
+	enqueueContext, enqueueCancel := context.WithTimeout(ginContext.Request.Context(), enqueueDuration)
+	select {
+	case taskQueue <- requestTask{
+		prompt:           chatRequest.prompt,
+		systemPrompt:     chatRequest.systemPrompt,
+		model:            chatRequest.modelIdentifier,
+		webSearchEnabled: chatRequest.webSearchEnabled,
+		reply:            replyChannel,
+	}:
+		enqueueCancel()
+	case <-enqueueContext.Done():
+		enqueueCancel()
+		ginContext.String(http.StatusServiceUnavailable, errorQueueFull)
+		return
+	}
+
+	requestContext, requestCancel := context.WithTimeout(ginContext.Request.Context(), requestTimeout)
+	select {
+	case outcome := <-replyChannel:
+		requestCancel()
+		if outcome.requestError != nil {
+			if errors.Is(outcome.requestError, ErrUnknownModel) {
+				ginContext.String(http.StatusBadRequest, outcome.requestError.Error())
+			} else if errors.Is(outcome.requestError, context.DeadlineExceeded) {
+				ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
+			} else {
+				ginContext.String(http.StatusBadGateway, outcome.requestError.Error())
+			}
+			return
+		}
+		mime := preferredMime(ginContext)
+		formattedBody, contentType := formatResponse(outcome.text, mime, chatRequest.prompt, structuredLogger)
+		ginContext.Data(http.StatusOK, contentType, []byte(formattedBody))
+	case <-requestContext.Done():
+		requestCancel()
+		ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
 	}
 }
 

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -1,12 +1,17 @@
 package proxy_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/temirov/llm-proxy/internal/proxy"
+	"go.uber.org/zap"
 )
 
 // chatHandlerScenario defines a single test scenario for model validation.
@@ -31,6 +36,16 @@ func TestChatHandlerValidatesModel(testingInstance *testing.T) {
 			modelIdentifier:    proxy.ModelNameGPT4o,
 			expectedStatusCode: http.StatusOK,
 		},
+		{
+			scenarioName:       "GPT-5.5 returns ok",
+			modelIdentifier:    proxy.ModelNameGPT55,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			scenarioName:       "GPT-5.5 pro returns ok",
+			modelIdentifier:    proxy.ModelNameGPT55Pro,
+			expectedStatusCode: http.StatusOK,
+		},
 	}
 
 	for _, testScenario := range testScenarios {
@@ -49,5 +64,90 @@ func TestChatHandlerValidatesModel(testingInstance *testing.T) {
 				subTestInstance.Fatalf("status=%d want=%d", responseRecorder.Code, testScenario.expectedStatusCode)
 			}
 		})
+	}
+}
+
+func TestChatHandlerAcceptsJSONBody(testingInstance *testing.T) {
+	const finalResponse = `{"status":"completed", "output":[{"type":"message", "role":"assistant", "content":[{"type":"text","text":"ok"}]}]}`
+	const russianPrompt = "\u0431\u043e\u043b\u044c\u0448\u043e\u0439 \u0440\u0443\u0441\u0441\u043a\u0438\u0439 \u0442\u0435\u043a\u0441\u0442"
+	const systemPrompt = "optional"
+
+	var capturedPayload map[string]any
+	mockServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		if httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/" {
+			bodyBytes, readError := io.ReadAll(httpRequest.Body)
+			if readError != nil {
+				testingInstance.Fatalf("read request body: %v", readError)
+			}
+			if unmarshalError := json.Unmarshal(bodyBytes, &capturedPayload); unmarshalError != nil {
+				testingInstance.Fatalf("unmarshal request body: %v", unmarshalError)
+			}
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(`{"id": "%s", "status": "queued"}`, TestJobID)))
+			return
+		}
+		if httpRequest.Method == http.MethodGet && strings.HasSuffix(httpRequest.URL.Path, TestJobID) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(finalResponse))
+			return
+		}
+		if httpRequest.Method == http.MethodPost && strings.HasSuffix(httpRequest.URL.Path, "/continue") {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"status": "in_progress"}`))
+			return
+		}
+		http.NotFound(responseWriter, httpRequest)
+	}))
+	defer mockServer.Close()
+
+	router := NewTestRouter(testingInstance, mockServer.URL)
+	requestBody := bytes.NewBufferString(`{"prompt":"` + russianPrompt + `","model":"` + proxy.ModelNameGPT55 + `","web_search":false,"system_prompt":"` + systemPrompt + `"}`)
+	request := httptest.NewRequest(http.MethodPost, "/?key="+TestSecret, requestBody)
+	request.Header.Set("Content-Type", "application/json")
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		testingInstance.Fatalf("status=%d want=%d", responseRecorder.Code, http.StatusOK)
+	}
+	if capturedPayload["model"] != proxy.ModelNameGPT55 {
+		testingInstance.Fatalf("model=%v want=%s", capturedPayload["model"], proxy.ModelNameGPT55)
+	}
+	if capturedPayload["input"] != systemPrompt+"\n\n"+russianPrompt {
+		testingInstance.Fatalf("input=%q", capturedPayload["input"])
+	}
+	if _, found := capturedPayload["tools"]; found {
+		testingInstance.Fatalf("tools must be omitted when web_search=false")
+	}
+}
+
+func TestChatHandlerRejectsOversizedJSONBody(testingInstance *testing.T) {
+	endpoints := proxy.NewEndpoints()
+	logger := zap.NewNop()
+	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+		MaxPromptBytes:             32,
+		Endpoints:                  endpoints,
+	}, logger.Sugar())
+	if buildRouterError != nil {
+		testingInstance.Fatalf(messageBuildRouterError, buildRouterError)
+	}
+
+	requestBody := bytes.NewBufferString(`{"prompt":"this body is intentionally larger than the configured JSON prompt limit"}`)
+	request := httptest.NewRequest(http.MethodPost, "/?key="+TestSecret, requestBody)
+	request.Header.Set("Content-Type", "application/json")
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusRequestEntityTooLarge {
+		testingInstance.Fatalf("status=%d want=%d", responseRecorder.Code, http.StatusRequestEntityTooLarge)
 	}
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/deploy.sh [options]
+
+Deploys llm-proxy through mprlab-gateway after verifying the release image has
+been published. llm-proxy is gateway-colocated, so the default gateway target is
+deploy-gateway.
+
+Options:
+  --gateway-dir <path>  Gateway checkout. Default: $GATEWAY_DIR or sibling ../mprlab-gateway
+  --gateway-target <target> Gateway make target. Default: $GATEWAY_DEPLOY_TARGET or deploy-gateway
+  --image <value>       Image repository. Default: $DOCKER_IMAGE or ghcr.io/tyemirov/llm-proxy
+  --tag <value>         Release tag. Default: v* tag pointing at HEAD
+  --skip-ci             Skip the local make ci deployment gate
+  --skip-image-verify   Skip release/latest image digest verification
+  --skip-gateway        Skip gateway deployment
+  --help                Show this help text
+USAGE
+}
+
+env_or_default() {
+  local name="$1"
+  local fallback="$2"
+  local value=""
+  if [[ -v "${name}" ]]; then
+    value="${!name}"
+  fi
+  if [[ -n "${value}" ]]; then
+    printf "%s\n" "${value}"
+  else
+    printf "%s\n" "${fallback}"
+  fi
+}
+
+GATEWAY_DIR="$(env_or_default GATEWAY_DIR "")"
+GATEWAY_TARGET="$(env_or_default GATEWAY_DEPLOY_TARGET deploy-gateway)"
+IMAGE_REPOSITORY="$(env_or_default DOCKER_IMAGE ghcr.io/tyemirov/llm-proxy)"
+TAG="$(env_or_default DEPLOY_TAG "")"
+SKIP_CI="false"
+SKIP_IMAGE_VERIFY="false"
+SKIP_GATEWAY="false"
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-master}"
+DEPLOY_REMOTE="${DEPLOY_REMOTE:-origin}"
+
+resolve_release_tag() {
+  if [[ -n "${TAG}" ]]; then
+    printf '%s\n' "${TAG}"
+    return
+  fi
+  git tag --points-at HEAD --list 'v*' --sort=-version:refname | head -n 1
+}
+
+image_digest() {
+  local image_ref="$1"
+  docker buildx imagetools inspect "$image_ref" | awk '/^Digest:/ { print $2; exit }'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --gateway-dir)
+      [[ $# -ge 2 ]] || { echo "error: --gateway-dir requires a value" >&2; exit 1; }
+      GATEWAY_DIR="$2"
+      shift 2
+      ;;
+    --gateway-target)
+      [[ $# -ge 2 ]] || { echo "error: --gateway-target requires a value" >&2; exit 1; }
+      GATEWAY_TARGET="$2"
+      shift 2
+      ;;
+    --image)
+      [[ $# -ge 2 ]] || { echo "error: --image requires a value" >&2; exit 1; }
+      IMAGE_REPOSITORY="$2"
+      shift 2
+      ;;
+    --tag)
+      [[ $# -ge 2 ]] || { echo "error: --tag requires a value" >&2; exit 1; }
+      TAG="$2"
+      shift 2
+      ;;
+    --skip-ci)
+      SKIP_CI="true"
+      shift
+      ;;
+    --skip-image-verify)
+      SKIP_IMAGE_VERIFY="true"
+      shift
+      ;;
+    --skip-gateway)
+      SKIP_GATEWAY="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v git >/dev/null 2>&1 || { echo "error: git is required" >&2; exit 1; }
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+resolve_gateway_dir() {
+  local candidate
+  if [[ -n "${GATEWAY_DIR}" ]]; then
+    printf "%s\n" "${GATEWAY_DIR}"
+    return
+  fi
+  for candidate in "${repo_root}/../mprlab-gateway" "../mprlab-gateway"; do
+    if [[ -d "${candidate}" ]]; then
+      printf "%s\n" "${candidate}"
+      return
+    fi
+  done
+}
+
+GATEWAY_DIR="$(resolve_gateway_dir)"
+[[ -n "${GATEWAY_DIR}" ]] || { echo "error: gateway checkout not found; set GATEWAY_DIR=/path/to/mprlab-gateway or pass --gateway-dir" >&2; exit 1; }
+[[ -d "${GATEWAY_DIR}" ]] || { echo "error: gateway checkout not found: ${GATEWAY_DIR}" >&2; exit 1; }
+
+if [[ "${SKIP_GATEWAY}" != "true" ]]; then
+  timeout -k 30s -s SIGKILL 30s git fetch "${DEPLOY_REMOTE}" "${DEPLOY_BRANCH}" --tags --prune
+
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  if [[ "${current_branch}" != "${DEPLOY_BRANCH}" ]]; then
+    echo "error: deployment is allowed only from branch '${DEPLOY_BRANCH}' (current: '${current_branch}')" >&2
+    exit 1
+  fi
+
+  if [[ -n "$(git status --porcelain)" ]]; then
+    echo "error: working tree is dirty; commit or stash changes before deploying" >&2
+    exit 1
+  fi
+
+  head_sha="$(git rev-parse HEAD)"
+  remote_branch_sha="$(git rev-parse "${DEPLOY_REMOTE}/${DEPLOY_BRANCH}")"
+  if [[ "${head_sha}" != "${remote_branch_sha}" ]]; then
+    echo "error: local ${DEPLOY_BRANCH} is not at ${DEPLOY_REMOTE}/${DEPLOY_BRANCH}; push or pull first" >&2
+    exit 1
+  fi
+
+  release_tag="$(resolve_release_tag)"
+  [[ -n "${release_tag}" ]] || { echo "error: no v* release tag points at HEAD; run make release first or pass --tag" >&2; exit 1; }
+  tag_sha="$(git rev-list -n 1 "${release_tag}" 2>/dev/null || true)"
+  if [[ "${tag_sha}" != "${head_sha}" ]]; then
+    echo "error: deploy tag ${release_tag} does not point at HEAD" >&2
+    exit 1
+  fi
+else
+  release_tag="$(resolve_release_tag)"
+fi
+
+if [[ "${SKIP_CI}" != "true" && "${SKIP_GATEWAY}" != "true" ]]; then
+  echo "==> [deploy] Running make ci before deployment"
+  timeout -k 350s -s SIGKILL 350s make ci
+fi
+
+if [[ "${SKIP_IMAGE_VERIFY}" != "true" && "${SKIP_GATEWAY}" != "true" ]]; then
+  command -v docker >/dev/null 2>&1 || { echo "error: docker is required for image verification" >&2; exit 1; }
+  docker buildx version >/dev/null 2>&1 || { echo "error: docker buildx is required for image verification" >&2; exit 1; }
+  echo "==> [deploy] Verifying ${IMAGE_REPOSITORY}:latest matches ${release_tag}"
+  release_digest="$(image_digest "${IMAGE_REPOSITORY}:${release_tag}")"
+  latest_digest="$(image_digest "${IMAGE_REPOSITORY}:latest")"
+  [[ -n "${release_digest}" ]] || { echo "error: could not resolve digest for ${IMAGE_REPOSITORY}:${release_tag}" >&2; exit 1; }
+  [[ -n "${latest_digest}" ]] || { echo "error: could not resolve digest for ${IMAGE_REPOSITORY}:latest" >&2; exit 1; }
+  if [[ "${release_digest}" != "${latest_digest}" ]]; then
+    echo "error: ${IMAGE_REPOSITORY}:latest digest ${latest_digest} does not match ${release_tag} digest ${release_digest}; run make publish first" >&2
+    exit 1
+  fi
+fi
+
+if [[ "${SKIP_GATEWAY}" != "true" ]]; then
+  echo "==> [deploy] Deploying llm-proxy through mprlab-gateway target ${GATEWAY_TARGET}"
+  timeout --foreground -k 1200s -s SIGKILL 1200s make -C "${GATEWAY_DIR}" "${GATEWAY_TARGET}"
+fi
+
+echo "llm-proxy deploy complete"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/publish.sh [options]
+
+Publishes the llm-proxy Docker image from the release branch by:
+  1. validating the clean local branch matches its remote
+  2. validating a pushed v* release tag points at HEAD
+  3. running make ci
+  4. building and pushing the multi-arch Docker image
+
+Options:
+  --image <value>       Full image name without tag. Default: $DOCKER_IMAGE or ghcr.io/tyemirov/llm-proxy
+  --platforms <value>   Docker platforms. Default: $PUBLISH_PLATFORMS or linux/amd64,linux/arm64
+  --tag <value>         Release tag to publish. Default: v* tag pointing at HEAD
+  --remote <value>      Git remote to validate from. Default: $PUBLISH_REMOTE or origin
+  --branch <value>      Release branch to publish from. Default: $PUBLISH_BRANCH or master
+  --no-latest           Do not push :latest
+  --dry-run             Run source checks and make ci without pushing images
+  --skip-checks         Skip the local make ci gate
+  --username <value>    Registry username. Default: gh auth user login
+  --token <value>       Registry token/password. Default: $GHCR_TOKEN or $GITHUB_TOKEN or $GH_TOKEN or gh auth token
+  --help                Show this help text
+USAGE
+}
+
+IMAGE="${DOCKER_IMAGE:-ghcr.io/tyemirov/llm-proxy}"
+PLATFORMS="${PUBLISH_PLATFORMS:-linux/amd64,linux/arm64}"
+TAG="${PUBLISH_TAG:-}"
+PUSH_LATEST="true"
+DRY_RUN="${PUBLISH_DRY_RUN:-false}"
+SKIP_CHECKS="false"
+USERNAME="${GHCR_USERNAME:-}"
+TOKEN="${GHCR_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
+PUBLISH_BRANCH="${PUBLISH_BRANCH:-master}"
+PUBLISH_REMOTE="${PUBLISH_REMOTE:-origin}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image)
+      [[ $# -ge 2 ]] || { echo "error: --image requires a value" >&2; exit 1; }
+      IMAGE="$2"
+      shift 2
+      ;;
+    --platforms)
+      [[ $# -ge 2 ]] || { echo "error: --platforms requires a value" >&2; exit 1; }
+      PLATFORMS="$2"
+      shift 2
+      ;;
+    --tag)
+      [[ $# -ge 2 ]] || { echo "error: --tag requires a value" >&2; exit 1; }
+      TAG="$2"
+      shift 2
+      ;;
+    --remote)
+      [[ $# -ge 2 ]] || { echo "error: --remote requires a value" >&2; exit 1; }
+      PUBLISH_REMOTE="$2"
+      shift 2
+      ;;
+    --branch)
+      [[ $# -ge 2 ]] || { echo "error: --branch requires a value" >&2; exit 1; }
+      PUBLISH_BRANCH="$2"
+      shift 2
+      ;;
+    --no-latest)
+      PUSH_LATEST="false"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --skip-checks)
+      SKIP_CHECKS="true"
+      shift
+      ;;
+    --username)
+      [[ $# -ge 2 ]] || { echo "error: --username requires a value" >&2; exit 1; }
+      USERNAME="$2"
+      shift 2
+      ;;
+    --token)
+      [[ $# -ge 2 ]] || { echo "error: --token requires a value" >&2; exit 1; }
+      TOKEN="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v docker >/dev/null 2>&1 || { echo "error: docker is required" >&2; exit 1; }
+command -v gh >/dev/null 2>&1 || { echo "error: gh is required" >&2; exit 1; }
+
+timeout -k 30s -s SIGKILL 30s git fetch "${PUBLISH_REMOTE}" "${PUBLISH_BRANCH}" --tags --prune
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "${current_branch}" != "${PUBLISH_BRANCH}" ]]; then
+  echo "error: publishing is allowed only from branch '${PUBLISH_BRANCH}' (current: '${current_branch}')" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "error: working tree is dirty; commit or stash changes before publishing" >&2
+  exit 1
+fi
+
+head_sha="$(git rev-parse HEAD)"
+remote_branch_sha="$(git rev-parse "${PUBLISH_REMOTE}/${PUBLISH_BRANCH}")"
+if [[ "${head_sha}" != "${remote_branch_sha}" ]]; then
+  echo "error: local ${PUBLISH_BRANCH} is not at ${PUBLISH_REMOTE}/${PUBLISH_BRANCH}; push or pull first" >&2
+  exit 1
+fi
+
+if [[ -z "${TAG}" ]]; then
+  TAG="$(git tag --points-at HEAD --list 'v*' --sort=-version:refname | head -n 1)"
+fi
+[[ -n "${TAG}" ]] || { echo "error: no v* release tag points at HEAD; run make release first or pass --tag" >&2; exit 1; }
+
+tag_sha="$(git rev-list -n 1 "${TAG}" 2>/dev/null || true)"
+if [[ "${tag_sha}" != "${head_sha}" ]]; then
+  echo "error: release tag ${TAG} does not point at HEAD" >&2
+  exit 1
+fi
+
+remote_tag_refs="$(git ls-remote --tags "${PUBLISH_REMOTE}" "refs/tags/${TAG}" "refs/tags/${TAG}^{}")"
+remote_tag_sha="$(awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { if (peeled != "") print peeled; else print direct }' <<<"${remote_tag_refs}")"
+if [[ "${remote_tag_sha}" != "${head_sha}" ]]; then
+  echo "error: release tag ${TAG} is not pushed to ${PUBLISH_REMOTE} at HEAD" >&2
+  exit 1
+fi
+
+if [[ "${SKIP_CHECKS}" != "true" ]]; then
+  echo "==> [publish] Running make ci before publishing"
+  timeout -k 350s -s SIGKILL 350s make ci
+fi
+
+registry_host="$(printf '%s' "${IMAGE}" | cut -d'/' -f1)"
+[[ -n "${registry_host}" ]] || { echo "error: unable to determine registry host from image: ${IMAGE}" >&2; exit 1; }
+
+if [[ "${DRY_RUN}" == "true" || "${DRY_RUN}" == "1" ]]; then
+  echo "publish_dry_run=true"
+  echo "release_branch=${PUBLISH_BRANCH}"
+  echo "release_tag=${TAG}"
+  echo "image=${IMAGE}:${TAG}"
+  if [[ "${PUSH_LATEST}" == "true" ]]; then
+    echo "image=${IMAGE}:latest"
+  fi
+  exit 0
+fi
+
+if [[ -z "${TOKEN}" ]]; then
+  TOKEN="$(gh auth token 2>/dev/null || true)"
+fi
+[[ -n "${TOKEN}" ]] || { echo "error: registry token is required (use --token or GHCR_TOKEN/GITHUB_TOKEN/GH_TOKEN)" >&2; exit 1; }
+
+if [[ -z "${USERNAME}" ]]; then
+  USERNAME="$(gh api user --jq '.login')"
+fi
+[[ -n "${USERNAME}" ]] || { echo "error: could not infer registry username; use --username or GHCR_USERNAME" >&2; exit 1; }
+
+echo "==> [publish] Logging in to ${registry_host}"
+echo "${TOKEN}" | timeout -k 30s -s SIGKILL 30s docker login "${registry_host}" -u "${USERNAME}" --password-stdin
+
+build_args=(
+  timeout -k 1200s -s SIGKILL 1200s
+  docker buildx build
+  --pull
+  --platform "${PLATFORMS}"
+  --push
+  -f Dockerfile
+  -t "${IMAGE}:${TAG}"
+)
+
+if [[ "${PUSH_LATEST}" == "true" ]]; then
+  build_args+=(-t "${IMAGE}:latest")
+fi
+
+build_args+=(.)
+"${build_args[@]}"
+
+echo "Published image: ${IMAGE}:${TAG}"
+if [[ "${PUSH_LATEST}" == "true" ]]; then
+  echo "Published image: ${IMAGE}:latest"
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/release.sh [options]
+
+Cuts an llm-proxy release from master:
+  1. validates the clean local branch matches origin/master
+  2. selects the next v* SemVer tag
+  3. runs make ci
+  4. inserts a CHANGELOG.md section when missing
+  5. commits the changelog when changed
+  6. creates and pushes an annotated tag
+
+The tag push triggers the GitHub release workflow, which builds and publishes
+release artifacts.
+
+Options:
+  --bump <patch|minor|major>  SemVer bump when RELEASE_VERSION is not set. Default: patch
+  --version <value>           Exact release tag/version to use, e.g. v1.2.3
+  --dry-run                   Report the selected version without changing files
+  --skip-ci                   Skip the local make ci release gate
+  --remote <value>            Git remote. Default: $RELEASE_REMOTE or origin
+  --branch <value>            Release branch. Default: $RELEASE_BRANCH or master
+  --help                      Show this help text
+USAGE
+}
+
+BUMP="${RELEASE_BUMP:-patch}"
+VERSION="${RELEASE_VERSION:-}"
+DRY_RUN="false"
+SKIP_CI="false"
+RELEASE_REMOTE="${RELEASE_REMOTE:-origin}"
+RELEASE_BRANCH="${RELEASE_BRANCH:-master}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bump)
+      [[ $# -ge 2 ]] || { echo "error: --bump requires a value" >&2; exit 1; }
+      BUMP="$2"
+      shift 2
+      ;;
+    --version)
+      [[ $# -ge 2 ]] || { echo "error: --version requires a value" >&2; exit 1; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --skip-ci)
+      SKIP_CI="true"
+      shift
+      ;;
+    --remote)
+      [[ $# -ge 2 ]] || { echo "error: --remote requires a value" >&2; exit 1; }
+      RELEASE_REMOTE="$2"
+      shift 2
+      ;;
+    --branch)
+      [[ $# -ge 2 ]] || { echo "error: --branch requires a value" >&2; exit 1; }
+      RELEASE_BRANCH="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+case "${BUMP}" in
+  patch|minor|major) ;;
+  *) echo "error: --bump must be patch, minor, or major" >&2; exit 1 ;;
+esac
+
+command -v git >/dev/null 2>&1 || { echo "error: git is required" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "error: python3 is required" >&2; exit 1; }
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+timeout -k 30s -s SIGKILL 30s git fetch "${RELEASE_REMOTE}" "${RELEASE_BRANCH}" --tags --prune
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "${current_branch}" != "${RELEASE_BRANCH}" ]]; then
+  echo "error: release is allowed only from branch '${RELEASE_BRANCH}' (current: '${current_branch}')" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "error: working tree is dirty; commit or stash changes before releasing" >&2
+  exit 1
+fi
+
+head_sha="$(git rev-parse HEAD)"
+remote_branch_sha="$(git rev-parse "${RELEASE_REMOTE}/${RELEASE_BRANCH}")"
+if [[ "${head_sha}" != "${remote_branch_sha}" ]]; then
+  echo "error: local ${RELEASE_BRANCH} is not at ${RELEASE_REMOTE}/${RELEASE_BRANCH}; push or pull first" >&2
+  exit 1
+fi
+
+latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)"
+if [[ -n "${VERSION}" ]]; then
+  next_version="${VERSION}"
+else
+  next_version="$(python3 - "${latest_tag}" "${BUMP}" <<'PY'
+import re
+import sys
+
+latest_tag = sys.argv[1].strip()
+bump = sys.argv[2]
+if not latest_tag:
+    print("v1.0.0")
+    raise SystemExit
+
+match = re.match(r"^v(\d+)\.(\d+)\.(\d+)$", latest_tag)
+if not match:
+    raise SystemExit(f"latest SemVer tag is invalid: {latest_tag}")
+
+major, minor, patch = (int(part) for part in match.groups())
+if bump == "major":
+    major, minor, patch = major + 1, 0, 0
+elif bump == "minor":
+    minor, patch = minor + 1, 0
+else:
+    patch += 1
+print(f"v{major}.{minor}.{patch}")
+PY
+)"
+fi
+
+if [[ ! "${next_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: release version must look like vX.Y.Z (got: ${next_version})" >&2
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/${next_version}" >/dev/null; then
+  echo "error: tag already exists: ${next_version}" >&2
+  exit 1
+fi
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "release_dry_run=true"
+  echo "release_branch=${RELEASE_BRANCH}"
+  echo "latest_tag=${latest_tag:-<none>}"
+  echo "next_version=${next_version}"
+  exit 0
+fi
+
+if [[ "${SKIP_CI}" != "true" ]]; then
+  echo "==> [release] Running make ci"
+  timeout -k 350s -s SIGKILL 350s make ci
+fi
+
+release_date="$(date +%Y-%m-%d)"
+if ! grep -Eq "^## \\[${next_version}\\]" CHANGELOG.md; then
+  notes_file="$(mktemp)"
+  changelog_file="$(mktemp)"
+  cleanup() {
+    rm -f "${notes_file}" "${changelog_file}"
+  }
+  trap cleanup EXIT
+
+  if [[ -n "${latest_tag}" ]]; then
+    git log --format='- %s' "${latest_tag}..HEAD" > "${notes_file}"
+  else
+    git log --format='- %s' > "${notes_file}"
+  fi
+  if [[ ! -s "${notes_file}" ]]; then
+    printf '%s\n' "- Maintenance release." > "${notes_file}"
+  fi
+
+  python3 - CHANGELOG.md "${changelog_file}" "${next_version}" "${release_date}" "${notes_file}" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1])
+target = pathlib.Path(sys.argv[2])
+version = sys.argv[3]
+release_date = sys.argv[4]
+notes = pathlib.Path(sys.argv[5]).read_text(encoding="utf-8").strip()
+text = source.read_text(encoding="utf-8")
+section = f"## [{version}] - {release_date}\n\n### Changes\n{notes}\n\n"
+marker = "\n## ["
+index = text.find(marker)
+if index == -1:
+    updated = text.rstrip() + "\n\n" + section
+else:
+    updated = text[: index + 1] + section + text[index + 1 :]
+target.write_text(updated, encoding="utf-8")
+PY
+  mv "${changelog_file}" CHANGELOG.md
+fi
+
+git add CHANGELOG.md
+if git diff --cached --quiet -- CHANGELOG.md; then
+  echo "==> [release] CHANGELOG.md already contains ${next_version}"
+else
+  git commit -m "Release ${next_version}"
+fi
+
+git tag -a "${next_version}" -m "Release ${next_version}"
+git push "${RELEASE_REMOTE}" "${RELEASE_BRANCH}"
+git push "${RELEASE_REMOTE}" "${next_version}"
+
+echo "Released ${next_version}"


### PR DESCRIPTION
## Summary
- Add supported aliases for 5.5 family models: `gpt-5.5` and `gpt-5.5-pro` in model validation/capability routing.
- Add `POST /` JSON request support for large Russian and other prompts:
  - `prompt`, `model`, `web_search`, `system_prompt`
  - keeps existing API key auth semantics (`?key=` service key) and server-side OpenAI key.
- Add configurable request-size protection for JSON payloads:
  - `max_prompt_bytes` CLI flag/env `GPT_MAX_PROMPT_BYTES`
  - reject oversized body with `413 Payload Too Large`.
- Add standard repo-local automation entrypoints: `make ci`, `make release`, `make publish`, and `make deploy`.
- Update GitHub test/release workflows so hosted checks run the local `make ci` contract.
- Update README docs for model aliases, JSON body schema, body size limit config, and local automation.

## Notes
- B001-related work is included here.
- Superseded dated model IDs: `gpt-5.5-2026-04-23`, `gpt-5.5-pro-2026-04-23` replaced with aliases `gpt-5.5`, `gpt-5.5-pro`.
- `make deploy` delegates to the sibling `mprlab-gateway` checkout because `llm-proxy` is gateway-colocated.

## Validation
- `timeout -k 350s -s SIGKILL 350s make ci`
- `make release RELEASE_ARGS=--help`
- `make publish PUBLISH_ARGS=--help`
- `make deploy DEPLOY_ARGS=--help`

## Files changed
- Makefile
- scripts/release.sh
- scripts/publish.sh
- scripts/deploy.sh
- README.md
- cmd/cli/root.go
- internal/proxy/config.go
- internal/proxy/constants.go
- internal/proxy/model_capabilities.go
- internal/proxy/model_capabilities_test.go
- internal/proxy/poll_timeout_test.go
- internal/proxy/router.go
- internal/proxy/router_test.go
- .github/workflows/test.yml
- .github/workflows/release.yml
- .gitignore
- .mprl/ISSUES.md
- Dockerfile
