### PR TITLE
gix/enforce-help-output-contract-and-heredoc-prohibition-for

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -380,7 +380,7 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   ### Resolution
   Pages deployment now resolves `git remote get-url --push` before release download, compares that effective destination with the configured fetch repository identity, and restricts `GH_REPO` fallback to fetch scoping so a different unparseable push target cannot inherit the expected identity. The deployment clone receives the validated URL as an explicit `pushurl`, its checkout-effective destination is validated again, and the branch is pushed by remote name so Git cannot apply `pushInsteadOf` a second time. Black-box coverage proves parseable and unparseable mismatched rewrites fail before GitHub access or either branch mutation, and a chained `A -> B -> C` rewrite deploys only to the validated `B` repository. Validation passed with `timeout -k 350s -s SIGKILL 350s make release-test` (30 tests), `git diff --check`, and an independent review with no remaining findings.
 
-- [ ] [B023] (P1) Preserve Pages release markers under branch publishing.
+- [x] [B023] (P1) Preserve Pages release markers under branch publishing.
   ### Summary
   Repository-owned Pages artifacts can omit `.nojekyll`, allowing legacy branch publishing to filter the hidden `.mprlab-release.json` marker even when the deployed branch contains it. The artifact and public-marker contract also needs explicit black-box proof for schema, release version, source provenance, and the distinct release-tag commit.
   ### Acceptance Criteria
@@ -390,8 +390,21 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   4. Black-box coverage proves the remote tag matches `release_commit` while artifact and public marker provenance match the distinct `source_commit`.
   ### Implementation
   The Pages builder now creates an empty `.nojekyll` after copying the source tree, archive validation rejects payloads without it, and public verification checks the complete marker identity rather than source commit alone. Release-pipeline coverage now inspects the builder's tarball and marker, exercises missing `.nojekyll` and invalid marker fields, and proves a release succeeds with intentionally different release and source commits.
-  ### Validation
-  Pending: `make release-test` and `make ci` were not authorized for this implementation pass, so B023 remains unresolved.
+  ### Resolution
+  The Pages builder now creates an empty `.nojekyll` after copying the source tree, archive validation rejects payloads without it before branch mutation, and public verification checks the complete marker identity rather than source commit alone. Release-pipeline coverage inspects the builder's tarball and marker, exercises missing `.nojekyll` and invalid marker fields, and proves a release succeeds with intentionally different release and source commits. Validation passed with `make release-test` (35 tests) and `make ci` (Go aggregate coverage 100.0%, Python 20 passed, Playwright 12 passed, release integrations 35 passed, and the live-provider preflight passed).
+
+- [x] [B024] (P1) Prevent shell help deadlocks under constrained pipe limits.
+  ### Summary
+  The first release after the repository-owned toolchain changes stalls in `TestOperationalReleaseWrapperUsesRepositoryOwnedTools` until the outer 350-second CI guard sends `SIGKILL`. On shells with `ulimit -p 1`, Bash can block while staging a heredoc larger than the 512-byte pipe capacity before the external reader starts; the same pattern exists across release, deployment, artifact, coverage, publication, and live-provider scripts, including later Python transforms on the default release path.
+  ### Acceptance Criteria
+  1. CI, release, publish, deployment, artifact, Pages, and live-provider shell scripts do not feed external commands through heredocs.
+  2. Release, deployment, artifact, Pages, container publication, and live-provider help commands terminate under the constrained-pipe shell contract.
+  3. Dotenv parsing, coverage fixture generation, Pages marker generation, and container metadata transforms retain their exact current contracts without pipe-capacity dependence.
+  4. Tracked container build context extraction preserves the complete `git archive HEAD` snapshot without a producer/consumer pipe that can surface a false `SIGPIPE` failure.
+  5. Black-box operational coverage bounds help execution and rejects reintroduction of an external usage writer.
+  6. The focused operational test, Go coverage suite, release integration suite, and full `make ci` gate pass without increasing the CI timeout.
+  ### Resolution
+  Replaced external-command heredocs across CI, release, publish, deployment, artifact, Pages, and live-provider scripts with Bash builtin output or direct Python command bodies, removing the pre-reader pipe staging that deadlocked with `ulimit -p 1`. Container build context extraction now writes `git archive HEAD` to a temporary tar before extraction so a completed reader cannot turn padding writes into a false `SIGPIPE` failure. Black-box operational coverage bounds every help command under the constrained-pipe contract, rejects shell heredocs in the governed script trees, validates the canonical container descriptor, and retains the existing dotenv, Pages marker, and publication coverage. Validation passed with focused operational tests, `bash -n`, `make go-test` (aggregate coverage 100.0%), `make release-test` (35 tests), `git diff --check`, and the unchanged 350-second `make ci` gate in 77.66 seconds.
 
 
 ## Improvements

--- a/scripts/build-container-artifact.sh
+++ b/scripts/build-container-artifact.sh
@@ -8,9 +8,15 @@ done
 
 repo_root="$(git rev-parse --show-toplevel)"
 source_directory="$(mktemp -d)"
-trap 'rm -rf "${source_directory}"' EXIT
+source_archive="$(mktemp)"
+cleanup() {
+  rm -rf "${source_directory}"
+  rm -f "${source_archive}"
+}
+trap cleanup EXIT
 
-git -C "${repo_root}" archive --format=tar HEAD | tar -xf - -C "${source_directory}"
+git -C "${repo_root}" archive --format=tar --output="${source_archive}" HEAD
+tar -xf "${source_archive}" -C "${source_directory}"
 "${RELEASE_TOOL_DIR}/prepare_container_artifact.sh" \
   --name llm-proxy \
   --image "${DOCKER_IMAGE:-ghcr.io/tyemirov/llm-proxy}" \

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -31,13 +31,11 @@ run_coverage_probe() {
 "$GO_BIN" build -cover -covermode=count -coverpkg="$RUNTIME_COVERPKG" -o "$TMP_DIR/llm-proxy.cover" ./cmd/cli
 "$GO_BIN" build -cover -covermode=count -coverpkg="$CLIENT_COVERPKG" -o "$TMP_DIR/llm-proxy-client.cover" ./llm-proxy-client
 
-cat > "$TMP_DIR/missing-openai.yml" <<'CONFIG'
-tenants:
+builtin printf '%s\n' 'tenants:
   - id: coverage
     secret: "service-secret"
 providers:
-  openai: {}
-CONFIG
+  openai: {}' >"$TMP_DIR/missing-openai.yml"
 
 mkdir -p "$TMP_DIR/cov-help" "$TMP_DIR/cov-missing-config" "$TMP_DIR/cov-missing-openai" "$TMP_DIR/cov-client-missing-config"
 run_coverage_probe "$TMP_DIR/cov-help" "$TMP_DIR/llm-proxy.cover" --help

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
-Usage:
+  builtin printf '%s\n' 'Usage:
   scripts/deploy.sh [options]
 
 Deploys llm-proxy after verifying the release image and Pages archive were
@@ -24,8 +23,7 @@ Options:
   --help                Show this help text
 
 Environment:
-  DEPLOY_CI_TIMEOUT_SECONDS  make ci timeout in seconds. Default: $LLM_PROXY_CI_TIMEOUT_SECONDS or 350
-USAGE
+  DEPLOY_CI_TIMEOUT_SECONDS  make ci timeout in seconds. Default: $LLM_PROXY_CI_TIMEOUT_SECONDS or 350'
 }
 
 require_positive_integer() {

--- a/scripts/test_live_providers.sh
+++ b/scripts/test_live_providers.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
-Usage:
+  builtin printf '%s\n' 'Usage:
   scripts/test_live_providers.sh [--preflight | --write-config <path>]
 
 Builds the current llm-proxy binary and runs live text smoke tests for providers
@@ -51,8 +50,7 @@ Per-provider model overrides:
   LLM_PROXY_LIVE_GEMINI_MODEL
   LLM_PROXY_LIVE_ANTHROPIC_MODEL
   LLM_PROXY_LIVE_META_MODEL
-  LLM_PROXY_LIVE_GROK_MODEL
-USAGE
+  LLM_PROXY_LIVE_GROK_MODEL'
 }
 
 env_or_default() {
@@ -73,7 +71,7 @@ load_env_file() {
   local env_path="$1"
   local parsed_path="${TMP_DIR}/dotenv-values"
   command -v python3 >/dev/null 2>&1 || { echo "error: python3 is required to load LIVE_ENV_FILE" >&2; exit 1; }
-  python3 - "${env_path}" >"${parsed_path}" <<'PY'
+  python3 -c '
 import ast
 import pathlib
 import re
@@ -93,13 +91,13 @@ for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlin
     if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
         raise SystemExit(f"invalid dotenv name: {path}:{line_number}")
     value = raw_value.strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {chr(39), chr(34)}:
         parsed_value = ast.literal_eval(value)
         if not isinstance(parsed_value, str):
             raise SystemExit(f"invalid dotenv value: {path}:{line_number}")
         value = parsed_value
     sys.stdout.buffer.write(name.encode("utf-8") + b"\0" + value.encode("utf-8") + b"\0")
-PY
+' "${env_path}" >"${parsed_path}"
 
   local variable_name
   local variable_value

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -1,16 +1,24 @@
 package tests_test
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
 	operationalScriptsDirectory     = "scripts"
 	operationalReleaseToolsRelative = "tools/gitrelease"
+	operationalHelpTimeout          = 5 * time.Second
+	operationalHelpWaitDelay        = time.Second
+	constrainedPipeHelpCommand      = `ulimit -p 1 2>/dev/null || true
+exec "$@"`
 )
 
 func TestOperationalReleaseWrapperUsesRepositoryOwnedTools(testingInstance *testing.T) {
@@ -20,14 +28,79 @@ func TestOperationalReleaseWrapperUsesRepositoryOwnedTools(testingInstance *test
 	copyOperationalDirectory(testingInstance, filepath.Join(repositoryRoot, operationalReleaseToolsRelative), filepath.Join(fixtureRoot, operationalReleaseToolsRelative))
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "init")
 
-	command := exec.Command(filepath.Join(fixtureRoot, operationalScriptsDirectory, "release.sh"), "--help")
-	command.Dir = fixtureRoot
-	output, commandError := command.CombinedOutput()
-	if commandError != nil {
-		testingInstance.Fatalf("repository-owned release wrapper failed: %v\n%s", commandError, output)
-	}
+	output := runOperationalHelpCommand(
+		testingInstance,
+		fixtureRoot,
+		filepath.Join(fixtureRoot, operationalScriptsDirectory, "release.sh"),
+		"--help",
+		nil,
+	)
 	if !strings.Contains(string(output), "Prepares a release entirely from local repository state") {
 		testingInstance.Fatalf("unexpected release help output: %s", output)
+	}
+}
+
+func TestOperationalHelpCommandsUseBuiltinOutput(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	restrictedPath := testingInstance.TempDir()
+	helpCommands := []struct {
+		name             string
+		path             string
+		expectedFragment string
+	}{
+		{name: "deploy", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "deploy.sh"), expectedFragment: "scripts/deploy.sh [options]"},
+		{name: "live-providers", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), expectedFragment: "scripts/test_live_providers.sh [--preflight | --write-config <path>]"},
+		{name: "deploy-pages", path: filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "deploy_pages_artifact.sh"), expectedFragment: "deploy_pages_artifact.sh --url <public-url> [options]"},
+		{name: "prepare-container", path: filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "prepare_container_artifact.sh"), expectedFragment: "prepare_container_artifact.sh --name <name> --image <registry/repository> [options]"},
+		{name: "prepare-pages", path: filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "prepare_pages_artifact.sh"), expectedFragment: "prepare_pages_artifact.sh --source <directory> [options]"},
+		{name: "prepare-release", path: filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "prepare_release.sh"), expectedFragment: "prepare_release.sh [options]"},
+		{name: "publish-container", path: filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "publish_container_artifacts.sh"), expectedFragment: "publish_container_artifacts.sh"},
+	}
+	for _, helpCommand := range helpCommands {
+		for _, helpArgument := range []string{"--help", "-h"} {
+			testingInstance.Run(helpCommand.name+"/"+helpArgument, func(testingInstance *testing.T) {
+				output := runOperationalHelpCommand(
+					testingInstance,
+					repositoryRoot,
+					helpCommand.path,
+					helpArgument,
+					[]string{"PATH=" + restrictedPath},
+				)
+				if !strings.Contains(output, helpCommand.expectedFragment) {
+					testingInstance.Fatalf("unexpected help output for %s: %s", helpCommand.path, output)
+				}
+			})
+		}
+	}
+}
+
+func TestOperationalShellScriptsDoNotUseHeredocs(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	heredocPattern := regexp.MustCompile(`<<-?[[:space:]]*['"]?[A-Za-z_][A-Za-z0-9_]*['"]?`)
+	offendingScripts := []string{}
+	for _, relativeRoot := range []string{operationalScriptsDirectory, filepath.Join(operationalReleaseToolsRelative, "scripts")} {
+		walkError := filepath.Walk(filepath.Join(repositoryRoot, relativeRoot), func(path string, fileInfo os.FileInfo, pathError error) error {
+			if pathError != nil {
+				return pathError
+			}
+			if fileInfo.IsDir() || filepath.Ext(path) != ".sh" {
+				return nil
+			}
+			fileBytes, readError := os.ReadFile(path)
+			if readError != nil {
+				return readError
+			}
+			if heredocPattern.Match(fileBytes) {
+				offendingScripts = append(offendingScripts, path)
+			}
+			return nil
+		})
+		if walkError != nil {
+			testingInstance.Fatalf("scan shell scripts under %s: %v", relativeRoot, walkError)
+		}
+	}
+	if len(offendingScripts) != 0 {
+		testingInstance.Fatalf("shell scripts feed external commands through heredocs: %s", strings.Join(offendingScripts, ", "))
 	}
 }
 
@@ -60,6 +133,89 @@ done
 	writeOperationalFile(testingInstance, filepath.Join(toolDirectory, "prepare_container_artifact.sh"), fakeTool, 0o755)
 	environment := append(os.Environ(), "RELEASE_TOOL_DIR="+toolDirectory)
 	runOperationalCommand(testingInstance, fixtureRoot, environment, filepath.Join(fixtureRoot, operationalScriptsDirectory, "build-container-artifact.sh"))
+}
+
+func TestOperationalContainerArtifactWritesCanonicalDescriptor(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	artifactDirectory := filepath.Join(fixtureRoot, "release-artifact")
+	writeOperationalFile(testingInstance, filepath.Join(fixtureRoot, "Dockerfile"), "FROM scratch\n", 0o644)
+	writeOperationalFile(testingInstance, filepath.Join(artifactDirectory, "staging.json"), "{}\n", 0o644)
+	fakeBinaryDirectory := filepath.Join(fixtureRoot, "bin")
+	fakeDocker := `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "buildx" && "$2" == "version" ]]; then exit 0; fi
+if [[ "$1" == "buildx" && "$2" == "build" ]]; then exit 0; fi
+if [[ "$1" == "image" && "$2" == "inspect" ]]; then builtin printf '%s\n' 'sha256:fixture-image'; exit 0; fi
+if [[ "$1" == "save" ]]; then
+  output=""
+  shift
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--output" ]]; then output="$2"; shift 2; else shift; fi
+  done
+  [[ -n "${output}" ]]
+  builtin printf '%s\n' 'fixture-archive' >"${output}"
+  exit 0
+fi
+echo "unsupported fake Docker command: $*" >&2
+exit 1
+`
+	writeOperationalFile(testingInstance, filepath.Join(fakeBinaryDirectory, "docker"), fakeDocker, 0o755)
+	environment := append(
+		os.Environ(),
+		"PATH="+fakeBinaryDirectory+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"RELEASE_VERSION=v1.2.3",
+		"RELEASE_ARTIFACT_DIR="+artifactDirectory,
+		"RELEASE_CONTAINER_BUILD_TIMEOUT_SECONDS=5",
+		"RELEASE_CONTAINER_SAVE_TIMEOUT_SECONDS=5",
+	)
+	runOperationalCommand(
+		testingInstance,
+		fixtureRoot,
+		environment,
+		filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "prepare_container_artifact.sh"),
+		"--name", "fixture",
+		"--image", "example/fixture",
+		"--file", "Dockerfile",
+		"--context", ".",
+		"--platforms", "linux/amd64",
+	)
+	descriptorPath := filepath.Join(artifactDirectory, "payloads", "containers", "fixture", "container.json")
+	descriptorBytes, readError := os.ReadFile(descriptorPath)
+	if readError != nil {
+		testingInstance.Fatalf("read container descriptor: %v", readError)
+	}
+	var descriptor struct {
+		SchemaVersion int    `json:"schema_version"`
+		ArtifactKind  string `json:"artifact_kind"`
+		Name          string `json:"name"`
+		Image         string `json:"image"`
+		Version       string `json:"version"`
+		Platforms     []struct {
+			Platform string `json:"platform"`
+			Token    string `json:"token"`
+			LocalRef string `json:"local_ref"`
+			ImageID  string `json:"image_id"`
+			Archive  string `json:"archive"`
+			SHA256   string `json:"sha256"`
+		} `json:"platforms"`
+	}
+	if unmarshalError := json.Unmarshal(descriptorBytes, &descriptor); unmarshalError != nil {
+		testingInstance.Fatalf("parse container descriptor: %v", unmarshalError)
+	}
+	if descriptor.SchemaVersion != 1 || descriptor.ArtifactKind != "mprlab.container" {
+		testingInstance.Fatalf("unexpected container descriptor contract: %s", descriptorBytes)
+	}
+	if descriptor.Name != "fixture" || descriptor.Image != "example/fixture" || descriptor.Version != "v1.2.3" {
+		testingInstance.Fatalf("unexpected container descriptor identity: %s", descriptorBytes)
+	}
+	if len(descriptor.Platforms) != 1 {
+		testingInstance.Fatalf("unexpected container descriptor platforms: %s", descriptorBytes)
+	}
+	platform := descriptor.Platforms[0]
+	if platform.Platform != "linux/amd64" || platform.Token != "linux-amd64" || platform.LocalRef != "mprlab-release.local/fixture:v1.2.3-linux-amd64" || platform.ImageID != "sha256:fixture-image" || platform.Archive != "payloads/containers/fixture/linux-amd64.tar" || platform.SHA256 == "" {
+		testingInstance.Fatalf("unexpected container platform descriptor: %s", descriptorBytes)
+	}
 }
 
 func TestOperationalDeployNoopMatchesGatewayVerifier(testingInstance *testing.T) {
@@ -328,6 +484,45 @@ func writeOperationalFile(testingInstance *testing.T, path string, contents stri
 	if writeError := os.WriteFile(path, []byte(contents), permissions); writeError != nil {
 		testingInstance.Fatalf("write operational file %s: %v", path, writeError)
 	}
+}
+
+func runOperationalHelpCommand(
+	testingInstance *testing.T,
+	directory string,
+	scriptPath string,
+	helpArgument string,
+	environment []string,
+) string {
+	testingInstance.Helper()
+	bashPath, lookupError := exec.LookPath("bash")
+	if lookupError != nil {
+		testingInstance.Fatalf("resolve Bash executable: %v", lookupError)
+	}
+	commandContext, cancelCommand := context.WithTimeout(context.Background(), operationalHelpTimeout)
+	defer cancelCommand()
+	command := exec.CommandContext(
+		commandContext,
+		bashPath,
+		"-c",
+		constrainedPipeHelpCommand,
+		"operational-help",
+		bashPath,
+		scriptPath,
+		helpArgument,
+	)
+	command.Dir = directory
+	command.WaitDelay = operationalHelpWaitDelay
+	if environment != nil {
+		command.Env = environment
+	}
+	output, commandError := command.CombinedOutput()
+	if commandContext.Err() == context.DeadlineExceeded {
+		testingInstance.Fatalf("operational help command timed out: %s %s", scriptPath, helpArgument)
+	}
+	if commandError != nil {
+		testingInstance.Fatalf("operational help command failed: %s %s: %v\n%s", scriptPath, helpArgument, commandError, output)
+	}
+	return string(output)
 }
 
 func runOperationalCommand(testingInstance *testing.T, directory string, environment []string, commandName string, arguments ...string) string {

--- a/tools/gitrelease/scripts/deploy_pages_artifact.sh
+++ b/tools/gitrelease/scripts/deploy_pages_artifact.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
-Usage:
+  builtin printf '%s\n' 'Usage:
   deploy_pages_artifact.sh --url <public-url> [options]
 
 Downloads manifest.json and pages.tar.gz from a published GitHub Release,
@@ -17,8 +16,7 @@ Options:
   --skip-configure      Do not create/update the Pages branch source setting
   --skip-verify         Do not verify the public release marker
   --verify-only         Validate the published artifact without mutating Pages
-  --help                Show this help text
-USAGE
+  --help                Show this help text'
 }
 
 remote="origin"

--- a/tools/gitrelease/scripts/prepare_container_artifact.sh
+++ b/tools/gitrelease/scripts/prepare_container_artifact.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
-Usage:
+  builtin printf '%s\n' 'Usage:
   prepare_container_artifact.sh --name <name> --image <registry/repository> [options]
 
 Builds one or more platform-specific container images into local Docker archives
@@ -19,8 +18,7 @@ Options:
   --label <value>        Repeatable image label
   --target <name>        Dockerfile target stage
   --pull                 Refresh referenced base images while building
-  --help                 Show this help text
-USAGE
+  --help                 Show this help text'
 }
 
 name=""
@@ -99,7 +97,7 @@ for platform in "${platform_list[@]}"; do
   printf '%s\t%s\t%s\t%s\t%s\n' "${platform}" "${platform_token}" "${local_ref}" "${image_id}" "${archive_sha256}" >>"${metadata_rows}"
 done
 
-python3 - "${artifact_root}/container.json" "${name}" "${image}" "${RELEASE_VERSION}" "${RELEASE_ARTIFACT_DIR}" "${metadata_rows}" <<'PY'
+python3 -c '
 import json
 import pathlib
 import sys
@@ -129,6 +127,6 @@ document = {
     "platforms": platforms,
 }
 pathlib.Path(output).write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+' "${artifact_root}/container.json" "${name}" "${image}" "${RELEASE_VERSION}" "${RELEASE_ARTIFACT_DIR}" "${metadata_rows}"
 
 echo "Prepared container artifact ${name} for ${platforms}."

--- a/tools/gitrelease/scripts/prepare_pages_artifact.sh
+++ b/tools/gitrelease/scripts/prepare_pages_artifact.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
-Usage:
+  builtin printf '%s\n' 'Usage:
   prepare_pages_artifact.sh --source <directory> [options]
 
 Packages a static site as pages.tar.gz in the active local release artifact.
@@ -12,8 +11,7 @@ The archive includes .mprlab-release.json for deploy-time verification.
 Options:
   --domain <domain>      Write a CNAME file with this domain
   --exclude <pattern>    Repeatable rsync exclusion pattern
-  --help                 Show this help text
-USAGE
+  --help                 Show this help text'
 }
 
 source_directory=""
@@ -51,7 +49,7 @@ if [[ -n "${domain}" ]]; then
   printf '%s\n' "${domain}" >"${site_directory}/CNAME"
 fi
 : >"${site_directory}/.nojekyll"
-python3 - "${staging_manifest}" "${site_directory}/.mprlab-release.json" <<'PY'
+python3 -c '
 import json
 import pathlib
 import sys
@@ -64,7 +62,7 @@ marker = {
     "release_timestamp": staging["release_timestamp"],
 }
 pathlib.Path(sys.argv[2]).write_text(json.dumps(marker, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+' "${staging_manifest}" "${site_directory}/.mprlab-release.json"
 
 asset_directory="${RELEASE_ARTIFACT_DIR}/payloads/release-assets"
 mkdir -p "${asset_directory}"

--- a/tools/gitrelease/scripts/prepare_release.sh
+++ b/tools/gitrelease/scripts/prepare_release.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
-Usage:
+  builtin printf '%s\n' 'Usage:
   prepare_release.sh [options]
 
 Prepares a release entirely from local repository state. The command validates
@@ -17,8 +16,7 @@ Options:
   --bump <patch|minor|major>  SemVer bump when no exact version is supplied. Default: patch
   --version <value>           Exact local release tag/version to prepare
   --dry-run                   Validate and report the selected version without changing files
-  --help                      Show this help text
-USAGE
+  --help                      Show this help text'
 }
 
 if [[ -v RELEASE_HELPER ]]; then

--- a/tools/gitrelease/scripts/publish_container_artifacts.sh
+++ b/tools/gitrelease/scripts/publish_container_artifacts.sh
@@ -2,13 +2,11 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
-Usage:
+  builtin printf '%s\n' 'Usage:
   publish_container_artifacts.sh
 
 Loads container archives prepared by make release, pushes platform images, and
-creates the version and latest manifests. It never builds an image.
-USAGE
+creates the version and latest manifests. It never builds an image.'
 }
 
 if [[ $# -gt 0 ]]; then
@@ -25,23 +23,22 @@ artifact_dir="$(git rev-parse --git-path mprlab-release)"
 [[ "${artifact_dir}" == /* ]] || artifact_dir="${repo_root}/${artifact_dir}"
 helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/release_helper.py"
 "${helper}" verify-release-artifact >/dev/null
-release_version="$(python3 - "${artifact_dir}/manifest.json" <<'PY'
+release_version="$(python3 -c '
 import json
 import sys
 print(json.load(open(sys.argv[1], encoding="utf-8"))["version"])
-PY
-)"
+' "${artifact_dir}/manifest.json")"
 publish_timeout="${PUBLISH_CONTAINER_TIMEOUT_SECONDS:-1200}"
 [[ "${publish_timeout}" =~ ^[1-9][0-9]*$ ]] || { echo "error: PUBLISH_CONTAINER_TIMEOUT_SECONDS must be a positive integer" >&2; exit 1; }
 
 mapfile -t descriptors < <(find "${artifact_dir}/payloads/containers" -mindepth 2 -maxdepth 2 -name container.json -type f | LC_ALL=C sort)
 [[ "${#descriptors[@]}" -gt 0 ]] || { echo "error: no prepared container artifacts found; run make release" >&2; exit 1; }
 
-if python3 - "${descriptors[@]}" <<'PY'
+if python3 -c '
 import json
 import sys
 raise SystemExit(0 if any(json.load(open(path, encoding="utf-8"))["image"].startswith("ghcr.io/") for path in sys.argv[1:]) else 1)
-PY
+' "${descriptors[@]}"
 then
   registry_username="$(gh api user --jq .login)"
   registry_token="$(gh auth token)"
@@ -50,7 +47,7 @@ then
 fi
 
 for descriptor in "${descriptors[@]}"; do
-  metadata="$(python3 - "${descriptor}" <<'PY'
+  metadata="$(python3 -c '
 import json
 import sys
 
@@ -62,8 +59,7 @@ print(data["image"])
 print(data["version"])
 for platform in data["platforms"]:
     print("\t".join([platform["platform"], platform["token"], platform["local_ref"], platform["image_id"], platform["archive"], platform["sha256"]]))
-PY
-)"
+' "${descriptor}")"
   name="$(sed -n '1p' <<<"${metadata}")"
   image="$(sed -n '2p' <<<"${metadata}")"
   version="$(sed -n '3p' <<<"${metadata}")"


### PR DESCRIPTION
This update addresses two key operational reliability issues for release, deployment, artifact, and provider validation scripts:

1. **Prevents Shell Help Deadlocks and Heredoc Usage**: Refactors all relevant shell scripts to replace heredoc-based external command feeding with inline Bash builtins or Python `-c` invocations. This avoids Bash stalling on pipes with constrained capacity (`ulimit -p 1`) and removes the risk of deadlocks on CI systems with strict resource limits.

2. **Enforces Consistent Help Output Implementation**: All governed scripts now provide self-contained help output using builtins, preventing future regressions. Operational tests validate help behavior under tight pipe constraints and forbid heredoc usage for feeding external commands.

Additionally, container artifact creation is made more robust by extracting from a temporary tar file rather than a pipe, preventing extraction failures due to reader termination or pipe capacity edges. Black-box operational tests were expanded to cover usage output contracts, heredoc absence, and canonical container descriptor emission.

Documentation has been updated to mark previously open issues B023 (Pages marker preservation) and B024 (help deadlock prevention) as resolved with implemented testable validations.