### PR TITLE
gix/enforce-provider-specific-max-tokens-limits-for-gemini

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1,0 +1,85 @@
+# ISSUES
+
+Working backlog for this repository. Keep entries in the canonical ISSUES.md format.
+
+## BugFixes
+
+- [x] [B001] (P1) Gemini POST responses can return thought or partial text as successful output
+  ### Summary
+  A production-comparable Russian semantic-stress QA run sent the full prompt through `POST /?provider=gemini` with `model=gemini-3.5-flash` and a large `max_tokens` body value, but the client received a non-JSON response and failed before materialization. The same prompt contract succeeds only when the proxy returns the model's answer text as parseable JSON or returns a structured proxy/provider error.
+
+  ### Impact
+  This blocks using Gemini as an alternate semantic reviewer for long JSON-only prompts. Downstream clients cannot distinguish model formatting drift, Gemini thought-part leakage, truncation, and proxy/provider errors; they only see invalid text even though the HTTP request path appears successful.
+
+  ### Reproduction
+  From the sibling Russian-language/Camu workflow, run the full pipeline rather than calling the proxy directly:
+
+  ```bash
+  /Users/tyemirov/Development/Smith/russian-language/russian_language/pipeline_runner.py \
+    --output-dir /Users/tyemirov/Documents/Projects/Camu/fairy-tales/runs/russian-language-puzyr-gemini35flash-256k-body-20260604T055725Z \
+    --llm-proxy-base-url "https://llm-proxy.mprlab.com/?provider=gemini" \
+    --llm-proxy-model gemini-3.5-flash \
+    --llm-proxy-timeout-seconds 300 \
+    --llm-proxy-max-tokens 262144 \
+    --llm-proxy-single-request \
+    /Users/tyemirov/Documents/Projects/Camu/fairy-tales/puzyr-solominka-i-lapot/source/narration.txt
+  ```
+
+  The semantic QA stage sends a POST body equivalent to:
+
+  ```json
+  {
+    "prompt": "<large semantic stress QA prompt>",
+    "model": "gemini-3.5-flash",
+    "web_search": false,
+    "max_tokens": 262144
+  }
+  ```
+
+  ### Observed
+  The full pipeline completed deterministic format, yofication, yofication QA, RuAccent stressor, and stressor QA, then failed in `llm-proxy` with:
+
+  ```text
+  semantic review response is not valid JSON and --llm-proxy-single-request forbids retry
+  ```
+
+  Latest compact state:
+
+  ```text
+  /Users/tyemirov/Documents/Projects/Camu/fairy-tales/runs/russian-language-puzyr-gemini35flash-256k-body-20260604T055725Z/pipeline-state-20260604T055725Z.json
+  ```
+
+  Earlier Gemini evidence for the same story captured a 1278-byte response that started with `thought`, then a fenced JSON block, and cut off mid-string:
+
+  ```text
+  /Users/tyemirov/Documents/Projects/Camu/fairy-tales/runs/russian-language-puzyr-vanilla-gemini35flash-20260604T052031Z/direct-semantic-evidence/puzyr-gemini35flash.llm_response.txt
+  ```
+
+  ### Suspected proxy gaps
+  `internal/proxy/gemini.go` currently parses only `candidates[].content.parts[].text`, concatenates every non-empty text part, and does not model Gemini response fields such as part-level `thought` or candidate-level `finishReason`. That can make the proxy return internal/thought text or a MAX_TOKENS-truncated answer as HTTP 200 plain text instead of returning only the final answer text or a provider error.
+
+  ### Expected
+  For Gemini text generation, `llm-proxy` should:
+
+  1. Forward `max_tokens` from POST JSON as `generationConfig.maxOutputTokens`.
+  2. Return only final, user-visible answer text from Gemini response parts; thought/internal parts must not be concatenated into the client-visible response.
+  3. Treat non-terminal or truncated Gemini candidates, including `finishReason` values that imply partial output such as MAX_TOKENS, as a proxy/provider error rather than returning partial text as success.
+  4. Preserve the existing plain-text response contract when the provider returns a complete final answer.
+
+  ### Acceptance Criteria
+  1. Add black-box/integration-style tests for `POST /?provider=gemini` with a fake Gemini upstream response containing a thought part plus an answer part; the proxy returns only the answer text.
+  2. Add a fake Gemini upstream response with a truncation/non-final `finishReason`; the proxy maps it to a failure status instead of returning partial text.
+  3. Add or keep coverage proving POST-body `max_tokens` maps to Gemini `generationConfig.maxOutputTokens`.
+  4. Rerun the Russian semantic-stress QA prompt through the full pipeline and verify the client receives either parseable JSON or a structured proxy error, not a thought-prefixed or truncated successful text body.
+
+  ### Resolution
+  Added black-box Gemini POST coverage for thought-marked parts returning only final answer text, non-final `finishReason` values such as `MAX_TOKENS` mapping to `502`, missing `finishReason` mapping to `502`, and POST/GET `max_tokens` values above Gemini's `65536` output-token limit returning `400` before upstream calls. The existing POST-body `max_tokens` to `generationConfig.maxOutputTokens` mapping remains covered for valid caps. `internal/proxy/gemini.go` now models `parts[].thought` and candidate `finishReason`, returns only non-thought text for completed `STOP` candidates, and treats missing or non-`STOP` finish reasons as provider API errors instead of successful partial output. `internal/proxy/router.go` validates known provider/model output-token ceilings at the HTTP edge so the reproduction's `max_tokens=262144` is classified as invalid client input instead of an upstream `502`. Validation passed with `timeout -k 30s -s SIGKILL 30s make fmt`, `timeout -k 350s -s SIGKILL 350s make test` (total coverage 100.0%), `timeout -k 350s -s SIGKILL 350s make lint`, and `timeout -k 350s -s SIGKILL 350s make ci` (total coverage 100.0%). The full Russian pipeline was rerun against the local fixed proxy at `http://127.0.0.1:18080/?provider=gemini`; it reached the semantic QA stage and received `HTTP Error 400: Bad Request` from request-edge validation, with the proxy log showing status `400` and zero upstream latency. State file: `/Users/tyemirov/Documents/Projects/Camu/fairy-tales/runs/russian-language-puzyr-gemini35flash-local-fixed-B001-max-token-400-20260604T062605Z/pipeline-state-20260604T062605Z.json`.
+
+## Improvements
+
+## Maintenance
+
+## Features
+
+## Planning
+*do not implement yet*

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ support the OpenAI web search tool.
 Text output length is also per request: pass `max_tokens` when a client wants
 to cap one generation. When omitted, the proxy does not send a provider
 max-token field.
+Provider-specific output-token limits are enforced at the request edge when
+known. Gemini text models currently reject `max_tokens` above `65536` with
+`400 Bad Request` before any upstream provider call.
 
 ## Running
 
@@ -171,6 +174,8 @@ JSON body fields:
 For `POST /`, `provider` remains a query parameter. Query `model` may override
 the JSON body only when the body omits `model` or provides the same value;
 conflicting values return `400 Bad Request`.
+Gemini `max_tokens` values above `65536` return `400 Bad Request` before the
+proxy calls Gemini.
 
 ### Choose an OpenAI model
 

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -14,6 +14,7 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 - `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies.
 - Omitted `max_tokens` means the proxy omits provider max-token fields and lets the selected provider/model default apply.
 - Provided `max_tokens` maps to OpenAI Responses `max_output_tokens`, OpenAI-compatible chat completions `max_tokens`, and Gemini `generationConfig.maxOutputTokens`.
+- Known provider-specific output-token ceilings are validated before upstream calls; Gemini text models reject `max_tokens` above `65536` with `400 Bad Request`.
 - For JSON `POST /`, query `model` may override the body only when the body omits `model` or provides the same value.
 - Conflicting query/body `model` values return `400 Bad Request`.
 - Upstream provider API keys are never accepted from client requests.

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -15,7 +15,12 @@ import (
 	"go.uber.org/zap"
 )
 
-const geminiAPIKeyHeader = "x-goog-api-key"
+const (
+	geminiAPIKeyHeader     = "x-goog-api-key"
+	geminiFinishReasonStop = geminiFinishReason("STOP")
+)
+
+type geminiFinishReason string
 
 type geminiGenerateContentClient struct {
 	httpClient     HTTPDoer
@@ -38,7 +43,8 @@ type geminiContent struct {
 }
 
 type geminiPart struct {
-	Text string `json:"text"`
+	Text    string `json:"text"`
+	Thought bool   `json:"thought"`
 }
 
 type geminiGenerateContentResponse struct {
@@ -47,7 +53,8 @@ type geminiGenerateContentResponse struct {
 }
 
 type geminiCandidate struct {
-	Content geminiContent `json:"content"`
+	Content      geminiContent      `json:"content"`
+	FinishReason geminiFinishReason `json:"finishReason"`
 }
 
 type geminiUsageMetadata struct {
@@ -121,18 +128,36 @@ func parseGeminiGenerateContentResponse(responseBytes []byte) (textGenerationRes
 		return textGenerationResult{}, usageError
 	}
 	for _, candidate := range response.Candidates {
-		var textBuilder strings.Builder
-		for _, part := range candidate.Content.Parts {
-			if strings.TrimSpace(part.Text) != constants.EmptyString {
-				textBuilder.WriteString(part.Text)
-			}
+		if finishReasonError := validateGeminiFinishReason(candidate.FinishReason); finishReasonError != nil {
+			return textGenerationResult{}, finishReasonError
 		}
-		trimmedText := strings.TrimSpace(textBuilder.String())
+		trimmedText := visibleGeminiCandidateText(candidate)
 		if trimmedText != constants.EmptyString {
 			return textGenerationResult{text: trimmedText, usage: usage}, nil
 		}
 	}
 	return textGenerationResult{}, fmt.Errorf("%w: gemini generateContent returned no text", ErrProviderAPI)
+}
+
+func validateGeminiFinishReason(reason geminiFinishReason) error {
+	if reason == geminiFinishReasonStop {
+		return nil
+	}
+	normalizedReason := strings.TrimSpace(string(reason))
+	if normalizedReason == constants.EmptyString {
+		return fmt.Errorf("%w: gemini generateContent missing finishReason", ErrProviderAPI)
+	}
+	return fmt.Errorf("%w: gemini generateContent finishReason=%s", ErrProviderAPI, normalizedReason)
+}
+
+func visibleGeminiCandidateText(candidate geminiCandidate) string {
+	var textBuilder strings.Builder
+	for _, part := range candidate.Content.Parts {
+		if !part.Thought && strings.TrimSpace(part.Text) != constants.EmptyString {
+			textBuilder.WriteString(part.Text)
+		}
+	}
+	return strings.TrimSpace(textBuilder.String())
 }
 
 func parseGeminiTokenUsage(usage *geminiUsageMetadata) (*tokenUsage, error) {

--- a/internal/proxy/provider_registry.go
+++ b/internal/proxy/provider_registry.go
@@ -87,11 +87,19 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			textTransport:       textTransportOpenAICompatibleChat,
 		},
 		geminiProviderID: {
-			identifier:          geminiProviderID,
-			textAPIKey:          configuration.GeminiKey,
-			textBaseURL:         configuration.GeminiBaseURL,
-			defaultTextModel:    modelID(ModelNameGemini35Flash),
-			textModels:          modelSet(ModelNameGemini35Flash, ModelNameGemini31FlashLite, ModelNameGemini25Flash, ModelNameGemini25FlashLite, ModelNameGemini25Pro),
+			identifier:       geminiProviderID,
+			textAPIKey:       configuration.GeminiKey,
+			textBaseURL:      configuration.GeminiBaseURL,
+			defaultTextModel: modelID(ModelNameGemini35Flash),
+			textModels:       modelSet(ModelNameGemini35Flash, ModelNameGemini31FlashLite, ModelNameGemini25Flash, ModelNameGemini25FlashLite, ModelNameGemini25Pro),
+			textOutputTokenLimits: tokenLimitSet(
+				geminiOutputTokenLimit,
+				ModelNameGemini35Flash,
+				ModelNameGemini31FlashLite,
+				ModelNameGemini25Flash,
+				ModelNameGemini25FlashLite,
+				ModelNameGemini25Pro,
+			),
 			transcriptionModels: map[string]modelID{},
 			textTransport:       textTransportGeminiGenerate,
 		},
@@ -122,6 +130,17 @@ func modelSet(modelIdentifiers ...string) map[string]modelID {
 		}
 	}
 	return models
+}
+
+func tokenLimitSet(limit int, modelIdentifiers ...string) map[string]int {
+	limits := map[string]int{}
+	for _, modelIdentifier := range modelIdentifiers {
+		trimmedModelIdentifier := strings.TrimSpace(modelIdentifier)
+		if trimmedModelIdentifier != constants.EmptyString {
+			limits[strings.ToLower(trimmedModelIdentifier)] = limit
+		}
+	}
+	return limits
 }
 
 func (registry *providerRegistry) resolveProvider(rawProvider string, defaultProvider string) (providerDefinition, error) {

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -217,7 +217,7 @@ func TestProviderRoutingSupportsGeminiGenerateContent(t *testing.T) {
 			t.Fatalf("unmarshal body: %v", unmarshalError)
 		}
 		responseWriter.Header().Set("Content-Type", "application/json")
-		_, _ = responseWriter.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"gemini ok"}]}}],"usageMetadata":{"promptTokenCount":13,"candidatesTokenCount":5}}`))
+		_, _ = responseWriter.Write([]byte(`{"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"gemini ok"}]}}],"usageMetadata":{"promptTokenCount":13,"candidatesTokenCount":5}}`))
 	}))
 	defer upstreamServer.Close()
 
@@ -295,7 +295,7 @@ func TestProviderRoutingSupportsGeminiJSONPost(t *testing.T) {
 			t.Fatalf("unmarshal body: %v", unmarshalError)
 		}
 		responseWriter.Header().Set("Content-Type", "application/json")
-		_, _ = responseWriter.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"gemini json ok"}]}}]}`))
+		_, _ = responseWriter.Write([]byte(`{"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"gemini internal thought","thought":true},{"text":"gemini json ok"}]}}]}`))
 	}))
 	defer upstreamServer.Close()
 
@@ -336,6 +336,84 @@ func TestProviderRoutingSupportsGeminiJSONPost(t *testing.T) {
 	}
 	if generationConfig, ok := capturedPayload["generationConfig"].(map[string]any); !ok || generationConfig["maxOutputTokens"] != float64(222) {
 		t.Fatalf("generationConfig=%v", capturedPayload["generationConfig"])
+	}
+}
+
+func TestProviderRoutingRejectsGeminiJSONPostMaxTokensAboveModelLimit(t *testing.T) {
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		t.Fatal("upstream must not be called for max_tokens above Gemini model limit")
+	}))
+	defer upstreamServer.Close()
+
+	logger := zap.NewNop()
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		GeminiKey:                  testGeminiKey,
+		GeminiBaseURL:              upstreamServer.URL,
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+	}, logger.Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	requestBody := bytes.NewBufferString(`{"prompt":"hello json","model":"` + proxy.ModelNameGemini35Flash + `","max_tokens":262144}`)
+	request := httptest.NewRequest(http.MethodPost, "/?key="+TestSecret+"&provider="+proxy.ProviderNameGemini, requestBody)
+	request.Header.Set("Content-Type", "application/json")
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusBadRequest, responseRecorder.Body.String())
+	}
+	if !strings.Contains(responseRecorder.Body.String(), "invalid max_tokens parameter") {
+		t.Fatalf("body=%q want invalid max_tokens parameter", responseRecorder.Body.String())
+	}
+}
+
+func TestProviderRoutingRejectsGeminiQueryMaxTokensAboveModelLimit(t *testing.T) {
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		t.Fatal("upstream must not be called for query max_tokens above Gemini model limit")
+	}))
+	defer upstreamServer.Close()
+
+	logger := zap.NewNop()
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		ServiceSecret:              TestSecret,
+		OpenAIKey:                  TestAPIKey,
+		GeminiKey:                  testGeminiKey,
+		GeminiBaseURL:              upstreamServer.URL,
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  1,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+	}, logger.Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	queryParameters := url.Values{}
+	queryParameters.Set("key", TestSecret)
+	queryParameters.Set("prompt", TestPrompt)
+	queryParameters.Set("provider", proxy.ProviderNameGemini)
+	queryParameters.Set("model", proxy.ModelNameGemini35Flash)
+	queryParameters.Set("max_tokens", "262144")
+	request := httptest.NewRequest(http.MethodGet, "/?"+queryParameters.Encode(), nil)
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusBadRequest, responseRecorder.Body.String())
+	}
+	if !strings.Contains(responseRecorder.Body.String(), "invalid max_tokens parameter") {
+		t.Fatalf("body=%q want invalid max_tokens parameter", responseRecorder.Body.String())
 	}
 }
 
@@ -449,8 +527,10 @@ func TestProviderRoutingMapsGeminiProviderErrors(t *testing.T) {
 		{name: "rate limited", statusCode: http.StatusTooManyRequests, body: `{}`, wantStatus: http.StatusTooManyRequests},
 		{name: "provider api failure", statusCode: http.StatusInternalServerError, body: `{}`, wantStatus: http.StatusBadGateway},
 		{name: "malformed json", statusCode: http.StatusOK, body: `{`, wantStatus: http.StatusBadGateway},
-		{name: "negative usage", statusCode: http.StatusOK, body: `{"candidates":[{"content":{"parts":[{"text":"bad usage"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":-1}}`, wantStatus: http.StatusBadGateway},
-		{name: "missing text", statusCode: http.StatusOK, body: `{"candidates":[{"content":{"parts":[{}]}}]}`, wantStatus: http.StatusBadGateway},
+		{name: "negative usage", statusCode: http.StatusOK, body: `{"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"bad usage"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":-1}}`, wantStatus: http.StatusBadGateway},
+		{name: "missing finish reason", statusCode: http.StatusOK, body: `{"candidates":[{"content":{"parts":[{"text":"unfinished text"}]}}]}`, wantStatus: http.StatusBadGateway},
+		{name: "max tokens finish reason", statusCode: http.StatusOK, body: `{"candidates":[{"finishReason":"MAX_TOKENS","content":{"parts":[{"text":"partial text"}]}}]}`, wantStatus: http.StatusBadGateway},
+		{name: "missing text", statusCode: http.StatusOK, body: `{"candidates":[{"finishReason":"STOP","content":{"parts":[{}]}}]}`, wantStatus: http.StatusBadGateway},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(subTest *testing.T) {

--- a/internal/proxy/provider_types.go
+++ b/internal/proxy/provider_types.go
@@ -35,6 +35,7 @@ const (
 	defaultZhipuBaseURL        = "https://open.bigmodel.cn/api/paas/v4"
 	defaultGeminiBaseURL       = "https://generativelanguage.googleapis.com/v1"
 	defaultSiliconFlowSTTModel = "FunAudioLLM/SenseVoiceSmall"
+	geminiOutputTokenLimit     = 65536
 )
 
 const (
@@ -113,6 +114,7 @@ type providerDefinition struct {
 	defaultTextModel          modelID
 	defaultTranscriptionModel modelID
 	textModels                map[string]modelID
+	textOutputTokenLimits     map[string]int
 	transcriptionModels       map[string]modelID
 	supportsDictation         bool
 	supportsWebSearch         bool
@@ -124,4 +126,12 @@ func (definition providerDefinition) credentialFor(endpoint endpointKind) string
 		return strings.TrimSpace(definition.transcriptionAPIKey)
 	}
 	return strings.TrimSpace(definition.textAPIKey)
+}
+
+func (definition providerDefinition) outputTokenLimitFor(modelIdentifier modelID) (int, bool) {
+	if definition.textOutputTokenLimits == nil {
+		return 0, false
+	}
+	limit, known := definition.textOutputTokenLimits[strings.ToLower(modelIdentifier.string())]
+	return limit, known
 }

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -187,6 +187,10 @@ func chatRequestFromQuery(ginContext *gin.Context, defaultSystemPrompt string, d
 		ginContext.String(statusCodeForError(verificationError), responseMessageForError(verificationError))
 		return chatRequestParameters{}, false
 	}
+	if maxTokensError := validateTextMaxTokens(providerDefinition, modelIdentifier, maxTokens); maxTokensError != nil {
+		ginContext.String(http.StatusBadRequest, errorInvalidMaxTokens)
+		return chatRequestParameters{}, false
+	}
 
 	return chatRequestParameters{
 		prompt:           userPrompt,
@@ -228,6 +232,10 @@ func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload,
 	)
 	if verificationError != nil {
 		ginContext.String(statusCodeForError(verificationError), responseMessageForError(verificationError))
+		return chatRequestParameters{}, false
+	}
+	if maxTokensError := validateTextMaxTokens(providerDefinition, resolvedModel, payload.MaxTokens); maxTokensError != nil {
+		ginContext.String(http.StatusBadRequest, errorInvalidMaxTokens)
 		return chatRequestParameters{}, false
 	}
 
@@ -361,6 +369,23 @@ func resolveJSONModelParameter(queryModel string, bodyModel string) (string, err
 		return trimmedQueryModel, nil
 	}
 	return trimmedBodyModel, nil
+}
+
+func validateTextMaxTokens(providerDefinition providerDefinition, modelIdentifier modelID, maxTokens *int) error {
+	if maxTokens == nil {
+		return nil
+	}
+	outputTokenLimit, hasOutputTokenLimit := providerDefinition.outputTokenLimitFor(modelIdentifier)
+	if !hasOutputTokenLimit || *maxTokens <= outputTokenLimit {
+		return nil
+	}
+	return fmt.Errorf(
+		"invalid max_tokens value: provider=%s model=%s max_tokens=%d output_token_limit=%d",
+		providerDefinition.identifier.string(),
+		modelIdentifier.string(),
+		*maxTokens,
+		outputTokenLimit,
+	)
 }
 
 func statusCodeForError(requestError error) int {


### PR DESCRIPTION
Enforce provider-specific max_tokens limits for Gemini text models by validating and rejecting requests with max_tokens above Gemini's known output-token ceiling (65536) at the HTTP request edge, returning 400 Bad Request before upstream calls. 

Enhance Gemini response parsing to:
- Validate candidate finishReason, accepting only "STOP" as successful completion.
- Exclude internal "thought" parts from client-visible output.
- Treat missing or non-"STOP" finishReason values as provider errors, preventing partial or truncated outputs from being returned as success.

Add comprehensive tests covering:
- Filtering out internal thought parts in Gemini responses.
- Handling non-final or missing finishReason as errors.
- Rejecting requests exceeding Gemini max_tokens limits before upstream calls.

Document Gemini max_tokens limits and related 400 Bad Request behavior in README and implementation docs.

Include a detailed ISSUES.md backlog entry analyzing the Gemini POST response bug (B001) and the implemented resolution.