### PR TITLE
gix/replace-global-defaults-with-per-tenant-secrets-and

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 LLM Proxy is a lightweight HTTP service that forwards user prompts to OpenAI's
 Responses API, OpenAI-compatible chat providers, Google Gemini's native
 generateContent API, and audio transcription APIs.
-It exposes protected HTTP endpoints that require a shared secret and simplify
+It exposes protected HTTP endpoints that require a tenant secret and simplify
 integrating provider capabilities without embedding API credentials in each
 client.
 
@@ -13,9 +13,9 @@ client.
   - `GET /?prompt=...&key=...[&provider=...]` for LLM responses
   - `POST /?key=...[&provider=...]` for large JSON prompt bodies
   - `POST /dictate?key=...[&provider=...]` for audio transcription
-- Choose the provider per request via `provider=...` (default: `openai`)
-- Choose the model per request via `model=...` (default: `gpt-4.1` for OpenAI)
-- Choose the dictation model per request via `model=...` on `/dictate` (default: `gpt-4o-mini-transcribe`)
+- Choose the provider per request via `provider=...`; omitted provider uses the authenticated tenant default
+- Choose the model per request via `model=...`; omitted model uses the selected provider default
+- Choose the dictation model per request via `model=...` on `/dictate`; omitted model uses the authenticated tenant default
 - Optional per-request OpenAI web search via `web_search=1|true|yes`
 - Optional logging at `debug` or `info` levels
 - Forwards requests using server-side provider API keys
@@ -36,7 +36,6 @@ environment, and all runtime code receives only the validated config value.
 
 ```yaml
 server:
-  service_secret: "${SERVICE_SECRET}"
   port: 8080
   log_level: info
   workers: 4
@@ -45,12 +44,15 @@ server:
   upstream_poll_timeout_seconds: 60
   max_prompt_bytes: 4194304
   max_input_audio_bytes: 26214400
-defaults:
-  provider: openai
-  model: gpt-4.1
-  dictation_provider: openai
-  dictation_model: gpt-4o-mini-transcribe
-  system_prompt: ""
+tenants:
+  - id: default
+    secret: "${SERVICE_SECRET}"
+    defaults:
+      provider: openai
+      model: gpt-4.1
+      dictation_provider: openai
+      dictation_model: gpt-4o-mini-transcribe
+      system_prompt: ""
 providers:
   openai:
     api_key: "${OPENAI_API_KEY}"
@@ -76,10 +78,11 @@ providers:
 ```
 
 Blank optional values use built-in provider defaults where applicable. Startup
-validates `server.service_secret`, the credential for `defaults.provider`, and
-the credential/endpoint support for `defaults.dictation_provider`. Credentials
-for non-default providers may stay blank; requests selecting those providers
-return `503 Service Unavailable` until the corresponding `api_key` is configured.
+validates that `tenants` includes at least one unique `id` and unique `secret`,
+then validates each tenant's default text provider and dictation provider.
+Credentials for providers not used by any tenant default may stay blank;
+requests selecting those providers return `503 Service Unavailable` until the
+corresponding `api_key` is configured.
 Unknown YAML keys fail startup.
 
 Web search is per request and currently supported only on OpenAI models that
@@ -108,8 +111,12 @@ Run the service with OpenAI defaults:
 Run the service with DeepSeek as the default text provider:
 
 ```yaml
-defaults:
-  provider: deepseek
+tenants:
+  - id: deepseek
+    secret: "${SERVICE_SECRET}"
+    defaults:
+      provider: deepseek
+      model: deepseek-v4-flash
 providers:
   deepseek:
     api_key: "${DEEPSEEK_API_KEY}"
@@ -118,8 +125,12 @@ providers:
 Run the service with Gemini as the default text provider:
 
 ```yaml
-defaults:
-  provider: gemini
+tenants:
+  - id: gemini
+    secret: "${SERVICE_SECRET}"
+    defaults:
+      provider: gemini
+      model: gemini-3.5-flash
 providers:
   gemini:
     api_key: "${GEMINI_API_KEY}"
@@ -251,7 +262,7 @@ curl --get \
 
 Use `POST /` with a JSON body when the prompt is too large for a URL query
 parameter. Authentication still uses the `key` query parameter, which is the
-configured `server.service_secret`. Provider selection also stays in the query parameter.
+configured tenant secret. Provider selection also stays in the query parameter.
 Do not send upstream provider secrets in the request body; the proxy reads them
 from server-side configuration. The JSON body is capped by
 `server.max_prompt_bytes`.
@@ -270,7 +281,7 @@ JSON body fields:
 | `prompt` | Yes | none | Full text to send to the LLM. Use this body field for large or non-ASCII prompts. |
 | `model` | No | provider default | Model identifier from the selected provider's supported model list. |
 | `web_search` | No | `false` | Enables OpenAI web search when the selected provider/model supports it. |
-| `system_prompt` | No | configured `defaults.system_prompt` | Per-request system prompt override. |
+| `system_prompt` | No | authenticated tenant default | Per-request system prompt override. |
 | `max_tokens` | No | provider default | Positive integer output-token cap for this request. The proxy maps it to OpenAI `max_output_tokens`, OpenAI-compatible `max_tokens`, or Gemini `generationConfig.maxOutputTokens`. |
 
 For `POST /`, `provider` remains a query parameter. Query `model` may override
@@ -465,7 +476,7 @@ below for web search.
 
 ## Security
 
-* All requests must include the shared secret via `key=...`.
+* All requests must include a configured tenant secret via `key=...`.
 * Client requests must not include upstream provider API keys; configure them on the server.
 * Do not expose this service to the public internet without appropriate network controls.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ client.
   - `POST /?key=...[&provider=...]` for large JSON prompt bodies
   - `POST /dictate?key=...[&provider=...]` for audio transcription
 - Choose the provider per request via `provider=...`; omitted provider uses the authenticated tenant default
-- Choose the model per request via `model=...`; omitted model uses the selected provider default
-- Choose the dictation model per request via `model=...` on `/dictate`; omitted model uses the authenticated tenant default
+- Choose the model per request via `model=...`; omitted model uses the tenant default when `provider` is omitted, otherwise the selected provider default
+- Choose the dictation model per request via `model=...` on `/dictate`; omitted model uses the tenant default when `provider` is omitted, otherwise the selected provider default
 - Optional per-request OpenAI web search via `web_search=1|true|yes`
 - Optional logging at `debug` or `info` levels
 - Forwards requests using server-side provider API keys
@@ -279,7 +279,7 @@ JSON body fields:
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `prompt` | Yes | none | Full text to send to the LLM. Use this body field for large or non-ASCII prompts. |
-| `model` | No | provider default | Model identifier from the selected provider's supported model list. |
+| `model` | No | tenant or provider default | Model identifier from the selected provider's supported model list. Omitted model uses the tenant default when `provider` is omitted; otherwise it uses the selected provider default. |
 | `web_search` | No | `false` | Enables OpenAI web search when the selected provider/model supports it. |
 | `system_prompt` | No | authenticated tenant default | Per-request system prompt override. |
 | `max_tokens` | No | provider default | Positive integer output-token cap for this request. The proxy maps it to OpenAI `max_output_tokens`, OpenAI-compatible `max_tokens`, or Gemini `generationConfig.maxOutputTokens`. |
@@ -389,8 +389,8 @@ JSON-format LLM responses include the same normalized counts:
 GET /
   ?prompt=STRING            # required
   &key=SERVICE_SECRET       # required
-  &provider=PROVIDER        # optional; defaults to openai
-  &model=MODEL_NAME         # optional; provider default
+  &provider=PROVIDER        # optional; tenant default
+  &model=MODEL_NAME         # optional; tenant or provider default
   &web_search=1|true|yes    # optional; OpenAI web_search tool
   &max_tokens=N             # optional positive integer per-request cap
   &format=CONTENT_TYPE      # optional; or use Accept header
@@ -399,21 +399,21 @@ GET /
 ```text
 POST /
   ?key=SERVICE_SECRET       # required
-  &provider=PROVIDER        # optional; defaults to openai
+  &provider=PROVIDER        # optional; tenant default
   &model=MODEL_NAME         # optional; overrides JSON body if absent or equal
   &format=CONTENT_TYPE      # optional; or use Accept header
 Content-Type: application/json
 {
   "prompt": "STRING",       # required
-  "model": "MODEL_NAME",    # optional; provider default
+  "model": "MODEL_NAME",    # optional; tenant or provider default
   "web_search": false,      # optional; defaults to false
-  "system_prompt": "STRING",# optional; defaults to configured system prompt
+  "system_prompt": "STRING",# optional; tenant default
   "max_tokens": 512         # optional positive integer per-request cap
 }
 ```
 
-The POST JSON body carries only LLM request parameters. The client shared
-secret remains in the `key` query parameter, and upstream provider API keys are
+The POST JSON body carries only LLM request parameters. The tenant secret
+remains in the `key` query parameter, and upstream provider API keys are
 never accepted from client requests.
 
 ### Dictation endpoint
@@ -421,8 +421,8 @@ never accepted from client requests.
 ```text
 POST /dictate
   ?key=SERVICE_SECRET       # required
-  &provider=PROVIDER        # optional; defaults to openai
-  &model=MODEL_NAME         # optional; provider default
+  &provider=PROVIDER        # optional; tenant default
+  &model=MODEL_NAME         # optional; tenant or provider default
 Content-Type: multipart/form-data
   audio=<file>              # required (alias: file)
 ```

--- a/cmd/cli/config_file.go
+++ b/cmd/cli/config_file.go
@@ -34,12 +34,11 @@ var (
 
 type fileConfiguration struct {
 	Server    serverConfiguration    `mapstructure:"server"`
-	Defaults  defaultsConfiguration  `mapstructure:"defaults"`
+	Tenants   []tenantConfiguration  `mapstructure:"tenants"`
 	Providers providersConfiguration `mapstructure:"providers"`
 }
 
 type serverConfiguration struct {
-	ServiceSecret              string `mapstructure:"service_secret"`
 	Port                       int    `mapstructure:"port"`
 	LogLevel                   string `mapstructure:"log_level"`
 	Workers                    int    `mapstructure:"workers"`
@@ -50,7 +49,13 @@ type serverConfiguration struct {
 	MaxInputAudioBytes         int64  `mapstructure:"max_input_audio_bytes"`
 }
 
-type defaultsConfiguration struct {
+type tenantConfiguration struct {
+	ID       string               `mapstructure:"id"`
+	Secret   string               `mapstructure:"secret"`
+	Defaults tenantDefaultsConfig `mapstructure:"defaults"`
+}
+
+type tenantDefaultsConfig struct {
 	Provider          string `mapstructure:"provider"`
 	Model             string `mapstructure:"model"`
 	DictationProvider string `mapstructure:"dictation_provider"`
@@ -161,7 +166,7 @@ func expandConfigPlaceholders(configContent string, expansionEnvironment map[str
 
 func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configuration, error) {
 	return proxy.NewConfiguration(proxy.Configuration{
-		ServiceSecret:                configuration.Server.ServiceSecret,
+		Tenants:                      tenantConfigurations(configuration.Tenants),
 		OpenAIKey:                    configuration.Providers.OpenAI.APIKey,
 		DeepSeekKey:                  configuration.Providers.DeepSeek.APIKey,
 		DashScopeKey:                 configuration.Providers.DashScope.APIKey,
@@ -169,9 +174,6 @@ func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configurati
 		SiliconFlowKey:               configuration.Providers.SiliconFlow.APIKey,
 		ZhipuKey:                     configuration.Providers.Zhipu.APIKey,
 		GeminiKey:                    configuration.Providers.Gemini.APIKey,
-		DefaultProvider:              configuration.Defaults.Provider,
-		DefaultModel:                 configuration.Defaults.Model,
-		DefaultDictationProvider:     configuration.Defaults.DictationProvider,
 		DeepSeekBaseURL:              configuration.Providers.DeepSeek.BaseURL,
 		DashScopeBaseURL:             configuration.Providers.DashScope.BaseURL,
 		MoonshotBaseURL:              configuration.Providers.Moonshot.BaseURL,
@@ -181,13 +183,29 @@ func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configurati
 		GeminiBaseURL:                configuration.Providers.Gemini.BaseURL,
 		Port:                         configuration.Server.Port,
 		LogLevel:                     configuration.Server.LogLevel,
-		SystemPrompt:                 configuration.Defaults.SystemPrompt,
 		WorkerCount:                  configuration.Server.Workers,
 		QueueSize:                    configuration.Server.QueueSize,
 		RequestTimeoutSeconds:        configuration.Server.RequestTimeoutSeconds,
 		UpstreamPollTimeoutSeconds:   configuration.Server.UpstreamPollTimeoutSeconds,
 		MaxPromptBytes:               configuration.Server.MaxPromptBytes,
-		DictationModel:               configuration.Defaults.DictationModel,
 		MaxInputAudioBytes:           configuration.Server.MaxInputAudioBytes,
 	})
+}
+
+func tenantConfigurations(rawTenants []tenantConfiguration) []proxy.TenantConfiguration {
+	tenants := make([]proxy.TenantConfiguration, 0, len(rawTenants))
+	for _, rawTenant := range rawTenants {
+		tenants = append(tenants, proxy.TenantConfiguration{
+			ID:     rawTenant.ID,
+			Secret: rawTenant.Secret,
+			Defaults: proxy.TenantDefaults{
+				Provider:          rawTenant.Defaults.Provider,
+				Model:             rawTenant.Defaults.Model,
+				DictationProvider: rawTenant.Defaults.DictationProvider,
+				DictationModel:    rawTenant.Defaults.DictationModel,
+				SystemPrompt:      rawTenant.Defaults.SystemPrompt,
+			},
+		})
+	}
+	return tenants
 }

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tyemirov/llm-proxy/internal/proxy"
-	"github.com/tyemirov/llm-proxy/internal/utils"
 	"go.uber.org/zap"
 )
 
@@ -62,8 +61,7 @@ var rootCmd = &cobra.Command{
 		structuredLogger.Infow(logEventStarting,
 			"port", runtimeConfiguration.Port,
 			"log_level", strings.ToLower(runtimeConfiguration.LogLevel),
-			"default_provider", runtimeConfiguration.DefaultProvider,
-			"secret_fingerprint", utils.Fingerprint(runtimeConfiguration.ServiceSecret),
+			"tenant_count", len(runtimeConfiguration.Tenants),
 		)
 		return serveProxy(runtimeConfiguration, structuredLogger)
 	},

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -20,7 +20,6 @@ func TestRootCommandRunsConfiguredProxyFromConfigFile(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := writeTestConfig(t, tempDir, `
 server:
-  service_secret: "${P411_SERVICE_SECRET}"
   port: 18080
   log_level: debug
   workers: 2
@@ -29,12 +28,15 @@ server:
   upstream_poll_timeout_seconds: 3
   max_prompt_bytes: 1024
   max_input_audio_bytes: 2048
-defaults:
-  provider: deepseek
-  model: gpt-5.5
-  dictation_provider: openai
-  dictation_model: gpt-4o-transcribe
-  system_prompt: "Be terse."
+tenants:
+  - id: default
+    secret: "${P411_SERVICE_SECRET}"
+    defaults:
+      provider: deepseek
+      model: deepseek-v4-flash
+      dictation_provider: openai
+      dictation_model: gpt-4o-transcribe
+      system_prompt: "Be terse."
 providers:
   openai:
     api_key: "${P411_OPENAI_KEY}"
@@ -65,14 +67,14 @@ P411_GEMINI_KEY=sk-gemini
 	if executeError != nil {
 		t.Fatalf("ExecuteC error: %v", executeError)
 	}
-	if capturedConfiguration.ServiceSecret != "process-secret" {
-		t.Fatalf("serviceSecret=%q", capturedConfiguration.ServiceSecret)
+	if capturedConfiguration.Tenants[0].Secret != "process-secret" {
+		t.Fatalf("tenantSecret=%q", capturedConfiguration.Tenants[0].Secret)
 	}
 	if capturedConfiguration.OpenAIKey != "sk-openai" {
 		t.Fatalf("openAIKey=%q", capturedConfiguration.OpenAIKey)
 	}
-	if capturedConfiguration.DefaultProvider != proxy.ProviderNameDeepSeek {
-		t.Fatalf("defaultProvider=%q", capturedConfiguration.DefaultProvider)
+	if capturedConfiguration.Tenants[0].Defaults.Provider != proxy.ProviderNameDeepSeek {
+		t.Fatalf("tenantDefaultProvider=%q", capturedConfiguration.Tenants[0].Defaults.Provider)
 	}
 	if capturedConfiguration.Port != 18080 {
 		t.Fatalf("port=%d", capturedConfiguration.Port)
@@ -89,8 +91,15 @@ func TestRootCommandRunsProductionLoggerFromConfigFile(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := writeTestConfig(t, tempDir, `
 server:
-  service_secret: "sekret"
   log_level: info
+tenants:
+  - id: default
+    secret: "sekret"
+    defaults:
+      provider: openai
+      model: gpt-4.1
+      dictation_provider: openai
+      dictation_model: gpt-4o-mini-transcribe
 providers:
   openai:
     api_key: "sk-openai"
@@ -145,7 +154,15 @@ func TestRootCommandRejectsMissingConfigPlaceholder(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := writeTestConfig(t, tempDir, `
 server:
-  service_secret: "${P411_MISSING_SERVICE_SECRET}"
+  log_level: info
+tenants:
+  - id: default
+    secret: "${P411_MISSING_SERVICE_SECRET}"
+    defaults:
+      provider: openai
+      model: gpt-4.1
+      dictation_provider: openai
+      dictation_model: gpt-4o-mini-transcribe
 providers:
   openai:
     api_key: "sk-openai"
@@ -171,7 +188,15 @@ func TestRootCommandRejectsUnreadableDotEnv(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := writeTestConfig(t, tempDir, `
 server:
-  service_secret: "sekret"
+  log_level: info
+tenants:
+  - id: default
+    secret: "sekret"
+    defaults:
+      provider: openai
+      model: gpt-4.1
+      dictation_provider: openai
+      dictation_model: gpt-4o-mini-transcribe
 providers:
   openai:
     api_key: "sk-openai"
@@ -190,8 +215,8 @@ providers:
 func TestRootCommandRejectsInvalidYAML(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := writeTestConfig(t, tempDir, `
-server:
-  service_secret: [
+tenants:
+  - id: [
 `)
 	withServeProxy(t, failingServeProxy(t))
 
@@ -205,8 +230,15 @@ func TestRootCommandRejectsUnknownConfigKeys(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := writeTestConfig(t, tempDir, `
 server:
-  service_secret: "sekret"
   unsupported: true
+tenants:
+  - id: default
+    secret: "sekret"
+    defaults:
+      provider: openai
+      model: gpt-4.1
+      dictation_provider: openai
+      dictation_model: gpt-4o-mini-transcribe
 providers:
   openai:
     api_key: "sk-openai"
@@ -222,11 +254,14 @@ providers:
 func TestRootCommandRejectsMissingDefaultProviderCredential(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := writeTestConfig(t, tempDir, `
-server:
-  service_secret: "sekret"
-defaults:
-  provider: gemini
-  dictation_provider: openai
+tenants:
+  - id: default
+    secret: "sekret"
+    defaults:
+      provider: gemini
+      model: gemini-3.5-flash
+      dictation_provider: openai
+      dictation_model: gpt-4o-mini-transcribe
 providers:
   openai:
     api_key: "sk-openai"

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -9,8 +9,8 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 ## Request Contract
 
 - `provider` is an optional query parameter on `GET /`, `POST /`, and `POST /dictate`.
-- Omitted `provider` means `openai`.
-- `model` keeps its current meaning.
+- Omitted `provider` means the authenticated tenant's default provider.
+- `model` keeps its current meaning; omitted `model` means the authenticated tenant's default model when set, otherwise the selected provider's native default.
 - `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies.
 - Omitted `max_tokens` means the proxy omits provider max-token fields and lets the selected provider/model default apply.
 - Provided `max_tokens` maps to OpenAI Responses `max_output_tokens`, OpenAI-compatible chat completions `max_tokens`, and Gemini `generationConfig.maxOutputTokens`.
@@ -39,7 +39,6 @@ The loader rejects unknown keys and missing placeholders before the proxy starts
 
 Shared config fields:
 
-- `server.service_secret`
 - `server.port`
 - `server.log_level`
 - `server.workers`
@@ -48,11 +47,13 @@ Shared config fields:
 - `server.upstream_poll_timeout_seconds`
 - `server.max_prompt_bytes`
 - `server.max_input_audio_bytes`
-- `defaults.provider`
-- `defaults.model`
-- `defaults.dictation_provider`
-- `defaults.dictation_model`
-- `defaults.system_prompt`
+- `tenants[].id`
+- `tenants[].secret`
+- `tenants[].defaults.provider`
+- `tenants[].defaults.model`
+- `tenants[].defaults.dictation_provider`
+- `tenants[].defaults.dictation_model`
+- `tenants[].defaults.system_prompt`
 
 Provider credentials and base URLs:
 
@@ -64,7 +65,7 @@ Provider credentials and base URLs:
 - `providers.zhipu.api_key`, `providers.zhipu.base_url`
 - `providers.gemini.api_key`, `providers.gemini.base_url`
 
-Startup validates `server.service_secret`, the credential required by the configured default text provider, and the endpoint/credential required by the configured default dictation provider. Credentials for non-default providers are validated when a request selects that provider.
+Startup validates configured tenants, rejects duplicate tenant ids and duplicate secrets, validates the credential required by each tenant's default text provider, and validates endpoint/credential support for each tenant's default dictation provider. Credentials for providers not used by tenant defaults are validated when a request selects that provider.
 
 ## Error Contract
 

--- a/internal/apperrors/apperrors.go
+++ b/internal/apperrors/apperrors.go
@@ -4,16 +4,12 @@ package apperrors
 import "errors"
 
 const (
-	configurationFieldServiceSecret = "server.service_secret"
-	configurationFieldOpenAIAPIKey  = "providers.openai.api_key"
-	messageSuffixMustBeSet          = " must be set"
-	messageMissingServiceSecret     = configurationFieldServiceSecret + messageSuffixMustBeSet
-	messageMissingOpenAIKey         = configurationFieldOpenAIAPIKey + messageSuffixMustBeSet
+	configurationFieldOpenAIAPIKey = "providers.openai.api_key"
+	messageSuffixMustBeSet         = " must be set"
+	messageMissingOpenAIKey        = configurationFieldOpenAIAPIKey + messageSuffixMustBeSet
 )
 
 var (
-	// ErrMissingServiceSecret is returned when the service secret configuration field is empty.
-	ErrMissingServiceSecret = errors.New(messageMissingServiceSecret)
 	// ErrMissingOpenAIKey is returned when the OpenAI API key configuration field is empty.
 	ErrMissingOpenAIKey = errors.New(messageMissingOpenAIKey)
 )

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tyemirov/llm-proxy/internal/apperrors"
 	"github.com/tyemirov/llm-proxy/internal/constants"
 )
 
@@ -33,7 +32,7 @@ const (
 
 // Configuration holds runtime settings.
 type Configuration struct {
-	ServiceSecret                string
+	Tenants                      []TenantConfiguration
 	OpenAIKey                    string
 	DeepSeekKey                  string
 	DashScopeKey                 string
@@ -41,9 +40,6 @@ type Configuration struct {
 	SiliconFlowKey               string
 	ZhipuKey                     string
 	GeminiKey                    string
-	DefaultProvider              string
-	DefaultModel                 string
-	DefaultDictationProvider     string
 	DeepSeekBaseURL              string
 	DashScopeBaseURL             string
 	MoonshotBaseURL              string
@@ -53,24 +49,25 @@ type Configuration struct {
 	GeminiBaseURL                string
 	Port                         int
 	LogLevel                     string
-	SystemPrompt                 string
 	WorkerCount                  int
 	QueueSize                    int
 	RequestTimeoutSeconds        int
 	UpstreamPollTimeoutSeconds   int
 	MaxPromptBytes               int64
-	DictationModel               string
 	MaxInputAudioBytes           int64
 	Endpoints                    *Endpoints
+	tenants                      tenantRegistry
 	validated                    bool
 }
 
 // NewConfiguration returns a normalized runtime configuration after validating startup invariants.
 func NewConfiguration(configuration Configuration) (Configuration, error) {
 	configuration.ApplyTunables()
-	if validationError := validateConfig(configuration); validationError != nil {
+	tenants, validationError := validateConfig(configuration)
+	if validationError != nil {
 		return Configuration{}, validationError
 	}
+	configuration.tenants = tenants
 	configuration.validated = true
 	return configuration, nil
 }
@@ -82,79 +79,22 @@ func ensureValidatedConfiguration(configuration Configuration) (Configuration, e
 	return NewConfiguration(configuration)
 }
 
-func validateConfig(configuration Configuration) error {
-	if strings.TrimSpace(configuration.ServiceSecret) == constants.EmptyString {
-		return apperrors.ErrMissingServiceSecret
+func validateConfig(configuration Configuration) (tenantRegistry, error) {
+	tenants, tenantError := newTenantRegistry(configuration.Tenants)
+	if tenantError != nil {
+		return tenantRegistry{}, tenantError
 	}
-	if credentialError := validateDefaultProviderCredential(configuration.DefaultProvider, configuration); credentialError != nil {
-		return credentialError
+	providers := newProviderRegistry(configuration)
+	validator := newModelValidator(providers)
+	for _, currentTenant := range tenants.tenants {
+		if _, _, verificationError := validator.ResolveText(constants.EmptyString, constants.EmptyString, currentTenant.defaults.provider, currentTenant.defaults.model, false); verificationError != nil {
+			return tenantRegistry{}, fmt.Errorf("%w: tenant=%s", verificationError, currentTenant.identifier.string())
+		}
+		if _, _, verificationError := validator.ResolveDictation(constants.EmptyString, constants.EmptyString, currentTenant.defaults.dictationProvider, currentTenant.defaults.dictationModel); verificationError != nil {
+			return tenantRegistry{}, fmt.Errorf("%w: tenant=%s", verificationError, currentTenant.identifier.string())
+		}
 	}
-	if credentialError := validateDefaultDictationProviderCredential(configuration.DefaultDictationProvider, configuration); credentialError != nil {
-		return credentialError
-	}
-	return nil
-}
-
-func validateDefaultProviderCredential(providerIdentifier string, configuration Configuration) error {
-	switch strings.ToLower(strings.TrimSpace(providerIdentifier)) {
-	case ProviderNameOpenAI:
-		if strings.TrimSpace(configuration.OpenAIKey) == constants.EmptyString {
-			return apperrors.ErrMissingOpenAIKey
-		}
-	case ProviderNameDeepSeek:
-		if strings.TrimSpace(configuration.DeepSeekKey) == constants.EmptyString {
-			return fmt.Errorf("%w: provider=%s", ErrProviderNotConfigured, ProviderNameDeepSeek)
-		}
-	case ProviderNameDashScope, providerAliasQwen:
-		if strings.TrimSpace(configuration.DashScopeKey) == constants.EmptyString {
-			return fmt.Errorf("%w: provider=%s", ErrProviderNotConfigured, ProviderNameDashScope)
-		}
-	case ProviderNameMoonshot, providerAliasKimi:
-		if strings.TrimSpace(configuration.MoonshotKey) == constants.EmptyString {
-			return fmt.Errorf("%w: provider=%s", ErrProviderNotConfigured, ProviderNameMoonshot)
-		}
-	case ProviderNameSiliconFlow:
-		if strings.TrimSpace(configuration.SiliconFlowKey) == constants.EmptyString {
-			return fmt.Errorf("%w: provider=%s", ErrProviderNotConfigured, ProviderNameSiliconFlow)
-		}
-	case ProviderNameZhipu, providerAliasGLM:
-		if strings.TrimSpace(configuration.ZhipuKey) == constants.EmptyString {
-			return fmt.Errorf("%w: provider=%s", ErrProviderNotConfigured, ProviderNameZhipu)
-		}
-	case ProviderNameGemini:
-		if strings.TrimSpace(configuration.GeminiKey) == constants.EmptyString {
-			return fmt.Errorf("%w: provider=%s", ErrProviderNotConfigured, ProviderNameGemini)
-		}
-	default:
-		return fmt.Errorf("%w: %s", ErrUnknownProvider, providerIdentifier)
-	}
-	return nil
-}
-
-func validateDefaultDictationProviderCredential(providerIdentifier string, configuration Configuration) error {
-	switch strings.ToLower(strings.TrimSpace(providerIdentifier)) {
-	case ProviderNameOpenAI:
-		if strings.TrimSpace(configuration.OpenAIKey) == constants.EmptyString {
-			return apperrors.ErrMissingOpenAIKey
-		}
-	case ProviderNameSiliconFlow:
-		if strings.TrimSpace(configuration.SiliconFlowKey) == constants.EmptyString {
-			return fmt.Errorf("%w: provider=%s endpoint=%s", ErrProviderNotConfigured, ProviderNameSiliconFlow, endpointKindDictation)
-		}
-	case ProviderNameDeepSeek:
-		return fmt.Errorf("%w: provider=%s endpoint=%s", ErrUnsupportedEndpoint, ProviderNameDeepSeek, endpointKindDictation)
-	case ProviderNameDashScope, providerAliasQwen:
-		return fmt.Errorf("%w: provider=%s endpoint=%s", ErrUnsupportedEndpoint, ProviderNameDashScope, endpointKindDictation)
-	case ProviderNameMoonshot, providerAliasKimi:
-		return fmt.Errorf("%w: provider=%s endpoint=%s", ErrUnsupportedEndpoint, ProviderNameMoonshot, endpointKindDictation)
-	case ProviderNameZhipu, providerAliasGLM:
-		return fmt.Errorf("%w: provider=%s endpoint=%s", ErrUnsupportedEndpoint, ProviderNameZhipu, endpointKindDictation)
-	case ProviderNameGemini:
-		return fmt.Errorf("%w: provider=%s endpoint=%s", ErrUnsupportedEndpoint, ProviderNameGemini, endpointKindDictation)
-	default:
-		return fmt.Errorf("%w: %s", ErrUnknownProvider, providerIdentifier)
-	}
-	return nil
+	return tenants, nil
 }
 
 // ErrUpstreamIncomplete indicates that the upstream provider returned an incomplete response before the poll deadline.
@@ -162,7 +102,6 @@ var ErrUpstreamIncomplete = errors.New(errorUpstreamIncomplete)
 
 // ApplyTunables ensures tunable configuration values have sensible defaults.
 func (configuration *Configuration) ApplyTunables() {
-	configuration.ServiceSecret = strings.TrimSpace(configuration.ServiceSecret)
 	configuration.OpenAIKey = strings.TrimSpace(configuration.OpenAIKey)
 	configuration.DeepSeekKey = strings.TrimSpace(configuration.DeepSeekKey)
 	configuration.DashScopeKey = strings.TrimSpace(configuration.DashScopeKey)
@@ -176,25 +115,9 @@ func (configuration *Configuration) ApplyTunables() {
 	if configuration.UpstreamPollTimeoutSeconds <= 0 {
 		configuration.UpstreamPollTimeoutSeconds = DefaultUpstreamPollTimeoutSeconds
 	}
-	if strings.TrimSpace(configuration.DefaultProvider) == constants.EmptyString {
-		configuration.DefaultProvider = DefaultProvider
-	}
-	configuration.DefaultProvider = strings.ToLower(strings.TrimSpace(configuration.DefaultProvider))
-	if strings.TrimSpace(configuration.DefaultModel) == constants.EmptyString {
-		configuration.DefaultModel = DefaultModel
-	}
-	configuration.DefaultModel = strings.TrimSpace(configuration.DefaultModel)
-	if strings.TrimSpace(configuration.DefaultDictationProvider) == constants.EmptyString {
-		configuration.DefaultDictationProvider = DefaultDictationProvider
-	}
-	configuration.DefaultDictationProvider = strings.ToLower(strings.TrimSpace(configuration.DefaultDictationProvider))
 	if configuration.MaxPromptBytes <= 0 {
 		configuration.MaxPromptBytes = DefaultMaxPromptBytes
 	}
-	if strings.TrimSpace(configuration.DictationModel) == constants.EmptyString {
-		configuration.DictationModel = DefaultDictationModel
-	}
-	configuration.DictationModel = strings.TrimSpace(configuration.DictationModel)
 	if configuration.MaxInputAudioBytes <= 0 {
 		configuration.MaxInputAudioBytes = DefaultMaxInputAudioBytes
 	}

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -33,6 +33,7 @@ const (
 	formFieldFile  = "file"
 
 	redactedPlaceholder = "***REDACTED***"
+	contextKeyTenant    = "tenant"
 
 	mimeApplicationJSON = "application/json"
 	mimeApplicationXML  = "application/xml"
@@ -139,11 +140,9 @@ const (
 	logFieldClientIP     = "client_ip"
 	logFieldStatus       = "status"
 	logFieldValue        = "value"
+	logFieldTenantID     = "tenant_id"
 	// logFieldID identifies the response identifier logged for traceability.
 	logFieldID = "id"
-
-	// logFieldExpectedFingerprint identifies the fingerprint of the expected client key.
-	logFieldExpectedFingerprint = "expected_fingerprint"
 
 	logEventOpenAIRequestError = "OpenAI request error"
 	logEventOpenAIResponse     = "OpenAI API response"

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -74,7 +74,7 @@ func textRouterWithResponsesHandler(t *testing.T, handler http.HandlerFunc) *gin
 	endpoints := proxy.NewEndpoints()
 	endpoints.SetResponsesURL(upstreamServer.URL)
 	return coverageRouter(t, proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		LogLevel:                   proxy.LogLevelInfo,
 		WorkerCount:                1,
@@ -422,87 +422,120 @@ func TestCoverageConfigurationValidationMatrix(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name:          "missing service secret",
+			name:          "missing tenants",
 			configuration: proxy.Configuration{OpenAIKey: TestAPIKey},
-			expectedError: "server.service_secret must be set",
+			expectedError: "tenants must include at least one tenant",
 		},
 		{
 			name:          "missing openai text credential",
-			configuration: proxy.Configuration{ServiceSecret: TestSecret},
-			expectedError: "providers.openai.api_key must be set",
+			configuration: proxy.Configuration{Tenants: proxy.SingleTenantConfigurations("test", TestSecret)},
+			expectedError: "provider not configured: provider=openai endpoint=text",
+		},
+		{
+			name: "duplicate tenant id",
+			configuration: proxy.Configuration{
+				Tenants: []proxy.TenantConfiguration{
+					proxy.DefaultTenantConfiguration("duplicate", "secret-one"),
+					proxy.DefaultTenantConfiguration("duplicate", "secret-two"),
+				},
+				OpenAIKey: TestAPIKey,
+			},
+			expectedError: "duplicate id=duplicate",
+		},
+		{
+			name: "missing tenant id",
+			configuration: proxy.Configuration{
+				Tenants: []proxy.TenantConfiguration{
+					proxy.DefaultTenantConfiguration("", "tenant-secret"),
+				},
+				OpenAIKey: TestAPIKey,
+			},
+			expectedError: "id must be set",
+		},
+		{
+			name: "missing tenant secret",
+			configuration: proxy.Configuration{
+				Tenants: []proxy.TenantConfiguration{
+					proxy.DefaultTenantConfiguration("tenant", ""),
+				},
+				OpenAIKey: TestAPIKey,
+			},
+			expectedError: "secret must be set",
+		},
+		{
+			name: "duplicate tenant secret",
+			configuration: proxy.Configuration{
+				Tenants: []proxy.TenantConfiguration{
+					proxy.DefaultTenantConfiguration("tenant-a", "shared-secret"),
+					proxy.DefaultTenantConfiguration("tenant-b", "shared-secret"),
+				},
+				OpenAIKey: TestAPIKey,
+			},
+			expectedError: "duplicate secret tenant=tenant-b existing_tenant=tenant-a",
 		},
 		{
 			name: "missing deepseek text credential",
 			configuration: proxy.Configuration{
-				ServiceSecret:   TestSecret,
-				OpenAIKey:       TestAPIKey,
-				DefaultProvider: proxy.ProviderNameDeepSeek,
+				Tenants:   proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameDeepSeek, Model: proxy.ModelNameDeepSeekV4Flash, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}),
+				OpenAIKey: TestAPIKey,
 			},
 			expectedError: "provider not configured: provider=deepseek",
 		},
 		{
 			name: "missing dashscope text credential from alias",
 			configuration: proxy.Configuration{
-				ServiceSecret:   TestSecret,
-				OpenAIKey:       TestAPIKey,
-				DefaultProvider: "qwen",
+				Tenants:   proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: "qwen", Model: proxy.ModelNameDashScopeQwenPlus, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}),
+				OpenAIKey: TestAPIKey,
 			},
 			expectedError: "provider not configured: provider=dashscope",
 		},
 		{
 			name: "missing moonshot text credential from alias",
 			configuration: proxy.Configuration{
-				ServiceSecret:   TestSecret,
-				OpenAIKey:       TestAPIKey,
-				DefaultProvider: "kimi",
+				Tenants:   proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: "kimi", Model: proxy.ModelNameMoonshotKimi, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}),
+				OpenAIKey: TestAPIKey,
 			},
 			expectedError: "provider not configured: provider=moonshot",
 		},
 		{
 			name: "missing siliconflow text credential",
 			configuration: proxy.Configuration{
-				ServiceSecret:   TestSecret,
-				OpenAIKey:       TestAPIKey,
-				DefaultProvider: proxy.ProviderNameSiliconFlow,
+				Tenants:   proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameSiliconFlow, Model: proxy.ModelNameSiliconFlowDeepSeek, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}),
+				OpenAIKey: TestAPIKey,
 			},
 			expectedError: "provider not configured: provider=siliconflow",
 		},
 		{
 			name: "missing zhipu text credential from alias",
 			configuration: proxy.Configuration{
-				ServiceSecret:   TestSecret,
-				OpenAIKey:       TestAPIKey,
-				DefaultProvider: "glm",
+				Tenants:   proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: "glm", Model: proxy.ModelNameZhipuGLM, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}),
+				OpenAIKey: TestAPIKey,
 			},
 			expectedError: "provider not configured: provider=zhipu",
 		},
 		{
 			name: "unknown default text provider",
 			configuration: proxy.Configuration{
-				ServiceSecret:   TestSecret,
-				OpenAIKey:       TestAPIKey,
-				DefaultProvider: "unknown",
+				Tenants:   proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: "unknown", Model: proxy.DefaultModel, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}),
+				OpenAIKey: TestAPIKey,
 			},
 			expectedError: "unknown provider: unknown",
 		},
 		{
 			name: "missing openai dictation credential",
 			configuration: proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameDeepSeek, Model: proxy.ModelNameDeepSeekV4Flash, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}),
 				DeepSeekKey:                testDeepSeekKey,
-				DefaultProvider:            proxy.ProviderNameDeepSeek,
-				DefaultDictationProvider:   proxy.ProviderNameOpenAI,
 				RequestTimeoutSeconds:      TestTimeout,
 				UpstreamPollTimeoutSeconds: TestTimeout,
 			},
-			expectedError: "providers.openai.api_key must be set",
+			expectedError: "provider not configured: provider=openai endpoint=dictation",
 		},
 		{
 			name: "unsupported qwen default dictation",
 			configuration: proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: "qwen"}),
 				OpenAIKey:                  TestAPIKey,
-				DefaultDictationProvider:   "qwen",
 				RequestTimeoutSeconds:      TestTimeout,
 				UpstreamPollTimeoutSeconds: TestTimeout,
 			},
@@ -511,9 +544,8 @@ func TestCoverageConfigurationValidationMatrix(t *testing.T) {
 		{
 			name: "unsupported kimi default dictation",
 			configuration: proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: "kimi"}),
 				OpenAIKey:                  TestAPIKey,
-				DefaultDictationProvider:   "kimi",
 				RequestTimeoutSeconds:      TestTimeout,
 				UpstreamPollTimeoutSeconds: TestTimeout,
 			},
@@ -522,9 +554,8 @@ func TestCoverageConfigurationValidationMatrix(t *testing.T) {
 		{
 			name: "unsupported glm default dictation",
 			configuration: proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: "glm"}),
 				OpenAIKey:                  TestAPIKey,
-				DefaultDictationProvider:   "glm",
 				RequestTimeoutSeconds:      TestTimeout,
 				UpstreamPollTimeoutSeconds: TestTimeout,
 			},
@@ -533,9 +564,8 @@ func TestCoverageConfigurationValidationMatrix(t *testing.T) {
 		{
 			name: "unknown default dictation provider",
 			configuration: proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: "unknown"}),
 				OpenAIKey:                  TestAPIKey,
-				DefaultDictationProvider:   "unknown",
 				RequestTimeoutSeconds:      TestTimeout,
 				UpstreamPollTimeoutSeconds: TestTimeout,
 			},
@@ -908,7 +938,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		})
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -990,7 +1020,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		})
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1043,7 +1073,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		endpoints := proxy.NewEndpoints()
 		endpoints.SetResponsesURL(upstreamServer.URL)
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1077,7 +1107,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		})}
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1111,7 +1141,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		})}
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1144,7 +1174,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		})}
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1202,7 +1232,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		})
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1231,7 +1261,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		endpoints := proxy.NewEndpoints()
 		endpoints.SetResponsesURL("http://[::1")
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1297,7 +1327,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		}))
 		subTest.Cleanup(upstreamServer.Close)
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			DashScopeKey:               "sk-qwen",
 			DashScopeBaseURL:           upstreamServer.URL,
@@ -1342,7 +1372,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 				}))
 				caseTest.Cleanup(upstreamServer.Close)
 				router := coverageRouter(caseTest, proxy.Configuration{
-					ServiceSecret:              TestSecret,
+					Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 					OpenAIKey:                  TestAPIKey,
 					DeepSeekKey:                testDeepSeekKey,
 					DeepSeekBaseURL:            upstreamServer.URL,
@@ -1369,7 +1399,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		})}
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			DeepSeekKey:                testDeepSeekKey,
 			DeepSeekBaseURL:            "https://deepseek.invalid",
@@ -1400,7 +1430,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		for _, testCase := range testCases {
 			subTest.Run(testCase.name, func(caseTest *testing.T) {
 				router := coverageRouter(caseTest, proxy.Configuration{
-					ServiceSecret:              TestSecret,
+					Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 					OpenAIKey:                  TestAPIKey,
 					DeepSeekKey:                testDeepSeekKey,
 					DeepSeekBaseURL:            testCase.baseURL,
@@ -1435,7 +1465,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		}))
 		subTest.Cleanup(upstreamServer.Close)
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			DeepSeekKey:                testDeepSeekKey,
 			DeepSeekBaseURL:            upstreamServer.URL,
@@ -1464,7 +1494,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		})}
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			DeepSeekKey:                testDeepSeekKey,
 			DeepSeekBaseURL:            "https://deepseek.invalid",
@@ -1486,7 +1516,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 func TestCoverageDictationEdges(t *testing.T) {
 	t.Run("invalid and missing audio forms", func(subTest *testing.T) {
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1518,7 +1548,7 @@ func TestCoverageDictationEdges(t *testing.T) {
 
 	t.Run("unsupported and unknown dictation requests", func(subTest *testing.T) {
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			DeepSeekKey:                testDeepSeekKey,
 			LogLevel:                   proxy.LogLevelInfo,
@@ -1560,7 +1590,7 @@ func TestCoverageDictationEdges(t *testing.T) {
 			{
 				name: "siliconflow missing credential",
 				configuration: proxy.Configuration{
-					ServiceSecret:              TestSecret,
+					Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 					OpenAIKey:                  TestAPIKey,
 					LogLevel:                   proxy.LogLevelInfo,
 					WorkerCount:                1,
@@ -1575,7 +1605,7 @@ func TestCoverageDictationEdges(t *testing.T) {
 			{
 				name: "siliconflow unknown model",
 				configuration: proxy.Configuration{
-					ServiceSecret:              TestSecret,
+					Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 					OpenAIKey:                  TestAPIKey,
 					SiliconFlowKey:             testSiliconFlowKey,
 					LogLevel:                   proxy.LogLevelInfo,
@@ -1591,11 +1621,9 @@ func TestCoverageDictationEdges(t *testing.T) {
 			{
 				name: "openai missing credential when non openai defaults are configured",
 				configuration: proxy.Configuration{
-					ServiceSecret:              TestSecret,
+					Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameDeepSeek, Model: proxy.ModelNameDeepSeekV4Flash, DictationProvider: proxy.ProviderNameSiliconFlow}),
 					DeepSeekKey:                testDeepSeekKey,
 					SiliconFlowKey:             testSiliconFlowKey,
-					DefaultProvider:            proxy.ProviderNameDeepSeek,
-					DefaultDictationProvider:   proxy.ProviderNameSiliconFlow,
 					LogLevel:                   proxy.LogLevelInfo,
 					WorkerCount:                1,
 					QueueSize:                  1,
@@ -1649,7 +1677,7 @@ func TestCoverageDictationEdges(t *testing.T) {
 				endpoints := proxy.NewEndpoints()
 				endpoints.SetTranscriptionsURL(upstreamServer.URL)
 				router := coverageRouter(caseTest, proxy.Configuration{
-					ServiceSecret:              TestSecret,
+					Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 					OpenAIKey:                  TestAPIKey,
 					LogLevel:                   proxy.LogLevelInfo,
 					WorkerCount:                1,
@@ -1682,7 +1710,7 @@ func TestCoverageDictationEdges(t *testing.T) {
 		endpoints := proxy.NewEndpoints()
 		endpoints.SetTranscriptionsURL("http://[::1")
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1716,7 +1744,7 @@ func TestCoverageDictationEdges(t *testing.T) {
 		})}
 		subTest.Cleanup(func() { proxy.HTTPClient = previousClient })
 		router := coverageRouter(subTest, proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			LogLevel:                   proxy.LogLevelInfo,
 			WorkerCount:                1,
@@ -1764,7 +1792,7 @@ func TestCoverageServeAndEndpointReset(t *testing.T) {
 	}
 
 	serveError := proxy.Serve(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		Port:                       -1,
 		LogLevel:                   proxy.LogLevelInfo,
@@ -1789,7 +1817,7 @@ func TestCoverageHTTPUtilityReadFailure(t *testing.T) {
 	})}
 	t.Cleanup(func() { proxy.HTTPClient = previousClient })
 	router := coverageRouter(t, proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		LogLevel:                   proxy.LogLevelInfo,
 		WorkerCount:                1,

--- a/internal/proxy/dictate_handler_test.go
+++ b/internal/proxy/dictate_handler_test.go
@@ -30,14 +30,13 @@ func newDictationRouter(t *testing.T, transcriptionsURL string, requestTimeoutSe
 	t.Cleanup(func() { _ = logger.Sync() })
 
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		LogLevel:                   proxy.LogLevelDebug,
 		WorkerCount:                1,
 		QueueSize:                  1,
 		RequestTimeoutSeconds:      requestTimeoutSeconds,
 		UpstreamPollTimeoutSeconds: requestTimeoutSeconds,
-		DictationModel:             proxy.DefaultDictationModel,
 		MaxInputAudioBytes:         1024 * 1024,
 		Endpoints:                  endpoints,
 	}, logger.Sugar())

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -5,12 +5,10 @@ import (
 	"crypto/sha256"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tyemirov/llm-proxy/internal/constants"
-	"github.com/tyemirov/llm-proxy/internal/utils"
 	"go.uber.org/zap"
 )
 
@@ -44,36 +42,47 @@ func requestResponseLogger(structuredLogger *zap.SugaredLogger) gin.HandlerFunc 
 
 		responseStatus := ginContext.Writer.Status()
 		responseLatencyMillis := time.Since(requestStart).Milliseconds()
-		structuredLogger.Infow(
-			logEventResponseSent,
+		responseFields := []any{
 			logFieldStatus, responseStatus,
 			constants.LogFieldLatencyMilliseconds, responseLatencyMillis,
-		)
+		}
+		if requestTenant, authenticated := tenantIfPresentFromContext(ginContext); authenticated {
+			responseFields = append(responseFields, logFieldTenantID, requestTenant.identifier.string())
+		}
+		structuredLogger.Infow(logEventResponseSent, responseFields...)
 	}
 }
 
-// secretMiddleware enforces the shared secret through a constant-time comparison of the `key` query parameter.
-func secretMiddleware(sharedSecret string, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
-	normalizedSecret := strings.TrimSpace(sharedSecret)
-	expectedSecretFingerprint := utils.Fingerprint(normalizedSecret)
+// tenantMiddleware authenticates the `key` query parameter and attaches the matched tenant to the request context.
+func tenantMiddleware(tenants tenantRegistry, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
-		presentedKey := strings.TrimSpace(ginContext.Query(queryParameterKey))
-		if !constantTimeEquals(normalizedSecret, presentedKey) {
+		requestTenant, authenticated := tenants.authenticate(ginContext.Query(queryParameterKey))
+		if !authenticated {
 			structuredLogger.Warnw(
 				logEventForbiddenRequest,
-				logFieldExpectedFingerprint, expectedSecretFingerprint,
 			)
 			ginContext.String(http.StatusForbidden, errorMissingClientKey)
 			ginContext.Abort()
 			return
 		}
+		ginContext.Set(contextKeyTenant, requestTenant)
 		ginContext.Next()
 	}
 }
 
-// constantTimeEquals compares two string values using HMAC equality on SHA-256 hashes.
-func constantTimeEquals(firstValue string, secondValue string) bool {
-	firstDigest := sha256.Sum256([]byte(firstValue))
-	secondDigest := sha256.Sum256([]byte(secondValue))
+func tenantIfPresentFromContext(ginContext *gin.Context) (tenant, bool) {
+	contextValue, exists := ginContext.Get(contextKeyTenant)
+	if !exists {
+		return tenant{}, false
+	}
+	requestTenant, ok := contextValue.(tenant)
+	return requestTenant, ok
+}
+
+func authenticatedTenantFromContext(ginContext *gin.Context) tenant {
+	return ginContext.MustGet(contextKeyTenant).(tenant)
+}
+
+func constantTimeDigestEquals(firstDigest [sha256.Size]byte, secondDigest [sha256.Size]byte) bool {
 	return hmac.Equal(firstDigest[:], secondDigest[:])
 }

--- a/internal/proxy/poll_timeout_test.go
+++ b/internal/proxy/poll_timeout_test.go
@@ -20,9 +20,6 @@ func TestApplyTunablesSetsDefaultUpstreamPollTimeout(testingInstance *testing.T)
 func TestApplyTunablesSetsDefaultDictationConfiguration(testingInstance *testing.T) {
 	configuration := proxy.Configuration{}
 	configuration.ApplyTunables()
-	if configuration.DictationModel != proxy.DefaultDictationModel {
-		testingInstance.Fatalf("dictationModel=%q want=%q", configuration.DictationModel, proxy.DefaultDictationModel)
-	}
 	if configuration.MaxInputAudioBytes != proxy.DefaultMaxInputAudioBytes {
 		testingInstance.Fatalf("maxInputAudioBytes=%d want=%d", configuration.MaxInputAudioBytes, proxy.DefaultMaxInputAudioBytes)
 	}

--- a/internal/proxy/provider_registry.go
+++ b/internal/proxy/provider_registry.go
@@ -26,10 +26,10 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			identifier:                openAIProviderID,
 			textAPIKey:                configuration.OpenAIKey,
 			transcriptionAPIKey:       configuration.OpenAIKey,
-			defaultTextModel:          modelID(configuration.DefaultModel),
-			defaultTranscriptionModel: modelID(configuration.DictationModel),
+			defaultTextModel:          modelID(DefaultModel),
+			defaultTranscriptionModel: modelID(DefaultDictationModel),
 			textModels:                modelSet(ModelNameGPT4oMini, ModelNameGPT4o, ModelNameGPT41, ModelNameGPT5Mini, ModelNameGPT5, ModelNameGPT55, ModelNameGPT55Pro),
-			transcriptionModels:       modelSet(configuration.DictationModel, DefaultDictationModel, "gpt-4o-transcribe"),
+			transcriptionModels:       modelSet(DefaultDictationModel, "gpt-4o-transcribe"),
 			supportsDictation:         true,
 			supportsWebSearch:         true,
 			textTransport:             textTransportOpenAIResponses,
@@ -166,7 +166,7 @@ func (registry *providerRegistry) resolveTextRequest(rawProvider string, rawMode
 	}
 	modelIdentifier := strings.TrimSpace(rawModel)
 	if modelIdentifier == constants.EmptyString {
-		if definition.identifier == providerID(ProviderNameOpenAI) {
+		if strings.TrimSpace(rawProvider) == constants.EmptyString && strings.TrimSpace(defaultModel) != constants.EmptyString {
 			modelIdentifier = defaultModel
 		} else {
 			modelIdentifier = definition.defaultTextModel.string()
@@ -192,7 +192,7 @@ func (registry *providerRegistry) resolveDictationRequest(rawProvider string, ra
 	}
 	modelIdentifier := strings.TrimSpace(rawModel)
 	if modelIdentifier == constants.EmptyString {
-		if definition.identifier == providerID(ProviderNameOpenAI) {
+		if strings.TrimSpace(rawProvider) == constants.EmptyString && strings.TrimSpace(defaultModel) != constants.EmptyString {
 			modelIdentifier = defaultModel
 		} else {
 			modelIdentifier = definition.defaultTranscriptionModel.string()

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -48,7 +48,7 @@ func TestProviderRoutingSupportsDeepSeekChatCompletions(t *testing.T) {
 
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		DeepSeekKey:                testDeepSeekKey,
 		DeepSeekBaseURL:            upstreamServer.URL,
@@ -103,7 +103,7 @@ func TestProviderRoutingTranslatesMaxTokensForOpenAICompatibleChat(t *testing.T)
 
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		DeepSeekKey:                testDeepSeekKey,
 		DeepSeekBaseURL:            upstreamServer.URL,
@@ -145,7 +145,7 @@ func TestProviderRoutingSurfacesChatCompletionTokenUsage(t *testing.T) {
 
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		DeepSeekKey:                testDeepSeekKey,
 		DeepSeekBaseURL:            upstreamServer.URL,
@@ -224,7 +224,7 @@ func TestProviderRoutingSupportsGeminiGenerateContent(t *testing.T) {
 
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		GeminiKey:                  testGeminiKey,
 		GeminiBaseURL:              upstreamServer.URL,
@@ -285,6 +285,163 @@ func TestProviderRoutingSupportsGeminiGenerateContent(t *testing.T) {
 	assertGeminiContentOmitsThought(t, capturedPayload["systemInstruction"], "systemInstruction")
 }
 
+func TestProviderRoutingSelectsDefaultsByTenantSecret(t *testing.T) {
+	const openAITenantSecret = "openai-tenant-secret"
+	const geminiTenantSecret = "gemini-tenant-secret"
+
+	var openAIModels []string
+	var openAIInputs []string
+	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodPost && request.URL.Path == "/" {
+			bodyBytes, readError := io.ReadAll(request.Body)
+			if readError != nil {
+				t.Fatalf("read OpenAI body: %v", readError)
+			}
+			var payload map[string]any
+			if unmarshalError := json.Unmarshal(bodyBytes, &payload); unmarshalError != nil {
+				t.Fatalf("unmarshal OpenAI body: %v", unmarshalError)
+			}
+			openAIModels = append(openAIModels, payload["model"].(string))
+			openAIInputs = append(openAIInputs, payload["input"].(string))
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"id":"resp_tenant_default","status":"queued"}`))
+			return
+		}
+		if request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "resp_tenant_default") {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"text","text":"openai tenant ok"}]}]}`))
+			return
+		}
+		http.NotFound(responseWriter, request)
+	}))
+	defer openAIServer.Close()
+
+	var geminiPath string
+	var geminiPayload map[string]any
+	geminiServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		geminiPath = request.URL.Path
+		bodyBytes, readError := io.ReadAll(request.Body)
+		if readError != nil {
+			t.Fatalf("read Gemini body: %v", readError)
+		}
+		if unmarshalError := json.Unmarshal(bodyBytes, &geminiPayload); unmarshalError != nil {
+			t.Fatalf("unmarshal Gemini body: %v", unmarshalError)
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"gemini tenant ok"}]}}]}`))
+	}))
+	defer geminiServer.Close()
+
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(openAIServer.URL)
+	router, buildError := proxy.BuildRouter(proxy.Configuration{
+		Tenants: []proxy.TenantConfiguration{
+			{
+				ID:     "openai",
+				Secret: openAITenantSecret,
+				Defaults: proxy.TenantDefaults{
+					Provider:          proxy.ProviderNameOpenAI,
+					Model:             proxy.ModelNameGPT41,
+					DictationProvider: proxy.ProviderNameOpenAI,
+					DictationModel:    proxy.DefaultDictationModel,
+					SystemPrompt:      "openai tenant system",
+				},
+			},
+			{
+				ID:     "gemini",
+				Secret: geminiTenantSecret,
+				Defaults: proxy.TenantDefaults{
+					Provider:          proxy.ProviderNameGemini,
+					Model:             proxy.ModelNameGemini35Flash,
+					DictationProvider: proxy.ProviderNameOpenAI,
+					DictationModel:    proxy.DefaultDictationModel,
+					SystemPrompt:      "gemini tenant system",
+				},
+			},
+		},
+		OpenAIKey:                  TestAPIKey,
+		GeminiKey:                  testGeminiKey,
+		GeminiBaseURL:              geminiServer.URL,
+		LogLevel:                   proxy.LogLevelInfo,
+		WorkerCount:                1,
+		QueueSize:                  3,
+		RequestTimeoutSeconds:      TestTimeout,
+		UpstreamPollTimeoutSeconds: TestTimeout,
+		Endpoints:                  endpoints,
+	}, zap.NewNop().Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	geminiQuery := url.Values{}
+	geminiQuery.Set("key", geminiTenantSecret)
+	geminiQuery.Set("prompt", "hello gemini default")
+	geminiResponse := httptest.NewRecorder()
+	router.ServeHTTP(geminiResponse, httptest.NewRequest(http.MethodGet, "/?"+geminiQuery.Encode(), nil))
+	if geminiResponse.Code != http.StatusOK {
+		t.Fatalf("gemini status=%d body=%s", geminiResponse.Code, geminiResponse.Body.String())
+	}
+	if strings.TrimSpace(geminiResponse.Body.String()) != "gemini tenant ok" {
+		t.Fatalf("gemini body=%q", geminiResponse.Body.String())
+	}
+	if geminiPath != "/models/"+proxy.ModelNameGemini35Flash+":generateContent" {
+		t.Fatalf("gemini path=%s", geminiPath)
+	}
+	if systemInstructionText(geminiPayload["systemInstruction"]) != "gemini tenant system" {
+		t.Fatalf("gemini systemInstruction=%v", geminiPayload["systemInstruction"])
+	}
+
+	openAIQuery := url.Values{}
+	openAIQuery.Set("key", openAITenantSecret)
+	openAIQuery.Set("prompt", "hello openai default")
+	openAIResponse := httptest.NewRecorder()
+	router.ServeHTTP(openAIResponse, httptest.NewRequest(http.MethodGet, "/?"+openAIQuery.Encode(), nil))
+	if openAIResponse.Code != http.StatusOK {
+		t.Fatalf("openai status=%d body=%s", openAIResponse.Code, openAIResponse.Body.String())
+	}
+
+	overrideQuery := url.Values{}
+	overrideQuery.Set("key", geminiTenantSecret)
+	overrideQuery.Set("prompt", "hello override")
+	overrideQuery.Set("provider", proxy.ProviderNameOpenAI)
+	overrideQuery.Set("model", proxy.ModelNameGPT41)
+	overrideResponse := httptest.NewRecorder()
+	router.ServeHTTP(overrideResponse, httptest.NewRequest(http.MethodGet, "/?"+overrideQuery.Encode(), nil))
+	if overrideResponse.Code != http.StatusOK {
+		t.Fatalf("override status=%d body=%s", overrideResponse.Code, overrideResponse.Body.String())
+	}
+
+	if len(openAIModels) != 2 {
+		t.Fatalf("openAIModels=%v want two OpenAI calls", openAIModels)
+	}
+	if openAIModels[0] != proxy.ModelNameGPT41 || openAIModels[1] != proxy.ModelNameGPT41 {
+		t.Fatalf("openAIModels=%v", openAIModels)
+	}
+	if openAIInputs[0] != "openai tenant system\n\nhello openai default" {
+		t.Fatalf("openAI default input=%q", openAIInputs[0])
+	}
+	if openAIInputs[1] != "gemini tenant system\n\nhello override" {
+		t.Fatalf("override input=%q", openAIInputs[1])
+	}
+}
+
+func systemInstructionText(rawSystemInstruction any) string {
+	systemInstruction, ok := rawSystemInstruction.(map[string]any)
+	if !ok {
+		return ""
+	}
+	parts, ok := systemInstruction["parts"].([]any)
+	if !ok || len(parts) == 0 {
+		return ""
+	}
+	firstPart, ok := parts[0].(map[string]any)
+	if !ok {
+		return ""
+	}
+	text, _ := firstPart["text"].(string)
+	return text
+}
+
 func TestProviderRoutingSupportsGeminiJSONPost(t *testing.T) {
 	var capturedPath string
 	var capturedPayload map[string]any
@@ -304,7 +461,7 @@ func TestProviderRoutingSupportsGeminiJSONPost(t *testing.T) {
 
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		GeminiKey:                  testGeminiKey,
 		GeminiBaseURL:              upstreamServer.URL,
@@ -385,7 +542,7 @@ func TestProviderRoutingRejectsGeminiJSONPostMaxTokensAboveModelLimit(t *testing
 
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		GeminiKey:                  testGeminiKey,
 		GeminiBaseURL:              upstreamServer.URL,
@@ -422,7 +579,7 @@ func TestProviderRoutingRejectsGeminiQueryMaxTokensAboveModelLimit(t *testing.T)
 
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		GeminiKey:                  testGeminiKey,
 		GeminiBaseURL:              upstreamServer.URL,
@@ -458,7 +615,7 @@ func TestProviderRoutingRejectsGeminiQueryMaxTokensAboveModelLimit(t *testing.T)
 func TestProviderRoutingRejectsGeminiUnsupportedAndInvalidRequests(t *testing.T) {
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		GeminiKey:                  testGeminiKey,
 		GeminiBaseURL:              "https://gemini.invalid",
@@ -515,7 +672,7 @@ func TestProviderRoutingRejectsGeminiUnsupportedAndInvalidRequests(t *testing.T)
 func TestProviderRoutingRejectsGeminiMissingCredential(t *testing.T) {
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		GeminiBaseURL:              "https://gemini.invalid",
 		LogLevel:                   proxy.LogLevelInfo,
@@ -541,9 +698,8 @@ func TestProviderRoutingRejectsGeminiMissingCredential(t *testing.T) {
 func TestProviderRoutingRejectsMissingGeminiDefaultCredential(t *testing.T) {
 	logger := zap.NewNop()
 	_, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameGemini, Model: proxy.ModelNameGemini35Flash, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}),
 		OpenAIKey:                  TestAPIKey,
-		DefaultProvider:            proxy.ProviderNameGemini,
 		LogLevel:                   proxy.LogLevelInfo,
 		WorkerCount:                1,
 		QueueSize:                  1,
@@ -581,7 +737,7 @@ func TestProviderRoutingMapsGeminiProviderErrors(t *testing.T) {
 
 			logger := zap.NewNop()
 			router, buildError := proxy.BuildRouter(proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 				OpenAIKey:                  TestAPIKey,
 				GeminiKey:                  testGeminiKey,
 				GeminiBaseURL:              upstreamServer.URL,
@@ -611,7 +767,7 @@ func TestProviderRoutingMapsGeminiTransportErrors(t *testing.T) {
 	t.Run("invalid request URL", func(subTest *testing.T) {
 		logger := zap.NewNop()
 		router, buildError := proxy.BuildRouter(proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			GeminiKey:                  testGeminiKey,
 			GeminiBaseURL:              "http://[::1",
@@ -642,7 +798,7 @@ func TestProviderRoutingMapsGeminiTransportErrors(t *testing.T) {
 
 		logger := zap.NewNop()
 		router, buildError := proxy.BuildRouter(proxy.Configuration{
-			ServiceSecret:              TestSecret,
+			Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:                  TestAPIKey,
 			GeminiKey:                  testGeminiKey,
 			GeminiBaseURL:              "https://gemini.invalid",
@@ -670,7 +826,7 @@ func TestProviderRoutingMapsGeminiTransportErrors(t *testing.T) {
 func TestProviderRoutingRejectsUnsupportedWebSearch(t *testing.T) {
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		DeepSeekKey:                testDeepSeekKey,
 		DeepSeekBaseURL:            "https://deepseek.invalid",
@@ -697,7 +853,7 @@ func TestProviderRoutingRejectsUnsupportedWebSearch(t *testing.T) {
 func TestProviderRoutingRejectsMissingProviderCredential(t *testing.T) {
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		DeepSeekBaseURL:            "https://deepseek.invalid",
 		LogLevel:                   proxy.LogLevelInfo,
@@ -729,9 +885,8 @@ func TestProviderRoutingRejectsInvalidDefaultDictationProvider(t *testing.T) {
 		{
 			name: "missing_siliconflow_credential",
 			configuration: proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: proxy.ProviderNameSiliconFlow}),
 				OpenAIKey:                  TestAPIKey,
-				DefaultDictationProvider:   proxy.ProviderNameSiliconFlow,
 				LogLevel:                   proxy.LogLevelInfo,
 				WorkerCount:                1,
 				QueueSize:                  1,
@@ -743,10 +898,9 @@ func TestProviderRoutingRejectsInvalidDefaultDictationProvider(t *testing.T) {
 		{
 			name: "unsupported_deepseek_dictation",
 			configuration: proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: proxy.ProviderNameDeepSeek}),
 				OpenAIKey:                  TestAPIKey,
 				DeepSeekKey:                testDeepSeekKey,
-				DefaultDictationProvider:   proxy.ProviderNameDeepSeek,
 				LogLevel:                   proxy.LogLevelInfo,
 				WorkerCount:                1,
 				QueueSize:                  1,
@@ -758,10 +912,9 @@ func TestProviderRoutingRejectsInvalidDefaultDictationProvider(t *testing.T) {
 		{
 			name: "unsupported_gemini_dictation",
 			configuration: proxy.Configuration{
-				ServiceSecret:              TestSecret,
+				Tenants:                    proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: proxy.ProviderNameGemini}),
 				OpenAIKey:                  TestAPIKey,
 				GeminiKey:                  testGeminiKey,
-				DefaultDictationProvider:   proxy.ProviderNameGemini,
 				LogLevel:                   proxy.LogLevelInfo,
 				WorkerCount:                1,
 				QueueSize:                  1,
@@ -785,7 +938,7 @@ func TestProviderRoutingRejectsInvalidDefaultDictationProvider(t *testing.T) {
 func TestProviderRoutingRejectsConflictingJSONModelParameters(t *testing.T) {
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		LogLevel:                   proxy.LogLevelInfo,
 		WorkerCount:                1,
@@ -833,7 +986,7 @@ func TestProviderRoutingSupportsSiliconFlowDictation(t *testing.T) {
 
 	logger := zap.NewNop()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:                TestSecret,
+		Tenants:                      proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                    TestAPIKey,
 		SiliconFlowKey:               testSiliconFlowKey,
 		SiliconFlowTranscriptionsURL: upstreamServer.URL,

--- a/internal/proxy/response_shapes_e2e_test.go
+++ b/internal/proxy/response_shapes_e2e_test.go
@@ -42,7 +42,7 @@ func withStubbedProxy(t *testing.T, initialResponse, finalResponse string) http.
 	logger, _ := zap.NewDevelopment()
 	t.Cleanup(func() { _ = logger.Sync() })
 	router, err := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		LogLevel:                   proxy.LogLevelDebug,
 		WorkerCount:                1,

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -99,10 +99,10 @@ func BuildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 		}()
 	}
 
-	router.Use(gin.Recovery(), secretMiddleware(configuration.ServiceSecret, structuredLogger))
-	router.GET(rootPath, chatHandler(taskQueue, configuration.SystemPrompt, configuration.DefaultProvider, configuration.DefaultModel, validator, requestTimeout, structuredLogger))
-	router.POST(rootPath, chatJSONHandler(taskQueue, configuration.SystemPrompt, configuration.DefaultProvider, configuration.DefaultModel, validator, requestTimeout, configuration.MaxPromptBytes, structuredLogger))
-	router.POST(dictatePath, dictateHandler(upstreamProviders, configuration.DefaultDictationProvider, configuration.DictationModel, validator, configuration.MaxInputAudioBytes, structuredLogger))
+	router.Use(gin.Recovery(), tenantMiddleware(configuration.tenants, structuredLogger))
+	router.GET(rootPath, chatHandler(taskQueue, validator, requestTimeout, structuredLogger))
+	router.POST(rootPath, chatJSONHandler(taskQueue, validator, requestTimeout, configuration.MaxPromptBytes, structuredLogger))
+	router.POST(dictatePath, dictateHandler(upstreamProviders, validator, configuration.MaxInputAudioBytes, structuredLogger))
 	return router, nil
 }
 
@@ -116,9 +116,10 @@ func Serve(configuration Configuration, structuredLogger *zap.SugaredLogger) err
 }
 
 // chatHandler returns a handler that forwards query-string requests to the task queue.
-func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, defaultProvider string, defaultModel string, validator *modelValidator, requestTimeout time.Duration, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+func chatHandler(taskQueue chan requestTask, validator *modelValidator, requestTimeout time.Duration, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
-		chatRequest, ok := chatRequestFromQuery(ginContext, defaultSystemPrompt, defaultProvider, defaultModel, validator, structuredLogger)
+		requestTenant := authenticatedTenantFromContext(ginContext)
+		chatRequest, ok := chatRequestFromQuery(ginContext, requestTenant.defaults, validator, structuredLogger)
 		if !ok {
 			return
 		}
@@ -127,8 +128,9 @@ func chatHandler(taskQueue chan requestTask, defaultSystemPrompt string, default
 }
 
 // chatJSONHandler accepts large prompt bodies while preserving the same model validation, queueing, and response formatting used by GET /.
-func chatJSONHandler(taskQueue chan requestTask, defaultSystemPrompt string, defaultProvider string, defaultModel string, validator *modelValidator, requestTimeout time.Duration, maxPromptBytes int64, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+func chatJSONHandler(taskQueue chan requestTask, validator *modelValidator, requestTimeout time.Duration, maxPromptBytes int64, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
+		requestTenant := authenticatedTenantFromContext(ginContext)
 		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxPromptBytes)
 		var payload chatRequestPayload
 		if decodeError := json.NewDecoder(ginContext.Request.Body).Decode(&payload); decodeError != nil {
@@ -141,7 +143,7 @@ func chatJSONHandler(taskQueue chan requestTask, defaultSystemPrompt string, def
 			return
 		}
 
-		chatRequest, ok := chatRequestFromPayload(ginContext, payload, defaultSystemPrompt, defaultProvider, defaultModel, validator)
+		chatRequest, ok := chatRequestFromPayload(ginContext, payload, requestTenant.defaults, validator)
 		if !ok {
 			return
 		}
@@ -149,7 +151,7 @@ func chatJSONHandler(taskQueue chan requestTask, defaultSystemPrompt string, def
 	}
 }
 
-func chatRequestFromQuery(ginContext *gin.Context, defaultSystemPrompt string, defaultProvider string, defaultModel string, validator *modelValidator, structuredLogger *zap.SugaredLogger) (chatRequestParameters, bool) {
+func chatRequestFromQuery(ginContext *gin.Context, defaults tenantDefaults, validator *modelValidator, structuredLogger *zap.SugaredLogger) (chatRequestParameters, bool) {
 	userPrompt := ginContext.Query(queryParameterPrompt)
 	if userPrompt == constants.EmptyString {
 		ginContext.String(http.StatusBadRequest, errorMissingPrompt)
@@ -158,7 +160,7 @@ func chatRequestFromQuery(ginContext *gin.Context, defaultSystemPrompt string, d
 
 	systemPrompt := ginContext.Query(queryParameterSystemPrompt)
 	if systemPrompt == constants.EmptyString {
-		systemPrompt = defaultSystemPrompt
+		systemPrompt = defaults.systemPrompt
 	}
 
 	webSearchQuery := strings.TrimSpace(ginContext.Query(queryParameterWebSearch))
@@ -179,8 +181,8 @@ func chatRequestFromQuery(ginContext *gin.Context, defaultSystemPrompt string, d
 	providerDefinition, modelIdentifier, verificationError := validator.ResolveText(
 		ginContext.Query(queryParameterProvider),
 		ginContext.Query(queryParameterModel),
-		defaultProvider,
-		defaultModel,
+		defaults.provider,
+		defaults.model,
 		webSearchEnabled,
 	)
 	if verificationError != nil {
@@ -202,7 +204,7 @@ func chatRequestFromQuery(ginContext *gin.Context, defaultSystemPrompt string, d
 	}, true
 }
 
-func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload, defaultSystemPrompt string, defaultProvider string, defaultModel string, validator *modelValidator) (chatRequestParameters, bool) {
+func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload, defaults tenantDefaults, validator *modelValidator) (chatRequestParameters, bool) {
 	if payload.Prompt == constants.EmptyString {
 		ginContext.String(http.StatusBadRequest, errorMissingPrompt)
 		return chatRequestParameters{}, false
@@ -210,7 +212,7 @@ func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload,
 
 	systemPrompt := payload.SystemPrompt
 	if systemPrompt == constants.EmptyString {
-		systemPrompt = defaultSystemPrompt
+		systemPrompt = defaults.systemPrompt
 	}
 
 	modelIdentifier, modelParameterError := resolveJSONModelParameter(ginContext.Query(queryParameterModel), payload.Model)
@@ -226,8 +228,8 @@ func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload,
 	providerDefinition, resolvedModel, verificationError := validator.ResolveText(
 		ginContext.Query(queryParameterProvider),
 		modelIdentifier,
-		defaultProvider,
-		defaultModel,
+		defaults.provider,
+		defaults.model,
 		payload.WebSearch,
 	)
 	if verificationError != nil {
@@ -279,8 +281,9 @@ func submitChatRequest(ginContext *gin.Context, taskQueue chan requestTask, chat
 	}
 }
 
-func dictateHandler(upstreamProviders *providerRouter, defaultProvider string, defaultModel string, validator *modelValidator, maxInputAudioBytes int64, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+func dictateHandler(upstreamProviders *providerRouter, validator *modelValidator, maxInputAudioBytes int64, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
+		requestTenant := authenticatedTenantFromContext(ginContext)
 		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxInputAudioBytes+2*1024*1024)
 		if parseError := ginContext.Request.ParseMultipartForm(maxInputAudioBytes); parseError != nil {
 			ginContext.String(http.StatusBadRequest, errorInvalidAudioForm)
@@ -308,8 +311,8 @@ func dictateHandler(upstreamProviders *providerRouter, defaultProvider string, d
 		providerDefinition, modelIdentifier, verificationError := validator.ResolveDictation(
 			ginContext.Query(queryParameterProvider),
 			ginContext.Query(queryParameterModel),
-			defaultProvider,
-			defaultModel,
+			requestTenant.defaults.dictationProvider,
+			requestTenant.defaults.dictationModel,
 		)
 		if verificationError != nil {
 			ginContext.String(statusCodeForError(verificationError), responseMessageForError(verificationError))

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -185,7 +185,7 @@ func TestChatHandlerRejectsOversizedJSONBody(testingInstance *testing.T) {
 	endpoints := proxy.NewEndpoints()
 	logger := zap.NewNop()
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		LogLevel:                   proxy.LogLevelInfo,
 		WorkerCount:                1,

--- a/internal/proxy/tenants.go
+++ b/internal/proxy/tenants.go
@@ -1,0 +1,174 @@
+package proxy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/tyemirov/llm-proxy/internal/constants"
+)
+
+var (
+	ErrMissingTenants = errors.New("tenants must include at least one tenant")
+	ErrInvalidTenant  = errors.New("invalid tenant")
+)
+
+// TenantConfiguration is the config-file shape for one authenticated tenant.
+type TenantConfiguration struct {
+	ID       string
+	Secret   string
+	Defaults TenantDefaults
+}
+
+// TenantDefaults holds default request values selected by an authenticated tenant.
+type TenantDefaults struct {
+	Provider          string
+	Model             string
+	DictationProvider string
+	DictationModel    string
+	SystemPrompt      string
+}
+
+type tenantID string
+
+func newTenantID(rawIdentifier string) (tenantID, error) {
+	normalizedIdentifier := strings.TrimSpace(rawIdentifier)
+	if normalizedIdentifier == constants.EmptyString {
+		return tenantID(""), fmt.Errorf("%w: id must be set", ErrInvalidTenant)
+	}
+	return tenantID(normalizedIdentifier), nil
+}
+
+func (identifier tenantID) string() string {
+	return string(identifier)
+}
+
+type tenantDefaults struct {
+	provider          string
+	model             string
+	dictationProvider string
+	dictationModel    string
+	systemPrompt      string
+}
+
+func newTenantDefaults(rawDefaults TenantDefaults) tenantDefaults {
+	defaults := tenantDefaults{
+		provider:          strings.TrimSpace(rawDefaults.Provider),
+		model:             strings.TrimSpace(rawDefaults.Model),
+		dictationProvider: strings.TrimSpace(rawDefaults.DictationProvider),
+		dictationModel:    strings.TrimSpace(rawDefaults.DictationModel),
+		systemPrompt:      rawDefaults.SystemPrompt,
+	}
+	if defaults.provider == constants.EmptyString {
+		defaults.provider = DefaultProvider
+	}
+	defaults.provider = strings.ToLower(defaults.provider)
+	if defaults.dictationProvider == constants.EmptyString {
+		defaults.dictationProvider = DefaultDictationProvider
+	}
+	defaults.dictationProvider = strings.ToLower(defaults.dictationProvider)
+	return defaults
+}
+
+type tenant struct {
+	identifier   tenantID
+	secretDigest [sha256.Size]byte
+	defaults     tenantDefaults
+}
+
+func newTenant(rawTenant TenantConfiguration) (tenant, error) {
+	identifier, identifierError := newTenantID(rawTenant.ID)
+	if identifierError != nil {
+		return tenant{}, identifierError
+	}
+	normalizedSecret := strings.TrimSpace(rawTenant.Secret)
+	if normalizedSecret == constants.EmptyString {
+		return tenant{}, fmt.Errorf("%w: id=%s secret must be set", ErrInvalidTenant, identifier.string())
+	}
+	return tenant{
+		identifier:   identifier,
+		secretDigest: sha256.Sum256([]byte(normalizedSecret)),
+		defaults:     newTenantDefaults(rawTenant.Defaults),
+	}, nil
+}
+
+type tenantRegistry struct {
+	tenants []tenant
+}
+
+func newTenantRegistry(rawTenants []TenantConfiguration) (tenantRegistry, error) {
+	if len(rawTenants) == 0 {
+		return tenantRegistry{}, ErrMissingTenants
+	}
+	seenIdentifiers := map[string]struct{}{}
+	seenSecretDigests := map[string]tenantID{}
+	tenants := make([]tenant, 0, len(rawTenants))
+	for _, rawTenant := range rawTenants {
+		currentTenant, tenantError := newTenant(rawTenant)
+		if tenantError != nil {
+			return tenantRegistry{}, tenantError
+		}
+		identifier := currentTenant.identifier.string()
+		if _, exists := seenIdentifiers[identifier]; exists {
+			return tenantRegistry{}, fmt.Errorf("%w: duplicate id=%s", ErrInvalidTenant, identifier)
+		}
+		seenIdentifiers[identifier] = struct{}{}
+		secretDigest := hex.EncodeToString(currentTenant.secretDigest[:])
+		if existingIdentifier, exists := seenSecretDigests[secretDigest]; exists {
+			return tenantRegistry{}, fmt.Errorf("%w: duplicate secret tenant=%s existing_tenant=%s", ErrInvalidTenant, identifier, existingIdentifier.string())
+		}
+		seenSecretDigests[secretDigest] = currentTenant.identifier
+		tenants = append(tenants, currentTenant)
+	}
+	return tenantRegistry{tenants: tenants}, nil
+}
+
+func (registry tenantRegistry) authenticate(rawSecret string) (tenant, bool) {
+	presentedSecret := strings.TrimSpace(rawSecret)
+	presentedDigest := sha256.Sum256([]byte(presentedSecret))
+	var matchedTenant tenant
+	matched := false
+	for _, candidate := range registry.tenants {
+		if constantTimeDigestEquals(candidate.secretDigest, presentedDigest) {
+			matchedTenant = candidate
+			matched = true
+		}
+	}
+	return matchedTenant, matched
+}
+
+// DefaultTenantDefaults returns the built-in request defaults for a single tenant.
+func DefaultTenantDefaults() TenantDefaults {
+	return TenantDefaults{
+		Provider:          DefaultProvider,
+		Model:             DefaultModel,
+		DictationProvider: DefaultDictationProvider,
+		DictationModel:    DefaultDictationModel,
+		SystemPrompt:      constants.EmptyString,
+	}
+}
+
+// DefaultTenantConfiguration returns one tenant using the built-in request defaults.
+func DefaultTenantConfiguration(identifier string, secret string) TenantConfiguration {
+	return TenantConfiguration{
+		ID:       identifier,
+		Secret:   secret,
+		Defaults: DefaultTenantDefaults(),
+	}
+}
+
+// SingleTenantConfigurations returns a tenant slice for tests and small deployments.
+func SingleTenantConfigurations(identifier string, secret string) []TenantConfiguration {
+	return []TenantConfiguration{DefaultTenantConfiguration(identifier, secret)}
+}
+
+// SingleTenantConfigurationsWithDefaults returns one tenant with caller-specified request defaults.
+func SingleTenantConfigurationsWithDefaults(identifier string, secret string, defaults TenantDefaults) []TenantConfiguration {
+	return []TenantConfiguration{{
+		ID:       identifier,
+		Secret:   secret,
+		Defaults: defaults,
+	}}
+}

--- a/internal/proxy/test_helpers_test.go
+++ b/internal/proxy/test_helpers_test.go
@@ -54,7 +54,7 @@ func NewTestRouter(t *testing.T, serverURL string) *gin.Engine {
 	t.Cleanup(func() { _ = logger.Sync() })
 
 	router, err := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              TestSecret,
+		Tenants:                    proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:                  TestAPIKey,
 		LogLevel:                   proxy.LogLevelDebug,
 		WorkerCount:                1,

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -120,6 +120,19 @@ These entries are always-available procedures. Keep them `[ ]` so they remain ru
 
 ## Features
 
+- [x] [F418] (P1) Add tenant-authenticated defaults.
+  Replace the single shared `server.service_secret` plus global `defaults` contract with an explicit tenant list where each tenant has its own client secret and default text/dictation settings. Requests continue to authenticate with the `key` query parameter, but the accepted key selects tenant defaults when provider/model/system prompt values are omitted.
+  Acceptance criteria:
+  1. `config.yml` defines `tenants[]` with unique non-empty `id` and `secret` values plus tenant-local `defaults.provider`, `defaults.model`, `defaults.dictation_provider`, `defaults.dictation_model`, and `defaults.system_prompt`.
+  2. `server.service_secret` and top-level `defaults` are removed from the canonical service schema; unknown legacy keys fail startup through the strict config loader.
+  3. Runtime configuration exposes a validated tenant registry instead of raw scalar auth/default fields.
+  4. `GET /`, JSON `POST /`, and `POST /dictate` use the authenticated tenant defaults when request parameters omit provider, model, dictation provider/model, or system prompt.
+  5. Explicit request provider/model/system prompt parameters keep their existing override semantics.
+  6. Missing or invalid `key` still returns `403` without logging raw secrets.
+  7. README, provider-routing docs, and mounted gateway config examples document the tenant schema.
+  8. Black-box CLI and HTTP tests cover tenant config loading, duplicate tenant validation, token-selected defaults, request overrides, dictation defaults, and invalid keys.
+  Resolution: Replaced the canonical single-secret/global-default schema with `tenants[]`, where each tenant owns a unique `id`, unique `secret`, and text/dictation defaults. Runtime startup now validates tenant identity, secret uniqueness, and each tenant's default provider/model contract. Auth middleware resolves `key` to a tenant and routes GET, JSON POST, and `/dictate` omitted provider/model/system prompt values through that tenant; explicit request parameters keep their override behavior. README, provider-routing docs, live Gemini smoke config, coverage probe config, and the mounted gateway config were updated to the tenant schema. Added black-box coverage for config loading, duplicate/missing tenant validation, token-selected defaults, overrides, dictation defaults, and invalid keys. Validation passed with `make fmt`, `make test` (Go total coverage 100.0%, Python pytest 12 passed), `make lint`, and `make ci` (Go total coverage 100.0%, Python pytest 12 passed).
+
 - [x] [F410] (P1) Replace global output-token configuration with request `max_tokens`.
   Remove the server-wide text output token cap configuration because providers do not require it and a single global budget has different semantics across provider APIs. Clients may request an explicit cap per call with `max_tokens`, and the proxy translates that public request parameter to each provider's native field.
   Acceptance criteria:

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -32,8 +32,9 @@ run_coverage_probe() {
 "$GO_BIN" build -cover -covermode=count -coverpkg="$CLIENT_COVERPKG" -o "$TMP_DIR/llm-proxy-client.cover" ./llm-proxy-client
 
 cat > "$TMP_DIR/missing-openai.yml" <<'CONFIG'
-server:
-  service_secret: "service-secret"
+tenants:
+  - id: coverage
+    secret: "service-secret"
 providers:
   openai: {}
 CONFIG

--- a/scripts/test_live_gemini.sh
+++ b/scripts/test_live_gemini.sh
@@ -83,12 +83,15 @@ GOEXPERIMENT= CGO_ENABLED=0 "${GO_BIN}" build -o "${BINARY_PATH}" ./cmd/cli
 
 cat > "${CONFIG_PATH}" <<'CONFIG'
 server:
-  service_secret: "${SERVICE_SECRET}"
   port: ${LLM_PROXY_LIVE_PORT}
   log_level: info
-defaults:
-  provider: gemini
-  dictation_provider: openai
+tenants:
+  - id: gemini-live
+    secret: "${SERVICE_SECRET}"
+    defaults:
+      provider: gemini
+      model: gemini-3.5-flash
+      dictation_provider: openai
 providers:
   openai:
     api_key: "${OPENAI_API_KEY}"

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -79,12 +79,12 @@ func TestIntegration_OmitsDisallowedParameters(testingInstance *testing.T) {
 			defer logger.Sync()
 
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-				ServiceSecret: serviceSecret,
-				OpenAIKey:     openAIKey,
-				LogLevel:      logLevel,
-				WorkerCount:   1,
-				QueueSize:     4,
-				Endpoints:     endpoints,
+				Tenants:     proxy.SingleTenantConfigurations("capabilities", serviceSecret),
+				OpenAIKey:   openAIKey,
+				LogLevel:    logLevel,
+				WorkerCount: 1,
+				QueueSize:   4,
+				Endpoints:   endpoints,
 			}, logger.Sugar())
 			if buildRouterError != nil {
 				subTestInstance.Fatalf("BuildRouter error: %v", buildRouterError)

--- a/tests/integration/high_load_queue_test.go
+++ b/tests/integration/high_load_queue_test.go
@@ -71,7 +71,7 @@ func TestIntegrationHighLoadQueue(testingInstance *testing.T) {
 	client := makeBlockingHTTPClient(testingInstance, endpoints, upstreamRequestStarted, releaseResponses)
 	configureProxy(testingInstance, client, endpoints)
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:         serviceSecretValue,
+		Tenants:               proxy.SingleTenantConfigurations("integration", serviceSecretValue),
 		OpenAIKey:             openAIKeyValue,
 		LogLevel:              logLevelDebug,
 		WorkerCount:           singleWorkerCount,

--- a/tests/integration/integration1_test.go
+++ b/tests/integration/integration1_test.go
@@ -48,7 +48,7 @@ func newIntegrationServerWithTimeout(testingInstance *testing.T, openAIServer *h
 	logger, _ := zap.NewDevelopment()
 	testingInstance.Cleanup(func() { _ = logger.Sync() })
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:         integrationServiceSecret,
+		Tenants:               proxy.SingleTenantConfigurations("integration", integrationServiceSecret),
 		OpenAIKey:             integrationOpenAIKey,
 		LogLevel:              logLevelDebug,
 		WorkerCount:           1,

--- a/tests/integration/integration2_test.go
+++ b/tests/integration/integration2_test.go
@@ -34,12 +34,12 @@ func TestClientResponseDelivery(testingInstance *testing.T) {
 			client, captured := makeHTTPClient(subTest, testCase.webSearch, endpoints)
 			configureProxy(subTest, client, endpoints)
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-				ServiceSecret: serviceSecretValue,
-				OpenAIKey:     openAIKeyValue,
-				LogLevel:      logLevelDebug,
-				WorkerCount:   1,
-				QueueSize:     8,
-				Endpoints:     endpoints,
+				Tenants:     proxy.SingleTenantConfigurations("integration", serviceSecretValue),
+				OpenAIKey:   openAIKeyValue,
+				LogLevel:    logLevelDebug,
+				WorkerCount: 1,
+				QueueSize:   8,
+				Endpoints:   endpoints,
 			}, newLogger(subTest))
 			if buildRouterError != nil {
 				subTest.Fatalf(buildRouterFailedFormat, buildRouterError)
@@ -91,18 +91,18 @@ func TestIntegrationConfiguration(testingInstance *testing.T) {
 		expectError    string
 	}{
 		{
-			name:        "missing_service_secret",
-			config:      proxy.Configuration{ServiceSecret: constants.EmptyString, OpenAIKey: openAIKeyValue},
-			expectError: "server.service_secret",
+			name:        "missing_tenants",
+			config:      proxy.Configuration{OpenAIKey: openAIKeyValue},
+			expectError: "tenants",
 		},
 		{
 			name:        "missing_openai_key",
-			config:      proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: constants.EmptyString},
-			expectError: "providers.openai.api_key",
+			config:      proxy.Configuration{Tenants: proxy.SingleTenantConfigurations("integration", serviceSecretValue), OpenAIKey: constants.EmptyString},
+			expectError: "provider not configured: provider=openai",
 		},
 		{
 			name:           "wrong_key",
-			config:         proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 4},
+			config:         proxy.Configuration{Tenants: proxy.SingleTenantConfigurations("integration", serviceSecretValue), OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 4},
 			requestKey:     "wrong",
 			expectedStatus: http.StatusForbidden,
 		},

--- a/tests/integration/integration_adaptive_test.go
+++ b/tests/integration/integration_adaptive_test.go
@@ -85,12 +85,12 @@ func newAdaptiveRouter(testingInstance *testing.T, mode string) *gin.Engine {
 	logger, _ := zap.NewDevelopment()
 	testingInstance.Cleanup(func() { _ = logger.Sync() })
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: serviceSecretValue,
-		OpenAIKey:     openAIKeyValue,
-		LogLevel:      logLevelDebug,
-		WorkerCount:   1,
-		QueueSize:     8,
-		Endpoints:     endpoints,
+		Tenants:     proxy.SingleTenantConfigurations("integration", serviceSecretValue),
+		OpenAIKey:   openAIKeyValue,
+		LogLevel:    logLevelDebug,
+		WorkerCount: 1,
+		QueueSize:   8,
+		Endpoints:   endpoints,
 	}, logger.Sugar())
 	if buildRouterError != nil {
 		testingInstance.Fatalf("BuildRouter failed: %v", buildRouterError)

--- a/tests/integration/integration_models_test.go
+++ b/tests/integration/integration_models_test.go
@@ -25,12 +25,12 @@ func TestIntegrationModelSpecSuppression(testingInstance *testing.T) {
 			client, captured := makeHTTPClient(subTest, true, endpoints)
 			configureProxy(subTest, client, endpoints)
 			router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-				ServiceSecret: serviceSecretValue,
-				OpenAIKey:     openAIKeyValue,
-				LogLevel:      logLevelDebug,
-				WorkerCount:   1,
-				QueueSize:     8,
-				Endpoints:     endpoints,
+				Tenants:     proxy.SingleTenantConfigurations("integration", serviceSecretValue),
+				OpenAIKey:   openAIKeyValue,
+				LogLevel:    logLevelDebug,
+				WorkerCount: 1,
+				QueueSize:   8,
+				Endpoints:   endpoints,
 			}, newLogger(subTest))
 			if buildRouterError != nil {
 				subTest.Fatalf(buildRouterFailedFormat, buildRouterError)
@@ -75,12 +75,12 @@ func TestIntegrationGPT5TemperatureSuppression(testingInstance *testing.T) {
 	client, captured := makeHTTPClient(testingInstance, true, endpoints)
 	configureProxy(testingInstance, client, endpoints)
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: serviceSecretValue,
-		OpenAIKey:     openAIKeyValue,
-		LogLevel:      logLevelDebug,
-		WorkerCount:   1,
-		QueueSize:     8,
-		Endpoints:     endpoints,
+		Tenants:     proxy.SingleTenantConfigurations("integration", serviceSecretValue),
+		OpenAIKey:   openAIKeyValue,
+		LogLevel:    logLevelDebug,
+		WorkerCount: 1,
+		QueueSize:   8,
+		Endpoints:   endpoints,
 	}, newLogger(testingInstance))
 	if buildRouterError != nil {
 		testingInstance.Fatalf(buildRouterFailedFormat, buildRouterError)

--- a/tests/integration/long_request_test.go
+++ b/tests/integration/long_request_test.go
@@ -61,7 +61,7 @@ func TestIntegrationResponseDeliveredAfterUpstreamRelease(testingInstance *testi
 			requestErrors := make(chan error, 1)
 			endpoints := proxy.NewEndpoints()
 			configureProxy(subTest, makeControlledResponseHTTPClient(subTest, endpoints, upstreamRequestStarted, releaseResponse), endpoints)
-			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: requestTimeoutSecondsDefault, Endpoints: endpoints}, newLogger(subTest))
+			router, buildError := proxy.BuildRouter(proxy.Configuration{Tenants: proxy.SingleTenantConfigurations("integration", serviceSecretValue), OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: requestTimeoutSecondsDefault, Endpoints: endpoints}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf(buildRouterFailedFormat, buildError)
 			}

--- a/tests/integration/missing_prompt_test.go
+++ b/tests/integration/missing_prompt_test.go
@@ -19,7 +19,7 @@ func TestRequestWithoutPromptReturnsMissingPromptError(testingInstance *testing.
 	endpoints := proxy.NewEndpoints()
 	client, _ := makeHTTPClient(testingInstance, false, endpoints)
 	configureProxy(testingInstance, client, endpoints)
-	router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, Endpoints: endpoints}, newLogger(testingInstance))
+	router, buildError := proxy.BuildRouter(proxy.Configuration{Tenants: proxy.SingleTenantConfigurations("integration", serviceSecretValue), OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, Endpoints: endpoints}, newLogger(testingInstance))
 	if buildError != nil {
 		testingInstance.Fatalf("BuildRouter failed: %v", buildError)
 	}

--- a/tests/integration/request_timeout_test.go
+++ b/tests/integration/request_timeout_test.go
@@ -100,7 +100,7 @@ func TestIntegrationGatewayContextTimeoutCancelsUpstreamRequest(testingInstance 
 	loggerInstance := zap.New(observedCore)
 	testingInstance.Cleanup(func() { _ = loggerInstance.Sync() })
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:                serviceSecretValue,
+		Tenants:                      proxy.SingleTenantConfigurations("integration", serviceSecretValue),
 		OpenAIKey:                    openAIKeyValue,
 		LogLevel:                     logLevelDebug,
 		WorkerCount:                  1,
@@ -108,10 +108,6 @@ func TestIntegrationGatewayContextTimeoutCancelsUpstreamRequest(testingInstance 
 		RequestTimeoutSeconds:        gatewayContextProxyTimeout,
 		UpstreamPollTimeoutSeconds:   gatewayContextProxyTimeout,
 		Endpoints:                    endpoints,
-		DefaultDictationProvider:     proxy.ProviderNameOpenAI,
-		DefaultProvider:              proxy.ProviderNameOpenAI,
-		DefaultModel:                 proxy.DefaultModel,
-		DictationModel:               proxy.DefaultDictationModel,
 		MaxPromptBytes:               proxy.DefaultMaxPromptBytes,
 		MaxInputAudioBytes:           proxy.DefaultMaxInputAudioBytes,
 		DeepSeekBaseURL:              "https://deepseek.invalid",
@@ -167,7 +163,7 @@ func TestIntegrationUpstreamRequestTimeoutTriggersGatewayTimeout(testingInstance
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			endpoints := proxy.NewEndpoints()
 			configureProxy(subTest, makeTimeoutHTTPClient(subTest, endpoints), endpoints)
-			router, buildError := proxy.BuildRouter(proxy.Configuration{ServiceSecret: serviceSecretValue, OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: timeoutRequestTimeout, Endpoints: endpoints}, newLogger(subTest))
+			router, buildError := proxy.BuildRouter(proxy.Configuration{Tenants: proxy.SingleTenantConfigurations("integration", serviceSecretValue), OpenAIKey: openAIKeyValue, LogLevel: logLevelDebug, WorkerCount: 1, QueueSize: 8, RequestTimeoutSeconds: timeoutRequestTimeout, Endpoints: endpoints}, newLogger(subTest))
 			if buildError != nil {
 				subTest.Fatalf("BuildRouter failed: %v", buildError)
 			}

--- a/tests/integration/semantic_review_test.go
+++ b/tests/integration/semantic_review_test.go
@@ -124,7 +124,7 @@ func TestIntegrationLargeSemanticReviewPostUsesRequestMaxTokens(testingInstance 
 	proxy.HTTPClient = openAIServer.Client()
 	testingInstance.Cleanup(func() { proxy.HTTPClient = originalClient })
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:              serviceSecretValue,
+		Tenants:                    proxy.SingleTenantConfigurations("integration", serviceSecretValue),
 		OpenAIKey:                  openAIKeyValue,
 		LogLevel:                   logLevelDebug,
 		WorkerCount:                1,

--- a/tests/integration/test_helpers_test.go
+++ b/tests/integration/test_helpers_test.go
@@ -127,12 +127,12 @@ func newIntegrationServer(testingInstance *testing.T, openAIServer *httptest.Ser
 	loggerInstance, _ := zap.NewDevelopment()
 	testingInstance.Cleanup(func() { _ = loggerInstance.Sync() })
 	router, buildRouterError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret: integrationServiceSecret,
-		OpenAIKey:     integrationOpenAIKey,
-		LogLevel:      logLevelDebug,
-		WorkerCount:   1,
-		QueueSize:     4,
-		Endpoints:     endpoints,
+		Tenants:     proxy.SingleTenantConfigurations("integration", integrationServiceSecret),
+		OpenAIKey:   integrationOpenAIKey,
+		LogLevel:    logLevelDebug,
+		WorkerCount: 1,
+		QueueSize:   4,
+		Endpoints:   endpoints,
 	}, loggerInstance.Sugar())
 	if buildRouterError != nil {
 		testingInstance.Fatalf(buildRouterErrorFormat, buildRouterError)

--- a/tests/llm-proxy/serve_test.go
+++ b/tests/llm-proxy/serve_test.go
@@ -64,7 +64,7 @@ func newRouterWithStubbedOpenAI(testingInstance *testing.T, modelsBody, response
 	logger, _ := zap.NewDevelopment()
 	defer logger.Sync()
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
-		ServiceSecret:         "sekret",
+		Tenants:               proxy.SingleTenantConfigurations("test", "sekret"),
 		OpenAIKey:             "sk-test",
 		LogLevel:              "debug",
 		WorkerCount:           workerCount,


### PR DESCRIPTION
This update replaces the previous global default configuration and single service secret with a multi-tenant configuration model. Each tenant now has its own unique secret and default provider settings, enabling per-tenant authentication and customization of provider defaults such as model and dictation settings. The configuration, CLI, tests, and documentation have been revised to support tenant-based secrets and defaults, improving security and flexibility by isolating tenant configurations and removing reliance on a single shared secret. Provider selection now defaults to the authenticated tenant's settings rather than a global default.