### PR TITLE
gix/remove-global-max-output-tokens-config-and-add-per

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ variables:
 | `--queue_size` / `LLM_PROXY_QUEUE_SIZE` | Request queue size (default `100`) |
 | `--request_timeout` / `LLM_PROXY_REQUEST_TIMEOUT_SECONDS` | Overall request timeout in seconds (default `180`) |
 | `--upstream_poll_timeout` / `LLM_PROXY_UPSTREAM_POLL_TIMEOUT_SECONDS` | Poll timeout in seconds after incomplete upstream responses (default `60`) |
-| `--max_output_tokens` / `LLM_PROXY_MAX_OUTPUT_TOKENS` | Max output token budget forwarded to text models (default `8192`) |
 | `--max_prompt_bytes` / `LLM_PROXY_MAX_PROMPT_BYTES` | Max accepted JSON body size for `POST /` prompts (default `4194304`) |
 | `--dictation_model` / `LLM_PROXY_DICTATION_MODEL` | Default model for `/dictate` when query model is not provided (default `gpt-4o-mini-transcribe`) |
 | `--max_input_audio_bytes` / `LLM_PROXY_MAX_INPUT_AUDIO_BYTES` | Max accepted upload size for `/dictate` (default `26214400`) |
 
 Web search is per request and currently supported only on OpenAI models that
 support the OpenAI web search tool.
+Text output length is also per request: pass `max_tokens` when a client wants
+to cap one generation. When omitted, the proxy does not send a provider
+max-token field.
 
 ## Running
 
@@ -136,6 +138,7 @@ curl --get \
   --data-urlencode "key=mysecret" \
   --data-urlencode "provider=gemini" \
   --data-urlencode "model=gemini-3.5-flash" \
+  --data-urlencode "max_tokens=512" \
   "http://localhost:8080/"
 ```
 
@@ -151,7 +154,7 @@ from server-side configuration. The JSON body is capped by `--max_prompt_bytes`
 ```shell
 curl -X POST \
   -H "Content-Type: application/json" \
-  --data '{"prompt":"large text...","model":"gpt-5.5","web_search":false,"system_prompt":"optional"}' \
+  --data '{"prompt":"large text...","model":"gpt-5.5","web_search":false,"system_prompt":"optional","max_tokens":4096}' \
   "http://localhost:8080/?key=mysecret"
 ```
 
@@ -163,6 +166,7 @@ JSON body fields:
 | `model` | No | provider default | Model identifier from the selected provider's supported model list. |
 | `web_search` | No | `false` | Enables OpenAI web search when the selected provider/model supports it. |
 | `system_prompt` | No | configured `SYSTEM_PROMPT` | Per-request system prompt override. |
+| `max_tokens` | No | provider default | Positive integer output-token cap for this request. The proxy maps it to OpenAI `max_output_tokens`, OpenAI-compatible `max_tokens`, or Gemini `generationConfig.maxOutputTokens`. |
 
 For `POST /`, `provider` remains a query parameter. Query `model` may override
 the JSON body only when the body omits `model` or provides the same value;
@@ -270,6 +274,7 @@ GET /
   &provider=PROVIDER        # optional; defaults to openai
   &model=MODEL_NAME         # optional; provider default
   &web_search=1|true|yes    # optional; OpenAI web_search tool
+  &max_tokens=N             # optional positive integer per-request cap
   &format=CONTENT_TYPE      # optional; or use Accept header
 ```
 
@@ -284,7 +289,8 @@ Content-Type: application/json
   "prompt": "STRING",       # required
   "model": "MODEL_NAME",    # optional; provider default
   "web_search": false,      # optional; defaults to false
-  "system_prompt": "STRING" # optional; defaults to configured system prompt
+  "system_prompt": "STRING",# optional; defaults to configured system prompt
+  "max_tokens": 512         # optional positive integer per-request cap
 }
 ```
 

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -41,7 +41,6 @@ const (
 	keyPort                         = "port"
 	keyRequestTimeoutSeconds        = "request_timeout_seconds"
 	keyUpstreamPollTimeoutSeconds   = "upstream_poll_timeout_seconds"
-	keyMaxOutputTokens              = "max_output_tokens"
 	keyMaxPromptBytes               = "max_prompt_bytes"
 	keyDictationModel               = "dictation_model"
 	keyMaxInputAudioBytes           = "max_input_audio_bytes"
@@ -71,7 +70,6 @@ const (
 	flagPort                         = keyPort
 	flagRequestTimeout               = "request_timeout"
 	flagUpstreamPollTimeout          = "upstream_poll_timeout"
-	flagMaxOutputTokens              = keyMaxOutputTokens
 	flagMaxPromptBytes               = keyMaxPromptBytes
 	flagDictationModel               = keyDictationModel
 	flagMaxInputAudioBytes           = keyMaxInputAudioBytes
@@ -101,7 +99,6 @@ const (
 	envPort                         = "HTTP_PORT"
 	envRequestTimeoutSeconds        = "LLM_PROXY_REQUEST_TIMEOUT_SECONDS"
 	envUpstreamPollTimeoutSeconds   = "LLM_PROXY_UPSTREAM_POLL_TIMEOUT_SECONDS"
-	envMaxOutputTokens              = "LLM_PROXY_MAX_OUTPUT_TOKENS"
 	envMaxPromptBytes               = "LLM_PROXY_MAX_PROMPT_BYTES"
 	envDictationModel               = "LLM_PROXY_DICTATION_MODEL"
 	envMaxInputAudioBytes           = "LLM_PROXY_MAX_INPUT_AUDIO_BYTES"
@@ -178,7 +175,6 @@ var rootCmd = &cobra.Command{
 		populateIntConfiguration(command, flagQueueSize, keyQueueSize, &config.QueueSize, proxy.DefaultQueueSize)
 		populateIntConfiguration(command, flagRequestTimeout, keyRequestTimeoutSeconds, &config.RequestTimeoutSeconds, proxy.DefaultRequestTimeoutSeconds)
 		populateIntConfiguration(command, flagUpstreamPollTimeout, keyUpstreamPollTimeoutSeconds, &config.UpstreamPollTimeoutSeconds, proxy.DefaultUpstreamPollTimeoutSeconds)
-		populateIntConfiguration(command, flagMaxOutputTokens, keyMaxOutputTokens, &config.MaxOutputTokens, proxy.DefaultMaxOutputTokens)
 		populateInt64Configuration(command, flagMaxPromptBytes, keyMaxPromptBytes, &config.MaxPromptBytes, proxy.DefaultMaxPromptBytes)
 		populateStringConfiguration(command, flagDictationModel, keyDictationModel, &config.DictationModel, proxy.DefaultDictationModel, trimSpacesAndQuotes)
 		populateInt64Configuration(command, flagMaxInputAudioBytes, keyMaxInputAudioBytes, &config.MaxInputAudioBytes, proxy.DefaultMaxInputAudioBytes)
@@ -252,7 +248,6 @@ func environmentBindings() []environmentBinding {
 		{key: keyPort, environmentVariables: []string{envPort}},
 		{key: keyRequestTimeoutSeconds, environmentVariables: []string{envRequestTimeoutSeconds}},
 		{key: keyUpstreamPollTimeoutSeconds, environmentVariables: []string{envUpstreamPollTimeoutSeconds}},
-		{key: keyMaxOutputTokens, environmentVariables: []string{envMaxOutputTokens}},
 		{key: keyMaxPromptBytes, environmentVariables: []string{envMaxPromptBytes}},
 		{key: keyDictationModel, environmentVariables: []string{envDictationModel}},
 		{key: keyMaxInputAudioBytes, environmentVariables: []string{envMaxInputAudioBytes}},
@@ -290,7 +285,6 @@ func init() {
 	rootCmd.Flags().IntVar(&config.QueueSize, flagQueueSize, 0, "request queue size (env: "+envQueueSize+")")
 	rootCmd.Flags().IntVar(&config.RequestTimeoutSeconds, flagRequestTimeout, 0, "overall request timeout in seconds (env: "+envRequestTimeoutSeconds+")")
 	rootCmd.Flags().IntVar(&config.UpstreamPollTimeoutSeconds, flagUpstreamPollTimeout, 0, "upstream poll timeout in seconds for incomplete responses (env: "+envUpstreamPollTimeoutSeconds+")")
-	rootCmd.Flags().IntVar(&config.MaxOutputTokens, flagMaxOutputTokens, 0, "maximum output tokens (env: "+envMaxOutputTokens+")")
 	rootCmd.Flags().Int64Var(&config.MaxPromptBytes, flagMaxPromptBytes, 0, "maximum accepted JSON prompt payload size for POST / in bytes (env: "+envMaxPromptBytes+")")
 	rootCmd.Flags().StringVar(&config.DictationModel, flagDictationModel, "", "default model for /dictate when query model is not provided (env: "+envDictationModel+")")
 	rootCmd.Flags().Int64Var(&config.MaxInputAudioBytes, flagMaxInputAudioBytes, 0, "maximum accepted audio payload size for /dictate in bytes (env: "+envMaxInputAudioBytes+")")

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -50,3 +50,19 @@ func TestExecuteRunsConfiguredProxyWithInjectedServe(t *testing.T) {
 		t.Fatalf("geminiBaseURL=%q", capturedConfiguration.GeminiBaseURL)
 	}
 }
+
+func TestRemovedGlobalMaxOutputTokensConfigSurface(t *testing.T) {
+	if rootCmd.Flags().Lookup("max_output_tokens") != nil {
+		t.Fatal("max_output_tokens flag must not be registered")
+	}
+	for _, binding := range environmentBindings() {
+		if binding.key == "max_output_tokens" {
+			t.Fatalf("max_output_tokens env binding must not be registered: %+v", binding)
+		}
+		for _, environmentVariable := range binding.environmentVariables {
+			if environmentVariable == "LLM_PROXY_MAX_OUTPUT_TOKENS" {
+				t.Fatalf("LLM_PROXY_MAX_OUTPUT_TOKENS env binding must not be registered: %+v", binding)
+			}
+		}
+	}
+}

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -11,6 +11,9 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 - `provider` is an optional query parameter on `GET /`, `POST /`, and `POST /dictate`.
 - Omitted `provider` means `openai`.
 - `model` keeps its current meaning.
+- `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies.
+- Omitted `max_tokens` means the proxy omits provider max-token fields and lets the selected provider/model default apply.
+- Provided `max_tokens` maps to OpenAI Responses `max_output_tokens`, OpenAI-compatible chat completions `max_tokens`, and Gemini `generationConfig.maxOutputTokens`.
 - For JSON `POST /`, query `model` may override the body only when the body omits `model` or provides the same value.
 - Conflicting query/body `model` values return `400 Bad Request`.
 - Upstream provider API keys are never accepted from client requests.

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -25,7 +25,6 @@ const (
 
 	DefaultRequestTimeoutSeconds      = 180 // overall app-side request timeout
 	DefaultUpstreamPollTimeoutSeconds = 60  // poll budget after "incomplete"
-	DefaultMaxOutputTokens            = 8192
 	// DefaultMaxPromptBytes limits JSON LLM request bodies accepted by POST /.
 	DefaultMaxPromptBytes     = 4 * 1024 * 1024
 	DefaultDictationModel     = "gpt-4o-mini-transcribe"
@@ -59,7 +58,6 @@ type Configuration struct {
 	QueueSize                    int
 	RequestTimeoutSeconds        int
 	UpstreamPollTimeoutSeconds   int
-	MaxOutputTokens              int
 	MaxPromptBytes               int64
 	DictationModel               string
 	MaxInputAudioBytes           int64
@@ -152,9 +150,6 @@ func (configuration *Configuration) ApplyTunables() {
 	}
 	if configuration.UpstreamPollTimeoutSeconds <= 0 {
 		configuration.UpstreamPollTimeoutSeconds = DefaultUpstreamPollTimeoutSeconds
-	}
-	if configuration.MaxOutputTokens <= 0 {
-		configuration.MaxOutputTokens = DefaultMaxOutputTokens
 	}
 	if strings.TrimSpace(configuration.DefaultProvider) == constants.EmptyString {
 		configuration.DefaultProvider = DefaultProvider

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -26,6 +26,7 @@ const (
 	queryParameterModel        = "model"
 	queryParameterWebSearch    = "web_search"
 	queryParameterSystemPrompt = "system_prompt"
+	queryParameterMaxTokens    = "max_tokens"
 	queryParameterFormat       = "format"
 
 	formFieldAudio = "audio"
@@ -41,6 +42,7 @@ const (
 
 	errorMissingPrompt         = "missing prompt parameter"
 	errorInvalidJSONRequest    = "invalid JSON request"
+	errorInvalidMaxTokens      = "invalid max_tokens parameter"
 	errorPromptPayloadTooLarge = "prompt payload too large"
 	// errorMissingClientKey indicates that the key query parameter is missing.
 	errorMissingClientKey           = "unknown client key"

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -67,10 +67,6 @@ func coverageRouter(t *testing.T, configuration proxy.Configuration) *gin.Engine
 }
 
 func textRouterWithResponsesHandler(t *testing.T, handler http.HandlerFunc) *gin.Engine {
-	return textRouterWithResponsesHandlerAndMaxOutputTokens(t, handler, proxy.DefaultMaxOutputTokens)
-}
-
-func textRouterWithResponsesHandlerAndMaxOutputTokens(t *testing.T, handler http.HandlerFunc, maxOutputTokens int) *gin.Engine {
 	t.Helper()
 	upstreamServer := httptest.NewServer(handler)
 	t.Cleanup(upstreamServer.Close)
@@ -84,7 +80,6 @@ func textRouterWithResponsesHandlerAndMaxOutputTokens(t *testing.T, handler http
 		QueueSize:                  2,
 		RequestTimeoutSeconds:      TestTimeout,
 		UpstreamPollTimeoutSeconds: TestTimeout,
-		MaxOutputTokens:            maxOutputTokens,
 		Endpoints:                  endpoints,
 	})
 }
@@ -294,6 +289,108 @@ func TestCoverageFormatsAndRequestEdges(t *testing.T) {
 		router.ServeHTTP(responseRecorder, request)
 		if responseRecorder.Code != http.StatusOK {
 			subTest.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+		}
+	})
+}
+
+func TestCoverageOpenAIResponsesMaxTokensContract(t *testing.T) {
+	t.Run("default request omits max_output_tokens", func(subTest *testing.T) {
+		var capturedPayload map[string]any
+		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			requestBytes, _ := io.ReadAll(httpRequest.Body)
+			if decodeError := json.Unmarshal(requestBytes, &capturedPayload); decodeError != nil {
+				subTest.Fatalf("decode upstream request: %v", decodeError)
+			}
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"output_text":"no cap"}`))
+		})
+		queryParameters := url.Values{}
+		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
+		if statusCode != http.StatusOK || body != "no cap" {
+			subTest.Fatalf("status=%d body=%q", statusCode, body)
+		}
+		if _, exists := capturedPayload["max_output_tokens"]; exists {
+			subTest.Fatalf("max_output_tokens must be omitted by default: %v", capturedPayload)
+		}
+	})
+
+	t.Run("query max_tokens maps to max_output_tokens", func(subTest *testing.T) {
+		var capturedPayload map[string]any
+		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			requestBytes, _ := io.ReadAll(httpRequest.Body)
+			if decodeError := json.Unmarshal(requestBytes, &capturedPayload); decodeError != nil {
+				subTest.Fatalf("decode upstream request: %v", decodeError)
+			}
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"output_text":"query cap"}`))
+		})
+		queryParameters := url.Values{}
+		queryParameters.Set("max_tokens", "777")
+		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
+		if statusCode != http.StatusOK || body != "query cap" {
+			subTest.Fatalf("status=%d body=%q", statusCode, body)
+		}
+		if capturedPayload["max_output_tokens"] != float64(777) {
+			subTest.Fatalf("max_output_tokens=%v payload=%v", capturedPayload["max_output_tokens"], capturedPayload)
+		}
+	})
+
+	t.Run("json body max_tokens maps to max_output_tokens", func(subTest *testing.T) {
+		var capturedPayload map[string]any
+		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			requestBytes, _ := io.ReadAll(httpRequest.Body)
+			if decodeError := json.Unmarshal(requestBytes, &capturedPayload); decodeError != nil {
+				subTest.Fatalf("decode upstream request: %v", decodeError)
+			}
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"output_text":"json cap"}`))
+		})
+		request := httptest.NewRequest(http.MethodPost, "/?key="+TestSecret, strings.NewReader(`{"prompt":"hello json","max_tokens":333}`))
+		request.Header.Set("Content-Type", "application/json")
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusOK || responseRecorder.Body.String() != "json cap" {
+			subTest.Fatalf("status=%d body=%q", responseRecorder.Code, responseRecorder.Body.String())
+		}
+		if capturedPayload["max_output_tokens"] != float64(333) {
+			subTest.Fatalf("max_output_tokens=%v payload=%v", capturedPayload["max_output_tokens"], capturedPayload)
+		}
+	})
+
+	t.Run("invalid query max_tokens is rejected before upstream", func(subTest *testing.T) {
+		upstreamCalled := false
+		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			upstreamCalled = true
+			responseWriter.WriteHeader(http.StatusInternalServerError)
+		})
+		for _, rawValue := range []string{"0", "-1", "abc"} {
+			queryParameters := url.Values{}
+			queryParameters.Set("max_tokens", rawValue)
+			statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
+			if statusCode != http.StatusBadRequest || !strings.Contains(body, "invalid max_tokens parameter") {
+				subTest.Fatalf("max_tokens=%q status=%d body=%q", rawValue, statusCode, body)
+			}
+		}
+		if upstreamCalled {
+			subTest.Fatal("upstream must not be called for invalid query max_tokens")
+		}
+	})
+
+	t.Run("invalid json max_tokens is rejected before upstream", func(subTest *testing.T) {
+		upstreamCalled := false
+		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			upstreamCalled = true
+			responseWriter.WriteHeader(http.StatusInternalServerError)
+		})
+		request := httptest.NewRequest(http.MethodPost, "/?key="+TestSecret, strings.NewReader(`{"prompt":"hello json","max_tokens":0}`))
+		request.Header.Set("Content-Type", "application/json")
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		if responseRecorder.Code != http.StatusBadRequest || !strings.Contains(responseRecorder.Body.String(), "invalid max_tokens parameter") {
+			subTest.Fatalf("status=%d body=%q", responseRecorder.Code, responseRecorder.Body.String())
+		}
+		if upstreamCalled {
+			subTest.Fatal("upstream must not be called for invalid json max_tokens")
 		}
 	})
 }
@@ -510,7 +607,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 	})
 
 	t.Run("initial incomplete continuation failure maps to bad gateway", func(subTest *testing.T) {
-		router := textRouterWithResponsesHandlerAndMaxOutputTokens(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")
 			switch {
 			case httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/":
@@ -526,7 +623,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 			default:
 				http.NotFound(responseWriter, httpRequest)
 			}
-		}, 1024)
+		})
 		queryParameters := url.Values{}
 		statusCode, _, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
 		if statusCode != http.StatusBadGateway {
@@ -639,7 +736,8 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 	})
 
 	t.Run("completed without final message starts synthesis continuation", func(subTest *testing.T) {
-		router := textRouterWithResponsesHandlerAndMaxOutputTokens(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		var synthesisPayload map[string]any
+		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")
 			switch {
 			case httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/":
@@ -650,17 +748,22 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 					_, _ = responseWriter.Write([]byte(`{"id":"needs_synthesis","status":"completed","output":[{"type":"web_search_call","action":{"query":"weather"}}]}`))
 					return
 				}
+				synthesisPayload = requestPayload
 				_, _ = responseWriter.Write([]byte(`{"id":"synthesis","status":"queued"}`))
 			case httpRequest.Method == http.MethodGet && httpRequest.URL.Path == "/synthesis":
 				_, _ = responseWriter.Write([]byte(`{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"synthesized"}]}]}`))
 			default:
 				http.NotFound(responseWriter, httpRequest)
 			}
-		}, 1024)
+		})
 		queryParameters := url.Values{}
+		queryParameters.Set("max_tokens", "222")
 		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
 		if statusCode != http.StatusOK || body != "synthesized" {
 			subTest.Fatalf("status=%d body=%q", statusCode, body)
+		}
+		if synthesisPayload["max_output_tokens"] != float64(222) {
+			subTest.Fatalf("synthesis max_output_tokens=%v payload=%v", synthesisPayload["max_output_tokens"], synthesisPayload)
 		}
 	})
 

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -18,15 +18,14 @@ import (
 const geminiAPIKeyHeader = "x-goog-api-key"
 
 type geminiGenerateContentClient struct {
-	httpClient      HTTPDoer
-	requestTimeout  time.Duration
-	maxOutputTokens int
+	httpClient     HTTPDoer
+	requestTimeout time.Duration
 }
 
 type geminiGenerateContentRequest struct {
-	Contents          []geminiContent        `json:"contents"`
-	SystemInstruction *geminiContent         `json:"systemInstruction,omitempty"`
-	GenerationConfig  geminiGenerationConfig `json:"generationConfig"`
+	Contents          []geminiContent         `json:"contents"`
+	SystemInstruction *geminiContent          `json:"systemInstruction,omitempty"`
+	GenerationConfig  *geminiGenerationConfig `json:"generationConfig,omitempty"`
 }
 
 type geminiGenerationConfig struct {
@@ -57,24 +56,25 @@ type geminiUsageMetadata struct {
 	TotalTokenCount      *int `json:"totalTokenCount"`
 }
 
-func newGeminiGenerateContentClient(httpClient HTTPDoer, requestTimeout time.Duration, maxOutputTokens int) *geminiGenerateContentClient {
+func newGeminiGenerateContentClient(httpClient HTTPDoer, requestTimeout time.Duration) *geminiGenerateContentClient {
 	return &geminiGenerateContentClient{
-		httpClient:      httpClient,
-		requestTimeout:  requestTimeout,
-		maxOutputTokens: maxOutputTokens,
+		httpClient:     httpClient,
+		requestTimeout: requestTimeout,
 	}
 }
 
-func (client *geminiGenerateContentClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier modelID, userPrompt string, systemPrompt string, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+func (client *geminiGenerateContentClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier modelID, userPrompt string, systemPrompt string, maxTokens *int, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
 	payload := geminiGenerateContentRequest{
 		Contents: []geminiContent{{
 			Role:  "user",
 			Parts: []geminiPart{{Text: userPrompt}},
 		}},
-		GenerationConfig: geminiGenerationConfig{MaxOutputTokens: client.maxOutputTokens},
 	}
 	if !utils.IsBlank(systemPrompt) {
 		payload.SystemInstruction = &geminiContent{Parts: []geminiPart{{Text: systemPrompt}}}
+	}
+	if maxTokens != nil {
+		payload.GenerationConfig = &geminiGenerationConfig{MaxOutputTokens: *maxTokens}
 	}
 	payloadBytes, _ := json.Marshal(payload)
 

--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -23,7 +23,7 @@ type Reasoning struct {
 type requestPayloadBase struct {
 	Model           string `json:"model"`
 	Input           string `json:"input"`
-	MaxOutputTokens int    `json:"max_output_tokens"`
+	MaxOutputTokens *int   `json:"max_output_tokens,omitempty"`
 }
 
 // requestPayloadWithTools is for models supporting tools but not temperature (e.g., gpt-5).
@@ -54,7 +54,7 @@ type Tool struct {
 }
 
 // BuildRequestPayload selects the correct struct for the given model and returns it.
-func BuildRequestPayload(modelIdentifier string, combinedPrompt string, webSearchEnabled bool, maxTokens int) any {
+func BuildRequestPayload(modelIdentifier string, combinedPrompt string, webSearchEnabled bool, maxTokens *int) any {
 	base := requestPayloadBase{
 		Model:           modelIdentifier,
 		Input:           combinedPrompt,

--- a/internal/proxy/model_capabilities_test.go
+++ b/internal/proxy/model_capabilities_test.go
@@ -15,6 +15,7 @@ const (
 	toolChoiceFieldPresenceMismatch  = "Mismatch in 'tool_choice' field presence. Got: %s, Want presence: %v"
 	reasoningFieldPresenceMismatch   = "Mismatch in 'reasoning' field presence. Got: %s, Want presence: %v"
 	reasoningFieldJSONFragment       = `"reasoning"`
+	maxOutputTokensFieldJSONFragment = `"max_output_tokens"`
 	modelFieldsMismatchFormat        = "model %s fields=%v want=%v"
 	promptValue                      = "hello"
 )
@@ -127,7 +128,7 @@ func TestBuildRequestPayload(testFramework *testing.T) {
 
 	for _, testCase := range testCases {
 		testFramework.Run(testCase.name, func(subTestFramework *testing.T) {
-			payload := proxy.BuildRequestPayload(testCase.modelIdentifier, promptValue, testCase.webSearchEnabled, proxy.DefaultMaxOutputTokens)
+			payload := proxy.BuildRequestPayload(testCase.modelIdentifier, promptValue, testCase.webSearchEnabled, nil)
 			payloadBytes, marshalError := json.Marshal(payload)
 			if marshalError != nil {
 				subTestFramework.Fatalf(marshalPayloadErrorFormat, marshalError)
@@ -146,6 +147,19 @@ func TestBuildRequestPayload(testFramework *testing.T) {
 			reasoningFieldPresent := strings.Contains(payloadJSON, reasoningFieldJSONFragment)
 			if reasoningFieldPresent != testCase.expectReasoning {
 				subTestFramework.Errorf(reasoningFieldPresenceMismatch, payloadJSON, testCase.expectReasoning)
+			}
+			if strings.Contains(payloadJSON, maxOutputTokensFieldJSONFragment) {
+				subTestFramework.Errorf("max_output_tokens must be omitted without request max_tokens: %s", payloadJSON)
+			}
+
+			maxTokens := 555
+			cappedPayload := proxy.BuildRequestPayload(testCase.modelIdentifier, promptValue, testCase.webSearchEnabled, &maxTokens)
+			cappedPayloadBytes, cappedMarshalError := json.Marshal(cappedPayload)
+			if cappedMarshalError != nil {
+				subTestFramework.Fatalf(marshalPayloadErrorFormat, cappedMarshalError)
+			}
+			if !strings.Contains(string(cappedPayloadBytes), `"max_output_tokens":555`) {
+				subTestFramework.Errorf("max_output_tokens missing with request max_tokens: %s", string(cappedPayloadBytes))
 			}
 		})
 	}

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -33,17 +33,15 @@ type OpenAIClient struct {
 	httpClient          HTTPDoer
 	endpoints           *Endpoints
 	requestTimeout      time.Duration
-	maxOutputTokens     int
 	upstreamPollTimeout time.Duration
 }
 
 // NewOpenAIClient constructs an OpenAIClient initialized with the supplied components.
-func NewOpenAIClient(httpClient HTTPDoer, endpoints *Endpoints, requestTimeout time.Duration, maxTokens int, pollTimeout time.Duration) *OpenAIClient {
+func NewOpenAIClient(httpClient HTTPDoer, endpoints *Endpoints, requestTimeout time.Duration, pollTimeout time.Duration) *OpenAIClient {
 	return &OpenAIClient{
 		httpClient:          httpClient,
 		endpoints:           endpoints,
 		requestTimeout:      requestTimeout,
-		maxOutputTokens:     maxTokens,
 		upstreamPollTimeout: pollTimeout,
 	}
 }
@@ -82,7 +80,7 @@ func hasFinalMessage(rawPayload []byte) bool {
 }
 
 // openAIRequest sends a prompt to the OpenAI responses API and returns the resulting text.
-func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIKey string, modelIdentifier string, userPrompt string, systemPrompt string, webSearchEnabled bool, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIKey string, modelIdentifier string, userPrompt string, systemPrompt string, webSearchEnabled bool, maxTokens *int, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
 	// The Responses API expects a single string input. We'll prepend the system prompt to the user prompt.
 	var combinedPrompt strings.Builder
 	if !utils.IsBlank(systemPrompt) {
@@ -91,7 +89,7 @@ func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIK
 	}
 	combinedPrompt.WriteString(userPrompt)
 
-	payload := BuildRequestPayload(modelIdentifier, combinedPrompt.String(), webSearchEnabled, client.maxOutputTokens)
+	payload := BuildRequestPayload(modelIdentifier, combinedPrompt.String(), webSearchEnabled, maxTokens)
 	payloadBytes, _ := json.Marshal(payload)
 
 	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
@@ -155,7 +153,7 @@ func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIK
 			return textGenerationResult{text: outputText, usage: initialUsage}, nil
 		}
 		if canContinueIncompleteResponse(decodedObject) && !utils.IsBlank(responseIdentifier) {
-			continuedResponseID, continuationError := client.startIncompleteContinuation(requestContext, openAIKey, responseIdentifier, modelIdentifier, webSearchEnabled, structuredLogger)
+			continuedResponseID, continuationError := client.startIncompleteContinuation(requestContext, openAIKey, responseIdentifier, modelIdentifier, webSearchEnabled, maxTokens, structuredLogger)
 			if continuationError != nil {
 				structuredLogger.Errorw(
 					logEventOpenAIContinueError,
@@ -182,7 +180,7 @@ func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIK
 	}
 
 	if forcedSynthesis && !utils.IsBlank(responseIdentifier) {
-		continuedResponseID, synthErr := client.startSynthesisContinuation(requestContext, openAIKey, responseIdentifier, modelIdentifier, structuredLogger)
+		continuedResponseID, synthErr := client.startSynthesisContinuation(requestContext, openAIKey, responseIdentifier, modelIdentifier, maxTokens, structuredLogger)
 		if synthErr != nil {
 			structuredLogger.Errorw(
 				logEventOpenAIContinueError,
@@ -239,18 +237,12 @@ func openAIStageError(stageError error) error {
 // startSynthesisContinuation begins a synthesis-only pass by POSTing /v1/responses with
 // previous_response_id and tool_choice set to "none". It allocates enough output tokens, limits reasoning effort to minimal, and includes a low-verbosity text format hint.
 // It returns the identifier of the new response.
-func (client *OpenAIClient) startSynthesisContinuation(parentContext context.Context, openAIKey string, previousResponseID string, modelIdentifier string, structuredLogger *zap.SugaredLogger) (string, error) {
-	outputTokenLimit := client.maxOutputTokens
-	if outputTokenLimit < 1536 {
-		outputTokenLimit = 1536
-	}
-
+func (client *OpenAIClient) startSynthesisContinuation(parentContext context.Context, openAIKey string, previousResponseID string, modelIdentifier string, maxTokens *int, structuredLogger *zap.SugaredLogger) (string, error) {
 	payload := map[string]any{
 		keyModel:              modelIdentifier,
 		keyPreviousResponseID: previousResponseID,
 		keyToolChoice:         toolChoiceNone,
 		keyInput:              synthesisInstructionPrimary,
-		keyMaxOutputTokens:    outputTokenLimit,
 		keyReasoning: map[string]any{
 			keyEffort: reasoningEffortMinimal,
 		},
@@ -259,16 +251,14 @@ func (client *OpenAIClient) startSynthesisContinuation(parentContext context.Con
 			keyVerbosity: verbosityLow,
 		},
 	}
+	if maxTokens != nil {
+		payload[keyMaxOutputTokens] = *maxTokens
+	}
 	return client.startContinuationResponse(parentContext, openAIKey, payload, structuredLogger)
 }
 
-func (client *OpenAIClient) startIncompleteContinuation(parentContext context.Context, openAIKey string, previousResponseID string, modelIdentifier string, webSearchEnabled bool, structuredLogger *zap.SugaredLogger) (string, error) {
-	outputTokenLimit := client.maxOutputTokens
-	if outputTokenLimit < 1536 {
-		outputTokenLimit = 1536
-	}
-
-	payload := buildStatefulContinuationPayload(modelIdentifier, continuationInstructionPrimary, webSearchEnabled, outputTokenLimit, previousResponseID)
+func (client *OpenAIClient) startIncompleteContinuation(parentContext context.Context, openAIKey string, previousResponseID string, modelIdentifier string, webSearchEnabled bool, maxTokens *int, structuredLogger *zap.SugaredLogger) (string, error) {
+	payload := buildStatefulContinuationPayload(modelIdentifier, continuationInstructionPrimary, webSearchEnabled, maxTokens, previousResponseID)
 	return client.startContinuationResponse(parentContext, openAIKey, payload, structuredLogger)
 }
 
@@ -298,7 +288,7 @@ func (client *OpenAIClient) startContinuationResponse(parentContext context.Cont
 	return newID, nil
 }
 
-func buildStatefulContinuationPayload(modelIdentifier string, inputText string, webSearchEnabled bool, maxTokens int, previousResponseID string) map[string]any {
+func buildStatefulContinuationPayload(modelIdentifier string, inputText string, webSearchEnabled bool, maxTokens *int, previousResponseID string) map[string]any {
 	payloadBytes, _ := json.Marshal(BuildRequestPayload(modelIdentifier, inputText, webSearchEnabled, maxTokens))
 	var payload map[string]any
 	_ = json.Unmarshal(payloadBytes, &payload)

--- a/internal/proxy/openai_compatible_chat.go
+++ b/internal/proxy/openai_compatible_chat.go
@@ -16,9 +16,8 @@ import (
 )
 
 type openAICompatibleChatClient struct {
-	httpClient      HTTPDoer
-	requestTimeout  time.Duration
-	maxOutputTokens int
+	httpClient     HTTPDoer
+	requestTimeout time.Duration
 }
 
 type chatCompletionMessage struct {
@@ -29,7 +28,7 @@ type chatCompletionMessage struct {
 type chatCompletionRequest struct {
 	Model     string                  `json:"model"`
 	Messages  []chatCompletionMessage `json:"messages"`
-	MaxTokens int                     `json:"max_tokens,omitempty"`
+	MaxTokens *int                    `json:"max_tokens,omitempty"`
 }
 
 type chatCompletionResponse struct {
@@ -46,15 +45,14 @@ type chatCompletionResponseMessage struct {
 	ReasoningContent string `json:"reasoning_content"`
 }
 
-func newOpenAICompatibleChatClient(httpClient HTTPDoer, requestTimeout time.Duration, maxOutputTokens int) *openAICompatibleChatClient {
+func newOpenAICompatibleChatClient(httpClient HTTPDoer, requestTimeout time.Duration) *openAICompatibleChatClient {
 	return &openAICompatibleChatClient{
-		httpClient:      httpClient,
-		requestTimeout:  requestTimeout,
-		maxOutputTokens: maxOutputTokens,
+		httpClient:     httpClient,
+		requestTimeout: requestTimeout,
 	}
 }
 
-func (client *openAICompatibleChatClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier modelID, userPrompt string, systemPrompt string, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+func (client *openAICompatibleChatClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier modelID, userPrompt string, systemPrompt string, maxTokens *int, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
 	messages := []chatCompletionMessage{}
 	if !utils.IsBlank(systemPrompt) {
 		messages = append(messages, chatCompletionMessage{Role: "system", Content: systemPrompt})
@@ -64,7 +62,7 @@ func (client *openAICompatibleChatClient) generateText(parentContext context.Con
 	payload := chatCompletionRequest{
 		Model:     modelIdentifier.string(),
 		Messages:  messages,
-		MaxTokens: client.maxOutputTokens,
+		MaxTokens: maxTokens,
 	}
 	payloadBytes, _ := json.Marshal(payload)
 

--- a/internal/proxy/openai_dictation_test.go
+++ b/internal/proxy/openai_dictation_test.go
@@ -77,7 +77,7 @@ func TestParseTranscriptionText(t *testing.T) {
 }
 
 func TestTranscribeAudioWithURLReturnsReaderError(t *testing.T) {
-	client := NewOpenAIClient(http.DefaultClient, NewEndpoints(), time.Second, DefaultMaxOutputTokens, time.Second)
+	client := NewOpenAIClient(http.DefaultClient, NewEndpoints(), time.Second, time.Second)
 	_, transcriptionError := client.transcribeAudioWithURL("key", "http://example.test", DefaultDictationModel, "audio.webm", transcriptionFailingReader{}, nil)
 	if transcriptionError == nil {
 		t.Fatalf("transcriptionError=nil want non-nil")

--- a/internal/proxy/provider_router.go
+++ b/internal/proxy/provider_router.go
@@ -29,6 +29,7 @@ func (router *providerRouter) generateText(requestContext context.Context, reque
 			request.prompt,
 			request.systemPrompt,
 			request.webSearchEnabled,
+			request.maxTokens,
 			structuredLogger,
 		)
 	}
@@ -40,6 +41,7 @@ func (router *providerRouter) generateText(requestContext context.Context, reque
 			request.model,
 			request.prompt,
 			request.systemPrompt,
+			request.maxTokens,
 			structuredLogger,
 		)
 	}
@@ -50,6 +52,7 @@ func (router *providerRouter) generateText(requestContext context.Context, reque
 		request.model,
 		request.prompt,
 		request.systemPrompt,
+		request.maxTokens,
 		structuredLogger,
 	)
 }

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -80,6 +80,59 @@ func TestProviderRoutingSupportsDeepSeekChatCompletions(t *testing.T) {
 	if capturedPayload["model"] != proxy.ModelNameDeepSeekV4Flash {
 		t.Fatalf("model=%v want=%s", capturedPayload["model"], proxy.ModelNameDeepSeekV4Flash)
 	}
+	if _, exists := capturedPayload["max_tokens"]; exists {
+		t.Fatalf("max_tokens must be omitted by default: %v", capturedPayload)
+	}
+}
+
+func TestProviderRoutingTranslatesMaxTokensForOpenAICompatibleChat(t *testing.T) {
+	var capturedPayload map[string]any
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		bodyBytes, readError := io.ReadAll(request.Body)
+		if readError != nil {
+			t.Fatalf("read body: %v", readError)
+		}
+		if unmarshalError := json.Unmarshal(bodyBytes, &capturedPayload); unmarshalError != nil {
+			t.Fatalf("unmarshal body: %v", unmarshalError)
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"deepseek cap ok"}}]}`))
+	}))
+	defer upstreamServer.Close()
+
+	logger := zap.NewNop()
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		DeepSeekKey:                testDeepSeekKey,
+		DeepSeekBaseURL:            upstreamServer.URL,
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+	}, logger.Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	queryParameters := url.Values{}
+	queryParameters.Set("key", TestSecret)
+	queryParameters.Set("prompt", TestPrompt)
+	queryParameters.Set("provider", proxy.ProviderNameDeepSeek)
+	queryParameters.Set("model", proxy.ModelNameDeepSeekV4Flash)
+	queryParameters.Set("max_tokens", "444")
+	request := httptest.NewRequest(http.MethodGet, "/?"+queryParameters.Encode(), nil)
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusOK, responseRecorder.Body.String())
+	}
+	if capturedPayload["max_tokens"] != float64(444) {
+		t.Fatalf("max_tokens=%v payload=%v", capturedPayload["max_tokens"], capturedPayload)
+	}
 }
 
 func TestProviderRoutingSurfacesChatCompletionTokenUsage(t *testing.T) {
@@ -179,7 +232,6 @@ func TestProviderRoutingSupportsGeminiGenerateContent(t *testing.T) {
 		QueueSize:                  1,
 		RequestTimeoutSeconds:      TestTimeout,
 		UpstreamPollTimeoutSeconds: TestTimeout,
-		MaxOutputTokens:            123,
 	}, logger.Sugar())
 	if buildError != nil {
 		t.Fatalf(messageBuildRouterError, buildError)
@@ -222,8 +274,8 @@ func TestProviderRoutingSupportsGeminiGenerateContent(t *testing.T) {
 	if response.Response != "gemini ok" || response.Usage.RequestTokens != 13 || response.Usage.ResponseTokens != 5 || response.Usage.TotalTokens != 18 {
 		t.Fatalf("response=%+v", response)
 	}
-	if generationConfig, ok := capturedPayload["generationConfig"].(map[string]any); !ok || generationConfig["maxOutputTokens"] != float64(123) {
-		t.Fatalf("generationConfig=%v", capturedPayload["generationConfig"])
+	if _, exists := capturedPayload["generationConfig"]; exists {
+		t.Fatalf("generationConfig must be omitted by default: %v", capturedPayload["generationConfig"])
 	}
 	if systemInstruction, ok := capturedPayload["systemInstruction"].(map[string]any); !ok || systemInstruction["parts"] == nil {
 		t.Fatalf("systemInstruction=%v", capturedPayload["systemInstruction"])
@@ -263,7 +315,7 @@ func TestProviderRoutingSupportsGeminiJSONPost(t *testing.T) {
 		t.Fatalf(messageBuildRouterError, buildError)
 	}
 
-	requestBody := bytes.NewBufferString(`{"prompt":"hello json","model":"` + proxy.ModelNameGemini25Pro + `","system_prompt":"system json"}`)
+	requestBody := bytes.NewBufferString(`{"prompt":"hello json","model":"` + proxy.ModelNameGemini25Pro + `","system_prompt":"system json","max_tokens":222}`)
 	request := httptest.NewRequest(http.MethodPost, "/?key="+TestSecret+"&provider="+proxy.ProviderNameGemini, requestBody)
 	request.Header.Set("Content-Type", "application/json")
 	responseRecorder := httptest.NewRecorder()
@@ -281,6 +333,9 @@ func TestProviderRoutingSupportsGeminiJSONPost(t *testing.T) {
 	}
 	if systemInstruction, ok := capturedPayload["systemInstruction"].(map[string]any); !ok || systemInstruction["parts"] == nil {
 		t.Fatalf("systemInstruction=%v", capturedPayload["systemInstruction"])
+	}
+	if generationConfig, ok := capturedPayload["generationConfig"].(map[string]any); !ok || generationConfig["maxOutputTokens"] != float64(222) {
+		t.Fatalf("generationConfig=%v", capturedPayload["generationConfig"])
 	}
 }
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +38,7 @@ type chatRequestPayload struct {
 	Model        string `json:"model"`
 	WebSearch    bool   `json:"web_search"`
 	SystemPrompt string `json:"system_prompt"`
+	MaxTokens    *int   `json:"max_tokens"`
 }
 
 // chatRequestParameters is the normalized request shape shared by GET and POST handlers after edge validation.
@@ -46,6 +48,7 @@ type chatRequestParameters struct {
 	provider         providerDefinition
 	model            modelID
 	webSearchEnabled bool
+	maxTokens        *int
 }
 
 type dictationRequestParameters struct {
@@ -83,9 +86,9 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	taskQueue := make(chan requestTask, configuration.QueueSize)
 	requestTimeout := time.Duration(configuration.RequestTimeoutSeconds) * time.Second
 	pollTimeout := time.Duration(configuration.UpstreamPollTimeoutSeconds) * time.Second
-	openAIClient := NewOpenAIClient(HTTPClient, configuration.Endpoints, requestTimeout, configuration.MaxOutputTokens, pollTimeout)
-	chatClient := newOpenAICompatibleChatClient(HTTPClient, requestTimeout, configuration.MaxOutputTokens)
-	geminiClient := newGeminiGenerateContentClient(HTTPClient, requestTimeout, configuration.MaxOutputTokens)
+	openAIClient := NewOpenAIClient(HTTPClient, configuration.Endpoints, requestTimeout, pollTimeout)
+	chatClient := newOpenAICompatibleChatClient(HTTPClient, requestTimeout)
+	geminiClient := newGeminiGenerateContentClient(HTTPClient, requestTimeout)
 	upstreamProviders := newProviderRouter(openAIClient, chatClient, geminiClient)
 	for workerIndex := 0; workerIndex < configuration.WorkerCount; workerIndex++ {
 		go func() {
@@ -167,6 +170,11 @@ func chatRequestFromQuery(ginContext *gin.Context, defaultSystemPrompt string, d
 			constants.LogFieldError, webSearchParseError,
 		)
 	}
+	maxTokens, maxTokensError := parseMaxTokensParameter(ginContext.Query(queryParameterMaxTokens))
+	if maxTokensError != nil {
+		ginContext.String(http.StatusBadRequest, errorInvalidMaxTokens)
+		return chatRequestParameters{}, false
+	}
 
 	providerDefinition, modelIdentifier, verificationError := validator.ResolveText(
 		ginContext.Query(queryParameterProvider),
@@ -186,6 +194,7 @@ func chatRequestFromQuery(ginContext *gin.Context, defaultSystemPrompt string, d
 		provider:         providerDefinition,
 		model:            modelIdentifier,
 		webSearchEnabled: webSearchEnabled,
+		maxTokens:        maxTokens,
 	}, true
 }
 
@@ -203,6 +212,10 @@ func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload,
 	modelIdentifier, modelParameterError := resolveJSONModelParameter(ginContext.Query(queryParameterModel), payload.Model)
 	if modelParameterError != nil {
 		ginContext.String(statusCodeForError(modelParameterError), responseMessageForError(modelParameterError))
+		return chatRequestParameters{}, false
+	}
+	if payload.MaxTokens != nil && *payload.MaxTokens <= 0 {
+		ginContext.String(http.StatusBadRequest, errorInvalidMaxTokens)
 		return chatRequestParameters{}, false
 	}
 
@@ -224,6 +237,7 @@ func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload,
 		provider:         providerDefinition,
 		model:            resolvedModel,
 		webSearchEnabled: payload.WebSearch,
+		maxTokens:        payload.MaxTokens,
 	}, true
 }
 
@@ -323,6 +337,18 @@ func parseWebSearchParameter(rawValue string) (bool, error) {
 	default:
 		return false, fmt.Errorf("invalid web_search value: %s", rawValue)
 	}
+}
+
+func parseMaxTokensParameter(rawValue string) (*int, error) {
+	trimmedValue := strings.TrimSpace(rawValue)
+	if trimmedValue == constants.EmptyString {
+		return nil, nil
+	}
+	maxTokens, parseError := strconv.Atoi(trimmedValue)
+	if parseError != nil || maxTokens <= 0 {
+		return nil, fmt.Errorf("invalid max_tokens value: %s", rawValue)
+	}
+	return &maxTokens, nil
 }
 
 func resolveJSONModelParameter(queryModel string, bodyModel string) (string, error) {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -27,7 +27,7 @@ Working backlog for this repository. Keep it current and small. Use @issues-md-f
   2. The test must fail before the implementation fix by reproducing the low-output-budget/incomplete-response path as a client-visible `502`.
   3. The proxy must forward a sufficiently large output budget for the large full-review request and return a normal text response from the upstream stub.
   4. The fix must not weaken downstream semantic validation expectations; chunked review remains a retry transport strategy, not an acceptance path.
-  Resolution: Added a black-box integration test for a 31 KB semantic-review JSON POST using `gpt-5.5-pro`; the pre-fix failure reproduced `502 OpenAI API error` with `max_output_tokens=1024` and an incomplete/max-output upstream path. The proxy now defaults text `max_output_tokens` to `8192`, README documents the `LLM_PROXY_MAX_OUTPUT_TOKENS` knob, low-budget continuation coverage remains explicit, and `make ci` passes with total coverage at 100.0%.
+  Resolution: Added a black-box integration test for a 31 KB semantic-review JSON POST using `gpt-5.5-pro`; the pre-fix failure reproduced `502 OpenAI API error` with a low `max_output_tokens` value and an incomplete/max-output upstream path. Large full-review requests are covered through the public JSON POST contract, low-budget continuation coverage remains explicit, and `make ci` passes with total coverage at 100.0%.
 
 - [x] [B404] (P0) Fix GPT-5.5 JSON body model requests returning 502.
   Reproduce and repair the `POST /?key=...` JSON request path where clients specify `"model": "gpt-5.5"` in the body and expect a successful OpenAI Responses API reply instead of a proxy-level `502 OpenAI API error`.
@@ -75,6 +75,17 @@ These entries are always-available procedures. Keep them `[ ]` so they remain ru
 
 ## Features
 
+- [x] [F410] (P1) Replace global output-token configuration with request `max_tokens`.
+  Remove the server-wide text output token cap configuration because providers do not require it and a single global budget has different semantics across provider APIs. Clients may request an explicit cap per call with `max_tokens`, and the proxy translates that public request parameter to each provider's native field.
+  Acceptance criteria:
+  1. `LLM_PROXY_MAX_OUTPUT_TOKENS`, `--max_output_tokens`, `Configuration.MaxOutputTokens`, and the default output-token cap are removed from runtime configuration.
+  2. When no client `max_tokens` is supplied, text provider requests omit OpenAI `max_output_tokens`, OpenAI-compatible `max_tokens`, and Gemini `generationConfig.maxOutputTokens`.
+  3. `GET /?...&max_tokens=N` and JSON `POST /?key=...` bodies with `"max_tokens": N` validate positive integer values and forward them as OpenAI `max_output_tokens`, OpenAI-compatible `max_tokens`, and Gemini `generationConfig.maxOutputTokens`.
+  4. Invalid, zero, or negative `max_tokens` values are rejected at the API edge with `400`.
+  5. README and provider-routing docs describe the request-level `max_tokens` contract and no longer document the removed environment variable.
+  6. Black-box HTTP and CLI tests cover the removed config surface and provider-specific request translations, and repository validation passes.
+  Resolution: Removed the server-wide max output token configuration surface from CLI flags, env bindings, runtime configuration, provider clients, and defaults. Added request-level `max_tokens` for GET query parameters and JSON POST bodies; absent values now omit provider max-token fields, while positive values map to OpenAI Responses `max_output_tokens`, OpenAI-compatible chat `max_tokens`, and Gemini `generationConfig.maxOutputTokens`. Invalid query/body values return `400` before upstream calls. README and provider-routing docs were updated, the large semantic-review integration test now uses request `max_tokens`, and validation passed with `timeout -k 30s -s SIGKILL 30s make fmt`, `timeout -k 350s -s SIGKILL 350s make test` (total coverage 100.0%), `timeout -k 350s -s SIGKILL 350s make lint`, and `timeout -k 350s -s SIGKILL 350s make ci` (total coverage 100.0%).
+
 - [x] [F409] (P1) Add Gemini as a native text provider.
   Add Google Gemini support to the authenticated LLM endpoint using Gemini's native `generateContent` API. The provider should be selected with `provider=gemini`, should use server-side `GEMINI_API_KEY`, should default to `gemini-3.5-flash`, and should support only text generation initially. `/dictate` and `web_search` must return existing unsupported endpoint/capability errors for Gemini until those capabilities are explicitly designed.
   Acceptance criteria:
@@ -87,3 +98,13 @@ These entries are always-available procedures. Keep them `[ ]` so they remain ru
   Resolution: Added native Gemini text routing through `provider=gemini` using Google's generateContent API, `GEMINI_API_KEY`, optional `GEMINI_BASE_URL`, and `gemini-3.5-flash` as the provider default model. Supported Gemini text models are `gemini-3.5-flash`, `gemini-3.1-flash-lite`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, and `gemini-2.5-pro`. Gemini token usage metadata is normalized into the existing usage headers and JSON response shape when upstream returns it. Gemini `/dictate`, `web_search`, unknown model, missing credential, upstream status, transport, malformed response, no-text response, and invalid usage cases are covered by black-box tests. README and provider-routing docs were updated. Validation passed with `timeout -k 30s -s SIGKILL 30s make fmt`, `timeout -k 350s -s SIGKILL 350s make test` (total coverage 100.0%), `timeout -k 350s -s SIGKILL 350s make lint`, `timeout -k 350s -s SIGKILL 350s make ci`, and `git diff --check`.
 
 ## Planning
+
+- [ ] [P411] (P1) {F410} Make `config.yml` the sole service configuration source.
+  Plan and implement a configuration refactor where the running service receives all service configuration from `config.yml`. Environment variables and `.env` files may only supply interpolation values for placeholders in that YAML file; the rest of the program must never read environment variables as configuration.
+  Acceptance criteria:
+  1. `config.yml` has a documented strict schema for server, defaults, provider credentials/base URLs, timeouts, prompt/body/audio limits, and logging.
+  2. The CLI stops binding service configuration flags and environment variables; only help and config-file path selection remain outside `config.yml`.
+  3. The config loader expands `${NAME}` placeholders from a single expansion map built at the config-loading boundary, fails on missing placeholders, and does not mutate process environment.
+  4. Runtime code receives a validated `proxy.Configuration` value produced by a smart constructor; router, providers, middleware, and clients never call Viper, gotenv, or OS env APIs.
+  5. Startup, README, provider-routing docs, Docker guidance, and coverage helper flows describe `config.yml` as authoritative and `.env` as interpolation input only.
+  6. Black-box CLI and HTTP tests cover config-file loading, `.env` expansion, missing placeholders, unknown YAML keys, removed env/flag config surfaces, and provider credential validation.

--- a/tests/integration/request_timeout_test.go
+++ b/tests/integration/request_timeout_test.go
@@ -112,7 +112,6 @@ func TestIntegrationGatewayContextTimeoutCancelsUpstreamRequest(testingInstance 
 		DefaultProvider:              proxy.ProviderNameOpenAI,
 		DefaultModel:                 proxy.DefaultModel,
 		DictationModel:               proxy.DefaultDictationModel,
-		MaxOutputTokens:              proxy.DefaultMaxOutputTokens,
 		MaxPromptBytes:               proxy.DefaultMaxPromptBytes,
 		MaxInputAudioBytes:           proxy.DefaultMaxInputAudioBytes,
 		DeepSeekBaseURL:              "https://deepseek.invalid",

--- a/tests/integration/semantic_review_test.go
+++ b/tests/integration/semantic_review_test.go
@@ -112,7 +112,7 @@ func newSemanticReviewOpenAIServer(testingInstance *testing.T, capture *semantic
 	}))
 }
 
-func TestIntegrationLargeSemanticReviewPostUsesSufficientOutputBudget(testingInstance *testing.T) {
+func TestIntegrationLargeSemanticReviewPostUsesRequestMaxTokens(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 	capture := &semanticReviewCapture{}
 	openAIServer := newSemanticReviewOpenAIServer(testingInstance, capture)
@@ -147,6 +147,7 @@ func TestIntegrationLargeSemanticReviewPostUsesSufficientOutputBudget(testingIns
 		"prompt":     largeSemanticReviewPrompt(testingInstance),
 		"model":      proxy.ModelNameGPT55Pro,
 		"web_search": false,
+		"max_tokens": semanticReviewRequiredOutputLimit,
 	}
 	requestBytes, marshalError := json.Marshal(requestPayload)
 	if marshalError != nil {


### PR DESCRIPTION
Removed the global max output tokens configuration and environment variable in favor of a per-request `max_tokens` parameter. Updated the proxy to support `max_tokens` as a query and JSON parameter that maps to provider-specific max token fields. Documentation, tests, and CLI flags were adjusted accordingly to reflect this change, ensuring output token limits are now specified per request rather than globally.