### PR TITLE
gix/update-default-gateway-deploy-target-to-deploy-llm-proxy

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -103,6 +103,15 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   [SSL] record layer failure (_ssl.c:2658)
   ```
   The forced-chunked `gpt-5-mini` retry also failed with the same SSL record-layer error before materialization. The small control request reported `semantic-stress-qa` passed with `transport: post`, `invocationMode: single`, and `materialize` passed.
+
+  2026-06-10 live retry after updating the Russian-language caller to the current v2 Python client contract (`ClientMessagesRequest` + `POST /v2`) still failed against `https://llm-proxy.mprlab.com` for the 8,528-character Camu story. Focused Russian-language transport tests passed, and a tiny live v2 pipeline smoke reached `semantic-stress-qa` and `materialize`. The long story failed before materialization with:
+  ```text
+  llm_proxy_client_transport_failure: provider=omitted model=gpt-5.5 timeout_seconds=240 reason=[SSL] record layer failure (_ssl.c:2658)
+  llm_proxy_client_transport_failure: provider=omitted model=gpt-5-mini timeout_seconds=600 reason=[SSL] record layer failure (_ssl.c:2658)
+  ```
+  Failed variants included normal v2 POST with `--llm-proxy-timeout-seconds 240 --llm-proxy-chunk-chars 1800`, forced chunking with `--llm-proxy-chunk-chars 900`, and forced chunking with `--llm-proxy-model gpt-5-mini --llm-proxy-timeout-seconds 600 --llm-proxy-chunk-chars 450`. This suggests the current branch/local replay fix has not reached, or is not sufficient for, the deployed default live endpoint used by Camu.
+
+  2026-06-10 deployed gateway inspection found the public `llm-proxy` Caddy transport using `response_header_timeout 240s` and `read_timeout 240s`, exactly equal to the canonical `server.request_timeout_seconds: 240` staged from `configs/config.yml`. That can race the proxy-owned final response or structured `504` and surface as an SSL record-layer failure from the public TLS endpoint. The sibling `mprlab-gateway` MG-336 patch now keeps the canonical proxy config unchanged, raises the dedicated Caddy transport to 300 seconds so llm-proxy owns the final success/error response, and adds a narrow `deploy-llm-proxy` gateway target. The llm-proxy deploy wrapper now defaults to that target. B002 remains open until `make deploy-llm-proxy` is completed and the long Camu story is retried against `https://llm-proxy.mprlab.com`; a first deploy attempt paused at `Gateway sudo password:` and was aborted before remote staging because no password was entered.
   ### Expected
   Long semantic-review POSTs should either complete successfully or return a structured proxy/provider error that the client can classify and retry. The proxy should not leave clients with opaque transport failures after the upstream request may still be in progress or recoverable.
   ### Acceptance Criteria

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DOCKER_IMAGE ?= ghcr.io/tyemirov/llm-proxy
 PUBLISH_REMOTE ?= origin
 PUBLISH_BRANCH ?= master
 GATEWAY_DIR ?=
-GATEWAY_DEPLOY_TARGET ?= deploy-gateway
+GATEWAY_DEPLOY_TARGET ?= deploy-llm-proxy
 
 GO_SOURCES := $(shell find . -name '*.go' -not -path './vendor/*')
 

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ command-specific `RELEASE_CI_TIMEOUT_SECONDS`, `PUBLISH_CI_TIMEOUT_SECONDS`,
 and `DEPLOY_CI_TIMEOUT_SECONDS` variables.
 
 `llm-proxy` is a gateway-local service in `mprlab-gateway`, so `make deploy`
-defaults to the gateway `deploy-gateway` target. Override the checkout or target
+defaults to the gateway `deploy-llm-proxy` target. Override the checkout or target
 with `GATEWAY_DIR=/path/to/mprlab-gateway` or
 `GATEWAY_DEPLOY_TARGET=<target>`.
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,11 +8,11 @@ Usage:
 
 Deploys llm-proxy through mprlab-gateway after verifying the release image has
 been published. llm-proxy is gateway-colocated, so the default gateway target is
-deploy-gateway.
+deploy-llm-proxy.
 
 Options:
   --gateway-dir <path>  Gateway checkout. Default: $GATEWAY_DIR or sibling ../mprlab-gateway
-  --gateway-target <target> Gateway make target. Default: $GATEWAY_DEPLOY_TARGET or deploy-gateway
+  --gateway-target <target> Gateway make target. Default: $GATEWAY_DEPLOY_TARGET or deploy-llm-proxy
   --image <value>       Image repository. Default: $DOCKER_IMAGE or ghcr.io/tyemirov/llm-proxy
   --tag <value>         Release tag. Default: v* tag pointing at HEAD
   --skip-ci             Skip the local make ci deployment gate
@@ -49,7 +49,7 @@ env_or_default() {
 }
 
 GATEWAY_DIR="$(env_or_default GATEWAY_DIR "")"
-GATEWAY_TARGET="$(env_or_default GATEWAY_DEPLOY_TARGET deploy-gateway)"
+GATEWAY_TARGET="$(env_or_default GATEWAY_DEPLOY_TARGET deploy-llm-proxy)"
 IMAGE_REPOSITORY="$(env_or_default DOCKER_IMAGE ghcr.io/tyemirov/llm-proxy)"
 TAG="$(env_or_default DEPLOY_TAG "")"
 SKIP_CI="false"


### PR DESCRIPTION
### Summary

This update changes the default deployment target from `deploy-gateway` to `deploy-llm-proxy` across the Makefile, deployment script, and documentation. It aligns the default deployment process with the newly introduced `deploy-llm-proxy` target, which is designed to address live retry and gateway timeout issues observed with the previous setup.

### Details

- The Makefile default `GATEWAY_DEPLOY_TARGET` is updated to `deploy-llm-proxy`.
- The deployment script's default gateway target and usage instructions now reference `deploy-llm-proxy`.
- README documentation is corrected to reflect the new default deploy target.
- The `.mprlab/ISSUES.md` file adds analysis on live retry failures and gateway timeout configurations, explaining the motivation behind raising the Caddy transport timeout and introducing the `deploy-llm-proxy` target to ensure more reliable long request handling.

This change improves deployment reliability by ensuring the proxy owns the final response timeout, preventing opaque SSL record-layer failures during long-running requests.