### PR TITLE
gix/add-gemini-provider-support-with-native-generatecontent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # LLM Proxy
 
 LLM Proxy is a lightweight HTTP service that forwards user prompts to OpenAI's
-Responses API, OpenAI-compatible chat providers, and audio transcription APIs.
+Responses API, OpenAI-compatible chat providers, Google Gemini's native
+generateContent API, and audio transcription APIs.
 It exposes protected HTTP endpoints that require a shared secret and simplify
 integrating provider capabilities without embedding API credentials in each
 client.
@@ -34,6 +35,7 @@ variables:
 | `--moonshot_api_key` / `MOONSHOT_API_KEY` | Moonshot/Kimi API key used when `provider=moonshot` or `provider=kimi` |
 | `--siliconflow_api_key` / `SILICONFLOW_API_KEY` | SiliconFlow API key used when `provider=siliconflow` |
 | `--zhipu_api_key` / `ZHIPU_API_KEY` | Zhipu/GLM API key used when `provider=zhipu` or `provider=glm` |
+| `--gemini_api_key` / `GEMINI_API_KEY` | Gemini API key used when `provider=gemini` |
 | `--default_provider` / `LLM_PROXY_DEFAULT_PROVIDER` | Default text provider when `provider` is omitted (default `openai`) |
 | `--default_model` / `LLM_PROXY_DEFAULT_MODEL` | Default text model when `model` is omitted for OpenAI (default `gpt-4.1`) |
 | `--default_dictation_provider` / `LLM_PROXY_DEFAULT_DICTATION_PROVIDER` | Default `/dictate` provider when `provider` is omitted (default `openai`) |
@@ -43,6 +45,7 @@ variables:
 | `--siliconflow_base_url` / `SILICONFLOW_BASE_URL` | SiliconFlow OpenAI-compatible base URL |
 | `--siliconflow_transcriptions_url` / `SILICONFLOW_TRANSCRIPTIONS_URL` | SiliconFlow audio transcription URL |
 | `--zhipu_base_url` / `ZHIPU_BASE_URL` | Zhipu OpenAI-compatible base URL |
+| `--gemini_base_url` / `GEMINI_BASE_URL` | Gemini API base URL |
 | `--port` / `HTTP_PORT` | Port for the HTTP server (default `8080`) |
 | `--log_level` / `LOG_LEVEL` | `debug` or `info` (default `info`) |
 | `--system_prompt` / `SYSTEM_PROMPT` | Optional system prompt text |
@@ -77,6 +80,13 @@ Run the service with DeepSeek as the default text provider:
 
 ```shell
 SERVICE_SECRET=mysecret DEEPSEEK_API_KEY=sk-xxxxx LLM_PROXY_DEFAULT_PROVIDER=deepseek \
+  ./llm-proxy --port=8080 --log_level=info
+```
+
+Run the service with Gemini as the default text provider:
+
+```shell
+SERVICE_SECRET=mysecret GEMINI_API_KEY=xxxxx LLM_PROXY_DEFAULT_PROVIDER=gemini \
   ./llm-proxy --port=8080 --log_level=info
 ```
 
@@ -115,6 +125,17 @@ curl --get \
   --data-urlencode "key=mysecret" \
   --data-urlencode "provider=deepseek" \
   --data-urlencode "model=deepseek-v4-flash" \
+  "http://localhost:8080/"
+```
+
+Gemini text generation:
+
+```shell
+curl --get \
+  --data-urlencode "prompt=Summarize this with Gemini" \
+  --data-urlencode "key=mysecret" \
+  --data-urlencode "provider=gemini" \
+  --data-urlencode "model=gemini-3.5-flash" \
   "http://localhost:8080/"
 ```
 
@@ -312,6 +333,11 @@ below for web search.
 | `kimi-k2-0905-preview` | Moonshot/Kimi | No |
 | `deepseek-ai/DeepSeek-R1` | SiliconFlow | No |
 | `glm-5.1` | Zhipu/GLM | No |
+| `gemini-3.5-flash` | Gemini | No |
+| `gemini-3.1-flash-lite` | Gemini | No |
+| `gemini-2.5-flash` | Gemini | No |
+| `gemini-2.5-flash-lite` | Gemini | No |
+| `gemini-2.5-pro` | Gemini | No |
 
 ### Status codes
 

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -22,6 +22,7 @@ const (
 	keyMoonshotAPIKey               = "moonshot_api_key"
 	keySiliconFlowAPIKey            = "siliconflow_api_key"
 	keyZhipuAPIKey                  = "zhipu_api_key"
+	keyGeminiAPIKey                 = "gemini_api_key"
 	keyServiceSecret                = "service_secret"
 	keyDefaultProvider              = "default_provider"
 	keyDefaultModel                 = "default_model"
@@ -32,6 +33,7 @@ const (
 	keySiliconFlowBaseURL           = "siliconflow_base_url"
 	keySiliconFlowTranscriptionsURL = "siliconflow_transcriptions_url"
 	keyZhipuBaseURL                 = "zhipu_base_url"
+	keyGeminiBaseURL                = "gemini_base_url"
 	keyLogLevel                     = "log_level"
 	keySystemPrompt                 = "system_prompt"
 	keyWorkers                      = "workers"
@@ -50,6 +52,7 @@ const (
 	flagMoonshotAPIKey               = keyMoonshotAPIKey
 	flagSiliconFlowAPIKey            = keySiliconFlowAPIKey
 	flagZhipuAPIKey                  = keyZhipuAPIKey
+	flagGeminiAPIKey                 = keyGeminiAPIKey
 	flagServiceSecret                = keyServiceSecret
 	flagDefaultProvider              = keyDefaultProvider
 	flagDefaultModel                 = keyDefaultModel
@@ -60,6 +63,7 @@ const (
 	flagSiliconFlowBaseURL           = keySiliconFlowBaseURL
 	flagSiliconFlowTranscriptionsURL = keySiliconFlowTranscriptionsURL
 	flagZhipuBaseURL                 = keyZhipuBaseURL
+	flagGeminiBaseURL                = keyGeminiBaseURL
 	flagLogLevel                     = keyLogLevel
 	flagSystemPrompt                 = keySystemPrompt
 	flagWorkers                      = keyWorkers
@@ -78,6 +82,7 @@ const (
 	envMoonshotAPIKey               = "MOONSHOT_API_KEY"
 	envSiliconFlowAPIKey            = "SILICONFLOW_API_KEY"
 	envZhipuAPIKey                  = "ZHIPU_API_KEY"
+	envGeminiAPIKey                 = "GEMINI_API_KEY"
 	envServiceSecret                = "SERVICE_SECRET"
 	envDefaultProvider              = "LLM_PROXY_DEFAULT_PROVIDER"
 	envDefaultModel                 = "LLM_PROXY_DEFAULT_MODEL"
@@ -88,6 +93,7 @@ const (
 	envSiliconFlowBaseURL           = "SILICONFLOW_BASE_URL"
 	envSiliconFlowTranscriptionsURL = "SILICONFLOW_TRANSCRIPTIONS_URL"
 	envZhipuBaseURL                 = "ZHIPU_BASE_URL"
+	envGeminiBaseURL                = "GEMINI_BASE_URL"
 	envLogLevel                     = "LOG_LEVEL"
 	envSystemPrompt                 = "SYSTEM_PROMPT"
 	envWorkers                      = "LLM_PROXY_WORKERS"
@@ -128,7 +134,8 @@ const (
 	// Additional commands should define their usage examples using a constant following this pattern.
 	rootCmdExample = `llm-proxy --service_secret=mysecret --openai_api_key=sk-xxxxx --log_level=debug
 SERVICE_SECRET=mysecret OPENAI_API_KEY=sk-xxxxx LOG_LEVEL=debug llm-proxy
-SERVICE_SECRET=mysecret DEEPSEEK_API_KEY=sk-xxxxx LLM_PROXY_DEFAULT_PROVIDER=deepseek llm-proxy`
+SERVICE_SECRET=mysecret DEEPSEEK_API_KEY=sk-xxxxx LLM_PROXY_DEFAULT_PROVIDER=deepseek llm-proxy
+SERVICE_SECRET=mysecret GEMINI_API_KEY=xxxxx LLM_PROXY_DEFAULT_PROVIDER=gemini llm-proxy`
 )
 
 // Execute runs the command-line interface.
@@ -153,6 +160,7 @@ var rootCmd = &cobra.Command{
 		populateStringConfiguration(command, flagMoonshotAPIKey, keyMoonshotAPIKey, &config.MoonshotKey, constants.EmptyString, trimSpacesAndQuotes)
 		populateStringConfiguration(command, flagSiliconFlowAPIKey, keySiliconFlowAPIKey, &config.SiliconFlowKey, constants.EmptyString, trimSpacesAndQuotes)
 		populateStringConfiguration(command, flagZhipuAPIKey, keyZhipuAPIKey, &config.ZhipuKey, constants.EmptyString, trimSpacesAndQuotes)
+		populateStringConfiguration(command, flagGeminiAPIKey, keyGeminiAPIKey, &config.GeminiKey, constants.EmptyString, trimSpacesAndQuotes)
 		populateStringConfiguration(command, flagDefaultProvider, keyDefaultProvider, &config.DefaultProvider, proxy.DefaultProvider, trimSpacesAndQuotes)
 		populateStringConfiguration(command, flagDefaultModel, keyDefaultModel, &config.DefaultModel, proxy.DefaultModel, trimSpacesAndQuotes)
 		populateStringConfiguration(command, flagDefaultDictationProvider, keyDefaultDictationProvider, &config.DefaultDictationProvider, proxy.DefaultDictationProvider, trimSpacesAndQuotes)
@@ -162,6 +170,7 @@ var rootCmd = &cobra.Command{
 		populateStringConfiguration(command, flagSiliconFlowBaseURL, keySiliconFlowBaseURL, &config.SiliconFlowBaseURL, constants.EmptyString, trimSpacesAndQuotes)
 		populateStringConfiguration(command, flagSiliconFlowTranscriptionsURL, keySiliconFlowTranscriptionsURL, &config.SiliconFlowTranscriptionsURL, constants.EmptyString, trimSpacesAndQuotes)
 		populateStringConfiguration(command, flagZhipuBaseURL, keyZhipuBaseURL, &config.ZhipuBaseURL, constants.EmptyString, trimSpacesAndQuotes)
+		populateStringConfiguration(command, flagGeminiBaseURL, keyGeminiBaseURL, &config.GeminiBaseURL, constants.EmptyString, trimSpacesAndQuotes)
 		populateIntConfiguration(command, flagPort, keyPort, &config.Port, proxy.DefaultPort)
 		populateStringConfiguration(command, flagLogLevel, keyLogLevel, &config.LogLevel, proxy.LogLevelInfo, identityTransformer)
 		populateStringConfiguration(command, flagSystemPrompt, keySystemPrompt, &config.SystemPrompt, constants.EmptyString, identityTransformer)
@@ -224,6 +233,7 @@ func environmentBindings() []environmentBinding {
 		{key: keyMoonshotAPIKey, environmentVariables: []string{envMoonshotAPIKey}},
 		{key: keySiliconFlowAPIKey, environmentVariables: []string{envSiliconFlowAPIKey}},
 		{key: keyZhipuAPIKey, environmentVariables: []string{envZhipuAPIKey}},
+		{key: keyGeminiAPIKey, environmentVariables: []string{envGeminiAPIKey}},
 		{key: keyServiceSecret, environmentVariables: []string{envServiceSecret}},
 		{key: keyDefaultProvider, environmentVariables: []string{envDefaultProvider}},
 		{key: keyDefaultModel, environmentVariables: []string{envDefaultModel}},
@@ -234,6 +244,7 @@ func environmentBindings() []environmentBinding {
 		{key: keySiliconFlowBaseURL, environmentVariables: []string{envSiliconFlowBaseURL}},
 		{key: keySiliconFlowTranscriptionsURL, environmentVariables: []string{envSiliconFlowTranscriptionsURL}},
 		{key: keyZhipuBaseURL, environmentVariables: []string{envZhipuBaseURL}},
+		{key: keyGeminiBaseURL, environmentVariables: []string{envGeminiBaseURL}},
 		{key: keyLogLevel, environmentVariables: []string{envLogLevel}},
 		{key: keySystemPrompt, environmentVariables: []string{envSystemPrompt}},
 		{key: keyWorkers, environmentVariables: []string{envWorkers}},
@@ -261,6 +272,7 @@ func init() {
 	rootCmd.Flags().StringVar(&config.MoonshotKey, flagMoonshotAPIKey, "", "Moonshot/Kimi API key (env: "+envMoonshotAPIKey+")")
 	rootCmd.Flags().StringVar(&config.SiliconFlowKey, flagSiliconFlowAPIKey, "", "SiliconFlow API key (env: "+envSiliconFlowAPIKey+")")
 	rootCmd.Flags().StringVar(&config.ZhipuKey, flagZhipuAPIKey, "", "Zhipu/GLM API key (env: "+envZhipuAPIKey+")")
+	rootCmd.Flags().StringVar(&config.GeminiKey, flagGeminiAPIKey, "", "Gemini API key (env: "+envGeminiAPIKey+")")
 	rootCmd.Flags().StringVar(&config.DefaultProvider, flagDefaultProvider, "", "default text provider (env: "+envDefaultProvider+")")
 	rootCmd.Flags().StringVar(&config.DefaultModel, flagDefaultModel, "", "default text model (env: "+envDefaultModel+")")
 	rootCmd.Flags().StringVar(&config.DefaultDictationProvider, flagDefaultDictationProvider, "", "default dictation provider (env: "+envDefaultDictationProvider+")")
@@ -270,6 +282,7 @@ func init() {
 	rootCmd.Flags().StringVar(&config.SiliconFlowBaseURL, flagSiliconFlowBaseURL, "", "SiliconFlow OpenAI-compatible base URL (env: "+envSiliconFlowBaseURL+")")
 	rootCmd.Flags().StringVar(&config.SiliconFlowTranscriptionsURL, flagSiliconFlowTranscriptionsURL, "", "SiliconFlow transcription URL (env: "+envSiliconFlowTranscriptionsURL+")")
 	rootCmd.Flags().StringVar(&config.ZhipuBaseURL, flagZhipuBaseURL, "", "Zhipu OpenAI-compatible base URL (env: "+envZhipuBaseURL+")")
+	rootCmd.Flags().StringVar(&config.GeminiBaseURL, flagGeminiBaseURL, "", "Gemini API base URL (env: "+envGeminiBaseURL+")")
 	rootCmd.Flags().IntVar(&config.Port, flagPort, 0, "TCP port to listen on (env: "+envPort+")")
 	rootCmd.Flags().StringVar(&config.LogLevel, flagLogLevel, "", "logging level: debug or info (env: "+envLogLevel+")")
 	rootCmd.Flags().StringVar(&config.SystemPrompt, flagSystemPrompt, "", "system prompt sent to the model (env: "+envSystemPrompt+")")

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -27,6 +27,8 @@ func TestExecuteRunsConfiguredProxyWithInjectedServe(t *testing.T) {
 		"--service_secret", "sekret",
 		"--default_provider", proxy.ProviderNameDeepSeek,
 		"--deepseek_api_key", "sk-deepseek",
+		"--gemini_api_key", "sk-gemini",
+		"--gemini_base_url", "https://gemini.example",
 		"--log_level", proxy.LogLevelDebug,
 		"--port", "18080",
 	})
@@ -40,5 +42,11 @@ func TestExecuteRunsConfiguredProxyWithInjectedServe(t *testing.T) {
 	}
 	if capturedConfiguration.Port != 18080 {
 		t.Fatalf("port=%d", capturedConfiguration.Port)
+	}
+	if capturedConfiguration.GeminiKey != "sk-gemini" {
+		t.Fatalf("geminiKey=%q", capturedConfiguration.GeminiKey)
+	}
+	if capturedConfiguration.GeminiBaseURL != "https://gemini.example" {
+		t.Fatalf("geminiBaseURL=%q", capturedConfiguration.GeminiBaseURL)
 	}
 }

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -25,6 +25,7 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 | `moonshot` | `kimi` | OpenAI-compatible chat completions | Not supported | Not supported |
 | `siliconflow` | none | OpenAI-compatible chat completions | OpenAI-compatible audio transcription | Not supported |
 | `zhipu` | `glm` | OpenAI-compatible chat completions | Not supported | Not supported |
+| `gemini` | none | Native Gemini generateContent | Not supported | Not supported |
 
 ## Configuration
 
@@ -44,6 +45,7 @@ Provider credentials and base URLs:
 - `MOONSHOT_API_KEY`, `MOONSHOT_BASE_URL`
 - `SILICONFLOW_API_KEY`, `SILICONFLOW_BASE_URL`, `SILICONFLOW_TRANSCRIPTIONS_URL`
 - `ZHIPU_API_KEY`, `ZHIPU_BASE_URL`
+- `GEMINI_API_KEY`, `GEMINI_BASE_URL`
 
 Startup validates `SERVICE_SECRET`, the credential required by the configured default text provider, and the endpoint/credential required by the configured default dictation provider. Credentials for non-default providers are validated when a request selects that provider.
 
@@ -62,6 +64,7 @@ Startup validates `SERVICE_SECRET`, the credential required by the configured de
 - Provider/model validation happens at the HTTP edge through a provider registry.
 - OpenAI keeps the existing Responses API adapter.
 - Non-OpenAI text providers use a shared OpenAI-compatible Chat Completions adapter.
+- Gemini uses a native generateContent adapter against `GEMINI_BASE_URL`.
 - Dictation routing reuses the multipart transcription adapter with provider-specific URLs.
 - Response formatting remains unchanged.
 

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -41,6 +41,7 @@ type Configuration struct {
 	MoonshotKey                  string
 	SiliconFlowKey               string
 	ZhipuKey                     string
+	GeminiKey                    string
 	DefaultProvider              string
 	DefaultModel                 string
 	DefaultDictationProvider     string
@@ -50,6 +51,7 @@ type Configuration struct {
 	SiliconFlowBaseURL           string
 	SiliconFlowTranscriptionsURL string
 	ZhipuBaseURL                 string
+	GeminiBaseURL                string
 	Port                         int
 	LogLevel                     string
 	SystemPrompt                 string
@@ -104,6 +106,10 @@ func validateDefaultProviderCredential(providerIdentifier string, config Configu
 		if strings.TrimSpace(config.ZhipuKey) == constants.EmptyString {
 			return fmt.Errorf("%w: provider=%s", ErrProviderNotConfigured, ProviderNameZhipu)
 		}
+	case ProviderNameGemini:
+		if strings.TrimSpace(config.GeminiKey) == constants.EmptyString {
+			return fmt.Errorf("%w: provider=%s", ErrProviderNotConfigured, ProviderNameGemini)
+		}
 	default:
 		return fmt.Errorf("%w: %s", ErrUnknownProvider, providerIdentifier)
 	}
@@ -128,6 +134,8 @@ func validateDefaultDictationProviderCredential(providerIdentifier string, confi
 		return fmt.Errorf("%w: provider=%s endpoint=%s", ErrUnsupportedEndpoint, ProviderNameMoonshot, endpointKindDictation)
 	case ProviderNameZhipu, providerAliasGLM:
 		return fmt.Errorf("%w: provider=%s endpoint=%s", ErrUnsupportedEndpoint, ProviderNameZhipu, endpointKindDictation)
+	case ProviderNameGemini:
+		return fmt.Errorf("%w: provider=%s endpoint=%s", ErrUnsupportedEndpoint, ProviderNameGemini, endpointKindDictation)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnknownProvider, providerIdentifier)
 	}
@@ -185,5 +193,8 @@ func (configuration *Configuration) ApplyTunables() {
 	}
 	if strings.TrimSpace(configuration.ZhipuBaseURL) == constants.EmptyString {
 		configuration.ZhipuBaseURL = defaultZhipuBaseURL
+	}
+	if strings.TrimSpace(configuration.GeminiBaseURL) == constants.EmptyString {
+		configuration.GeminiBaseURL = defaultGeminiBaseURL
 	}
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -1,0 +1,143 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/temirov/llm-proxy/internal/constants"
+	"github.com/temirov/llm-proxy/internal/utils"
+	"go.uber.org/zap"
+)
+
+const geminiAPIKeyHeader = "x-goog-api-key"
+
+type geminiGenerateContentClient struct {
+	httpClient      HTTPDoer
+	requestTimeout  time.Duration
+	maxOutputTokens int
+}
+
+type geminiGenerateContentRequest struct {
+	Contents          []geminiContent        `json:"contents"`
+	SystemInstruction *geminiContent         `json:"systemInstruction,omitempty"`
+	GenerationConfig  geminiGenerationConfig `json:"generationConfig"`
+}
+
+type geminiGenerationConfig struct {
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiGenerateContentResponse struct {
+	Candidates    []geminiCandidate    `json:"candidates"`
+	UsageMetadata *geminiUsageMetadata `json:"usageMetadata"`
+}
+
+type geminiCandidate struct {
+	Content geminiContent `json:"content"`
+}
+
+type geminiUsageMetadata struct {
+	PromptTokenCount     *int `json:"promptTokenCount"`
+	CandidatesTokenCount *int `json:"candidatesTokenCount"`
+	TotalTokenCount      *int `json:"totalTokenCount"`
+}
+
+func newGeminiGenerateContentClient(httpClient HTTPDoer, requestTimeout time.Duration, maxOutputTokens int) *geminiGenerateContentClient {
+	return &geminiGenerateContentClient{
+		httpClient:      httpClient,
+		requestTimeout:  requestTimeout,
+		maxOutputTokens: maxOutputTokens,
+	}
+}
+
+func (client *geminiGenerateContentClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier modelID, userPrompt string, systemPrompt string, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	payload := geminiGenerateContentRequest{
+		Contents: []geminiContent{{
+			Role:  "user",
+			Parts: []geminiPart{{Text: userPrompt}},
+		}},
+		GenerationConfig: geminiGenerationConfig{MaxOutputTokens: client.maxOutputTokens},
+	}
+	if !utils.IsBlank(systemPrompt) {
+		payload.SystemInstruction = &geminiContent{Parts: []geminiPart{{Text: systemPrompt}}}
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	requestURL := geminiGenerateContentURL(baseURL, modelIdentifier)
+	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
+	defer cancelRequest()
+	httpRequest, buildError := http.NewRequestWithContext(requestContext, http.MethodPost, requestURL, bytes.NewReader(payloadBytes))
+	if buildError != nil {
+		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
+		return textGenerationResult{}, buildError
+	}
+	httpRequest.Header.Set(headerContentType, mimeApplicationJSON)
+	httpRequest.Header.Set(geminiAPIKeyHeader, strings.TrimSpace(apiKey))
+
+	statusCode, responseBytes, _, requestError := utils.PerformHTTPRequest(client.httpClient.Do, httpRequest, structuredLogger, logEventProviderRequestError)
+	if requestError != nil {
+		return textGenerationResult{}, requestError
+	}
+	if statusCode == http.StatusTooManyRequests {
+		return textGenerationResult{}, fmt.Errorf("%w: gemini generateContent", ErrProviderRateLimited)
+	}
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return textGenerationResult{}, fmt.Errorf("%w: status=%d", ErrProviderAPI, statusCode)
+	}
+	generation, parseError := parseGeminiGenerateContentResponse(responseBytes)
+	if parseError != nil {
+		return textGenerationResult{}, parseError
+	}
+	return generation, nil
+}
+
+func geminiGenerateContentURL(baseURL string, modelIdentifier modelID) string {
+	trimmedBaseURL := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	return trimmedBaseURL + "/models/" + url.PathEscape(modelIdentifier.string()) + ":generateContent"
+}
+
+func parseGeminiGenerateContentResponse(responseBytes []byte) (textGenerationResult, error) {
+	var response geminiGenerateContentResponse
+	if decodeError := json.Unmarshal(responseBytes, &response); decodeError != nil {
+		return textGenerationResult{}, decodeError
+	}
+	usage, usageError := parseGeminiTokenUsage(response.UsageMetadata)
+	if usageError != nil {
+		return textGenerationResult{}, usageError
+	}
+	for _, candidate := range response.Candidates {
+		var textBuilder strings.Builder
+		for _, part := range candidate.Content.Parts {
+			if strings.TrimSpace(part.Text) != constants.EmptyString {
+				textBuilder.WriteString(part.Text)
+			}
+		}
+		trimmedText := strings.TrimSpace(textBuilder.String())
+		if trimmedText != constants.EmptyString {
+			return textGenerationResult{text: trimmedText, usage: usage}, nil
+		}
+	}
+	return textGenerationResult{}, fmt.Errorf("%w: gemini generateContent returned no text", ErrProviderAPI)
+}
+
+func parseGeminiTokenUsage(usage *geminiUsageMetadata) (*tokenUsage, error) {
+	if usage == nil {
+		return nil, nil
+	}
+	return normalizeTokenUsage(usage.PromptTokenCount, usage.CandidatesTokenCount, usage.TotalTokenCount)
+}

--- a/internal/proxy/provider_registry.go
+++ b/internal/proxy/provider_registry.go
@@ -19,6 +19,7 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 	moonshotProviderID := providerID(ProviderNameMoonshot)
 	siliconFlowProviderID := providerID(ProviderNameSiliconFlow)
 	zhipuProviderID := providerID(ProviderNameZhipu)
+	geminiProviderID := providerID(ProviderNameGemini)
 
 	definitions := map[providerID]providerDefinition{
 		openAIProviderID: {
@@ -31,7 +32,7 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			transcriptionModels:       modelSet(configuration.DictationModel, DefaultDictationModel, "gpt-4o-transcribe"),
 			supportsDictation:         true,
 			supportsWebSearch:         true,
-			usesOpenAIResponses:       true,
+			textTransport:             textTransportOpenAIResponses,
 		},
 		deepSeekProviderID: {
 			identifier:          deepSeekProviderID,
@@ -40,6 +41,7 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:    modelID(ModelNameDeepSeekV4Flash),
 			textModels:          modelSet(ModelNameDeepSeekV4Flash, ModelNameDeepSeekV4Pro, ModelNameDeepSeekChat, ModelNameDeepSeekReasoner),
 			transcriptionModels: map[string]modelID{},
+			textTransport:       textTransportOpenAICompatibleChat,
 		},
 		dashScopeProviderID: {
 			identifier:          dashScopeProviderID,
@@ -49,6 +51,7 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:    modelID(ModelNameDashScopeQwenPlus),
 			textModels:          modelSet(ModelNameDashScopeQwenPlus),
 			transcriptionModels: map[string]modelID{},
+			textTransport:       textTransportOpenAICompatibleChat,
 		},
 		moonshotProviderID: {
 			identifier:          moonshotProviderID,
@@ -58,6 +61,7 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:    modelID(ModelNameMoonshotKimi),
 			textModels:          modelSet(ModelNameMoonshotKimi),
 			transcriptionModels: map[string]modelID{},
+			textTransport:       textTransportOpenAICompatibleChat,
 		},
 		siliconFlowProviderID: {
 			identifier:                siliconFlowProviderID,
@@ -70,6 +74,7 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			textModels:                modelSet(ModelNameSiliconFlowDeepSeek),
 			transcriptionModels:       modelSet(defaultSiliconFlowSTTModel),
 			supportsDictation:         true,
+			textTransport:             textTransportOpenAICompatibleChat,
 		},
 		zhipuProviderID: {
 			identifier:          zhipuProviderID,
@@ -79,6 +84,16 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:    modelID(ModelNameZhipuGLM),
 			textModels:          modelSet(ModelNameZhipuGLM),
 			transcriptionModels: map[string]modelID{},
+			textTransport:       textTransportOpenAICompatibleChat,
+		},
+		geminiProviderID: {
+			identifier:          geminiProviderID,
+			textAPIKey:          configuration.GeminiKey,
+			textBaseURL:         configuration.GeminiBaseURL,
+			defaultTextModel:    modelID(ModelNameGemini35Flash),
+			textModels:          modelSet(ModelNameGemini35Flash, ModelNameGemini31FlashLite, ModelNameGemini25Flash, ModelNameGemini25FlashLite, ModelNameGemini25Pro),
+			transcriptionModels: map[string]modelID{},
+			textTransport:       textTransportGeminiGenerate,
 		},
 	}
 

--- a/internal/proxy/provider_router.go
+++ b/internal/proxy/provider_router.go
@@ -9,17 +9,19 @@ import (
 type providerRouter struct {
 	openAIClient *OpenAIClient
 	chatClient   *openAICompatibleChatClient
+	geminiClient *geminiGenerateContentClient
 }
 
-func newProviderRouter(openAIClient *OpenAIClient, chatClient *openAICompatibleChatClient) *providerRouter {
+func newProviderRouter(openAIClient *OpenAIClient, chatClient *openAICompatibleChatClient, geminiClient *geminiGenerateContentClient) *providerRouter {
 	return &providerRouter{
 		openAIClient: openAIClient,
 		chatClient:   chatClient,
+		geminiClient: geminiClient,
 	}
 }
 
 func (router *providerRouter) generateText(requestContext context.Context, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
-	if request.provider.usesOpenAIResponses {
+	if request.provider.textTransport == textTransportOpenAIResponses {
 		return router.openAIClient.openAIRequest(
 			requestContext,
 			request.provider.credentialFor(endpointKindText),
@@ -27,6 +29,17 @@ func (router *providerRouter) generateText(requestContext context.Context, reque
 			request.prompt,
 			request.systemPrompt,
 			request.webSearchEnabled,
+			structuredLogger,
+		)
+	}
+	if request.provider.textTransport == textTransportGeminiGenerate {
+		return router.geminiClient.generateText(
+			requestContext,
+			request.provider.credentialFor(endpointKindText),
+			request.provider.textBaseURL,
+			request.model,
+			request.prompt,
+			request.systemPrompt,
 			structuredLogger,
 		)
 	}

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -18,6 +18,7 @@ import (
 const (
 	testDeepSeekKey    = "sk-deepseek"
 	testSiliconFlowKey = "sk-siliconflow"
+	testGeminiKey      = "sk-gemini"
 )
 
 func TestProviderRoutingSupportsDeepSeekChatCompletions(t *testing.T) {
@@ -143,6 +144,354 @@ func TestProviderRoutingSurfacesChatCompletionTokenUsage(t *testing.T) {
 	}
 }
 
+func TestProviderRoutingSupportsGeminiGenerateContent(t *testing.T) {
+	var capturedPayload map[string]any
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Fatalf("method=%s want=%s", request.Method, http.MethodPost)
+		}
+		if request.URL.Path != "/models/"+proxy.ModelNameGemini35Flash+":generateContent" {
+			t.Fatalf("path=%s want=%s", request.URL.Path, "/models/"+proxy.ModelNameGemini35Flash+":generateContent")
+		}
+		if apiKeyHeader := request.Header.Get("x-goog-api-key"); apiKeyHeader != testGeminiKey {
+			t.Fatalf("x-goog-api-key=%q want=%q", apiKeyHeader, testGeminiKey)
+		}
+		bodyBytes, readError := io.ReadAll(request.Body)
+		if readError != nil {
+			t.Fatalf("read body: %v", readError)
+		}
+		if unmarshalError := json.Unmarshal(bodyBytes, &capturedPayload); unmarshalError != nil {
+			t.Fatalf("unmarshal body: %v", unmarshalError)
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"gemini ok"}]}}],"usageMetadata":{"promptTokenCount":13,"candidatesTokenCount":5}}`))
+	}))
+	defer upstreamServer.Close()
+
+	logger := zap.NewNop()
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		GeminiKey:                  testGeminiKey,
+		GeminiBaseURL:              upstreamServer.URL,
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+		MaxOutputTokens:            123,
+	}, logger.Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	queryParameters := url.Values{}
+	queryParameters.Set("key", TestSecret)
+	queryParameters.Set("prompt", TestPrompt)
+	queryParameters.Set("provider", proxy.ProviderNameGemini)
+	queryParameters.Set("system_prompt", "system text")
+	queryParameters.Set("format", "application/json")
+	request := httptest.NewRequest(http.MethodGet, "/?"+queryParameters.Encode(), nil)
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusOK, responseRecorder.Body.String())
+	}
+	if responseRecorder.Header().Get(testHeaderLLMProxyRequestTokens) != "13" {
+		t.Fatalf("request tokens header=%q", responseRecorder.Header().Get(testHeaderLLMProxyRequestTokens))
+	}
+	if responseRecorder.Header().Get(testHeaderLLMProxyResponseTokens) != "5" {
+		t.Fatalf("response tokens header=%q", responseRecorder.Header().Get(testHeaderLLMProxyResponseTokens))
+	}
+	if responseRecorder.Header().Get(testHeaderLLMProxyTotalTokens) != "18" {
+		t.Fatalf("total tokens header=%q", responseRecorder.Header().Get(testHeaderLLMProxyTotalTokens))
+	}
+	var response struct {
+		Response string `json:"response"`
+		Usage    struct {
+			RequestTokens  int `json:"request_tokens"`
+			ResponseTokens int `json:"response_tokens"`
+			TotalTokens    int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if decodeError := json.Unmarshal(responseRecorder.Body.Bytes(), &response); decodeError != nil {
+		t.Fatalf("decode json: %v", decodeError)
+	}
+	if response.Response != "gemini ok" || response.Usage.RequestTokens != 13 || response.Usage.ResponseTokens != 5 || response.Usage.TotalTokens != 18 {
+		t.Fatalf("response=%+v", response)
+	}
+	if generationConfig, ok := capturedPayload["generationConfig"].(map[string]any); !ok || generationConfig["maxOutputTokens"] != float64(123) {
+		t.Fatalf("generationConfig=%v", capturedPayload["generationConfig"])
+	}
+	if systemInstruction, ok := capturedPayload["systemInstruction"].(map[string]any); !ok || systemInstruction["parts"] == nil {
+		t.Fatalf("systemInstruction=%v", capturedPayload["systemInstruction"])
+	}
+}
+
+func TestProviderRoutingSupportsGeminiJSONPost(t *testing.T) {
+	var capturedPath string
+	var capturedPayload map[string]any
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		capturedPath = request.URL.Path
+		bodyBytes, readError := io.ReadAll(request.Body)
+		if readError != nil {
+			t.Fatalf("read body: %v", readError)
+		}
+		if unmarshalError := json.Unmarshal(bodyBytes, &capturedPayload); unmarshalError != nil {
+			t.Fatalf("unmarshal body: %v", unmarshalError)
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"gemini json ok"}]}}]}`))
+	}))
+	defer upstreamServer.Close()
+
+	logger := zap.NewNop()
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		GeminiKey:                  testGeminiKey,
+		GeminiBaseURL:              upstreamServer.URL,
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+	}, logger.Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	requestBody := bytes.NewBufferString(`{"prompt":"hello json","model":"` + proxy.ModelNameGemini25Pro + `","system_prompt":"system json"}`)
+	request := httptest.NewRequest(http.MethodPost, "/?key="+TestSecret+"&provider="+proxy.ProviderNameGemini, requestBody)
+	request.Header.Set("Content-Type", "application/json")
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusOK, responseRecorder.Body.String())
+	}
+	if strings.TrimSpace(responseRecorder.Body.String()) != "gemini json ok" {
+		t.Fatalf("body=%q want=%q", responseRecorder.Body.String(), "gemini json ok")
+	}
+	if capturedPath != "/models/"+proxy.ModelNameGemini25Pro+":generateContent" {
+		t.Fatalf("path=%s want=%s", capturedPath, "/models/"+proxy.ModelNameGemini25Pro+":generateContent")
+	}
+	if systemInstruction, ok := capturedPayload["systemInstruction"].(map[string]any); !ok || systemInstruction["parts"] == nil {
+		t.Fatalf("systemInstruction=%v", capturedPayload["systemInstruction"])
+	}
+}
+
+func TestProviderRoutingRejectsGeminiUnsupportedAndInvalidRequests(t *testing.T) {
+	logger := zap.NewNop()
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		GeminiKey:                  testGeminiKey,
+		GeminiBaseURL:              "https://gemini.invalid",
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+	}, logger.Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	testCases := []struct {
+		name         string
+		method       string
+		target       string
+		expectedCode int
+	}{
+		{name: "unknown model", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=gemini&model=unknown", expectedCode: http.StatusBadRequest},
+		{name: "unsupported web search", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=gemini&web_search=1", expectedCode: http.StatusBadRequest},
+		{name: "unsupported dictation", method: http.MethodPost, target: "/dictate?key=" + TestSecret + "&provider=gemini", expectedCode: http.StatusBadRequest},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			var request *http.Request
+			if testCase.target == "/dictate?key="+TestSecret+"&provider=gemini" {
+				body := &bytes.Buffer{}
+				writer := multipart.NewWriter(body)
+				filePart, createError := writer.CreateFormFile("audio", "recording.webm")
+				if createError != nil {
+					subTest.Fatalf("CreateFormFile error: %v", createError)
+				}
+				if _, writeError := filePart.Write([]byte(testAudioPayload)); writeError != nil {
+					subTest.Fatalf("write audio: %v", writeError)
+				}
+				if closeError := writer.Close(); closeError != nil {
+					subTest.Fatalf("Close writer error: %v", closeError)
+				}
+				request = httptest.NewRequest(testCase.method, testCase.target, body)
+				request.Header.Set("Content-Type", writer.FormDataContentType())
+			} else {
+				request = httptest.NewRequest(testCase.method, testCase.target, nil)
+			}
+			responseRecorder := httptest.NewRecorder()
+			router.ServeHTTP(responseRecorder, request)
+			if responseRecorder.Code != testCase.expectedCode {
+				subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, testCase.expectedCode, responseRecorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestProviderRoutingRejectsGeminiMissingCredential(t *testing.T) {
+	logger := zap.NewNop()
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		GeminiBaseURL:              "https://gemini.invalid",
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+	}, logger.Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/?key="+TestSecret+"&prompt=hello&provider=gemini", nil)
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusServiceUnavailable, responseRecorder.Body.String())
+	}
+}
+
+func TestProviderRoutingRejectsMissingGeminiDefaultCredential(t *testing.T) {
+	logger := zap.NewNop()
+	_, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		DefaultProvider:            proxy.ProviderNameGemini,
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+	}, logger.Sugar())
+	if buildError == nil || !strings.Contains(buildError.Error(), "provider not configured: provider=gemini") {
+		t.Fatalf("error=%v want Gemini provider not configured", buildError)
+	}
+}
+
+func TestProviderRoutingMapsGeminiProviderErrors(t *testing.T) {
+	testCases := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantStatus int
+	}{
+		{name: "rate limited", statusCode: http.StatusTooManyRequests, body: `{}`, wantStatus: http.StatusTooManyRequests},
+		{name: "provider api failure", statusCode: http.StatusInternalServerError, body: `{}`, wantStatus: http.StatusBadGateway},
+		{name: "malformed json", statusCode: http.StatusOK, body: `{`, wantStatus: http.StatusBadGateway},
+		{name: "negative usage", statusCode: http.StatusOK, body: `{"candidates":[{"content":{"parts":[{"text":"bad usage"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":-1}}`, wantStatus: http.StatusBadGateway},
+		{name: "missing text", statusCode: http.StatusOK, body: `{"candidates":[{"content":{"parts":[{}]}}]}`, wantStatus: http.StatusBadGateway},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+				responseWriter.Header().Set("Content-Type", "application/json")
+				responseWriter.WriteHeader(testCase.statusCode)
+				_, _ = responseWriter.Write([]byte(testCase.body))
+			}))
+			defer upstreamServer.Close()
+
+			logger := zap.NewNop()
+			router, buildError := proxy.BuildRouter(proxy.Configuration{
+				ServiceSecret:              TestSecret,
+				OpenAIKey:                  TestAPIKey,
+				GeminiKey:                  testGeminiKey,
+				GeminiBaseURL:              upstreamServer.URL,
+				LogLevel:                   proxy.LogLevelInfo,
+				WorkerCount:                1,
+				QueueSize:                  1,
+				RequestTimeoutSeconds:      TestTimeout,
+				UpstreamPollTimeoutSeconds: TestTimeout,
+			}, logger.Sugar())
+			if buildError != nil {
+				subTest.Fatalf(messageBuildRouterError, buildError)
+			}
+
+			request := httptest.NewRequest(http.MethodGet, "/?key="+TestSecret+"&prompt=hello&provider=gemini", nil)
+			responseRecorder := httptest.NewRecorder()
+
+			router.ServeHTTP(responseRecorder, request)
+
+			if responseRecorder.Code != testCase.wantStatus {
+				subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, testCase.wantStatus, responseRecorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestProviderRoutingMapsGeminiTransportErrors(t *testing.T) {
+	t.Run("invalid request URL", func(subTest *testing.T) {
+		logger := zap.NewNop()
+		router, buildError := proxy.BuildRouter(proxy.Configuration{
+			ServiceSecret:              TestSecret,
+			OpenAIKey:                  TestAPIKey,
+			GeminiKey:                  testGeminiKey,
+			GeminiBaseURL:              "http://[::1",
+			LogLevel:                   proxy.LogLevelInfo,
+			WorkerCount:                1,
+			QueueSize:                  1,
+			RequestTimeoutSeconds:      TestTimeout,
+			UpstreamPollTimeoutSeconds: TestTimeout,
+		}, logger.Sugar())
+		if buildError != nil {
+			subTest.Fatalf(messageBuildRouterError, buildError)
+		}
+
+		request := httptest.NewRequest(http.MethodGet, "/?key="+TestSecret+"&prompt=hello&provider=gemini", nil)
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusBadGateway {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusBadGateway, responseRecorder.Body.String())
+		}
+	})
+
+	t.Run("transport error", func(subTest *testing.T) {
+		originalHTTPClient := proxy.HTTPClient
+		proxy.HTTPClient = coverageHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF
+		})
+		subTest.Cleanup(func() { proxy.HTTPClient = originalHTTPClient })
+
+		logger := zap.NewNop()
+		router, buildError := proxy.BuildRouter(proxy.Configuration{
+			ServiceSecret:              TestSecret,
+			OpenAIKey:                  TestAPIKey,
+			GeminiKey:                  testGeminiKey,
+			GeminiBaseURL:              "https://gemini.invalid",
+			LogLevel:                   proxy.LogLevelInfo,
+			WorkerCount:                1,
+			QueueSize:                  1,
+			RequestTimeoutSeconds:      1,
+			UpstreamPollTimeoutSeconds: TestTimeout,
+		}, logger.Sugar())
+		if buildError != nil {
+			subTest.Fatalf(messageBuildRouterError, buildError)
+		}
+
+		request := httptest.NewRequest(http.MethodGet, "/?key="+TestSecret+"&prompt=hello&provider=gemini", nil)
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusGatewayTimeout {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusGatewayTimeout, responseRecorder.Body.String())
+		}
+	})
+}
+
 func TestProviderRoutingRejectsUnsupportedWebSearch(t *testing.T) {
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
@@ -230,6 +579,21 @@ func TestProviderRoutingRejectsInvalidDefaultDictationProvider(t *testing.T) {
 				UpstreamPollTimeoutSeconds: TestTimeout,
 			},
 			expectedError: "unsupported provider endpoint: provider=deepseek endpoint=dictation",
+		},
+		{
+			name: "unsupported_gemini_dictation",
+			configuration: proxy.Configuration{
+				ServiceSecret:              TestSecret,
+				OpenAIKey:                  TestAPIKey,
+				GeminiKey:                  testGeminiKey,
+				DefaultDictationProvider:   proxy.ProviderNameGemini,
+				LogLevel:                   proxy.LogLevelInfo,
+				WorkerCount:                1,
+				QueueSize:                  1,
+				RequestTimeoutSeconds:      TestTimeout,
+				UpstreamPollTimeoutSeconds: TestTimeout,
+			},
+			expectedError: "unsupported provider endpoint: provider=gemini endpoint=dictation",
 		},
 	}
 	for _, testCase := range testCases {

--- a/internal/proxy/provider_types.go
+++ b/internal/proxy/provider_types.go
@@ -17,6 +17,8 @@ const (
 	ProviderNameSiliconFlow = "siliconflow"
 	// ProviderNameZhipu identifies Zhipu/GLM routing.
 	ProviderNameZhipu = "zhipu"
+	// ProviderNameGemini identifies Google Gemini routing.
+	ProviderNameGemini = "gemini"
 )
 
 const (
@@ -31,6 +33,7 @@ const (
 	defaultMoonshotBaseURL     = "https://api.moonshot.ai/v1"
 	defaultSiliconFlowBaseURL  = "https://api.siliconflow.com/v1"
 	defaultZhipuBaseURL        = "https://open.bigmodel.cn/api/paas/v4"
+	defaultGeminiBaseURL       = "https://generativelanguage.googleapis.com/v1"
 	defaultSiliconFlowSTTModel = "FunAudioLLM/SenseVoiceSmall"
 )
 
@@ -51,6 +54,16 @@ const (
 	ModelNameSiliconFlowDeepSeek = "deepseek-ai/DeepSeek-R1"
 	// ModelNameZhipuGLM identifies the GLM 5.1 model.
 	ModelNameZhipuGLM = "glm-5.1"
+	// ModelNameGemini35Flash identifies Gemini 3.5 Flash.
+	ModelNameGemini35Flash = "gemini-3.5-flash"
+	// ModelNameGemini31FlashLite identifies Gemini 3.1 Flash-Lite.
+	ModelNameGemini31FlashLite = "gemini-3.1-flash-lite"
+	// ModelNameGemini25Flash identifies Gemini 2.5 Flash.
+	ModelNameGemini25Flash = "gemini-2.5-flash"
+	// ModelNameGemini25FlashLite identifies Gemini 2.5 Flash-Lite.
+	ModelNameGemini25FlashLite = "gemini-2.5-flash-lite"
+	// ModelNameGemini25Pro identifies Gemini 2.5 Pro.
+	ModelNameGemini25Pro = "gemini-2.5-pro"
 )
 
 type endpointKind string
@@ -58,6 +71,14 @@ type endpointKind string
 const (
 	endpointKindText      endpointKind = "text"
 	endpointKindDictation endpointKind = "dictation"
+)
+
+type providerTextTransport string
+
+const (
+	textTransportOpenAIResponses      providerTextTransport = "openai_responses"
+	textTransportOpenAICompatibleChat providerTextTransport = "openai_compatible_chat"
+	textTransportGeminiGenerate       providerTextTransport = "gemini_generate"
 )
 
 type providerID string
@@ -95,7 +116,7 @@ type providerDefinition struct {
 	transcriptionModels       map[string]modelID
 	supportsDictation         bool
 	supportsWebSearch         bool
-	usesOpenAIResponses       bool
+	textTransport             providerTextTransport
 }
 
 func (definition providerDefinition) credentialFor(endpoint endpointKind) string {

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -85,7 +85,8 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	pollTimeout := time.Duration(configuration.UpstreamPollTimeoutSeconds) * time.Second
 	openAIClient := NewOpenAIClient(HTTPClient, configuration.Endpoints, requestTimeout, configuration.MaxOutputTokens, pollTimeout)
 	chatClient := newOpenAICompatibleChatClient(HTTPClient, requestTimeout, configuration.MaxOutputTokens)
-	upstreamProviders := newProviderRouter(openAIClient, chatClient)
+	geminiClient := newGeminiGenerateContentClient(HTTPClient, requestTimeout, configuration.MaxOutputTokens)
+	upstreamProviders := newProviderRouter(openAIClient, chatClient, geminiClient)
 	for workerIndex := 0; workerIndex < configuration.WorkerCount; workerIndex++ {
 		go func() {
 			for pending := range taskQueue {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -75,4 +75,15 @@ These entries are always-available procedures. Keep them `[ ]` so they remain ru
 
 ## Features
 
+- [x] [F409] (P1) Add Gemini as a native text provider.
+  Add Google Gemini support to the authenticated LLM endpoint using Gemini's native `generateContent` API. The provider should be selected with `provider=gemini`, should use server-side `GEMINI_API_KEY`, should default to `gemini-3.5-flash`, and should support only text generation initially. `/dictate` and `web_search` must return existing unsupported endpoint/capability errors for Gemini until those capabilities are explicitly designed.
+  Acceptance criteria:
+  1. `GET /` and JSON `POST /` route Gemini requests to the native Gemini API with the configured Gemini API key.
+  2. Known Gemini models validate through the provider registry, unknown Gemini models return `400`, and omitted Gemini model values use `gemini-3.5-flash`.
+  3. Missing Gemini credentials return `503` for selected Gemini requests and fail startup when Gemini is configured as the default provider.
+  4. Gemini dictation and Gemini `web_search` requests return the existing unsupported endpoint/capability errors.
+  5. README and implementation docs describe Gemini configuration, usage, supported models, and capability limits.
+  6. Black-box HTTP and CLI tests cover success and failure paths, and repository validation passes.
+  Resolution: Added native Gemini text routing through `provider=gemini` using Google's generateContent API, `GEMINI_API_KEY`, optional `GEMINI_BASE_URL`, and `gemini-3.5-flash` as the provider default model. Supported Gemini text models are `gemini-3.5-flash`, `gemini-3.1-flash-lite`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, and `gemini-2.5-pro`. Gemini token usage metadata is normalized into the existing usage headers and JSON response shape when upstream returns it. Gemini `/dictate`, `web_search`, unknown model, missing credential, upstream status, transport, malformed response, no-text response, and invalid usage cases are covered by black-box tests. README and provider-routing docs were updated. Validation passed with `timeout -k 30s -s SIGKILL 30s make fmt`, `timeout -k 350s -s SIGKILL 350s make test` (total coverage 100.0%), `timeout -k 350s -s SIGKILL 350s make lint`, `timeout -k 350s -s SIGKILL 350s make ci`, and `git diff --check`.
+
 ## Planning


### PR DESCRIPTION
Add native Gemini text generation provider support

- Introduce Gemini provider with native generateContent API integration
- Add Gemini API key and base URL configuration flags and environment variables
- Update provider routing plan and configuration documentation to include Gemini
- Extend CLI flags and configuration validation for Gemini credentials
- Add usage examples and model listings for Gemini in README and issues documentation
- Include comprehensive tests for Gemini provider routing and configuration handling