### PR TITLE
sync/llm-proxy/internal

### DIFF
--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -716,6 +716,80 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		}
 	})
 
+	t.Run("poll fetch timeout maps to bad gateway", func(subTest *testing.T) {
+		endpoints := proxy.NewEndpoints()
+		endpoints.SetResponsesURL("https://openai.invalid/v1/responses")
+		previousClient := proxy.HTTPClient
+		proxy.HTTPClient = &http.Client{Transport: coverageRoundTripper(func(httpRequest *http.Request) (*http.Response, error) {
+			switch httpRequest.URL.String() {
+			case endpoints.GetResponsesURL():
+				return coverageHTTPResponse(http.StatusOK, `{"id":"slow","status":"queued"}`), nil
+			case endpoints.GetResponsesURL() + "/slow":
+				<-httpRequest.Context().Done()
+				return nil, httpRequest.Context().Err()
+			default:
+				subTest.Fatalf("unexpected request to %s", httpRequest.URL.String())
+				return nil, nil
+			}
+		})}
+		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
+		router := coverageRouter(subTest, proxy.Configuration{
+			ServiceSecret:              TestSecret,
+			OpenAIKey:                  TestAPIKey,
+			LogLevel:                   proxy.LogLevelInfo,
+			WorkerCount:                1,
+			QueueSize:                  1,
+			RequestTimeoutSeconds:      2,
+			UpstreamPollTimeoutSeconds: 1,
+			Endpoints:                  endpoints,
+		})
+		queryParameters := url.Values{}
+		statusCode, _, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
+		if statusCode != http.StatusBadGateway {
+			subTest.Fatalf("status=%d want=%d", statusCode, http.StatusBadGateway)
+		}
+	})
+
+	t.Run("request context cancellation during poll sleep maps to gateway timeout", func(subTest *testing.T) {
+		endpoints := proxy.NewEndpoints()
+		endpoints.SetResponsesURL("https://openai.invalid/v1/responses")
+		previousClient := proxy.HTTPClient
+		proxy.HTTPClient = &http.Client{Transport: coverageRoundTripper(func(httpRequest *http.Request) (*http.Response, error) {
+			switch httpRequest.URL.String() {
+			case endpoints.GetResponsesURL():
+				return coverageHTTPResponse(http.StatusOK, `{"id":"slow","status":"queued"}`), nil
+			case endpoints.GetResponsesURL() + "/slow":
+				return coverageHTTPResponse(http.StatusOK, `{"status":"in_progress"}`), nil
+			default:
+				subTest.Fatalf("unexpected request to %s", httpRequest.URL.String())
+				return nil, nil
+			}
+		})}
+		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
+		router := coverageRouter(subTest, proxy.Configuration{
+			ServiceSecret:              TestSecret,
+			OpenAIKey:                  TestAPIKey,
+			LogLevel:                   proxy.LogLevelInfo,
+			WorkerCount:                1,
+			QueueSize:                  1,
+			RequestTimeoutSeconds:      2,
+			UpstreamPollTimeoutSeconds: 2,
+			Endpoints:                  endpoints,
+		})
+		queryParameters := url.Values{}
+		queryParameters.Set("key", TestSecret)
+		queryParameters.Set("prompt", TestPrompt)
+		request := httptest.NewRequest(http.MethodGet, "/?"+queryParameters.Encode(), nil)
+		requestContext, cancelRequest := context.WithTimeout(request.Context(), 100*time.Millisecond)
+		defer cancelRequest()
+		request = request.WithContext(requestContext)
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusGatewayTimeout {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusGatewayTimeout, responseRecorder.Body.String())
+		}
+	})
+
 	t.Run("poll completed without text maps to bad gateway", func(subTest *testing.T) {
 		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -51,6 +51,7 @@ func NewOpenAIClient(httpClient HTTPDoer, endpoints *Endpoints, requestTimeout t
 const (
 	synthesisInstructionPrimary    = "Now synthesize the final answer with concise citations."
 	continuationInstructionPrimary = "Continue from the previous response and provide the final answer."
+	responsePollInterval           = 500 * time.Millisecond
 )
 
 // hasFinalMessage checks if the response payload contains the terminal assistant message.
@@ -81,7 +82,7 @@ func hasFinalMessage(rawPayload []byte) bool {
 }
 
 // openAIRequest sends a prompt to the OpenAI responses API and returns the resulting text.
-func (client *OpenAIClient) openAIRequest(openAIKey string, modelIdentifier string, userPrompt string, systemPrompt string, webSearchEnabled bool, structuredLogger *zap.SugaredLogger) (string, error) {
+func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIKey string, modelIdentifier string, userPrompt string, systemPrompt string, webSearchEnabled bool, structuredLogger *zap.SugaredLogger) (string, error) {
 	// The Responses API expects a single string input. We'll prepend the system prompt to the user prompt.
 	var combinedPrompt strings.Builder
 	if !utils.IsBlank(systemPrompt) {
@@ -93,7 +94,7 @@ func (client *OpenAIClient) openAIRequest(openAIKey string, modelIdentifier stri
 	payload := BuildRequestPayload(modelIdentifier, combinedPrompt.String(), webSearchEnabled, client.maxOutputTokens)
 	payloadBytes, _ := json.Marshal(payload)
 
-	requestContext, cancelRequest := context.WithTimeout(context.Background(), client.requestTimeout)
+	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
 	defer cancelRequest()
 	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodPost, client.endpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
 	if buildError != nil {
@@ -149,23 +150,23 @@ func (client *OpenAIClient) openAIRequest(openAIKey string, modelIdentifier stri
 			return outputText, nil
 		}
 		if canContinueIncompleteResponse(decodedObject) && !utils.IsBlank(responseIdentifier) {
-			continuedResponseID, continuationError := client.startIncompleteContinuation(openAIKey, responseIdentifier, modelIdentifier, webSearchEnabled, structuredLogger)
+			continuedResponseID, continuationError := client.startIncompleteContinuation(requestContext, openAIKey, responseIdentifier, modelIdentifier, webSearchEnabled, structuredLogger)
 			if continuationError != nil {
 				structuredLogger.Errorw(
 					logEventOpenAIContinueError,
 					logFieldID, responseIdentifier,
 					constants.LogFieldError, continuationError,
 				)
-				return constants.EmptyString, errors.New(errorOpenAIAPI)
+				return constants.EmptyString, openAIStageError(continuationError)
 			}
-			finalText, pollError := client.pollResponseUntilDone(openAIKey, continuedResponseID, structuredLogger)
+			finalText, pollError := client.pollResponseUntilDone(requestContext, openAIKey, continuedResponseID, structuredLogger)
 			if pollError != nil {
 				structuredLogger.Errorw(
 					logEventOpenAIPollError,
 					logFieldID, continuedResponseID,
 					constants.LogFieldError, pollError,
 				)
-				return constants.EmptyString, errors.New(errorOpenAIAPI)
+				return constants.EmptyString, openAIStageError(pollError)
 			}
 			if !utils.IsBlank(finalText) {
 				return finalText, nil
@@ -175,23 +176,23 @@ func (client *OpenAIClient) openAIRequest(openAIKey string, modelIdentifier stri
 	}
 
 	if forcedSynthesis && !utils.IsBlank(responseIdentifier) {
-		continuedResponseID, synthErr := client.startSynthesisContinuation(openAIKey, responseIdentifier, modelIdentifier, structuredLogger)
+		continuedResponseID, synthErr := client.startSynthesisContinuation(requestContext, openAIKey, responseIdentifier, modelIdentifier, structuredLogger)
 		if synthErr != nil {
 			structuredLogger.Errorw(
 				logEventOpenAIContinueError,
 				logFieldID, responseIdentifier,
 				constants.LogFieldError, synthErr,
 			)
-			return constants.EmptyString, errors.New(errorOpenAIAPI)
+			return constants.EmptyString, openAIStageError(synthErr)
 		}
-		finalText, pollError := client.pollResponseUntilDone(openAIKey, continuedResponseID, structuredLogger)
+		finalText, pollError := client.pollResponseUntilDone(requestContext, openAIKey, continuedResponseID, structuredLogger)
 		if pollError != nil {
 			structuredLogger.Errorw(
 				logEventOpenAIPollError,
 				logFieldID, continuedResponseID,
 				constants.LogFieldError, pollError,
 			)
-			return constants.EmptyString, errors.New(errorOpenAIAPI)
+			return constants.EmptyString, openAIStageError(pollError)
 		}
 		if !utils.IsBlank(finalText) {
 			return finalText, nil
@@ -199,14 +200,14 @@ func (client *OpenAIClient) openAIRequest(openAIKey string, modelIdentifier stri
 	}
 
 	if !isTerminalStatus && !utils.IsBlank(responseIdentifier) {
-		finalText, pollError := client.pollResponseUntilDone(openAIKey, responseIdentifier, structuredLogger)
+		finalText, pollError := client.pollResponseUntilDone(requestContext, openAIKey, responseIdentifier, structuredLogger)
 		if pollError != nil {
 			structuredLogger.Errorw(
 				logEventOpenAIPollError,
 				logFieldID, responseIdentifier,
 				constants.LogFieldError, pollError,
 			)
-			return constants.EmptyString, errors.New(errorOpenAIAPI)
+			return constants.EmptyString, openAIStageError(pollError)
 		}
 		if !utils.IsBlank(finalText) {
 			return finalText, nil
@@ -220,10 +221,17 @@ func (client *OpenAIClient) openAIRequest(openAIKey string, modelIdentifier stri
 	return outputText, nil
 }
 
+func openAIStageError(stageError error) error {
+	if errors.Is(stageError, context.Canceled) || errors.Is(stageError, context.DeadlineExceeded) {
+		return stageError
+	}
+	return errors.New(errorOpenAIAPI)
+}
+
 // startSynthesisContinuation begins a synthesis-only pass by POSTing /v1/responses with
 // previous_response_id and tool_choice set to "none". It allocates enough output tokens, limits reasoning effort to minimal, and includes a low-verbosity text format hint.
 // It returns the identifier of the new response.
-func (client *OpenAIClient) startSynthesisContinuation(openAIKey string, previousResponseID string, modelIdentifier string, structuredLogger *zap.SugaredLogger) (string, error) {
+func (client *OpenAIClient) startSynthesisContinuation(parentContext context.Context, openAIKey string, previousResponseID string, modelIdentifier string, structuredLogger *zap.SugaredLogger) (string, error) {
 	outputTokenLimit := client.maxOutputTokens
 	if outputTokenLimit < 1536 {
 		outputTokenLimit = 1536
@@ -243,23 +251,23 @@ func (client *OpenAIClient) startSynthesisContinuation(openAIKey string, previou
 			keyVerbosity: verbosityLow,
 		},
 	}
-	return client.startContinuationResponse(openAIKey, payload, structuredLogger)
+	return client.startContinuationResponse(parentContext, openAIKey, payload, structuredLogger)
 }
 
-func (client *OpenAIClient) startIncompleteContinuation(openAIKey string, previousResponseID string, modelIdentifier string, webSearchEnabled bool, structuredLogger *zap.SugaredLogger) (string, error) {
+func (client *OpenAIClient) startIncompleteContinuation(parentContext context.Context, openAIKey string, previousResponseID string, modelIdentifier string, webSearchEnabled bool, structuredLogger *zap.SugaredLogger) (string, error) {
 	outputTokenLimit := client.maxOutputTokens
 	if outputTokenLimit < 1536 {
 		outputTokenLimit = 1536
 	}
 
 	payload := buildStatefulContinuationPayload(modelIdentifier, continuationInstructionPrimary, webSearchEnabled, outputTokenLimit, previousResponseID)
-	return client.startContinuationResponse(openAIKey, payload, structuredLogger)
+	return client.startContinuationResponse(parentContext, openAIKey, payload, structuredLogger)
 }
 
-func (client *OpenAIClient) startContinuationResponse(openAIKey string, payload map[string]any, structuredLogger *zap.SugaredLogger) (string, error) {
+func (client *OpenAIClient) startContinuationResponse(parentContext context.Context, openAIKey string, payload map[string]any, structuredLogger *zap.SugaredLogger) (string, error) {
 	payloadBytes, _ := json.Marshal(payload)
 
-	requestContext, cancelRequest := context.WithTimeout(context.Background(), client.requestTimeout)
+	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
 	defer cancelRequest()
 	request, _ := buildAuthorizedJSONRequest(requestContext, http.MethodPost, client.endpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
 
@@ -305,14 +313,18 @@ func canContinueIncompleteResponse(decodedObject map[string]any) bool {
 }
 
 // pollResponseUntilDone repeatedly fetches a response until it is complete or the poll timeout elapses.
-func (client *OpenAIClient) pollResponseUntilDone(openAIKey string, responseIdentifier string, structuredLogger *zap.SugaredLogger) (string, error) {
-	deadlineInstant := time.Now().Add(client.upstreamPollTimeout)
+func (client *OpenAIClient) pollResponseUntilDone(parentContext context.Context, openAIKey string, responseIdentifier string, structuredLogger *zap.SugaredLogger) (string, error) {
+	pollContext, cancelPoll := context.WithTimeout(parentContext, client.upstreamPollTimeout)
+	defer cancelPoll()
 	for {
-		if time.Now().After(deadlineInstant) {
-			return constants.EmptyString, ErrUpstreamIncomplete
-		}
-		textCandidate, responseComplete, fetchError := client.fetchResponseByID(deadlineInstant, openAIKey, responseIdentifier, structuredLogger)
+		textCandidate, responseComplete, fetchError := client.fetchResponseByID(pollContext, openAIKey, responseIdentifier, structuredLogger)
 		if fetchError != nil {
+			if parentContext.Err() != nil {
+				return constants.EmptyString, parentContext.Err()
+			}
+			if pollContext.Err() != nil {
+				return constants.EmptyString, ErrUpstreamIncomplete
+			}
 			return constants.EmptyString, fetchError
 		}
 		if responseComplete && !utils.IsBlank(textCandidate) {
@@ -321,14 +333,21 @@ func (client *OpenAIClient) pollResponseUntilDone(openAIKey string, responseIden
 		if responseComplete {
 			return constants.EmptyString, errors.New(errorOpenAIAPINoText)
 		}
-		time.Sleep(500 * time.Millisecond)
+		select {
+		case <-time.After(responsePollInterval):
+		case <-pollContext.Done():
+			if parentContext.Err() != nil {
+				return constants.EmptyString, parentContext.Err()
+			}
+			return constants.EmptyString, ErrUpstreamIncomplete
+		}
 	}
 }
 
 // fetchResponseByID retrieves a response by identifier and reports whether the response is complete.
-func (client *OpenAIClient) fetchResponseByID(deadline time.Time, openAIKey string, responseIdentifier string, structuredLogger *zap.SugaredLogger) (string, bool, error) {
+func (client *OpenAIClient) fetchResponseByID(parentContext context.Context, openAIKey string, responseIdentifier string, structuredLogger *zap.SugaredLogger) (string, bool, error) {
 	resourceURL := client.endpoints.GetResponsesURL() + "/" + responseIdentifier
-	requestContext, cancel := context.WithDeadline(context.Background(), deadline)
+	requestContext, cancel := context.WithTimeout(parentContext, client.requestTimeout)
 	defer cancel()
 
 	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodGet, resourceURL, openAIKey, nil)

--- a/internal/proxy/openai_compatible_chat.go
+++ b/internal/proxy/openai_compatible_chat.go
@@ -53,7 +53,7 @@ func newOpenAICompatibleChatClient(httpClient HTTPDoer, requestTimeout time.Dura
 	}
 }
 
-func (client *openAICompatibleChatClient) generateText(apiKey string, baseURL string, modelIdentifier modelID, userPrompt string, systemPrompt string, structuredLogger *zap.SugaredLogger) (string, error) {
+func (client *openAICompatibleChatClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier modelID, userPrompt string, systemPrompt string, structuredLogger *zap.SugaredLogger) (string, error) {
 	messages := []chatCompletionMessage{}
 	if !utils.IsBlank(systemPrompt) {
 		messages = append(messages, chatCompletionMessage{Role: "system", Content: systemPrompt})
@@ -67,7 +67,7 @@ func (client *openAICompatibleChatClient) generateText(apiKey string, baseURL st
 	}
 	payloadBytes, _ := json.Marshal(payload)
 
-	requestContext, cancelRequest := context.WithTimeout(context.Background(), client.requestTimeout)
+	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
 	defer cancelRequest()
 	requestURL := strings.TrimRight(baseURL, "/") + "/chat/completions"
 	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodPost, requestURL, apiKey, bytes.NewReader(payloadBytes))

--- a/internal/proxy/provider_router.go
+++ b/internal/proxy/provider_router.go
@@ -1,6 +1,10 @@
 package proxy
 
-import "go.uber.org/zap"
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
 
 type providerRouter struct {
 	openAIClient *OpenAIClient
@@ -14,9 +18,10 @@ func newProviderRouter(openAIClient *OpenAIClient, chatClient *openAICompatibleC
 	}
 }
 
-func (router *providerRouter) generateText(request chatRequestParameters, structuredLogger *zap.SugaredLogger) (string, error) {
+func (router *providerRouter) generateText(requestContext context.Context, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (string, error) {
 	if request.provider.usesOpenAIResponses {
 		return router.openAIClient.openAIRequest(
+			requestContext,
 			request.provider.credentialFor(endpointKindText),
 			request.model.string(),
 			request.prompt,
@@ -26,6 +31,7 @@ func (router *providerRouter) generateText(request chatRequestParameters, struct
 		)
 	}
 	return router.chatClient.generateText(
+		requestContext,
 		request.provider.credentialFor(endpointKindText),
 		request.provider.textBaseURL,
 		request.model,

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -25,6 +25,7 @@ type result struct {
 // requestTask carries all details needed to process a user request in the
 // worker queue.
 type requestTask struct {
+	context    context.Context
 	parameters chatRequestParameters
 	reply      chan result
 }
@@ -88,7 +89,7 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	for workerIndex := 0; workerIndex < configuration.WorkerCount; workerIndex++ {
 		go func() {
 			for pending := range taskQueue {
-				text, requestError := upstreamProviders.generateText(pending.parameters, structuredLogger)
+				text, requestError := upstreamProviders.generateText(pending.context, pending.parameters, structuredLogger)
 				pending.reply <- result{text: text, requestError: requestError}
 			}
 		}()
@@ -227,28 +228,21 @@ func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload,
 
 func submitChatRequest(ginContext *gin.Context, taskQueue chan requestTask, chatRequest chatRequestParameters, requestTimeout time.Duration, structuredLogger *zap.SugaredLogger) {
 	replyChannel := make(chan result, 1)
-	requestDeadline, deadlineFound := ginContext.Request.Context().Deadline()
-	enqueueDuration := requestTimeout
-	if deadlineFound {
-		enqueueDuration = time.Until(requestDeadline)
-	}
-	enqueueContext, enqueueCancel := context.WithTimeout(ginContext.Request.Context(), enqueueDuration)
+	requestContext, requestCancel := context.WithTimeout(ginContext.Request.Context(), requestTimeout)
+	defer requestCancel()
 	select {
 	case taskQueue <- requestTask{
+		context:    requestContext,
 		parameters: chatRequest,
 		reply:      replyChannel,
 	}:
-		enqueueCancel()
-	case <-enqueueContext.Done():
-		enqueueCancel()
+	case <-requestContext.Done():
 		ginContext.String(http.StatusServiceUnavailable, errorQueueFull)
 		return
 	}
 
-	requestContext, requestCancel := context.WithTimeout(ginContext.Request.Context(), requestTimeout)
 	select {
 	case outcome := <-replyChannel:
-		requestCancel()
 		if outcome.requestError != nil {
 			ginContext.String(statusCodeForError(outcome.requestError), responseMessageForError(outcome.requestError))
 			return
@@ -257,7 +251,6 @@ func submitChatRequest(ginContext *gin.Context, taskQueue chan requestTask, chat
 		formattedBody, contentType := formatResponse(outcome.text, mime, chatRequest.prompt)
 		ginContext.Data(http.StatusOK, contentType, []byte(formattedBody))
 	case <-requestContext.Done():
-		requestCancel()
 		ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
 	}
 }
@@ -350,7 +343,7 @@ func statusCodeForError(requestError error) int {
 		return http.StatusServiceUnavailable
 	case errors.Is(requestError, ErrProviderRateLimited):
 		return http.StatusTooManyRequests
-	case errors.Is(requestError, context.DeadlineExceeded):
+	case errors.Is(requestError, context.DeadlineExceeded), errors.Is(requestError, context.Canceled):
 		return http.StatusGatewayTimeout
 	default:
 		return http.StatusBadGateway
@@ -358,7 +351,7 @@ func statusCodeForError(requestError error) int {
 }
 
 func responseMessageForError(requestError error) string {
-	if errors.Is(requestError, context.DeadlineExceeded) {
+	if errors.Is(requestError, context.DeadlineExceeded) || errors.Is(requestError, context.Canceled) {
 		return errorRequestTimedOut
 	}
 	return requestError.Error()

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -7,6 +7,15 @@ Working backlog for this repository. Keep it current and small. Use @issues-md-f
 
 ## BugFixes
 
+- [x] [B407] (P0) Cancel upstream text generation when downstream requests time out.
+  Handler timeout and client/gateway disconnect contexts must flow through queued text work, provider routing, OpenAI Responses requests, OpenAI-compatible chat requests, continuation creation, and polling. After the proxy sends a timeout response, upstream work must not keep running long enough to produce a usable late OpenAI response.
+  Acceptance criteria:
+  1. `requestTask` carries a request context derived from the HTTP request and app timeout.
+  2. OpenAI Responses, OpenAI-compatible chat, continuation, and polling HTTP requests derive from that request context instead of `context.Background()`.
+  3. An integration test proves a gateway-style timed-out request causes the upstream request context to be canceled.
+  4. The integration test proves no late usable OpenAI API response is accepted after the proxy has sent `504 Gateway Timeout`.
+  Resolution: Threaded the handler-derived request context through queued text tasks, provider routing, OpenAI Responses, OpenAI-compatible chat, continuation creation, and response polling. Added integration coverage that fails on a late usable OpenAI response after a proxy `504`, plus poll-path coverage for fetch-timeout and poll-sleep cancellation behavior. Validation passed with `timeout -k 30s -s SIGKILL 30s make fmt`, `timeout -k 350s -s SIGKILL 350s make test` (total coverage 100.0%), and `timeout -k 350s -s SIGKILL 350s make lint`.
+
 - [x] [B406] (P1) Document request timeout knobs for gateway alignment.
   Public gateway routes need their upstream transport timeout to stay aligned with llm-proxy's app-side request timeout; otherwise long-running LLM calls can be cut off by the gateway before the proxy returns its own response.
   Resolution: Documented `LLM_PROXY_REQUEST_TIMEOUT_SECONDS` and `LLM_PROXY_UPSTREAM_POLL_TIMEOUT_SECONDS` in the README so operators can keep gateway transport settings aligned with the proxy's request and poll windows. Validation passed with `git diff --check`.

--- a/tests/integration/request_timeout_test.go
+++ b/tests/integration/request_timeout_test.go
@@ -1,23 +1,34 @@
 package integration_test
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/temirov/llm-proxy/internal/proxy"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 const (
-	timeoutExpectedStatusCode = http.StatusGatewayTimeout
-	timeoutRequestTimeout     = 1
-	timeoutUpstreamDelay      = 3 * time.Second
-	timeoutHTTPClientTimeout  = timeoutUpstreamDelay + 2*time.Second
+	timeoutExpectedStatusCode       = http.StatusGatewayTimeout
+	timeoutRequestTimeout           = 1
+	timeoutUpstreamDelay            = 3 * time.Second
+	timeoutHTTPClientTimeout        = timeoutUpstreamDelay + 2*time.Second
+	gatewayContextRequestTimeout    = 150 * time.Millisecond
+	gatewayContextProxyTimeout      = 2
+	gatewayContextLateResponseDelay = 650 * time.Millisecond
+	gatewayContextAssertionTimeout  = 2 * time.Second
+	openAIAPIResponseLogMessage     = "OpenAI API response"
+	lateOpenAIResponseBody          = `{"output_text":"LATE_OPENAI_RESPONSE"}`
 )
 
 // makeTimeoutHTTPClient returns an HTTP client whose responses delay longer than the request timeout.
@@ -43,6 +54,109 @@ func makeTimeoutHTTPClient(testingInstance *testing.T, endpoints *proxy.Endpoint
 			}
 		}),
 		Timeout: timeoutHTTPClientTimeout,
+	}
+}
+
+// TestIntegrationGatewayContextTimeoutCancelsUpstreamRequest verifies gateway-style request cancellation stops upstream OpenAI work before any late response is accepted.
+func TestIntegrationGatewayContextTimeoutCancelsUpstreamRequest(testingInstance *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstreamRequestCanceled := make(chan struct{})
+	lateUsableOpenAIResponse := make(chan struct{})
+	var upstreamCancelOnce sync.Once
+	var lateResponseOnce sync.Once
+	endpoints := proxy.NewEndpoints()
+	timeoutClient := &http.Client{
+		Transport: roundTripperFunc(func(httpRequest *http.Request) (*http.Response, error) {
+			switch {
+			case httpRequest.URL.String() == endpoints.GetModelsURL():
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(modelsListBody)), Header: make(http.Header)}, nil
+			case strings.HasPrefix(httpRequest.URL.String(), endpoints.GetModelsURL()+"/"):
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(metadataTemperatureTools)), Header: make(http.Header)}, nil
+			case httpRequest.URL.String() == endpoints.GetResponsesURL():
+				responseHeader := make(http.Header)
+				responseHeader.Set(contentTypeHeaderKey, contentTypeJSON)
+				select {
+				case <-httpRequest.Context().Done():
+					upstreamCancelOnce.Do(func() { close(upstreamRequestCanceled) })
+					return nil, httpRequest.Context().Err()
+				case <-time.After(gatewayContextLateResponseDelay):
+					lateResponseOnce.Do(func() { close(lateUsableOpenAIResponse) })
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(lateOpenAIResponseBody)), Header: responseHeader}, nil
+				}
+			default:
+				testingInstance.Fatalf(unexpectedRequestFormat, httpRequest.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	previousHTTPClient := proxy.HTTPClient
+	proxy.HTTPClient = timeoutClient
+	testingInstance.Cleanup(func() { proxy.HTTPClient = previousHTTPClient })
+	endpoints.SetModelsURL(mockModelsURL)
+	endpoints.SetResponsesURL(mockResponsesURL)
+
+	observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+	loggerInstance := zap.New(observedCore)
+	testingInstance.Cleanup(func() { _ = loggerInstance.Sync() })
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:                serviceSecretValue,
+		OpenAIKey:                    openAIKeyValue,
+		LogLevel:                     logLevelDebug,
+		WorkerCount:                  1,
+		QueueSize:                    4,
+		RequestTimeoutSeconds:        gatewayContextProxyTimeout,
+		UpstreamPollTimeoutSeconds:   gatewayContextProxyTimeout,
+		Endpoints:                    endpoints,
+		DefaultDictationProvider:     proxy.ProviderNameOpenAI,
+		DefaultProvider:              proxy.ProviderNameOpenAI,
+		DefaultModel:                 proxy.DefaultModel,
+		DictationModel:               proxy.DefaultDictationModel,
+		MaxOutputTokens:              proxy.DefaultMaxOutputTokens,
+		MaxPromptBytes:               proxy.DefaultMaxPromptBytes,
+		MaxInputAudioBytes:           proxy.DefaultMaxInputAudioBytes,
+		DeepSeekBaseURL:              "https://deepseek.invalid",
+		DashScopeBaseURL:             "https://dashscope.invalid",
+		MoonshotBaseURL:              "https://moonshot.invalid",
+		SiliconFlowBaseURL:           "https://siliconflow.invalid",
+		SiliconFlowTranscriptionsURL: "https://siliconflow.invalid/audio/transcriptions",
+		ZhipuBaseURL:                 "https://zhipu.invalid",
+	}, loggerInstance.Sugar())
+	if buildError != nil {
+		testingInstance.Fatalf(buildRouterFailedFormat, buildError)
+	}
+
+	applicationServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		gatewayContext, cancelGatewayContext := context.WithTimeout(httpRequest.Context(), gatewayContextRequestTimeout)
+		defer cancelGatewayContext()
+		router.ServeHTTP(responseWriter, httpRequest.WithContext(gatewayContext))
+	}))
+	testingInstance.Cleanup(applicationServer.Close)
+
+	requestURL, _ := url.Parse(applicationServer.URL)
+	queryValues := requestURL.Query()
+	queryValues.Set(promptQueryParameter, promptValue)
+	queryValues.Set(keyQueryParameter, serviceSecretValue)
+	requestURL.RawQuery = queryValues.Encode()
+	httpResponse, requestError := applicationServer.Client().Get(requestURL.String())
+	if requestError != nil {
+		testingInstance.Fatalf(getFailedFormat, requestError)
+	}
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode != timeoutExpectedStatusCode {
+		responseBody, _ := io.ReadAll(httpResponse.Body)
+		testingInstance.Fatalf(statusWantBodyFormat, httpResponse.StatusCode, timeoutExpectedStatusCode, string(responseBody))
+	}
+
+	select {
+	case <-upstreamRequestCanceled:
+	case <-lateUsableOpenAIResponse:
+		testingInstance.Fatal("upstream produced a late usable OpenAI API response after proxy sent 504")
+	case <-time.After(gatewayContextAssertionTimeout):
+		testingInstance.Fatal("upstream request context was not canceled after proxy sent 504")
+	}
+	if observedLogs.FilterMessage(openAIAPIResponseLogMessage).Len() != 0 {
+		testingInstance.Fatal("observed late OpenAI API response log after proxy sent 504")
 	}
 }
 


### PR DESCRIPTION
Improve request context propagation and timeout handling for OpenAI upstream calls

- Propagate parent request context through all OpenAI client calls to enable proper cancellation and timeout handling.
- Use context with timeout for polling and continuation requests to avoid hanging on upstream calls.
- Refine error handling to distinguish context cancellations and deadline exceeded errors.
- Add integration tests covering gateway timeout and cancellation scenarios during upstream polling.
- Map upstream poll timeouts and request cancellations to appropriate HTTP status codes (502 Bad Gateway, 504 Gateway Timeout).