### PR TITLE
Fix large semantic review output budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ variables:
 | `--system_prompt` / `SYSTEM_PROMPT` | Optional system prompt text |
 | `--workers` / `LLM_PROXY_WORKERS` | Number of worker goroutines (default `4`) |
 | `--queue_size` / `LLM_PROXY_QUEUE_SIZE` | Request queue size (default `100`) |
+| `--max_output_tokens` / `LLM_PROXY_MAX_OUTPUT_TOKENS` | Max output token budget forwarded to text models (default `8192`) |
 | `--max_prompt_bytes` / `LLM_PROXY_MAX_PROMPT_BYTES` | Max accepted JSON body size for `POST /` prompts (default `4194304`) |
 | `--dictation_model` / `LLM_PROXY_DICTATION_MODEL` | Default model for `/dictate` when query model is not provided (default `gpt-4o-mini-transcribe`) |
 | `--max_input_audio_bytes` / `LLM_PROXY_MAX_INPUT_AUDIO_BYTES` | Max accepted upload size for `/dictate` (default `26214400`) |

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -25,7 +25,7 @@ const (
 
 	DefaultRequestTimeoutSeconds      = 180 // overall app-side request timeout
 	DefaultUpstreamPollTimeoutSeconds = 60  // poll budget after "incomplete"
-	DefaultMaxOutputTokens            = 1024
+	DefaultMaxOutputTokens            = 8192
 	// DefaultMaxPromptBytes limits JSON LLM request bodies accepted by POST /.
 	DefaultMaxPromptBytes     = 4 * 1024 * 1024
 	DefaultDictationModel     = "gpt-4o-mini-transcribe"

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -61,6 +61,10 @@ func coverageRouter(t *testing.T, configuration proxy.Configuration) *gin.Engine
 }
 
 func textRouterWithResponsesHandler(t *testing.T, handler http.HandlerFunc) *gin.Engine {
+	return textRouterWithResponsesHandlerAndMaxOutputTokens(t, handler, proxy.DefaultMaxOutputTokens)
+}
+
+func textRouterWithResponsesHandlerAndMaxOutputTokens(t *testing.T, handler http.HandlerFunc, maxOutputTokens int) *gin.Engine {
 	t.Helper()
 	upstreamServer := httptest.NewServer(handler)
 	t.Cleanup(upstreamServer.Close)
@@ -74,6 +78,7 @@ func textRouterWithResponsesHandler(t *testing.T, handler http.HandlerFunc) *gin
 		QueueSize:                  2,
 		RequestTimeoutSeconds:      TestTimeout,
 		UpstreamPollTimeoutSeconds: TestTimeout,
+		MaxOutputTokens:            maxOutputTokens,
 		Endpoints:                  endpoints,
 	})
 }
@@ -414,7 +419,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 	})
 
 	t.Run("initial incomplete continuation failure maps to bad gateway", func(subTest *testing.T) {
-		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		router := textRouterWithResponsesHandlerAndMaxOutputTokens(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")
 			switch {
 			case httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/":
@@ -430,7 +435,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 			default:
 				http.NotFound(responseWriter, httpRequest)
 			}
-		})
+		}, 1024)
 		queryParameters := url.Values{}
 		statusCode, _, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
 		if statusCode != http.StatusBadGateway {
@@ -465,7 +470,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 	})
 
 	t.Run("completed without final message starts synthesis continuation", func(subTest *testing.T) {
-		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		router := textRouterWithResponsesHandlerAndMaxOutputTokens(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")
 			switch {
 			case httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/":
@@ -482,7 +487,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 			default:
 				http.NotFound(responseWriter, httpRequest)
 			}
-		})
+		}, 1024)
 		queryParameters := url.Values{}
 		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
 		if statusCode != http.StatusOK || body != "synthesized" {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -7,6 +7,15 @@ Working backlog for this repository. Keep it current and small. Use @issues-md-f
 
 ## BugFixes
 
+- [x] [B405] (P0) Fix large semantic review POSTs for heavy GPT-5.5-family models.
+  Full semantic stress review requests can be around 31 KB and need a response budget large enough to return a complete reviewed transcript. The public `POST /?key=...` JSON body path must support those review jobs without forcing callers into chunked review, because chunked model responses can mutate source text or drop required stress coverage.
+  Acceptance criteria:
+  1. Add an end-to-end integration test that sends a large semantic-review JSON body through the public HTTP route with a heavier GPT-5.5-family model.
+  2. The test must fail before the implementation fix by reproducing the low-output-budget/incomplete-response path as a client-visible `502`.
+  3. The proxy must forward a sufficiently large output budget for the large full-review request and return a normal text response from the upstream stub.
+  4. The fix must not weaken downstream semantic validation expectations; chunked review remains a retry transport strategy, not an acceptance path.
+  Resolution: Added a black-box integration test for a 31 KB semantic-review JSON POST using `gpt-5.5-pro`; the pre-fix failure reproduced `502 OpenAI API error` with `max_output_tokens=1024` and an incomplete/max-output upstream path. The proxy now defaults text `max_output_tokens` to `8192`, README documents the `LLM_PROXY_MAX_OUTPUT_TOKENS` knob, low-budget continuation coverage remains explicit, and `make ci` passes with total coverage at 100.0%.
+
 - [x] [B404] (P0) Fix GPT-5.5 JSON body model requests returning 502.
   Reproduce and repair the `POST /?key=...` JSON request path where clients specify `"model": "gpt-5.5"` in the body and expect a successful OpenAI Responses API reply instead of a proxy-level `502 OpenAI API error`.
   Acceptance criteria:

--- a/tests/integration/semantic_review_test.go
+++ b/tests/integration/semantic_review_test.go
@@ -1,0 +1,186 @@
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/temirov/llm-proxy/internal/proxy"
+)
+
+const (
+	semanticReviewMinimumPromptBytes  = 31 * 1024
+	semanticReviewRequiredOutputLimit = 8192
+	semanticReviewAcceptedResponse    = `{"decisions":[{"target":"stress","accepted":true}]}`
+	semanticReviewPromptPathEnv       = "LLM_PROXY_SEMANTIC_REVIEW_PROMPT_PATH"
+)
+
+type semanticReviewCapture struct {
+	mutex              sync.Mutex
+	initialPromptBytes int
+	initialModel       string
+	initialOutputLimit int
+	requestCount       int
+}
+
+func (capture *semanticReviewCapture) record(payload map[string]any) {
+	capture.mutex.Lock()
+	defer capture.mutex.Unlock()
+	capture.requestCount++
+	if _, hasPreviousResponse := payload["previous_response_id"]; hasPreviousResponse {
+		return
+	}
+	capture.initialModel, _ = payload["model"].(string)
+	promptText, _ := payload["input"].(string)
+	capture.initialPromptBytes = len([]byte(promptText))
+	outputLimit, _ := payload["max_output_tokens"].(float64)
+	capture.initialOutputLimit = int(outputLimit)
+}
+
+func (capture *semanticReviewCapture) snapshot() semanticReviewCapture {
+	capture.mutex.Lock()
+	defer capture.mutex.Unlock()
+	return semanticReviewCapture{
+		initialPromptBytes: capture.initialPromptBytes,
+		initialModel:       capture.initialModel,
+		initialOutputLimit: capture.initialOutputLimit,
+		requestCount:       capture.requestCount,
+	}
+}
+
+func largeSemanticReviewPrompt(testingInstance *testing.T) string {
+	testingInstance.Helper()
+	promptPath := strings.TrimSpace(os.Getenv(semanticReviewPromptPathEnv))
+	if promptPath != "" {
+		promptBytes, readError := os.ReadFile(promptPath)
+		if readError != nil {
+			testingInstance.Fatalf("read semantic review prompt from %s: %v", promptPath, readError)
+		}
+		return string(promptBytes)
+	}
+
+	var promptBuilder strings.Builder
+	promptBuilder.WriteString("Return decisions JSON for semantic stress review. Preserve source bytes exactly and only adjust stress coverage.\n")
+	for promptBuilder.Len() < semanticReviewMinimumPromptBytes {
+		promptBuilder.WriteString("source_token=belaya_utochka_review_target stress_target=required keep_boundary_whitespace=true\n")
+	}
+	return promptBuilder.String()
+}
+
+func newSemanticReviewOpenAIServer(testingInstance *testing.T, capture *semanticReviewCapture) *httptest.Server {
+	testingInstance.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		responseWriter.Header().Set("Content-Type", contentTypeJSON)
+		switch {
+		case httpRequest.Method == http.MethodPost && httpRequest.URL.Path == integrationResponsesPath:
+			requestBytes, readError := io.ReadAll(httpRequest.Body)
+			if readError != nil {
+				testingInstance.Fatalf("read upstream request: %v", readError)
+			}
+			var payload map[string]any
+			if unmarshalError := json.Unmarshal(requestBytes, &payload); unmarshalError != nil {
+				testingInstance.Fatalf("unmarshal upstream request: %v", unmarshalError)
+			}
+			capture.record(payload)
+			outputLimit, _ := payload["max_output_tokens"].(float64)
+			if int(outputLimit) < semanticReviewRequiredOutputLimit {
+				responseIdentifier := "semantic_review_initial"
+				if _, hasPreviousResponse := payload["previous_response_id"]; hasPreviousResponse {
+					responseIdentifier = "semantic_review_continued"
+				}
+				_, _ = responseWriter.Write([]byte(`{"id":"` + responseIdentifier + `","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[]}`))
+				return
+			}
+			encodedResponseText, marshalError := json.Marshal(semanticReviewAcceptedResponse)
+			if marshalError != nil {
+				testingInstance.Fatalf("marshal upstream response text: %v", marshalError)
+			}
+			_, _ = responseWriter.Write([]byte(`{"id":"semantic_review_complete","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":` + string(encodedResponseText) + `}]}]}`))
+		case httpRequest.Method == http.MethodGet && strings.HasPrefix(httpRequest.URL.Path, integrationResponsesPath+"/"):
+			_, _ = responseWriter.Write([]byte(`{"id":"semantic_review_continued","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[]}`))
+		default:
+			http.NotFound(responseWriter, httpRequest)
+		}
+	}))
+}
+
+func TestIntegrationLargeSemanticReviewPostUsesSufficientOutputBudget(testingInstance *testing.T) {
+	gin.SetMode(gin.TestMode)
+	capture := &semanticReviewCapture{}
+	openAIServer := newSemanticReviewOpenAIServer(testingInstance, capture)
+	testingInstance.Cleanup(openAIServer.Close)
+
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(openAIServer.URL + integrationResponsesPath)
+	originalClient := proxy.HTTPClient
+	proxy.HTTPClient = openAIServer.Client()
+	testingInstance.Cleanup(func() { proxy.HTTPClient = originalClient })
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              serviceSecretValue,
+		OpenAIKey:                  openAIKeyValue,
+		LogLevel:                   logLevelDebug,
+		WorkerCount:                1,
+		QueueSize:                  8,
+		RequestTimeoutSeconds:      requestTimeoutSecondsDefault,
+		UpstreamPollTimeoutSeconds: requestTimeoutSecondsDefault,
+		Endpoints:                  endpoints,
+	}, newLogger(testingInstance))
+	if buildError != nil {
+		testingInstance.Fatalf(buildRouterFailedFormat, buildError)
+	}
+	applicationServer := httptest.NewServer(router)
+	testingInstance.Cleanup(applicationServer.Close)
+
+	requestURL, _ := url.Parse(applicationServer.URL)
+	queryValues := requestURL.Query()
+	queryValues.Set(keyQueryParameter, serviceSecretValue)
+	requestURL.RawQuery = queryValues.Encode()
+	requestPayload := map[string]any{
+		"prompt":     largeSemanticReviewPrompt(testingInstance),
+		"model":      proxy.ModelNameGPT55Pro,
+		"web_search": false,
+	}
+	requestBytes, marshalError := json.Marshal(requestPayload)
+	if marshalError != nil {
+		testingInstance.Fatalf("marshal request: %v", marshalError)
+	}
+	httpResponse, requestError := http.Post(requestURL.String(), contentTypeJSON, bytes.NewReader(requestBytes))
+	if requestError != nil {
+		testingInstance.Fatalf(requestErrorFormat, requestError)
+	}
+	defer httpResponse.Body.Close()
+	responseBytes, _ := io.ReadAll(httpResponse.Body)
+	captured := capture.snapshot()
+
+	if httpResponse.StatusCode != http.StatusOK {
+		testingInstance.Fatalf(
+			"status=%d body=%s initial_model=%s initial_prompt_bytes=%d initial_max_output_tokens=%d upstream_requests=%d",
+			httpResponse.StatusCode,
+			string(responseBytes),
+			captured.initialModel,
+			captured.initialPromptBytes,
+			captured.initialOutputLimit,
+			captured.requestCount,
+		)
+	}
+	if string(responseBytes) != semanticReviewAcceptedResponse {
+		testingInstance.Fatalf(bodyMismatchFormat, string(responseBytes), semanticReviewAcceptedResponse)
+	}
+	if captured.initialModel != proxy.ModelNameGPT55Pro {
+		testingInstance.Fatalf("model=%s want=%s", captured.initialModel, proxy.ModelNameGPT55Pro)
+	}
+	if captured.initialPromptBytes < semanticReviewMinimumPromptBytes {
+		testingInstance.Fatalf("prompt_bytes=%d want>=%d", captured.initialPromptBytes, semanticReviewMinimumPromptBytes)
+	}
+	if captured.initialOutputLimit < semanticReviewRequiredOutputLimit {
+		testingInstance.Fatalf("max_output_tokens=%d want>=%d", captured.initialOutputLimit, semanticReviewRequiredOutputLimit)
+	}
+}


### PR DESCRIPTION
## Summary
- add a black-box integration test for a large Belaya Utochka-style semantic review POST routed through `POST /` with `gpt-5.5-pro`
- raise the default text `max_output_tokens` budget from `1024` to `8192` so full semantic-review jobs do not fall into the incomplete/max-output `502` path by default
- document `LLM_PROXY_MAX_OUTPUT_TOKENS` and keep low-budget continuation behavior covered explicitly

## Root Cause
Large/full semantic review prompts and heavier GPT-5.5-family models were still using the old default `max_output_tokens=1024`. That made the upstream Responses API path likely to return `status: "incomplete"` for review jobs that need to return a complete corrected transcript. The proxy then surfaced the incomplete path as `502 OpenAI API error`, forcing callers toward chunking even though chunked semantic review is not a safe acceptance path.

## Validation
- `LLM_PROXY_SEMANTIC_REVIEW_PROMPT_PATH=/Users/tyemirov/Documents/Projects/Camu/fairy-tales/russian/belaya-utochka/performance/speech-semantic-review-prompt.md timeout -k 350s -s SIGKILL 350s go test ./tests/integration -run TestIntegrationLargeSemanticReviewPostUsesSufficientOutputBudget -count=1 -v`
- `timeout -k 350s -s SIGKILL 350s make ci`
- Total coverage: `100.0%`
