### PR TITLE
gix/refactor-slow-release-gate-tests-for-deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ This repository exposes the standard local targets used by MPR app repos:
 | `make publish` | Validate the release source and publish `ghcr.io/tyemirov/llm-proxy:<tag>` plus `:latest`. |
 | `make deploy` | Verify the published image and deploy through the sibling `../mprlab-gateway` checkout. |
 
-The release lifecycle commands wrap their local `make ci` gate with a
-1200-second timeout by default. Override all three with
-`LLM_PROXY_CI_TIMEOUT_SECONDS=<seconds>`, or use the command-specific
-`RELEASE_CI_TIMEOUT_SECONDS`, `PUBLISH_CI_TIMEOUT_SECONDS`, and
-`DEPLOY_CI_TIMEOUT_SECONDS` variables.
+The release lifecycle commands wrap their local `make ci` gate with the
+standard 350-second timeout by default. For exceptional local diagnostics,
+override all three with `LLM_PROXY_CI_TIMEOUT_SECONDS=<seconds>`, or use the
+command-specific `RELEASE_CI_TIMEOUT_SECONDS`, `PUBLISH_CI_TIMEOUT_SECONDS`,
+and `DEPLOY_CI_TIMEOUT_SECONDS` variables.
 
 `llm-proxy` is a gateway-local service in `mprlab-gateway`, so `make deploy`
 defaults to the gateway `deploy-gateway` target. Override the checkout or target

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -32,6 +32,7 @@ const (
 	testHeaderLLMProxyRequestTokens  = "X-LLM-Proxy-Request-Tokens"
 	testHeaderLLMProxyResponseTokens = "X-LLM-Proxy-Response-Tokens"
 	testHeaderLLMProxyTotalTokens    = "X-LLM-Proxy-Total-Tokens"
+	coverageShortRequestTimeout      = 25 * time.Millisecond
 )
 
 func (httpDoer coverageHTTPDoer) Do(httpRequest *http.Request) (*http.Response, error) {
@@ -98,6 +99,25 @@ func performCoverageTextRequest(t *testing.T, router http.Handler, queryParamete
 	}
 	responseRecorder := httptest.NewRecorder()
 	router.ServeHTTP(responseRecorder, request)
+	return responseRecorder.Code, responseRecorder.Body.String(), responseRecorder.Header().Get("Content-Type")
+}
+
+func performCoverageTextRequestWithTimeout(t *testing.T, router http.Handler, queryParameters url.Values, acceptHeader string, timeoutDuration time.Duration) (int, string, string) {
+	t.Helper()
+	if queryParameters.Get("key") == "" {
+		queryParameters.Set("key", TestSecret)
+	}
+	if queryParameters.Get("prompt") == "" {
+		queryParameters.Set("prompt", TestPrompt)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/?"+queryParameters.Encode(), nil)
+	if acceptHeader != "" {
+		request.Header.Set("Accept", acceptHeader)
+	}
+	requestContext, cancelRequest := context.WithTimeout(request.Context(), timeoutDuration)
+	defer cancelRequest()
+	responseRecorder := httptest.NewRecorder()
+	router.ServeHTTP(responseRecorder, request.WithContext(requestContext))
 	return responseRecorder.Code, responseRecorder.Body.String(), responseRecorder.Header().Get("Content-Type")
 }
 
@@ -1375,7 +1395,6 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 			wantStatus int
 		}{
 			{name: "unknown model", baseURL: "https://deepseek.invalid", model: "unknown-model", wantStatus: http.StatusBadRequest},
-			{name: "blank model uses provider default", baseURL: "https://deepseek.invalid", model: " ", wantStatus: http.StatusGatewayTimeout},
 			{name: "invalid provider base URL", baseURL: "http://[::1", model: proxy.ModelNameDeepSeekV4Flash, wantStatus: http.StatusBadGateway},
 		}
 		for _, testCase := range testCases {
@@ -1402,6 +1421,42 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		}
 	})
 
+	t.Run("blank model uses provider default", func(subTest *testing.T) {
+		var capturedPayload map[string]any
+		upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			bodyBytes, readError := io.ReadAll(httpRequest.Body)
+			if readError != nil {
+				subTest.Fatalf("read body: %v", readError)
+			}
+			if unmarshalError := json.Unmarshal(bodyBytes, &capturedPayload); unmarshalError != nil {
+				subTest.Fatalf("unmarshal body: %v", unmarshalError)
+			}
+			_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"default ok"}}]}`))
+		}))
+		subTest.Cleanup(upstreamServer.Close)
+		router := coverageRouter(subTest, proxy.Configuration{
+			ServiceSecret:              TestSecret,
+			OpenAIKey:                  TestAPIKey,
+			DeepSeekKey:                testDeepSeekKey,
+			DeepSeekBaseURL:            upstreamServer.URL,
+			LogLevel:                   proxy.LogLevelInfo,
+			WorkerCount:                1,
+			QueueSize:                  1,
+			RequestTimeoutSeconds:      TestTimeout,
+			UpstreamPollTimeoutSeconds: TestTimeout,
+		})
+		queryParameters := url.Values{}
+		queryParameters.Set("provider", proxy.ProviderNameDeepSeek)
+		queryParameters.Set("model", " ")
+		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
+		if statusCode != http.StatusOK {
+			subTest.Fatalf("status=%d want=%d body=%s", statusCode, http.StatusOK, body)
+		}
+		if capturedPayload["model"] != proxy.ModelNameDeepSeekV4Flash {
+			subTest.Fatalf("model=%v want=%s", capturedPayload["model"], proxy.ModelNameDeepSeekV4Flash)
+		}
+	})
+
 	t.Run("provider non deadline transport error maps to bad gateway", func(subTest *testing.T) {
 		previousClient := proxy.HTTPClient
 		proxy.HTTPClient = &http.Client{Transport: coverageRoundTripper(func(httpRequest *http.Request) (*http.Response, error) {
@@ -1421,7 +1476,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		})
 		queryParameters := url.Values{}
 		queryParameters.Set("provider", proxy.ProviderNameDeepSeek)
-		statusCode, _, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
+		statusCode, _, _ := performCoverageTextRequestWithTimeout(subTest, router, queryParameters, "", coverageShortRequestTimeout)
 		if statusCode != http.StatusGatewayTimeout {
 			subTest.Fatalf("status=%d want=%d", statusCode, http.StatusGatewayTimeout)
 		}
@@ -1743,7 +1798,7 @@ func TestCoverageHTTPUtilityReadFailure(t *testing.T) {
 		UpstreamPollTimeoutSeconds: TestTimeout,
 	})
 	queryParameters := url.Values{}
-	statusCode, _, _ := performCoverageTextRequest(t, router, queryParameters, "")
+	statusCode, _, _ := performCoverageTextRequestWithTimeout(t, router, queryParameters, "", coverageShortRequestTimeout)
 	if statusCode != http.StatusGatewayTimeout {
 		t.Fatalf("status=%d want=%d", statusCode, http.StatusGatewayTimeout)
 	}

--- a/internal/proxy/dictate_handler_test.go
+++ b/internal/proxy/dictate_handler_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"mime/multipart"
@@ -10,7 +11,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tyemirov/llm-proxy/internal/proxy"
@@ -258,14 +258,13 @@ func TestDictateHandlerUpstreamFailures(t *testing.T) {
 	})
 
 	t.Run("upstream timeout returns gateway timeout", func(subTest *testing.T) {
-		upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
-			time.Sleep(1500 * time.Millisecond)
-			responseWriter.Header().Set("Content-Type", "application/json")
-			_, _ = responseWriter.Write([]byte(`{"text":"late"}`))
-		}))
-		defer upstreamServer.Close()
+		previousClient := proxy.HTTPClient
+		proxy.HTTPClient = coverageHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			return nil, context.DeadlineExceeded
+		})
+		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 
-		router := newDictationRouter(subTest, upstreamServer.URL, 1)
+		router := newDictationRouter(subTest, "https://transcriptions.invalid", TestTimeout)
 		body, contentType := buildMultipartAudioRequest(subTest, "audio")
 		request := httptest.NewRequest(http.MethodPost, "/dictate?key="+TestSecret, body)
 		request.Header.Set("Content-Type", contentType)

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -497,6 +497,9 @@ func (client *OpenAIClient) performResponsesRequest(httpRequest *http.Request, s
 		var transportError error
 		statusCode, responseBytes, latencyMillis, transportError = utils.PerformHTTPRequest(client.httpClient.Do, httpRequest, structuredLogger, logEvent)
 		if transportError != nil {
+			if errors.Is(transportError, context.Canceled) || errors.Is(transportError, context.DeadlineExceeded) {
+				return backoff.Permanent(transportError)
+			}
 			return transportError
 		}
 		// Retry on server errors (5xx) and rate limit errors (429).

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"mime/multipart"
@@ -656,8 +657,10 @@ func TestProviderRoutingMapsGeminiTransportErrors(t *testing.T) {
 		}
 
 		request := httptest.NewRequest(http.MethodGet, "/?key="+TestSecret+"&prompt=hello&provider=gemini", nil)
+		requestContext, cancelRequest := context.WithTimeout(request.Context(), coverageShortRequestTimeout)
+		defer cancelRequest()
 		responseRecorder := httptest.NewRecorder()
-		router.ServeHTTP(responseRecorder, request)
+		router.ServeHTTP(responseRecorder, request.WithContext(requestContext))
 		if responseRecorder.Code != http.StatusGatewayTimeout {
 			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusGatewayTimeout, responseRecorder.Body.String())
 		}

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -57,6 +59,9 @@ func PerformHTTPRequest(executeRequest func(*http.Request) (*http.Response, erro
 		if httpError != nil {
 			if structuredLogger != nil {
 				structuredLogger.Errorw(logEventOnTransportError, constants.LogFieldError, httpError)
+			}
+			if errors.Is(httpError, context.Canceled) || errors.Is(httpError, context.DeadlineExceeded) {
+				return backoff.Permanent(httpError)
 			}
 			return httpError
 		}

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -78,6 +78,15 @@ Working backlog for this repository. Keep it current and small. Use @issues-md-f
 
 ## Maintenance
 
+- [x] [M417] (P1) Refactor slow release-gate tests instead of extending the CI timeout.
+  `make release` still timed out after the release lifecycle timeout was extended to 1200 seconds because the Go integration suite can spend long periods in fixed sleeps and retry waits before the coverage summary and Python tests run. The release gate should be made deterministic by refactoring the slow test fixtures, not by extending the default release timeout.
+  Acceptance criteria:
+  1. Release, publish, and deploy local `make ci` wrappers default back to the original 350-second gate while retaining explicit operator overrides.
+  2. Long-running integration tests stop sleeping for fixed multi-second or 30-second intervals when a channel-controlled upstream fixture can prove the same black-box route behavior.
+  3. The integration package runtime drops materially while preserving the 100% Go coverage gate.
+  4. Focused Go integration coverage and full `make ci` pass locally.
+  Resolution: Restored the release, publish, and deploy CI wrappers to the standard 350-second default while keeping shared and command-specific timeout overrides for exceptional diagnostics. Refactored slow Go fixtures to use channel-controlled upstream release/cancellation, one-slot queue saturation, short request contexts for retry-mapping checks, and injected deadline errors for dictation timeout coverage. Request cancellation and deadline errors now stop retry loops immediately. The post-test coverage binary probes also redirect stdin from `/dev/null` and fail explicitly on timeout so interactive `make ci` cannot block inside `llm-proxy-client.cover`. Validation passed with `timeout -k 120s -s SIGKILL 120s go test -count=1 ./internal/utils ./internal/proxy ./tests/integration`, `timeout -k 120s -s SIGKILL 120s make go-test` from a TTY (total coverage 100.0%, real 0m8.946s), and `timeout -k 350s -s SIGKILL 350s make ci` (real 0m13.283s).
+
 - [x] [M416] (P1) Keep release lifecycle CI wrappers aligned with the expanded Makefile gate.
   `make release` still wrapped `make ci` in a hard-coded 350-second timeout after the Makefile gate expanded to include Python mypy and pytest. Release validation can finish the Go coverage gate and then be killed by the wrapper before the remaining `make ci` steps complete. `make publish` and `make deploy` use the same local CI wrapper and should share the same operator timeout contract.
   Acceptance criteria:

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -7,6 +7,7 @@ CLIENT_COVERPKG="./llm-proxy-client,./pkg/llmproxyclient"
 COVERPKG="$RUNTIME_COVERPKG,$CLIENT_COVERPKG"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
+COVERAGE_PROBE_TIMEOUT_SECONDS=5
 
 cleanup() {
   rm -rf "$TMP_DIR"
@@ -14,6 +15,17 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$ROOT_DIR"
+
+run_coverage_probe() {
+  local cover_dir="$1"
+  shift
+  local probe_status=0
+  timeout -k "${COVERAGE_PROBE_TIMEOUT_SECONDS}s" -s SIGKILL "${COVERAGE_PROBE_TIMEOUT_SECONDS}s" env -i GOCOVERDIR="$cover_dir" "$@" </dev/null >/dev/null 2>/dev/null || probe_status=$?
+  if [[ "$probe_status" -eq 124 || "$probe_status" -eq 137 ]]; then
+    printf 'coverage probe timed out: %s\n' "$*" >&2
+    return "$probe_status"
+  fi
+}
 
 "$GO_BIN" test -count=1 ./... -covermode=count -coverpkg="$COVERPKG" -coverprofile="$TMP_DIR/go-test.coverprofile"
 "$GO_BIN" build -cover -covermode=count -coverpkg="$RUNTIME_COVERPKG" -o "$TMP_DIR/llm-proxy.cover" ./cmd/cli
@@ -27,10 +39,10 @@ providers:
 CONFIG
 
 mkdir -p "$TMP_DIR/cov-help" "$TMP_DIR/cov-missing-config" "$TMP_DIR/cov-missing-openai" "$TMP_DIR/cov-client-missing-config"
-env -i GOCOVERDIR="$TMP_DIR/cov-help" "$TMP_DIR/llm-proxy.cover" --help >/dev/null 2>/dev/null || true
-env -i GOCOVERDIR="$TMP_DIR/cov-missing-config" "$TMP_DIR/llm-proxy.cover" --config "$TMP_DIR/missing.yml" >/dev/null 2>/dev/null || true
-env -i GOCOVERDIR="$TMP_DIR/cov-missing-openai" "$TMP_DIR/llm-proxy.cover" --config "$TMP_DIR/missing-openai.yml" >/dev/null 2>/dev/null || true
-env -i GOCOVERDIR="$TMP_DIR/cov-client-missing-config" "$TMP_DIR/llm-proxy-client.cover" >/dev/null 2>/dev/null || true
+run_coverage_probe "$TMP_DIR/cov-help" "$TMP_DIR/llm-proxy.cover" --help
+run_coverage_probe "$TMP_DIR/cov-missing-config" "$TMP_DIR/llm-proxy.cover" --config "$TMP_DIR/missing.yml"
+run_coverage_probe "$TMP_DIR/cov-missing-openai" "$TMP_DIR/llm-proxy.cover" --config "$TMP_DIR/missing-openai.yml"
+run_coverage_probe "$TMP_DIR/cov-client-missing-config" "$TMP_DIR/llm-proxy-client.cover"
 
 "$GO_BIN" tool covdata textfmt -i="$TMP_DIR/cov-help" -o="$TMP_DIR/bin-help.coverprofile"
 "$GO_BIN" tool covdata textfmt -i="$TMP_DIR/cov-missing-config" -o="$TMP_DIR/bin-missing-config.coverprofile"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ Options:
   --help                Show this help text
 
 Environment:
-  DEPLOY_CI_TIMEOUT_SECONDS  make ci timeout in seconds. Default: $LLM_PROXY_CI_TIMEOUT_SECONDS or 1200
+  DEPLOY_CI_TIMEOUT_SECONDS  make ci timeout in seconds. Default: $LLM_PROXY_CI_TIMEOUT_SECONDS or 350
 USAGE
 }
 
@@ -57,7 +57,7 @@ SKIP_IMAGE_VERIFY="false"
 SKIP_GATEWAY="false"
 DEPLOY_BRANCH="${DEPLOY_BRANCH:-master}"
 DEPLOY_REMOTE="${DEPLOY_REMOTE:-origin}"
-CI_TIMEOUT_SECONDS="${DEPLOY_CI_TIMEOUT_SECONDS:-${LLM_PROXY_CI_TIMEOUT_SECONDS:-1200}}"
+CI_TIMEOUT_SECONDS="${DEPLOY_CI_TIMEOUT_SECONDS:-${LLM_PROXY_CI_TIMEOUT_SECONDS:-350}}"
 
 resolve_release_tag() {
   if [[ -n "${TAG}" ]]; then

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -26,7 +26,7 @@ Options:
   --help                Show this help text
 
 Environment:
-  PUBLISH_CI_TIMEOUT_SECONDS  make ci timeout in seconds. Default: $LLM_PROXY_CI_TIMEOUT_SECONDS or 1200
+  PUBLISH_CI_TIMEOUT_SECONDS  make ci timeout in seconds. Default: $LLM_PROXY_CI_TIMEOUT_SECONDS or 350
 USAGE
 }
 
@@ -49,7 +49,7 @@ USERNAME="${GHCR_USERNAME:-}"
 TOKEN="${GHCR_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
 PUBLISH_BRANCH="${PUBLISH_BRANCH:-master}"
 PUBLISH_REMOTE="${PUBLISH_REMOTE:-origin}"
-CI_TIMEOUT_SECONDS="${PUBLISH_CI_TIMEOUT_SECONDS:-${LLM_PROXY_CI_TIMEOUT_SECONDS:-1200}}"
+CI_TIMEOUT_SECONDS="${PUBLISH_CI_TIMEOUT_SECONDS:-${LLM_PROXY_CI_TIMEOUT_SECONDS:-350}}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -27,7 +27,7 @@ Options:
   --help                      Show this help text
 
 Environment:
-  RELEASE_CI_TIMEOUT_SECONDS  make ci timeout in seconds. Default: $LLM_PROXY_CI_TIMEOUT_SECONDS or 1200
+  RELEASE_CI_TIMEOUT_SECONDS  make ci timeout in seconds. Default: $LLM_PROXY_CI_TIMEOUT_SECONDS or 350
 USAGE
 }
 
@@ -46,7 +46,7 @@ DRY_RUN="false"
 SKIP_CI="false"
 RELEASE_REMOTE="${RELEASE_REMOTE:-origin}"
 RELEASE_BRANCH="${RELEASE_BRANCH:-master}"
-CI_TIMEOUT_SECONDS="${RELEASE_CI_TIMEOUT_SECONDS:-${LLM_PROXY_CI_TIMEOUT_SECONDS:-1200}}"
+CI_TIMEOUT_SECONDS="${RELEASE_CI_TIMEOUT_SECONDS:-${LLM_PROXY_CI_TIMEOUT_SECONDS:-350}}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/tests/integration/high_load_queue_test.go
+++ b/tests/integration/high_load_queue_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,19 +16,26 @@ import (
 )
 
 const (
-	// queueRequestDelay is the time each upstream call sleeps to keep workers busy.
-	queueRequestDelay = 2 * time.Second
 	// requestTimeoutSeconds is the proxy request timeout used for queue saturation.
 	requestTimeoutSeconds = 1
 	// singleWorkerCount specifies the number of workers used in this test.
 	singleWorkerCount = 1
+	// singleQueueSlot specifies the number of queued requests used in this test.
+	singleQueueSlot = 1
+	// queueSaturationRequestCount is the number of concurrent requests needed to fill one worker, one queue slot, and one rejected request.
+	queueSaturationRequestCount = singleWorkerCount + singleQueueSlot + 1
+	// queueAssertionTimeout bounds synchronization failures without driving the tested behavior.
+	queueAssertionTimeout = 2 * time.Second
+	// queueGatewayTimeout bounds queue-full requests through the inbound request context.
+	queueGatewayTimeout = 25 * time.Millisecond
 	// queueFullCountFormat reports the number of queue-full responses.
 	queueFullCountFormat = "queue_full=%d"
 )
 
-// makeDelayedHTTPClient returns an HTTP client that delays responses to simulate a slow upstream server.
-func makeDelayedHTTPClient(testingInstance *testing.T, endpoints *proxy.Endpoints) *http.Client {
+// makeBlockingHTTPClient returns an HTTP client that keeps the first upstream response pending until released.
+func makeBlockingHTTPClient(testingInstance *testing.T, endpoints *proxy.Endpoints, upstreamRequestStarted chan<- struct{}, releaseResponses <-chan struct{}) *http.Client {
 	testingInstance.Helper()
+	var closeStartedOnce sync.Once
 	return &http.Client{Transport: roundTripperFunc(func(httpRequest *http.Request) (*http.Response, error) {
 		switch {
 		case httpRequest.URL.String() == endpoints.GetModelsURL():
@@ -40,8 +48,13 @@ func makeDelayedHTTPClient(testingInstance *testing.T, endpoints *proxy.Endpoint
 			}
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(metadata)), Header: make(http.Header)}, nil
 		case httpRequest.URL.String() == endpoints.GetResponsesURL():
-			time.Sleep(queueRequestDelay)
-			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"output_text":"` + integrationOKBody + `"}`)), Header: make(http.Header)}, nil
+			closeStartedOnce.Do(func() { close(upstreamRequestStarted) })
+			select {
+			case <-httpRequest.Context().Done():
+				return nil, httpRequest.Context().Err()
+			case <-releaseResponses:
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"output_text":"` + integrationOKBody + `"}`)), Header: make(http.Header)}, nil
+			}
 		default:
 			testingInstance.Fatalf(unexpectedRequestFormat, httpRequest.URL.String())
 			return nil, nil
@@ -53,14 +66,16 @@ func makeDelayedHTTPClient(testingInstance *testing.T, endpoints *proxy.Endpoint
 func TestIntegrationHighLoadQueue(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 	endpoints := proxy.NewEndpoints()
-	client := makeDelayedHTTPClient(testingInstance, endpoints)
+	upstreamRequestStarted := make(chan struct{})
+	releaseResponses := make(chan struct{})
+	client := makeBlockingHTTPClient(testingInstance, endpoints, upstreamRequestStarted, releaseResponses)
 	configureProxy(testingInstance, client, endpoints)
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
 		ServiceSecret:         serviceSecretValue,
 		OpenAIKey:             openAIKeyValue,
 		LogLevel:              logLevelDebug,
 		WorkerCount:           singleWorkerCount,
-		QueueSize:             proxy.DefaultQueueSize,
+		QueueSize:             singleQueueSlot,
 		RequestTimeoutSeconds: requestTimeoutSeconds,
 		Endpoints:             endpoints,
 	}, newLogger(testingInstance))
@@ -69,31 +84,43 @@ func TestIntegrationHighLoadQueue(testingInstance *testing.T) {
 	}
 	server := httptest.NewServer(router)
 	testingInstance.Cleanup(server.Close)
+	queueServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		requestContext, cancelRequest := context.WithTimeout(httpRequest.Context(), queueGatewayTimeout)
+		defer cancelRequest()
+		router.ServeHTTP(responseWriter, httpRequest.WithContext(requestContext))
+	}))
+	testingInstance.Cleanup(queueServer.Close)
 	requestURL, _ := url.Parse(server.URL)
 	queryValues := requestURL.Query()
 	queryValues.Set(promptQueryParameter, promptValue)
 	queryValues.Set(keyQueryParameter, serviceSecretValue)
 	requestURL.RawQuery = queryValues.Encode()
+	queueRequestURL, _ := url.Parse(queueServer.URL)
+	queueQueryValues := queueRequestURL.Query()
+	queueQueryValues.Set(promptQueryParameter, promptValue)
+	queueQueryValues.Set(keyQueryParameter, serviceSecretValue)
+	queueRequestURL.RawQuery = queueQueryValues.Encode()
 
-	totalRequests := proxy.DefaultQueueSize + singleWorkerCount + 1
-	statuses := make([]int, totalRequests)
+	statuses := make(chan int, queueSaturationRequestCount)
 	var waitGroup sync.WaitGroup
-	waitGroup.Add(totalRequests)
-	for requestIndex := 0; requestIndex < totalRequests; requestIndex++ {
-		go func(index int) {
+	waitGroup.Add(queueSaturationRequestCount)
+	go func() {
+		defer waitGroup.Done()
+		statuses <- performQueueRequest(requestURL.String())
+	}()
+	<-upstreamRequestStarted
+	for requestIndex := 1; requestIndex < queueSaturationRequestCount; requestIndex++ {
+		go func() {
 			defer waitGroup.Done()
-			httpResponse, requestError := http.Get(requestURL.String())
-			if requestError != nil {
-				return
-			}
-			statuses[index] = httpResponse.StatusCode
-			httpResponse.Body.Close()
-		}(requestIndex)
+			statuses <- performQueueRequest(queueRequestURL.String())
+		}()
 	}
+	queueFullCount := waitForQueueFullResponse(testingInstance, statuses)
+	close(releaseResponses)
 	waitGroup.Wait()
+	close(statuses)
 
-	var queueFullCount int
-	for _, status := range statuses {
+	for status := range statuses {
 		if status == http.StatusServiceUnavailable {
 			queueFullCount++
 		}
@@ -101,4 +128,29 @@ func TestIntegrationHighLoadQueue(testingInstance *testing.T) {
 	if queueFullCount != 1 {
 		testingInstance.Fatalf(queueFullCountFormat, queueFullCount)
 	}
+}
+
+func performQueueRequest(requestURL string) int {
+	httpResponse, requestError := http.Get(requestURL)
+	if requestError != nil {
+		return 0
+	}
+	defer httpResponse.Body.Close()
+	return httpResponse.StatusCode
+}
+
+func waitForQueueFullResponse(testingInstance *testing.T, statuses <-chan int) int {
+	testingInstance.Helper()
+	for receivedStatusCount := 0; receivedStatusCount < queueSaturationRequestCount-1; receivedStatusCount++ {
+		select {
+		case status := <-statuses:
+			if status == http.StatusServiceUnavailable {
+				return 1
+			}
+		case <-time.After(queueAssertionTimeout):
+			testingInstance.Fatal("queue-full response was not observed")
+		}
+	}
+	testingInstance.Fatal("queue-full response was not observed")
+	return 0
 }

--- a/tests/integration/long_request_test.go
+++ b/tests/integration/long_request_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,14 +17,15 @@ import (
 const (
 	modelsListBody               = `{"data":[{"id":"` + proxy.ModelNameGPT41 + `"}]}`
 	expectedResponseBody         = "SLOW_OK"
-	responseDelay                = 31 * time.Second
-	httpClientTimeout            = responseDelay + 5*time.Second
 	requestTimeoutSecondsDefault = 40
+	responseReadyAssertion       = "response returned before upstream release"
+	responseReleaseTimeout       = 2 * time.Second
 )
 
-// makeSlowHTTPClient returns an HTTP client that simulates a delayed upstream response.
-func makeSlowHTTPClient(testingInstance *testing.T, endpoints *proxy.Endpoints) *http.Client {
+// makeControlledResponseHTTPClient returns an HTTP client whose response waits for explicit release.
+func makeControlledResponseHTTPClient(testingInstance *testing.T, endpoints *proxy.Endpoints, upstreamRequestStarted chan<- struct{}, releaseResponse <-chan struct{}) *http.Client {
 	testingInstance.Helper()
+	var closeStartedOnce sync.Once
 	return &http.Client{
 		Transport: roundTripperFunc(func(httpRequest *http.Request) (*http.Response, error) {
 			switch {
@@ -32,25 +34,33 @@ func makeSlowHTTPClient(testingInstance *testing.T, endpoints *proxy.Endpoints) 
 			case strings.HasPrefix(httpRequest.URL.String(), endpoints.GetModelsURL()+"/"):
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(metadataTemperatureTools)), Header: make(http.Header)}, nil
 			case httpRequest.URL.String() == endpoints.GetResponsesURL():
-				time.Sleep(responseDelay)
-				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"output_text":"` + expectedResponseBody + `"}`)), Header: make(http.Header)}, nil
+				closeStartedOnce.Do(func() { close(upstreamRequestStarted) })
+				select {
+				case <-httpRequest.Context().Done():
+					return nil, httpRequest.Context().Err()
+				case <-releaseResponse:
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"output_text":"` + expectedResponseBody + `"}`)), Header: make(http.Header)}, nil
+				}
 			default:
 				testingInstance.Fatalf(unexpectedRequestFormat, httpRequest.URL.String())
 				return nil, nil
 			}
 		}),
-		Timeout: httpClientTimeout,
 	}
 }
 
-// TestIntegrationResponseDeliveredAfterDelay verifies responses are sent after long upstream delays.
-func TestIntegrationResponseDeliveredAfterDelay(testingInstance *testing.T) {
+// TestIntegrationResponseDeliveredAfterUpstreamRelease verifies pending upstream responses are delivered before the configured request timeout.
+func TestIntegrationResponseDeliveredAfterUpstreamRelease(testingInstance *testing.T) {
 	gin.SetMode(gin.TestMode)
 	testCases := []struct{ name string }{{name: "delayed_response"}}
 	for _, testCase := range testCases {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			upstreamRequestStarted := make(chan struct{})
+			releaseResponse := make(chan struct{})
+			responseReturned := make(chan *http.Response, 1)
+			requestErrors := make(chan error, 1)
 			endpoints := proxy.NewEndpoints()
-			configureProxy(subTest, makeSlowHTTPClient(subTest, endpoints), endpoints)
+			configureProxy(subTest, makeControlledResponseHTTPClient(subTest, endpoints, upstreamRequestStarted, releaseResponse), endpoints)
 			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: requestTimeoutSecondsDefault, Endpoints: endpoints}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf(buildRouterFailedFormat, buildError)
@@ -62,9 +72,40 @@ func TestIntegrationResponseDeliveredAfterDelay(testingInstance *testing.T) {
 			queryValues.Set(promptQueryParameter, promptValue)
 			queryValues.Set(keyQueryParameter, serviceSecretValue)
 			requestURL.RawQuery = queryValues.Encode()
-			httpResponse, requestError := http.Get(requestURL.String())
-			if requestError != nil {
+
+			go func() {
+				httpResponse, requestError := server.Client().Get(requestURL.String())
+				if requestError != nil {
+					requestErrors <- requestError
+					return
+				}
+				responseReturned <- httpResponse
+			}()
+
+			select {
+			case <-upstreamRequestStarted:
+			case <-time.After(responseReleaseTimeout):
+				subTest.Fatal("upstream response request was not observed")
+			}
+			select {
+			case httpResponse := <-responseReturned:
+				if httpResponse != nil {
+					httpResponse.Body.Close()
+				}
+				subTest.Fatal(responseReadyAssertion)
+			case requestError := <-requestErrors:
 				subTest.Fatalf(getFailedFormat, requestError)
+			default:
+			}
+			close(releaseResponse)
+
+			var httpResponse *http.Response
+			select {
+			case httpResponse = <-responseReturned:
+			case requestError := <-requestErrors:
+				subTest.Fatalf(getFailedFormat, requestError)
+			case <-time.After(responseReleaseTimeout):
+				subTest.Fatal("released upstream response was not delivered")
 			}
 			defer httpResponse.Body.Close()
 			if httpResponse.StatusCode != http.StatusOK {

--- a/tests/integration/openai_5xx_retry_test.go
+++ b/tests/integration/openai_5xx_retry_test.go
@@ -11,6 +11,7 @@ const (
 	contentTypeHeaderKey = "Content-Type"
 	mimeApplicationJSON  = "application/json"
 	minimumExpectedCalls = 2
+	retryTimeoutSeconds  = 1
 )
 
 // TestOpenAIResponsesRetries verifies that the proxy retries upstream server errors and ultimately returns HTTP 504.
@@ -30,7 +31,7 @@ func TestOpenAIResponsesRetries(testingInstance *testing.T) {
 	}))
 	testingInstance.Cleanup(openAIServer.Close)
 
-	applicationServer := newIntegrationServerWithTimeout(testingInstance, openAIServer, 4)
+	applicationServer := newIntegrationServerWithTimeout(testingInstance, openAIServer, retryTimeoutSeconds)
 	requestURL := applicationServer.URL + "?prompt=ping&key=" + integrationServiceSecret
 	httpResponse, requestError := http.Get(requestURL)
 	if requestError != nil {


### PR DESCRIPTION
Refactor slow and flaky integration tests to improve determinism and reduce runtime by replacing fixed sleep intervals with channel-controlled upstream fixtures and injected deadline errors. Restore release lifecycle command timeouts to a standard 350 seconds with overrides for diagnostics, addressing prior CI timeout issues caused by long test sleeps and retries. Enhance timeout handling by mapping context cancellation and deadline errors to permanent failures to stop retry loops immediately. Add coverage probe timeouts in CI scripts to prevent blocking. Update documentation to reflect these changes and improve test reliability and overall CI efficiency.