### PR TITLE
I020: Declare app-owned TAuth tenant

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -548,6 +548,14 @@ Format: `- [ ] [B042] (P1) {I007} Title`
 
 ## Improvements
 
+- [x] [I020] (P1) Declare LLM Proxy's TAuth tenant requirements in the app-owned deployment manifest.
+  ### Summary
+  Move stable tenant identity, production origin, cookie names, and provider references into .mprlab/deploy/resources.yml while keeping credential values, shared TTLs, and server policy gateway-owned.
+  ### Acceptance Criteria
+  1. The gateway discovers the declaration without reading a TAuth-owned deployment registry.
+  2. The assembled fleet configuration passes generic TAuth doctor validation.
+  ### Resolution
+  Added the canonical app-owned `tauth_tenant` declaration. The gateway assembled the 13-tenant fleet, the generic TAuth doctor accepted it with zero errors, and `make ci` passed.
 - [x] [I001] (P1) Make missing placeholder handling field-aware.
   ### Summary
   Review found that allowing missing `${...}` placeholders globally can silently mutate non-key configuration values. Keep the new disabled-provider behavior for missing provider API-key placeholders, but fail startup for missing placeholders everywhere else and for partial API-key placeholders.

--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -12,6 +12,22 @@ mprlab_resources:
         release: release
         publish: publish
         deploy: deploy
+    - type: tauth_tenant
+      name: llm-proxy-authentication
+      tenant:
+        id: llm-proxy
+        display_name: LLM Proxy
+        tenant_origins:
+          - https://llm-proxy.mprlab.com
+        google_web_client_id: "${TAUTH_GOOGLE_WEB_CLIENT_ID_LLM_PROXY}"
+        jwt_signing_key: "${TAUTH_JWT_SIGNING_KEY_LLM_PROXY}"
+        cookie_domain: .mprlab.com
+        session_cookie_name: app_session_llm_proxy
+        refresh_cookie_name: app_refresh_llm_proxy
+        session_ttl: "${TAUTH_SESSION_TTL}"
+        refresh_ttl: "${TAUTH_REFRESH_TTL}"
+        nonce_ttl: "${TAUTH_NONCE_TTL}"
+        allow_insecure_http: "${TAUTH_ALLOW_INSECURE_HTTP}"
     - type: container_service
       name: llm-proxy
       host_group: gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Declare the llm-proxy TAuth tenant requirements in the app-owned deployment manifest for gateway assembly.
+
 ## [v0.2.32] - 2026-07-15
 
 - Merge pull request #198 from tyemirov/gix/hydrate-dashboard-from-canonical-mpr-ui-auth-lifecycle
@@ -574,4 +578,3 @@ All notable changes to this project will be documented in this file.
 
 ### Limitations
 - Supports only OpenAI models; no other providers currently.
-


### PR DESCRIPTION
## Summary
- declare stable TAuth tenant intent in the app-owned `.mprlab/deploy/resources.yml`
- leave credentials, shared TTLs, and server policy under gateway ownership

## Validation
- repository `make ci`
- gateway fleet assembler: 13 tenants
- generic TAuth doctor: 0 errors