### PR TITLE
gix/add-reloadable-per-user-model-profiles-to-go-python

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1514,5 +1514,283 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   Resolution:
   Declared the `llm-proxy` TAuth tenant in the application-owned manifest using deployment-environment placeholders only, and described the container with the canonical port list, compose file/project identity, ignored private environment asset, tracked environment example, and tracked runtime configuration. The independent TAuth repository remains vanilla and no concrete credential values were added. The post-change `make ci` gate passed with 100.0% aggregate Go coverage, 20 Python tests, 16 Playwright management scenarios, the real local TAuth browser scenario, 38 release-contract tests, and the live-provider harness preflight. The gateway aggregate verifier is run from the gateway after this owner contract is committed.
 
+- [x] [F015] (P1) Let application users change the model through reloadable client profiles.
+  Goal:
+  Let an application integrate an LLM Proxy client once, then let each of its
+  users change the provider/model pair from the application without a source
+  change, rebuild, restart, or deployment for each selection. This is distinct
+  from a managed LLM Proxy tenant owner changing that tenant's routing default.
+
+  Requirements:
+  - Define one canonical, application-owned JSON model-profile document shared
+    by the Go library, the installable Go CLI, and the Python package. The
+    document contains exactly a `provider` and `model` pair; it never contains a
+    tenant secret, upstream provider credential, or TAuth material.
+  - Add an explicit profile path to the Go `ConfigInput`/`Config`, Go CLI, and
+    Python `ClientConfig`. Each outbound v2 request reads the current profile so
+    a completed application setting update affects the next request without
+    recreating the client process.
+  - Treat the profile as the sole provider/model source when configured. Reject
+    a request-level model, a configured provider override, or a base-URL
+    provider/model query that competes with it; do not silently prefer one
+    source or retain a stale parsed profile.
+  - Validate profile JSON and require nonblank provider and model identifiers at
+    the client edge. The proxy remains the authority that validates the exact
+    configured provider/model pair and returns its existing stable public error.
+  - Require applications to publish profile updates atomically. If the client
+    cannot read or validate the current profile, fail that request with explicit
+    context; do not fall back to the previous profile, a request literal, a
+    tenant default, or a provider default.
+  - Preserve the current model-omitting path when no profile path is configured:
+    it continues to delegate to the authenticated tenant default or selected
+    provider default. Document this as a separate, mutually exclusive contract.
+  - Support per-application-user selection by allowing each client instance to
+    use that user's profile path. Application identity, authorization, storage,
+    UI, and atomic profile publication remain application-owned.
+
+  Deliverables:
+  - Add the shared profile schema, Go/Python profile loaders, Go CLI
+    `--model-profile` surface, edge validation, error types, and public API
+    documentation.
+  - Update Go and Python examples to show model omission for tenant-owned
+    defaults and a separate app-user profile integration.
+  - Do not add a second config format, an implicit environment alias, profile
+    caching, a compatibility parser, or a best-effort resolution path.
+
+  Validation:
+  - Add black-box Go library, Go CLI, and Python client scenarios that send with
+    profile A, atomically replace it with profile B, and prove the next request
+    carries exactly B without client recreation.
+  - Prove malformed, incomplete, unreadable, and competing profile/request
+    inputs fail before an HTTP call and never reuse an earlier model.
+  - Prove an unknown or unsupported profile pair reaches the proxy's existing
+    public validation boundary, while a valid pair routes to the configured
+    provider/model.
+  - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci`
+    pair for the implementation, with the final run after the last code edit.
+  Resolution:
+  Added the single strict JSON `provider`/`model` profile contract to the Go
+  library, installable Go CLI (`--model-profile`), and Python package. Each
+  profile-backed v2 request rereads its application-owned path; valid atomic A
+  to B replacements change the next request without retaining a stale profile.
+  Competing request/config/base-URL sources and unreadable, malformed,
+  incomplete, or unsupported profile documents fail explicitly without an HTTP
+  fallback, while unknown pairs reach the proxy validation boundary. README and
+  implementation documentation now distinguish tenant-owned model omission
+  from application-user profile selection. The required baseline and final
+  `timeout -k 350s -s SIGKILL 350s make ci` runs passed; the final gate included
+  100.0% Go coverage, 29 Python tests, 16 Playwright UI tests, the management
+  auth black-box test, 38 release tests, and the live-provider preflight.
+
 ## Planning
 *do not implement yet*
+
+- [ ] [P001] (P1) {F014} Design a tenant-scoped provider, model, and key-acquisition onboarding flow.
+  Goal:
+  Let a signed-in managed user complete one clear text-routing setup: select a
+  supported provider, select one of that provider's supported text models, and
+  either paste an existing provider API key or open that provider's official
+  key-acquisition page in a new window before returning to paste it. A completed
+  setup must make the chosen provider/model the active tenant's usable text
+  route without asking the user to reconcile separate provider, default, and
+  client-secret forms.
+
+  Requirements:
+  - Build the flow on the canonical F014 active-tenant context. It must read and
+    write only the selected tenant; another tenant or user must never inherit a
+    provider key, model choice, in-progress form value, or completion state.
+  - Serve provider labels, text-model choices, capabilities, and the verified
+    official credential-acquisition URL from one validated provider catalog.
+    Do not hard-code provider/model lists or provider registration URLs in the
+    browser. The public/management catalog build must reject a self-service
+    provider without a canonical HTTPS credential URL rather than render a
+    guessed link.
+  - Make provider selection the first step and expose only that provider's text
+    models in the next step. Explain whether the provider already has a saved
+    key, but never show the raw key or make a model from another provider
+    selectable.
+  - When the user has no key, render a descriptive provider-specific anchor
+    that opens the official acquisition page with `target="_blank"` and
+    `rel="noopener noreferrer"`. Do not send tenant IDs, TAuth data, proxy
+    secrets, provider keys, or tracking query values to the external site, and
+    do not attempt to detect registration completion.
+  - Keep selection local while the external page is open. On return, require a
+    manually pasted key and make one atomic authenticated operation that saves
+    the encrypted provider key, the selected provider text model, and the
+    tenant's text defaults. A failure leaves no partial routing state and shows
+    an explicit error; it must not reuse a prior model or key as a fallback.
+  - Preserve existing security boundaries: public proxy requests still reject
+    upstream provider keys; management responses and generated examples never
+    return them; saved keys remain encrypted at rest and masked after save.
+  - Keep the generated client-secret step visibly separate but adjacent to
+    completion, including one-time secret display and copyable route examples.
+    Do not create a second client-authentication or provider-key storage path.
+
+  Deliverables:
+  - Add a validated, sanitized provider catalog projection containing the
+    provider identity, label, text models, capability metadata, and official
+    credential-acquisition URL; use it for the management API and browser UI.
+  - Replace the disconnected Settings controls with a tenant-scoped onboarding
+    surface and one canonical management mutation for completed provider/model/
+    key setup.
+  - Update typed frontend contracts, management API documentation, examples,
+    and accessibility copy to describe the exact sequence and no-key path.
+  - Do not add provider aliases, hidden default selection, a browser-maintained
+    catalog, a compatibility endpoint, a key-import shortcut, or a best-effort
+    retry/fallback path.
+
+  Validation:
+  - Add black-box configuration and management API coverage for invalid/missing
+    credential URLs, provider/model mismatches, atomic rollback, tenant/user
+    isolation, masked responses, and the absence of provider keys in profile,
+    example, and public-proxy payloads.
+  - Add Playwright coverage for a first-time user choosing a provider, seeing
+    only its models, opening the correctly protected official link in a new
+    page, returning to save a key, receiving the selected default route, and
+    generating/copying a client secret. Cover keyboard, screen-reader labels,
+    narrow layouts, saved-key updates, and explicit failure states.
+  - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci`
+    pair for the implementation, with the final run after the last code edit.
+
+- [ ] [P002] (P1) Create a canonical public landing page and generated capability catalog.
+  Goal:
+  Make the Pages root an indexable, useful LLM Proxy landing page that accurately
+  explains what the service does, who it is for, how it is used, and every
+  currently supported provider/model capability. Move the existing authenticated
+  management workspace to the one canonical `/manage/` route so public product
+  discovery and key-management workspaces are not competing root pages.
+
+  Requirements:
+  - Serve a public, useful `https://llm-proxy.mprlab.com/` landing page without
+    requiring a management session. Keep the separate API origin's `GET /`,
+    `POST /`, `/v2`, and `/dictate` contracts unchanged; only the Pages
+    information architecture changes.
+  - Move the current MPR UI/TAuth management shell, its rendered
+    `data-config-url`, header navigation, logout destination, browser tests,
+    and release renderer to `/manage/`. `/manage/` is a private workspace
+    entry, uses `noindex`, and is absent from the public sitemap; do not leave
+    a duplicate root workspace, JavaScript/meta-refresh redirect, or legacy
+    management route.
+  - Generate a sanitized public capability catalog from the same validated
+    provider registry used for request validation and management profiles. The
+    landing matrix must enumerate every supported text and dictation provider
+    and model, defaults, dictation availability, web-search availability, and
+    known proxy output limits without exposing provider keys, tenant state,
+    configured base URLs, or non-public deployment data.
+  - Do not maintain a second hand-written provider/model table. A catalog change
+    must update the landing matrix deterministically or fail the site build,
+    including missing/duplicate providers or models and capabilities that cannot
+    be represented publicly.
+  - Describe the full current capability set with evidence-backed language:
+    tenant-secret authenticated text and canonical `/v2` messages, native and
+    compatible provider routing, dictation, constrained OpenAI web search,
+    response formats and normalized usage metadata, request limits/clear error
+    behavior, self-service encrypted provider-key management, generated-secret
+    rotation, usage visibility, and Go/Python/CLI integration options. State
+    model/provider limitations rather than implying universal feature parity.
+  - Provide clear crawlable calls to action for `/manage/`, the resource hub,
+    and current integration documentation. Use semantic HTML, visible focus,
+    accessible tables/filters, concise unique metadata, canonical root URLs,
+    and structured data that describes only visible landing-page content.
+
+  Deliverables:
+  - Add the canonical catalog projection/build contract and a static public
+    landing page with capability sections, provider/model matrix, limitations,
+    and conversion paths.
+  - Relocate and render the management application at `/manage/`, update all
+    root/resource/header/footer links, and document the new public-vs-private
+    Pages route contract in README and deployment/site-render guidance.
+  - Update the resource hub and shared site shell so public navigation points to
+    the landing page while management calls to action point only to `/manage/`.
+  - Do not duplicate catalogs in HTML/JavaScript/docs, make availability claims
+    based on whether a particular user has a key, expose secrets, or preserve a
+    second root management implementation.
+
+  Validation:
+  - Add black-box build/render coverage proving the public matrix exactly
+    reflects the validated catalog, has no secret-bearing fields, and rejects
+    catalog/render drift.
+  - Add Playwright coverage for an anonymous public landing, its accessible
+    provider/model matrix and CTAs, navigation to `/manage/`, and the full
+    existing authenticated management lifecycle at that new route.
+  - Verify root canonical, Open Graph, JSON-LD, sitemap, and resource links use
+    the final public URL form, while `/manage/` is noindex and excluded from
+    sitemap output.
+  - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci`
+    pair for the implementation, with the final run after the last code edit.
+
+- [ ] [P003] (P1) {P002} Re-audit and expand the SEO/use-case resource system from verified product contracts.
+  Goal:
+  Refresh LLM Proxy's search and resource strategy from the current repository
+  contract so prospective users can discover concrete, supported ways to use
+  the service without creating duplicate doorway pages or claiming roadmap work
+  as shipped functionality.
+
+  Requirements:
+  - Produce a new repo-grounded SEO report before changing public copy. It must
+    inventory current capabilities, limits, public routes, existing resource
+    pages, claim evidence, unsupported claims, the final landing/`/manage/`
+    separation, and every current provider/model capability from P002's
+    generated catalog.
+  - Audit and cover distinct user jobs including: self-service bring-your-own
+    provider-key onboarding; multi-provider and model routing; provider/default
+    model selection; `/v2` messages and direct REST integration; Go, Python,
+    and CLI clients; text response formats and usage headers; dictation;
+    supported OpenAI web search; generated-secret lifecycle; tenant/admin usage
+    visibility without prompt or key exposure; native/compatible provider
+    adapters; runtime configuration; and queue, rate-limit, timeout, and error
+    handling. Merge or reject a page unless it has at least three independent
+    distinctions such as audience, job, workflow, feature set, example,
+    objection, FAQ, CTA, or internal-link path.
+  - For every approved page, record audience, problem, search intent, primary
+    and secondary keyword candidates, product evidence, allowed and forbidden
+    claims, differentiating examples, internal-link path, and doorway-page
+    risk. Do not claim search volume, rankings, pricing, benchmarks,
+    testimonials, compliance, provider performance, or support for F014/F015
+    roadmap behavior before it is implemented.
+  - Replace the generator's arbitrary page-count quota and fixed modified-date
+    snapshot with an evidence-backed content manifest. Compute `lastmod` only
+    from maintainable source/build data or omit it; never publish stale dates.
+    Keep every model/provider assertion tied to the generated public catalog.
+  - Enforce the complete indexing contract: canonical, sitemap, Open Graph,
+    JSON-LD, and crawlable internal links use one final trailing-slash URL;
+    root and the resource hub link to all public content; `/manage/`, private
+    API pages, token pages, redirects, and noindex pages stay out of the
+    sitemap. Schema must match visible content, and article-like pages need
+    visible maintainer attribution and a verifiable publication/modification
+    policy.
+  - Preserve or improve useful existing resources rather than regenerating
+    generic copy. Each indexable page must have a concrete repository-derived
+    command/configuration example, problem-specific FAQ, limitation section,
+    meaningful CTA, and accessible/lazy-loaded presentation where applicable.
+
+  Deliverables:
+  - Update `docs/marketing/seo-resource-cluster-report.md` with the fresh repo
+    analysis, use-case opportunity list, recommended generation order,
+    rejected/merged ideas, claim audit, indexing audit, and explicit evaluation
+    scores.
+  - Replace the static SEO source/generator with a deterministic evidence-backed
+    manifest, refreshed resource hub/pages, contextual related links, sitemap,
+    robots, and landing-page discovery paths.
+  - Add a release-verification checklist covering final URL responses,
+    canonical/sitemap alignment, JSON-LD validity, internal-link crawlability,
+    Google Search Console URL Inspection, and Rich Results Test where the
+    visible schema qualifies.
+  - Do not manufacture pages merely to reach a count, rely on sitemap-only
+    discoverability, repeat a generic FAQ across a cluster, or retain stale
+    provider/model and roadmap claims as marketing copy.
+
+  Validation:
+  - Make generation fail on missing evidence, duplicate or orphaned pages,
+    unsupported claims, stale date metadata, incompatible canonical URLs,
+    sitemap entries that are not public `200` pages, invalid JSON-LD, or a page
+    that does not meet the documented specificity/doorway thresholds.
+  - Add black-box static-site/browser coverage for the public root, hub,
+    representative pages from every use-case family, `/manage/` exclusion, and
+    crawlable navigation from landing page to hub to resource page.
+  - Require an evaluation result of at least 4/5 for repo grounding, use-case
+    specificity, doorway safety, metadata, conversion clarity, duplicate-risk,
+    site integration, and indexing readiness, and exactly 5/5 for factual
+    integrity before publication.
+  - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci`
+    pair for the implementation, with the final run after the last code edit.

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1581,6 +1581,12 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   `timeout -k 350s -s SIGKILL 350s make ci` runs passed; the final gate included
   100.0% Go coverage, 29 Python tests, 16 Playwright UI tests, the management
   auth black-box test, 38 release tests, and the live-provider preflight.
+  Follow-up review fixes reject invalid UTF-8 Go profile bytes before JSON
+  decoding or HTTP and convert every ordinary Python profile-reader failure to
+  `LLMProxyModelProfileError` with profile-path context; the final same gate
+  passed with 100.0% Go coverage, 30 Python tests, 16 Playwright UI tests, the
+  management auth black-box test, 38 release tests, and the live-provider
+  preflight.
 
 ## Planning
 *do not implement yet*

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ python-test:
 	$(MAKE) python-root-import-test
 
 python-root-import-test:
-	$(UV) run --no-project --with-editable . python -c 'from llm_proxy_client import Client, ClientConfig, ClientMessage, ClientMessagesRequest; assert Client and ClientConfig and ClientMessage and ClientMessagesRequest'
+	$(UV) run --no-project --with-editable . python -c 'from llm_proxy_client import Client, ClientConfig, ClientMessage, ClientMessagesRequest, LLMProxyModelProfileError; assert Client and ClientConfig and ClientMessage and ClientMessagesRequest and LLMProxyModelProfileError'
 
 frontend-test:
 	$(NPM) run frontend:test

--- a/README.md
+++ b/README.md
@@ -899,7 +899,6 @@ Use it with explicit flags:
 llm-proxy-client \
   --base-url "http://localhost:8080/?provider=gemini" \
   --secret "$SERVICE_SECRET" \
-  --model gemini-2.5-flash \
   --prompt "Summarize this"
 ```
 
@@ -908,7 +907,7 @@ Or read configuration and prompt text from environment/stdin:
 ```shell
 export LLM_PROXY_BASE_URL="http://localhost:8080/"
 export LLM_PROXY_SECRET="$SERVICE_SECRET"
-printf 'large prompt...\n' | llm-proxy-client --model gpt-5.5 --max-tokens 4096
+printf 'large prompt...\n' | llm-proxy-client --max-tokens 4096
 ```
 
 The client always uses canonical `POST /v2?key=...` with a JSON body. It keeps
@@ -922,6 +921,84 @@ configured default model.
 The reusable Go package under `pkg/llmproxyclient` is v2-only: construct a
 `MessagesRequest` with `NewMessagesRequest` and send it with
 `Client.PostMessages`.
+
+#### Model selection without application redeployment
+
+Every bundled client deliberately leaves `model` out of a request when the
+caller does not set it. This is the correct integration when LLM Proxy owns
+model selection: a managed-tenant owner can change that tenant's routing
+default in the LLM Proxy Settings UI, and the next model-omitting request uses
+the saved default without an application code or deployment change. An explicit
+`--model` or request `model` pins that one request and does not follow a tenant
+default.
+
+Changing `providers.<provider>.text.default_model` in the service config affects
+only requests that resolve through that provider catalog default. It does not
+rewrite a managed tenant's saved routing default or a saved provider text model.
+
+#### Application-user model profiles
+
+For application-owned, per-user selection, configure one client instance with
+that user's JSON model-profile path. The document contains exactly these two
+nonblank string fields and never contains credentials or TAuth material:
+
+```json
+{
+  "provider": "gemini",
+  "model": "gemini-2.5-flash"
+}
+```
+
+The client reads this file for every outbound v2 request. An application can
+write a replacement in the same filesystem and atomically rename it onto the
+user's profile path; the next request from the existing client instance then
+uses the new provider/model pair. The application continues to own the user
+identity, authorization, storage, and atomic publication of that file.
+
+Use the profile directly from the installable CLI:
+
+```shell
+llm-proxy-client \
+  --base-url "http://localhost:8080/" \
+  --secret "$SERVICE_SECRET" \
+  --model-profile "/var/lib/my-app/users/42/model.json" \
+  --prompt "Summarize this"
+```
+
+For the Go package, inject the application's file reader when creating the
+validated config once:
+
+```go
+config, err := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+    BaseURL:            "http://localhost:8080/",
+    Secret:             serviceSecret,
+    ModelProfilePath:   userModelProfilePath,
+    ModelProfileReader: os.ReadFile,
+    Timeout:            390 * time.Second,
+})
+if err != nil {
+    return err
+}
+client, err := llmproxyclient.NewClient(config, http.DefaultClient)
+if err != nil {
+    return err
+}
+```
+
+`Config.MessagesPostURL` also resolves the current profile and therefore returns
+`(string, error)` in profile-capable client versions.
+
+The profile is the sole provider/model source in this mode. Do not combine it
+with `--model`, a request `model`, `--provider`, `ConfigInput.Provider`, or a
+`provider` or `model` query parameter on the base URL. The clients reject those
+competing inputs; they never choose a winner or retain a previous parsed
+profile. A missing, unreadable, malformed, incomplete, or unsupported profile
+also fails that request before HTTP with `ErrInvalidModelProfile` (Go) or
+`LLMProxyModelProfileError` (Python). The proxy remains responsible for
+validating whether the resulting provider/model pair is supported.
+
+Without a profile path, the model-omitting tenant/provider-default path above
+remains the separate normal contract.
 
 ### Python client package
 
@@ -944,7 +1021,6 @@ client = Client(
 text = client.post_messages(
     ClientMessagesRequest(
         messages=(ClientMessage(role="user", content="Summarize this"),),
-        model="gemini-2.5-flash",
         max_tokens=512,
     )
 )
@@ -964,6 +1040,34 @@ chat_text = client.post_messages(
     )
 )
 ```
+
+Pass `model` only when an application intentionally pins one request instead
+of using the tenant or selected-provider default.
+
+To give one application user a reloadable model choice, configure that user's
+profile path and reader once. The client does not cache its parsed contents:
+
+```python
+from pathlib import Path
+
+
+def read_model_profile(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+user_client = Client(
+    ClientConfig(
+        base_url="http://localhost:8080/",
+        secret="mysecret",
+        model_profile_path="/var/lib/my-app/users/42/model.json",
+        model_profile_reader=read_model_profile,
+    )
+)
+```
+
+Publish a complete replacement JSON document atomically at that path after the
+user selects a new provider/model pair. Do not set `provider` on the config or
+base URL, or `model` on the request, when this profile is configured.
 
 The optional `order` field is for callers that do not want to rely on array
 position. When any message includes `order`, every submitted message must

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -196,8 +196,28 @@ Bundled clients intentionally expose only the canonical `POST /v2` text
 contract. The installable Go CLI maps prompt flags or stdin into v2 `system` and
 `user` messages, while the reusable Go and Python packages expose only
 messages-request constructors and `PostMessages`/`post_messages` send methods.
+When a bundled-client request omits `model`, it deliberately sends no model
+field and delegates selection to the authenticated tenant or selected provider.
 The server keeps `GET /` and compatibility JSON `POST /` available for direct
 REST callers.
+
+This permits a managed-tenant owner to change the tenant's routing default in
+the LLM Proxy Settings UI and have subsequent model-omitting client requests
+use that saved value without an application deployment. Application end-user
+model selection is a separate, client-owned contract: the Go library, Go CLI,
+and Python client all accept one application-owned JSON model-profile path per
+client instance. Its complete document is exactly nonblank `provider` and
+`model` string fields, contains no secret or TAuth material, and is reread for
+every outbound v2 request. An application atomically replaces a user's profile
+after their selection changes, so the next request from the existing client
+uses the new pair without a rebuild, restart, or deployment.
+
+Profile mode is mutually exclusive with a request model, configured provider,
+or base-URL `provider`/`model` query value. An unreadable, malformed,
+incomplete, or competing profile fails before HTTP and never reuses a previous
+profile or tenant/provider default. The proxy remains the authority for whether
+the resulting provider/model pair is valid. Without a profile path, model
+omission keeps the existing tenant/provider-default behavior.
 
 `server.workers` limits concurrent upstream provider HTTP operations, not whole
 client request lifecycles. `server.queue_size` limits the number of additional

--- a/llm-proxy-client/main.go
+++ b/llm-proxy-client/main.go
@@ -21,6 +21,7 @@ const (
 	flagSecret       = "secret"
 	flagProvider     = "provider"
 	flagModel        = "model"
+	flagModelProfile = "model-profile"
 	flagPrompt       = "prompt"
 	flagPromptFile   = "prompt-file"
 	flagWebSearch    = "web-search"
@@ -35,16 +36,17 @@ const (
 )
 
 type commandOptions struct {
-	baseURL      string
-	secret       string
-	provider     string
-	model        string
-	prompt       string
-	promptFile   string
-	webSearch    bool
-	systemPrompt string
-	maxTokens    int
-	timeout      time.Duration
+	baseURL          string
+	secret           string
+	provider         string
+	model            string
+	modelProfilePath string
+	prompt           string
+	promptFile       string
+	webSearch        bool
+	systemPrompt     string
+	maxTokens        int
+	timeout          time.Duration
 }
 
 type httpClientFactory func(timeout time.Duration) llmproxyclient.HTTPDoer
@@ -98,12 +100,17 @@ func newRootCommand(
 			if prompt == "" {
 				return fmt.Errorf("llm_proxy_client_request_failed: %w: missing prompt", llmproxyclient.ErrInvalidClientRequest)
 			}
-			config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
-				BaseURL:  configuredString(command, flagBaseURL, envNameBaseURL, options.baseURL),
-				Secret:   configuredString(command, flagSecret, envNameSecret, options.secret),
-				Provider: options.provider,
-				Timeout:  options.timeout,
-			})
+			configInput := llmproxyclient.ConfigInput{
+				BaseURL:          configuredString(command, flagBaseURL, envNameBaseURL, options.baseURL),
+				Secret:           configuredString(command, flagSecret, envNameSecret, options.secret),
+				Provider:         options.provider,
+				ModelProfilePath: options.modelProfilePath,
+				Timeout:          options.timeout,
+			}
+			if options.modelProfilePath != "" {
+				configInput.ModelProfileReader = os.ReadFile
+			}
+			config, configError := llmproxyclient.NewConfig(configInput)
 			if configError != nil {
 				return fmt.Errorf("llm_proxy_client_config_failed: %w", configError)
 			}
@@ -145,6 +152,7 @@ func newRootCommand(
 	flagSet.StringVar(&options.secret, flagSecret, "", "llm-proxy shared secret")
 	flagSet.StringVar(&options.provider, flagProvider, "", "provider query override")
 	flagSet.StringVar(&options.model, flagModel, "", "v2 model body field")
+	flagSet.StringVar(&options.modelProfilePath, flagModelProfile, "", "path to application-owned JSON provider/model profile")
 	flagSet.StringVar(&options.prompt, flagPrompt, "", "user message text")
 	flagSet.StringVar(&options.promptFile, flagPromptFile, "", "path to user message text file")
 	flagSet.BoolVar(&options.webSearch, flagWebSearch, false, "enable OpenAI web search")

--- a/llm-proxy-client/main_test.go
+++ b/llm-proxy-client/main_test.go
@@ -255,6 +255,149 @@ func TestCommandReadsPromptFileAndOptionalBodyFields(t *testing.T) {
 	}
 }
 
+func TestCommandReadsCurrentModelProfile(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "current-model.json")
+	replaceCommandModelProfile(t, profilePath, `{"provider":"gemini","model":"gemini-2.5-flash"}`)
+	capturedRequests := []capturedProxyRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		bodyBytes, readError := io.ReadAll(httpRequest.Body)
+		if readError != nil {
+			t.Fatalf("read body: %v", readError)
+		}
+		capturedRequests = append(capturedRequests, capturedProxyRequest{
+			path: httpRequest.URL.RequestURI(),
+			body: string(bodyBytes),
+		})
+		_, _ = responseWriter.Write([]byte("profile-ok"))
+	}))
+	t.Cleanup(server.Close)
+
+	arguments := []string{
+		"--base-url", server.URL,
+		"--secret", "test-secret",
+		"--model-profile", profilePath,
+		"--prompt", "Use the selected model",
+	}
+	for _, expected := range []struct {
+		provider string
+		model    string
+	}{
+		{provider: "gemini", model: "gemini-2.5-flash"},
+		{provider: "openai", model: "gpt-5-mini"},
+	} {
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		exitCode := run(arguments, strings.NewReader(""), &stdout, &stderr, defaultHTTPClientFactory)
+		if exitCode != 0 {
+			t.Fatalf("exit=%d stderr=%s", exitCode, stderr.String())
+		}
+		if stdout.String() != "profile-ok" {
+			t.Fatalf("stdout=%q", stdout.String())
+		}
+		if expected.provider == "gemini" {
+			replaceCommandModelProfile(t, profilePath, `{"provider":"openai","model":"gpt-5-mini"}`)
+		}
+	}
+
+	if len(capturedRequests) != 2 {
+		t.Fatalf("requests=%v", capturedRequests)
+	}
+	for requestIndex, expected := range []struct {
+		provider string
+		model    string
+	}{
+		{provider: "gemini", model: "gemini-2.5-flash"},
+		{provider: "openai", model: "gpt-5-mini"},
+	} {
+		parsedURL, parseError := url.Parse(capturedRequests[requestIndex].path)
+		if parseError != nil {
+			t.Fatalf("parse request %d: %v", requestIndex, parseError)
+		}
+		if parsedURL.Query().Get("provider") != expected.provider {
+			t.Fatalf("request %d provider=%q", requestIndex, parsedURL.Query().Get("provider"))
+		}
+		if !strings.Contains(capturedRequests[requestIndex].body, `"model":"`+expected.model+`"`) {
+			t.Fatalf("request %d body=%s", requestIndex, capturedRequests[requestIndex].body)
+		}
+	}
+}
+
+func TestCommandRejectsCompetingModelProfileSourcesBeforeHTTP(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "current-model.json")
+	replaceCommandModelProfile(t, profilePath, `{"provider":"gemini","model":"gemini-2.5-flash"}`)
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		requestCount++
+		_, _ = responseWriter.Write([]byte("unexpected"))
+	}))
+	t.Cleanup(server.Close)
+
+	testCases := []struct {
+		name        string
+		arguments   []string
+		errorString string
+	}{
+		{
+			name: "request model",
+			arguments: []string{
+				"--base-url", server.URL,
+				"--secret", "test-secret",
+				"--model-profile", profilePath,
+				"--model", "gpt-5-mini",
+				"--prompt", "Do not compete",
+			},
+			errorString: "request model conflicts with model_profile",
+		},
+		{
+			name: "configured provider",
+			arguments: []string{
+				"--base-url", server.URL,
+				"--secret", "test-secret",
+				"--model-profile", profilePath,
+				"--provider", "openai",
+				"--prompt", "Do not compete",
+			},
+			errorString: "model_profile_path conflicts with provider",
+		},
+		{
+			name: "base URL provider",
+			arguments: []string{
+				"--base-url", server.URL + "?provider=openai",
+				"--secret", "test-secret",
+				"--model-profile", profilePath,
+				"--prompt", "Do not compete",
+			},
+			errorString: "base_url provider query",
+		},
+		{
+			name: "base URL model",
+			arguments: []string{
+				"--base-url", server.URL + "?model=gpt-5-mini",
+				"--secret", "test-secret",
+				"--model-profile", profilePath,
+				"--prompt", "Do not compete",
+			},
+			errorString: "base_url model query",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := run(testCase.arguments, strings.NewReader(""), &stdout, &stderr, defaultHTTPClientFactory)
+			if exitCode != 1 {
+				t.Fatalf("exit=%d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), testCase.errorString) {
+				t.Fatalf("stderr=%q missing %q", stderr.String(), testCase.errorString)
+			}
+			if requestCount != 0 {
+				t.Fatalf("competing input reached HTTP; request count=%d", requestCount)
+			}
+		})
+	}
+}
+
 func TestCommandRejectsInvalidInputs(t *testing.T) {
 	t.Setenv(envNameBaseURL, "")
 	t.Setenv(envNameSecret, "")
@@ -450,4 +593,15 @@ func TestCommandReportsProxyAndIOErrors(t *testing.T) {
 			t.Fatalf("stderr=%q", stderr.String())
 		}
 	})
+}
+
+func replaceCommandModelProfile(t *testing.T, profilePath string, profileDocument string) {
+	t.Helper()
+	replacementPath := filepath.Join(filepath.Dir(profilePath), "next-model.json")
+	if writeError := os.WriteFile(replacementPath, []byte(profileDocument), 0600); writeError != nil {
+		t.Fatalf("write replacement model profile: %v", writeError)
+	}
+	if renameError := os.Rename(replacementPath, profilePath); renameError != nil {
+		t.Fatalf("replace model profile: %v", renameError)
+	}
 }

--- a/pkg/llmproxyclient/client.go
+++ b/pkg/llmproxyclient/client.go
@@ -22,6 +22,7 @@ const (
 	jsonContentType           = "application/json; charset=utf-8"
 	queryFormat               = "format"
 	queryKey                  = "key"
+	queryModel                = "model"
 	queryProvider             = "provider"
 )
 
@@ -36,13 +37,15 @@ var (
 	ErrInvalidClientConfig = errors.New("llm_proxy_client_invalid_config")
 	// ErrInvalidClientRequest reports invalid llm-proxy request input.
 	ErrInvalidClientRequest = errors.New("llm_proxy_client_invalid_request")
+	// ErrInvalidModelProfile reports an unreadable or invalid model-profile document.
+	ErrInvalidModelProfile = errors.New("llm_proxy_client_invalid_model_profile")
 	// ErrClientHTTPFailure reports an unsuccessful llm-proxy HTTP response.
 	ErrClientHTTPFailure = errors.New("llm_proxy_client_http_failure")
 )
 
 var postBodyQueryKeys = map[string]struct{}{
 	"messages":          {},
-	"model":             {},
+	queryModel:          {},
 	"max_output_tokens": {},
 	"max_tokens":        {},
 	"prompt":            {},
@@ -57,18 +60,22 @@ type HTTPDoer interface {
 
 // ConfigInput is the unvalidated external configuration for an llm-proxy client.
 type ConfigInput struct {
-	BaseURL  string
-	Secret   string
-	Provider string
-	Timeout  time.Duration
+	BaseURL            string
+	Secret             string
+	Provider           string
+	ModelProfilePath   string
+	ModelProfileReader ModelProfileReader
+	Timeout            time.Duration
 }
 
 // Config is validated llm-proxy client configuration.
 type Config struct {
-	baseURL  *url.URL
-	secret   string
-	provider string
-	timeout  time.Duration
+	baseURL            *url.URL
+	secret             string
+	provider           string
+	modelProfilePath   string
+	modelProfileReader ModelProfileReader
+	timeout            time.Duration
 }
 
 // NewConfig validates external client configuration.
@@ -87,6 +94,26 @@ func NewConfig(input ConfigInput) (Config, error) {
 	if parsedBaseURL.Host == "" {
 		return Config{}, fmt.Errorf("%w: base_url must include host", ErrInvalidClientConfig)
 	}
+	trimmedProvider := strings.TrimSpace(input.Provider)
+	trimmedModelProfilePath := strings.TrimSpace(input.ModelProfilePath)
+	if trimmedModelProfilePath == "" && input.ModelProfileReader != nil {
+		return Config{}, fmt.Errorf("%w: model_profile_reader requires model_profile_path", ErrInvalidClientConfig)
+	}
+	if trimmedModelProfilePath != "" {
+		if input.ModelProfileReader == nil {
+			return Config{}, fmt.Errorf("%w: model_profile_path requires model_profile_reader", ErrInvalidClientConfig)
+		}
+		if trimmedProvider != "" {
+			return Config{}, fmt.Errorf("%w: model_profile_path conflicts with provider", ErrInvalidClientConfig)
+		}
+		queryValues := parsedBaseURL.Query()
+		if queryValues.Has(queryProvider) {
+			return Config{}, fmt.Errorf("%w: model_profile_path conflicts with base_url provider query", ErrInvalidClientConfig)
+		}
+		if queryValues.Has(queryModel) {
+			return Config{}, fmt.Errorf("%w: model_profile_path conflicts with base_url model query", ErrInvalidClientConfig)
+		}
+	}
 	trimmedSecret := strings.TrimSpace(input.Secret)
 	if trimmedSecret == "" {
 		return Config{}, fmt.Errorf("%w: missing secret", ErrInvalidClientConfig)
@@ -95,10 +122,12 @@ func NewConfig(input ConfigInput) (Config, error) {
 		return Config{}, fmt.Errorf("%w: timeout must be positive", ErrInvalidClientConfig)
 	}
 	return Config{
-		baseURL:  parsedBaseURL,
-		secret:   trimmedSecret,
-		provider: strings.TrimSpace(input.Provider),
-		timeout:  input.Timeout,
+		baseURL:            parsedBaseURL,
+		secret:             trimmedSecret,
+		provider:           trimmedProvider,
+		modelProfilePath:   trimmedModelProfilePath,
+		modelProfileReader: input.ModelProfileReader,
+		timeout:            input.Timeout,
 	}, nil
 }
 
@@ -108,26 +137,41 @@ func (config Config) Timeout() time.Duration {
 }
 
 // MessagesPostURL builds the authenticated v2 JSON POST URL for this config.
-func (config Config) MessagesPostURL() string {
-	requestURL := config.messagesPostURL()
-	return requestURL.String()
+func (config Config) MessagesPostURL() (string, error) {
+	requestURL, requestError := config.messagesPostURL()
+	if requestError != nil {
+		return "", requestError
+	}
+	return requestURL.String(), nil
 }
 
-func (config Config) messagesPostURL() url.URL {
+func (config Config) messagesPostURL() (url.URL, error) {
+	provider := config.provider
+	if config.modelProfilePath != "" {
+		modelProfile, profileError := config.currentModelProfile()
+		if profileError != nil {
+			return url.URL{}, profileError
+		}
+		provider = modelProfile.provider
+	}
+	return config.messagesPostURLForProvider(provider), nil
+}
+
+func (config Config) messagesPostURLForProvider(provider string) url.URL {
 	requestURL := *config.baseURL
 	requestURL.Path = v2EndpointPath(requestURL.Path)
-	return config.authenticatedPostURL(requestURL)
+	return config.authenticatedPostURL(requestURL, provider)
 }
 
-func (config Config) authenticatedPostURL(requestURL url.URL) url.URL {
+func (config Config) authenticatedPostURL(requestURL url.URL, provider string) url.URL {
 	queryValues := requestURL.Query()
 	for queryKeyName := range postBodyQueryKeys {
 		queryValues.Del(queryKeyName)
 	}
 	queryValues.Set(queryKey, config.secret)
 	queryValues.Set(queryFormat, formatQueryValueTextPlain)
-	if config.provider != "" {
-		queryValues.Set(queryProvider, config.provider)
+	if provider != "" {
+		queryValues.Set(queryProvider, provider)
 	}
 	requestURL.RawQuery = queryValues.Encode()
 	return requestURL
@@ -194,13 +238,13 @@ func NewMessagesRequest(input MessagesRequestInput) (MessagesRequest, error) {
 	}, nil
 }
 
-func (request MessagesRequest) payloadBody() []byte {
+func (request MessagesRequest) payloadBody(model string) []byte {
 	payload := map[string]any{
 		"messages":   messagePayload(request.messages),
 		"web_search": request.webSearch,
 	}
-	if request.model != "" {
-		payload["model"] = request.model
+	if model != "" {
+		payload[queryModel] = model
 	}
 	if request.maxTokens != nil {
 		payload["max_tokens"] = *request.maxTokens
@@ -299,7 +343,29 @@ func NewClient(config Config, httpClient HTTPDoer) (Client, error) {
 
 // PostMessages sends a v2 JSON POST messages request and returns the response text.
 func (client Client) PostMessages(contextValue context.Context, request MessagesRequest) (string, error) {
-	return client.postPayload(contextValue, client.config.messagesPostURL(), request.payloadBody())
+	requestURL, requestBody, requestError := client.messagesPostRequest(request)
+	if requestError != nil {
+		return "", requestError
+	}
+	return client.postPayload(contextValue, requestURL, requestBody)
+}
+
+func (client Client) messagesPostRequest(request MessagesRequest) (url.URL, []byte, error) {
+	if client.config.modelProfilePath == "" {
+		return client.config.messagesPostURLForProvider(client.config.provider), request.payloadBody(request.model), nil
+	}
+	if request.model != "" {
+		return url.URL{}, nil, fmt.Errorf(
+			"%w: request model conflicts with model_profile path=%q",
+			ErrInvalidModelProfile,
+			client.config.modelProfilePath,
+		)
+	}
+	modelProfile, profileError := client.config.currentModelProfile()
+	if profileError != nil {
+		return url.URL{}, nil, profileError
+	}
+	return client.config.messagesPostURLForProvider(modelProfile.provider), request.payloadBody(modelProfile.model), nil
 }
 
 func (client Client) postPayload(contextValue context.Context, requestURL url.URL, requestBody []byte) (string, error) {

--- a/pkg/llmproxyclient/client_test.go
+++ b/pkg/llmproxyclient/client_test.go
@@ -3,10 +3,13 @@ package llmproxyclient_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -25,7 +28,11 @@ func TestConfigMessagesPostURLShapesAuthenticatedV2JSONPostURL(testingInstance *
 		testingInstance.Fatalf("config error: %v", configError)
 	}
 
-	parsedURL, parseError := url.Parse(config.MessagesPostURL())
+	messagesPostURL, messagesPostURLError := config.MessagesPostURL()
+	if messagesPostURLError != nil {
+		testingInstance.Fatalf("messages post URL error: %v", messagesPostURLError)
+	}
+	parsedURL, parseError := url.Parse(messagesPostURL)
 	if parseError != nil {
 		testingInstance.Fatalf("parse messages post url: %v", parseError)
 	}
@@ -40,7 +47,11 @@ func TestConfigMessagesPostURLShapesAuthenticatedV2JSONPostURL(testingInstance *
 	if v2ConfigError != nil {
 		testingInstance.Fatalf("v2 config error: %v", v2ConfigError)
 	}
-	parsedExistingMessagesURL, existingMessagesParseError := url.Parse(v2Config.MessagesPostURL())
+	existingMessagesPostURL, existingMessagesPostURLError := v2Config.MessagesPostURL()
+	if existingMessagesPostURLError != nil {
+		testingInstance.Fatalf("existing messages post URL error: %v", existingMessagesPostURLError)
+	}
+	parsedExistingMessagesURL, existingMessagesParseError := url.Parse(existingMessagesPostURL)
 	if existingMessagesParseError != nil {
 		testingInstance.Fatalf("parse existing messages post url: %v", existingMessagesParseError)
 	}
@@ -190,6 +201,412 @@ func TestClientOmitsModelWhenRequestUsesProviderDefault(testingInstance *testing
 	}
 }
 
+func TestClientReloadsAtomicallyReplacedModelProfile(testingInstance *testing.T) {
+	profilePath := filepath.Join(testingInstance.TempDir(), "current-model.json")
+	replaceModelProfile(testingInstance, profilePath, `{"provider":"gemini","model":"gemini-2.5-flash"}`)
+
+	type capturedModelProfileRequest struct {
+		provider string
+		model    string
+	}
+	capturedRequests := []capturedModelProfileRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		bodyBytes, readError := io.ReadAll(httpRequest.Body)
+		if readError != nil {
+			testingInstance.Fatalf("read body: %v", readError)
+		}
+		body := map[string]any{}
+		if decodeError := json.Unmarshal(bodyBytes, &body); decodeError != nil {
+			testingInstance.Fatalf("decode body: %v", decodeError)
+		}
+		model, modelExists := body["model"].(string)
+		if !modelExists {
+			testingInstance.Fatalf("profile request omitted model: %v", body)
+		}
+		capturedRequests = append(capturedRequests, capturedModelProfileRequest{
+			provider: httpRequest.URL.Query().Get("provider"),
+			model:    model,
+		})
+		_, _ = responseWriter.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+		BaseURL:            server.URL,
+		Secret:             "sekret",
+		ModelProfilePath:   profilePath,
+		ModelProfileReader: os.ReadFile,
+		Timeout:            time.Second,
+	})
+	if configError != nil {
+		testingInstance.Fatalf("config error: %v", configError)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		testingInstance.Fatalf("client error: %v", clientError)
+	}
+	request, requestError := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+		Messages: []llmproxyclient.MessageInput{{Role: "user", Content: "Select my model"}},
+	})
+	if requestError != nil {
+		testingInstance.Fatalf("request error: %v", requestError)
+	}
+
+	if _, postError := client.PostMessages(context.Background(), request); postError != nil {
+		testingInstance.Fatalf("post profile A: %v", postError)
+	}
+	replaceModelProfile(testingInstance, profilePath, `{"provider":"openai","model":"gpt-5-mini"}`)
+	if _, postError := client.PostMessages(context.Background(), request); postError != nil {
+		testingInstance.Fatalf("post profile B: %v", postError)
+	}
+
+	wantRequests := []capturedModelProfileRequest{
+		{provider: "gemini", model: "gemini-2.5-flash"},
+		{provider: "openai", model: "gpt-5-mini"},
+	}
+	if len(capturedRequests) != len(wantRequests) {
+		testingInstance.Fatalf("requests=%v", capturedRequests)
+	}
+	for requestIndex, wantRequest := range wantRequests {
+		if capturedRequests[requestIndex] != wantRequest {
+			testingInstance.Fatalf("request[%d]=%+v want=%+v", requestIndex, capturedRequests[requestIndex], wantRequest)
+		}
+	}
+}
+
+func TestConfigMessagesPostURLReloadsModelProfile(testingInstance *testing.T) {
+	profilePath := filepath.Join(testingInstance.TempDir(), "current-model.json")
+	replaceModelProfile(testingInstance, profilePath, `{"provider":"gemini","model":"gemini-2.5-flash"}`)
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+		BaseURL:            "https://proxy.example/review",
+		Secret:             "sekret",
+		ModelProfilePath:   profilePath,
+		ModelProfileReader: os.ReadFile,
+		Timeout:            time.Second,
+	})
+	if configError != nil {
+		testingInstance.Fatalf("config error: %v", configError)
+	}
+
+	firstURL, firstURLError := config.MessagesPostURL()
+	if firstURLError != nil {
+		testingInstance.Fatalf("first messages post URL error: %v", firstURLError)
+	}
+	firstParsedURL, firstParseError := url.Parse(firstURL)
+	if firstParseError != nil {
+		testingInstance.Fatalf("parse first URL: %v", firstParseError)
+	}
+	if firstParsedURL.Query().Get("provider") != "gemini" {
+		testingInstance.Fatalf("first provider=%q", firstParsedURL.Query().Get("provider"))
+	}
+
+	replaceModelProfile(testingInstance, profilePath, `{"provider":"openai","model":"gpt-5-mini"}`)
+	secondURL, secondURLError := config.MessagesPostURL()
+	if secondURLError != nil {
+		testingInstance.Fatalf("second messages post URL error: %v", secondURLError)
+	}
+	secondParsedURL, secondParseError := url.Parse(secondURL)
+	if secondParseError != nil {
+		testingInstance.Fatalf("parse second URL: %v", secondParseError)
+	}
+	if secondParsedURL.Query().Get("provider") != "openai" {
+		testingInstance.Fatalf("second provider=%q", secondParsedURL.Query().Get("provider"))
+	}
+
+	if removeError := os.Remove(profilePath); removeError != nil {
+		testingInstance.Fatalf("remove profile: %v", removeError)
+	}
+	if _, postURLError := config.MessagesPostURL(); !errors.Is(postURLError, llmproxyclient.ErrInvalidModelProfile) {
+		testingInstance.Fatalf("missing-profile URL error=%v", postURLError)
+	}
+}
+
+func TestClientRejectsInvalidOrCompetingModelProfilesBeforeHTTP(testingInstance *testing.T) {
+	profilePath := filepath.Join(testingInstance.TempDir(), "current-model.json")
+	replaceModelProfile(testingInstance, profilePath, `{"provider":"gemini","model":"gemini-2.5-flash"}`)
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		requestCount++
+		_, _ = responseWriter.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+		BaseURL:            server.URL,
+		Secret:             "sekret",
+		ModelProfilePath:   profilePath,
+		ModelProfileReader: os.ReadFile,
+		Timeout:            time.Second,
+	})
+	if configError != nil {
+		testingInstance.Fatalf("config error: %v", configError)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		testingInstance.Fatalf("client error: %v", clientError)
+	}
+	request, requestError := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+		Messages: []llmproxyclient.MessageInput{{Role: "user", Content: "Keep profile current"}},
+	})
+	if requestError != nil {
+		testingInstance.Fatalf("request error: %v", requestError)
+	}
+	if _, postError := client.PostMessages(context.Background(), request); postError != nil {
+		testingInstance.Fatalf("post valid profile: %v", postError)
+	}
+	if requestCount != 1 {
+		testingInstance.Fatalf("request count after valid profile=%d", requestCount)
+	}
+
+	invalidProfileCases := []struct {
+		name         string
+		prepare      func(*testing.T, string)
+		errorMessage string
+	}{
+		{
+			name: "empty document",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, "")
+			},
+			errorMessage: "decode model_profile",
+		},
+		{
+			name: "array document",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, "[]")
+			},
+			errorMessage: "document must be an object",
+		},
+		{
+			name: "malformed",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"provider":"gemini"`)
+			},
+			errorMessage: "decode model_profile",
+		},
+		{
+			name: "malformed second field",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"provider":"gemini",`)
+			},
+			errorMessage: "decode model_profile",
+		},
+		{
+			name: "non-string value",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"provider":7,"model":"gemini-2.5-flash"}`)
+			},
+			errorMessage: "decode model_profile",
+		},
+		{
+			name: "incomplete",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"provider":"gemini"}`)
+			},
+			errorMessage: "missing model",
+		},
+		{
+			name: "missing provider",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"model":"gemini-2.5-flash"}`)
+			},
+			errorMessage: "missing provider",
+		},
+		{
+			name: "unexpected field",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"provider":"gemini","model":"gemini-2.5-flash","secret":"forbidden"}`)
+			},
+			errorMessage: "unsupported field",
+		},
+		{
+			name: "duplicate field",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"provider":"gemini","provider":"openai","model":"gpt-5-mini"}`)
+			},
+			errorMessage: "duplicate field",
+		},
+		{
+			name: "trailing malformed JSON",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"provider":"gemini","model":"gemini-2.5-flash"} trailing`)
+			},
+			errorMessage: "decode model_profile",
+		},
+		{
+			name: "trailing JSON document",
+			prepare: func(subTest *testing.T, path string) {
+				replaceModelProfile(subTest, path, `{"provider":"gemini","model":"gemini-2.5-flash"}{}`)
+			},
+			errorMessage: "one JSON value",
+		},
+		{
+			name: "unreadable",
+			prepare: func(subTest *testing.T, path string) {
+				if removeError := os.Remove(path); removeError != nil {
+					subTest.Fatalf("remove profile: %v", removeError)
+				}
+			},
+			errorMessage: "read model_profile",
+		},
+	}
+	for _, invalidProfileCase := range invalidProfileCases {
+		testingInstance.Run(invalidProfileCase.name, func(subTest *testing.T) {
+			invalidProfileCase.prepare(subTest, profilePath)
+			_, postError := client.PostMessages(context.Background(), request)
+			if !errors.Is(postError, llmproxyclient.ErrInvalidModelProfile) {
+				subTest.Fatalf("post error=%v", postError)
+			}
+			if !strings.Contains(postError.Error(), invalidProfileCase.errorMessage) {
+				subTest.Fatalf("post error=%v missing %q", postError, invalidProfileCase.errorMessage)
+			}
+			if requestCount != 1 {
+				subTest.Fatalf("invalid profile reused a prior model; request count=%d", requestCount)
+			}
+			replaceModelProfile(subTest, profilePath, `{"provider":"gemini","model":"gemini-2.5-flash"}`)
+		})
+	}
+
+	pinnedRequest, pinnedRequestError := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+		Messages: []llmproxyclient.MessageInput{{Role: "user", Content: "Do not compete"}},
+		Model:    "gpt-5-mini",
+	})
+	if pinnedRequestError != nil {
+		testingInstance.Fatalf("pinned request error: %v", pinnedRequestError)
+	}
+	if _, postError := client.PostMessages(context.Background(), pinnedRequest); !errors.Is(postError, llmproxyclient.ErrInvalidModelProfile) {
+		testingInstance.Fatalf("pinned profile post error=%v", postError)
+	}
+	if requestCount != 1 {
+		testingInstance.Fatalf("competing request model reached HTTP; request count=%d", requestCount)
+	}
+}
+
+func TestConfigRejectsModelProfileSourceConflicts(testingInstance *testing.T) {
+	profileReader := llmproxyclient.ModelProfileReader(os.ReadFile)
+	testCases := []struct {
+		name        string
+		input       llmproxyclient.ConfigInput
+		errorString string
+	}{
+		{
+			name: "reader without path",
+			input: llmproxyclient.ConfigInput{
+				BaseURL:            "https://proxy.example",
+				Secret:             "sekret",
+				ModelProfileReader: profileReader,
+				Timeout:            time.Second,
+			},
+			errorString: "model_profile_reader requires model_profile_path",
+		},
+		{
+			name: "missing reader",
+			input: llmproxyclient.ConfigInput{
+				BaseURL:          "https://proxy.example",
+				Secret:           "sekret",
+				ModelProfilePath: "/profiles/user.json",
+				Timeout:          time.Second,
+			},
+			errorString: "model_profile_path requires model_profile_reader",
+		},
+		{
+			name: "configured provider",
+			input: llmproxyclient.ConfigInput{
+				BaseURL:            "https://proxy.example",
+				Secret:             "sekret",
+				Provider:           "gemini",
+				ModelProfilePath:   "/profiles/user.json",
+				ModelProfileReader: profileReader,
+				Timeout:            time.Second,
+			},
+			errorString: "conflicts with provider",
+		},
+		{
+			name: "base URL provider",
+			input: llmproxyclient.ConfigInput{
+				BaseURL:            "https://proxy.example?provider=gemini",
+				Secret:             "sekret",
+				ModelProfilePath:   "/profiles/user.json",
+				ModelProfileReader: profileReader,
+				Timeout:            time.Second,
+			},
+			errorString: "base_url provider query",
+		},
+		{
+			name: "base URL model",
+			input: llmproxyclient.ConfigInput{
+				BaseURL:            "https://proxy.example?model=gpt-5-mini",
+				Secret:             "sekret",
+				ModelProfilePath:   "/profiles/user.json",
+				ModelProfileReader: profileReader,
+				Timeout:            time.Second,
+			},
+			errorString: "base_url model query",
+		},
+	}
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			_, configError := llmproxyclient.NewConfig(testCase.input)
+			if !errors.Is(configError, llmproxyclient.ErrInvalidClientConfig) {
+				subTest.Fatalf("config error=%v", configError)
+			}
+			if !strings.Contains(configError.Error(), testCase.errorString) {
+				subTest.Fatalf("config error=%v missing %q", configError, testCase.errorString)
+			}
+		})
+	}
+}
+
+func TestClientSendsUnknownModelProfilePairToProxy(testingInstance *testing.T) {
+	profilePath := filepath.Join(testingInstance.TempDir(), "current-model.json")
+	replaceModelProfile(testingInstance, profilePath, `{"provider":"unknown","model":"unknown-model"}`)
+	var capturedProvider string
+	var capturedModel string
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		capturedProvider = httpRequest.URL.Query().Get("provider")
+		bodyBytes, readError := io.ReadAll(httpRequest.Body)
+		if readError != nil {
+			testingInstance.Fatalf("read body: %v", readError)
+		}
+		body := map[string]any{}
+		if decodeError := json.Unmarshal(bodyBytes, &body); decodeError != nil {
+			testingInstance.Fatalf("decode body: %v", decodeError)
+		}
+		capturedModel, _ = body["model"].(string)
+		responseWriter.WriteHeader(http.StatusBadRequest)
+		_, _ = responseWriter.Write([]byte("unknown provider/model pair"))
+	}))
+	defer server.Close()
+
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+		BaseURL:            server.URL,
+		Secret:             "sekret",
+		ModelProfilePath:   profilePath,
+		ModelProfileReader: os.ReadFile,
+		Timeout:            time.Second,
+	})
+	if configError != nil {
+		testingInstance.Fatalf("config error: %v", configError)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		testingInstance.Fatalf("client error: %v", clientError)
+	}
+	request, requestError := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+		Messages: []llmproxyclient.MessageInput{{Role: "user", Content: "Route this pair"}},
+	})
+	if requestError != nil {
+		testingInstance.Fatalf("request error: %v", requestError)
+	}
+
+	if _, postError := client.PostMessages(context.Background(), request); !errors.Is(postError, llmproxyclient.ErrClientHTTPFailure) {
+		testingInstance.Fatalf("post error=%v", postError)
+	}
+	if capturedProvider != "unknown" || capturedModel != "unknown-model" {
+		testingInstance.Fatalf("proxy received provider=%q model=%q", capturedProvider, capturedModel)
+	}
+}
+
 func TestMessagesRequestRejectsInvalidInputs(testingInstance *testing.T) {
 	testCases := []struct {
 		name        string
@@ -245,6 +662,17 @@ func TestMessagesRequestRejectsInvalidInputs(testingInstance *testing.T) {
 				subTest.Fatalf("error=%v want contains %q", requestError, testCase.errorString)
 			}
 		})
+	}
+}
+
+func replaceModelProfile(testingInstance *testing.T, profilePath string, profileDocument string) {
+	testingInstance.Helper()
+	replacementPath := filepath.Join(filepath.Dir(profilePath), "next-model.json")
+	if writeError := os.WriteFile(replacementPath, []byte(profileDocument), 0600); writeError != nil {
+		testingInstance.Fatalf("write replacement model profile: %v", writeError)
+	}
+	if renameError := os.Rename(replacementPath, profilePath); renameError != nil {
+		testingInstance.Fatalf("replace model profile: %v", renameError)
 	}
 }
 

--- a/pkg/llmproxyclient/client_test.go
+++ b/pkg/llmproxyclient/client_test.go
@@ -371,6 +371,15 @@ func TestClientRejectsInvalidOrCompetingModelProfilesBeforeHTTP(testingInstance 
 			errorMessage: "decode model_profile",
 		},
 		{
+			name: "invalid UTF-8 document",
+			prepare: func(subTest *testing.T, path string) {
+				invalidProfile := []byte(`{"provider":"gemini","model":"gemini-2.5-flash"}`)
+				invalidProfile[len(invalidProfile)-3] = 0xff
+				replaceModelProfileBytes(subTest, path, invalidProfile)
+			},
+			errorMessage: "valid UTF-8",
+		},
+		{
 			name: "array document",
 			prepare: func(subTest *testing.T, path string) {
 				replaceModelProfile(subTest, path, "[]")
@@ -667,8 +676,13 @@ func TestMessagesRequestRejectsInvalidInputs(testingInstance *testing.T) {
 
 func replaceModelProfile(testingInstance *testing.T, profilePath string, profileDocument string) {
 	testingInstance.Helper()
+	replaceModelProfileBytes(testingInstance, profilePath, []byte(profileDocument))
+}
+
+func replaceModelProfileBytes(testingInstance *testing.T, profilePath string, profileBytes []byte) {
+	testingInstance.Helper()
 	replacementPath := filepath.Join(filepath.Dir(profilePath), "next-model.json")
-	if writeError := os.WriteFile(replacementPath, []byte(profileDocument), 0600); writeError != nil {
+	if writeError := os.WriteFile(replacementPath, profileBytes, 0600); writeError != nil {
 		testingInstance.Fatalf("write replacement model profile: %v", writeError)
 	}
 	if renameError := os.Rename(replacementPath, profilePath); renameError != nil {

--- a/pkg/llmproxyclient/model_profile.go
+++ b/pkg/llmproxyclient/model_profile.go
@@ -1,0 +1,118 @@
+package llmproxyclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const modelProfileSubject = "model_profile"
+
+// ModelProfileReader reads the current JSON model-profile document from a configured path.
+type ModelProfileReader func(path string) ([]byte, error)
+
+type modelProfile struct {
+	provider string
+	model    string
+}
+
+func (config Config) currentModelProfile() (modelProfile, error) {
+	profileBytes, readError := config.modelProfileReader(config.modelProfilePath)
+	if readError != nil {
+		return modelProfile{}, fmt.Errorf(
+			"%w: read %s path=%q: %v",
+			ErrInvalidModelProfile,
+			modelProfileSubject,
+			config.modelProfilePath,
+			readError,
+		)
+	}
+	return decodeModelProfile(config.modelProfilePath, profileBytes)
+}
+
+func decodeModelProfile(profilePath string, profileBytes []byte) (modelProfile, error) {
+	decoder := json.NewDecoder(bytes.NewReader(profileBytes))
+	openingToken, openingError := decoder.Token()
+	if openingError != nil {
+		return modelProfile{}, modelProfileDecodeError(profilePath, openingError)
+	}
+	openingDelimiter, isDelimiter := openingToken.(json.Delim)
+	if !isDelimiter || openingDelimiter != '{' {
+		return modelProfile{}, modelProfileSchemaError(profilePath, "document must be an object")
+	}
+
+	profileValues := map[string]string{}
+	for decoder.More() {
+		profileFieldToken, fieldError := decoder.Token()
+		if fieldError != nil {
+			return modelProfile{}, modelProfileDecodeError(profilePath, fieldError)
+		}
+		profileField := fmt.Sprint(profileFieldToken)
+		if !isModelProfileField(profileField) {
+			return modelProfile{}, modelProfileSchemaError(profilePath, fmt.Sprintf("unsupported field=%q", profileField))
+		}
+		if _, exists := profileValues[profileField]; exists {
+			return modelProfile{}, modelProfileSchemaError(profilePath, fmt.Sprintf("duplicate field=%q", profileField))
+		}
+		var profileValue string
+		if valueError := decoder.Decode(&profileValue); valueError != nil {
+			return modelProfile{}, modelProfileDecodeError(profilePath, valueError)
+		}
+		profileValues[profileField] = profileValue
+	}
+
+	_, closingError := decoder.Token()
+	if closingError != nil {
+		return modelProfile{}, modelProfileDecodeError(profilePath, closingError)
+	}
+	if trailingError := decoder.Decode(&struct{}{}); trailingError != io.EOF {
+		if trailingError != nil {
+			return modelProfile{}, modelProfileDecodeError(profilePath, trailingError)
+		}
+		return modelProfile{}, modelProfileSchemaError(profilePath, "document must contain one JSON value")
+	}
+	return newModelProfile(profilePath, profileValues[queryProvider], profileValues[queryModel])
+}
+
+func isModelProfileField(profileField string) bool {
+	switch profileField {
+	case queryProvider, queryModel:
+		return true
+	default:
+		return false
+	}
+}
+
+func newModelProfile(profilePath string, provider string, model string) (modelProfile, error) {
+	trimmedProvider := strings.TrimSpace(provider)
+	if trimmedProvider == "" {
+		return modelProfile{}, modelProfileSchemaError(profilePath, "missing provider")
+	}
+	trimmedModel := strings.TrimSpace(model)
+	if trimmedModel == "" {
+		return modelProfile{}, modelProfileSchemaError(profilePath, "missing model")
+	}
+	return modelProfile{provider: trimmedProvider, model: trimmedModel}, nil
+}
+
+func modelProfileDecodeError(profilePath string, decodeError error) error {
+	return fmt.Errorf(
+		"%w: decode %s path=%q: %v",
+		ErrInvalidModelProfile,
+		modelProfileSubject,
+		profilePath,
+		decodeError,
+	)
+}
+
+func modelProfileSchemaError(profilePath string, message string) error {
+	return fmt.Errorf(
+		"%w: validate %s path=%q: %s",
+		ErrInvalidModelProfile,
+		modelProfileSubject,
+		profilePath,
+		message,
+	)
+}

--- a/pkg/llmproxyclient/model_profile.go
+++ b/pkg/llmproxyclient/model_profile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 )
 
 const modelProfileSubject = "model_profile"
@@ -33,6 +34,9 @@ func (config Config) currentModelProfile() (modelProfile, error) {
 }
 
 func decodeModelProfile(profilePath string, profileBytes []byte) (modelProfile, error) {
+	if !utf8.Valid(profileBytes) {
+		return modelProfile{}, modelProfileSchemaError(profilePath, "document must use valid UTF-8")
+	}
 	decoder := json.NewDecoder(bytes.NewReader(profileBytes))
 	openingToken, openingError := decoder.Token()
 	if openingError != nil {

--- a/python/llm_proxy_client/__init__.py
+++ b/python/llm_proxy_client/__init__.py
@@ -7,6 +7,7 @@ from .client import (
     ClientMessage,
     LLMProxyClientError,
     LLMProxyHTTPError,
+    LLMProxyModelProfileError,
     LLMProxyTransportError,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "ClientMessage",
     "LLMProxyClientError",
     "LLMProxyHTTPError",
+    "LLMProxyModelProfileError",
     "LLMProxyTransportError",
 ]

--- a/python/llm_proxy_client/client.py
+++ b/python/llm_proxy_client/client.py
@@ -149,7 +149,7 @@ class ClientConfig:
         model_profile_reader = cast(ModelProfileReader, self.model_profile_reader)
         try:
             model_profile_document = model_profile_reader(model_profile_path)
-        except (OSError, UnicodeError) as error:
+        except Exception as error:
             raise LLMProxyModelProfileError(
                 f"llm_proxy_client_invalid_model_profile: read {MODEL_PROFILE_SUBJECT} "
                 f"path={model_profile_path!r}: {error}"

--- a/python/llm_proxy_client/client.py
+++ b/python/llm_proxy_client/client.py
@@ -16,10 +16,13 @@ FORMAT_QUERY_VALUE_TEXT_PLAIN = "text/plain"
 JSON_CONTENT_TYPE = "application/json; charset=utf-8"
 KEY_QUERY_KEY = "key"
 PROVIDER_QUERY_KEY = "provider"
+MODEL_PROFILE_MODEL_KEY = "model"
+MODEL_PROFILE_SUBJECT = "model_profile"
+MODEL_PROFILE_FIELDS = frozenset({PROVIDER_QUERY_KEY, MODEL_PROFILE_MODEL_KEY})
 POST_BODY_QUERY_KEYS = frozenset(
     {
         "messages",
-        "model",
+        MODEL_PROFILE_MODEL_KEY,
         "max_output_tokens",
         "max_tokens",
         "prompt",
@@ -32,6 +35,10 @@ MESSAGE_ROLES = frozenset({"system", "user", "assistant"})
 
 class LLMProxyClientError(ValueError):
     """Raised when llm-proxy client config or request input is invalid."""
+
+
+class LLMProxyModelProfileError(LLMProxyClientError):
+    """Raised when a configured JSON model-profile document is invalid."""
 
 
 class LLMProxyHTTPError(RuntimeError):
@@ -59,6 +66,24 @@ class ResponseOpener(Protocol):
         """Return decoded response text for the prepared request."""
 
 
+class ModelProfileReader(Protocol):
+    """Callable that reads a current JSON model-profile document."""
+
+    def __call__(self, path: str) -> str:
+        """Return the model-profile document at the configured path."""
+
+
+@dataclass(frozen=True)
+class _JSONModelProfileObject:
+    pairs: tuple[tuple[str, Any], ...]
+
+
+@dataclass(frozen=True)
+class _ModelProfile:
+    provider: str
+    model: str
+
+
 @dataclass(frozen=True)
 class ClientConfig:
     """Validated llm-proxy client configuration."""
@@ -67,6 +92,8 @@ class ClientConfig:
     secret: str
     provider: str = ""
     timeout_seconds: float = 390.0
+    model_profile_path: str = ""
+    model_profile_reader: ModelProfileReader | None = None
 
     def __post_init__(self) -> None:
         if not self.base_url.strip():
@@ -81,8 +108,56 @@ class ClientConfig:
         if self.timeout_seconds <= 0:
             raise LLMProxyClientError("llm_proxy_client_invalid_config: timeout_seconds must be positive")
 
+        model_profile_path = self.model_profile_path.strip()
+        if not model_profile_path and self.model_profile_reader is not None:
+            raise LLMProxyClientError(
+                "llm_proxy_client_invalid_config: model_profile_reader requires model_profile_path"
+            )
+        if model_profile_path:
+            if self.model_profile_reader is None:
+                raise LLMProxyClientError(
+                    "llm_proxy_client_invalid_config: model_profile_path requires model_profile_reader"
+                )
+            if not callable(self.model_profile_reader):
+                raise LLMProxyClientError(
+                    "llm_proxy_client_invalid_config: model_profile_reader must be callable"
+                )
+            if self.provider.strip():
+                raise LLMProxyClientError("llm_proxy_client_invalid_config: model_profile_path conflicts with provider")
+            query_keys = {query_key for query_key, _ in urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)}
+            if PROVIDER_QUERY_KEY in query_keys:
+                raise LLMProxyClientError(
+                    "llm_proxy_client_invalid_config: model_profile_path conflicts with base_url provider query"
+                )
+            if MODEL_PROFILE_MODEL_KEY in query_keys:
+                raise LLMProxyClientError(
+                    "llm_proxy_client_invalid_config: model_profile_path conflicts with base_url model query"
+                )
+
     def messages_post_url(self) -> str:
         """Return the authenticated v2 JSON POST URL for this config."""
+
+        provider = self.provider.strip()
+        if self.model_profile_path.strip():
+            provider = self._current_model_profile().provider
+        return self._messages_post_url_for_provider(provider)
+
+    def _current_model_profile(self) -> _ModelProfile:
+        """Read and validate the current model-profile document."""
+
+        model_profile_path = self.model_profile_path.strip()
+        model_profile_reader = cast(ModelProfileReader, self.model_profile_reader)
+        try:
+            model_profile_document = model_profile_reader(model_profile_path)
+        except (OSError, UnicodeError) as error:
+            raise LLMProxyModelProfileError(
+                f"llm_proxy_client_invalid_model_profile: read {MODEL_PROFILE_SUBJECT} "
+                f"path={model_profile_path!r}: {error}"
+            ) from error
+        return _decode_model_profile(model_profile_path, model_profile_document)
+
+    def _messages_post_url_for_provider(self, provider: str) -> str:
+        """Return the authenticated v2 JSON POST URL for one validated provider override."""
 
         parsed_url = urllib.parse.urlparse(self.base_url.strip())
         request_path = parsed_url.path or "/"
@@ -90,7 +165,7 @@ class ClientConfig:
         query_items = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
         stripped_query_keys = set(POST_BODY_QUERY_KEYS)
         stripped_query_keys.update({KEY_QUERY_KEY, FORMAT_QUERY_KEY})
-        if self.provider.strip():
+        if provider.strip():
             stripped_query_keys.add(PROVIDER_QUERY_KEY)
         preserved_items = [
             (query_key, query_value) for query_key, query_value in query_items if query_key not in stripped_query_keys
@@ -101,8 +176,8 @@ class ClientConfig:
                 (FORMAT_QUERY_KEY, FORMAT_QUERY_VALUE_TEXT_PLAIN),
             ]
         )
-        if self.provider.strip():
-            preserved_items.append((PROVIDER_QUERY_KEY, self.provider.strip()))
+        if provider.strip():
+            preserved_items.append((PROVIDER_QUERY_KEY, provider.strip()))
         return urllib.parse.urlunparse(
             (
                 parsed_url.scheme,
@@ -113,6 +188,73 @@ class ClientConfig:
                 "",
             )
         )
+
+
+def _decode_model_profile(model_profile_path: str, model_profile_document: str) -> _ModelProfile:
+    """Decode one exact provider/model JSON document from a configured path."""
+
+    if not isinstance(model_profile_document, str):
+        raise LLMProxyModelProfileError(
+            f"llm_proxy_client_invalid_model_profile: read {MODEL_PROFILE_SUBJECT} "
+            f"path={model_profile_path!r}: reader must return text"
+        )
+    try:
+        decoded_document = json.loads(model_profile_document, object_pairs_hook=_json_model_profile_object)
+    except json.JSONDecodeError as error:
+        raise LLMProxyModelProfileError(
+            f"llm_proxy_client_invalid_model_profile: decode {MODEL_PROFILE_SUBJECT} "
+            f"path={model_profile_path!r}: {error}"
+        ) from error
+    if not isinstance(decoded_document, _JSONModelProfileObject):
+        raise LLMProxyModelProfileError(
+            f"llm_proxy_client_invalid_model_profile: validate {MODEL_PROFILE_SUBJECT} "
+            f"path={model_profile_path!r}: document must be an object"
+        )
+
+    profile_values: dict[str, str] = {}
+    for profile_field, profile_value in decoded_document.pairs:
+        if profile_field not in MODEL_PROFILE_FIELDS:
+            raise LLMProxyModelProfileError(
+                f"llm_proxy_client_invalid_model_profile: validate {MODEL_PROFILE_SUBJECT} "
+                f"path={model_profile_path!r}: unsupported field={profile_field!r}"
+            )
+        if profile_field in profile_values:
+            raise LLMProxyModelProfileError(
+                f"llm_proxy_client_invalid_model_profile: validate {MODEL_PROFILE_SUBJECT} "
+                f"path={model_profile_path!r}: duplicate field={profile_field!r}"
+            )
+        if not isinstance(profile_value, str):
+            raise LLMProxyModelProfileError(
+                f"llm_proxy_client_invalid_model_profile: validate {MODEL_PROFILE_SUBJECT} "
+                f"path={model_profile_path!r}: field={profile_field!r} must be a string"
+            )
+        profile_values[profile_field] = profile_value
+    try:
+        provider = profile_values[PROVIDER_QUERY_KEY].strip()
+        model = profile_values[MODEL_PROFILE_MODEL_KEY].strip()
+    except KeyError as error:
+        missing_field = str(error).strip("'")
+        raise LLMProxyModelProfileError(
+            f"llm_proxy_client_invalid_model_profile: validate {MODEL_PROFILE_SUBJECT} "
+            f"path={model_profile_path!r}: missing {missing_field}"
+        ) from error
+    if not provider:
+        raise LLMProxyModelProfileError(
+            f"llm_proxy_client_invalid_model_profile: validate {MODEL_PROFILE_SUBJECT} "
+            f"path={model_profile_path!r}: missing provider"
+        )
+    if not model:
+        raise LLMProxyModelProfileError(
+            f"llm_proxy_client_invalid_model_profile: validate {MODEL_PROFILE_SUBJECT} "
+            f"path={model_profile_path!r}: missing model"
+        )
+    return _ModelProfile(provider=provider, model=model)
+
+
+def _json_model_profile_object(profile_pairs: list[tuple[str, Any]]) -> _JSONModelProfileObject:
+    """Preserve profile object field ordering and duplicate keys while decoding JSON."""
+
+    return _JSONModelProfileObject(pairs=tuple(profile_pairs))
 
 
 def v2_endpoint_path(base_path: str) -> str:
@@ -170,12 +312,17 @@ class ClientMessagesRequest:
     def body(self) -> dict[str, Any]:
         """Return the JSON body payload for this v2 request."""
 
+        return self._body_with_model(self.model.strip())
+
+    def _body_with_model(self, model: str) -> dict[str, Any]:
+        """Return the JSON body payload with one resolved model value."""
+
         payload: dict[str, Any] = {
             "messages": [message.body() for message in ordered_messages(self.messages)],
             "web_search": self.web_search,
         }
-        if self.model.strip():
-            payload["model"] = self.model.strip()
+        if model:
+            payload[MODEL_PROFILE_MODEL_KEY] = model
         if self.max_tokens is not None:
             payload["max_tokens"] = self.max_tokens
         return payload
@@ -212,6 +359,17 @@ class Client:
     def post_messages(self, request: ClientMessagesRequest) -> str:
         """Send a v2 messages-only JSON POST request and return the response text."""
 
+        if self.config.model_profile_path.strip():
+            if request.model.strip():
+                raise LLMProxyModelProfileError(
+                    f"llm_proxy_client_invalid_model_profile: request model conflicts with "
+                    f"{MODEL_PROFILE_SUBJECT} path={self.config.model_profile_path.strip()!r}"
+                )
+            model_profile = self.config._current_model_profile()
+            return self._post_json(
+                request._body_with_model(model_profile.model),
+                self.config._messages_post_url_for_provider(model_profile.provider),
+            )
         return self._post_json(request.body(), self.config.messages_post_url())
 
     def _post_json(self, request_payload: dict[str, Any], request_url: str) -> str:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -290,6 +290,33 @@ def test_client_rejects_invalid_or_competing_model_profiles_before_http(
     assert len(CapturingHandler.captured_requests) == 1
 
 
+def test_client_normalizes_model_profile_reader_failures_before_http(running_server: RunningServer) -> None:
+    """Application reader failures are typed and never reach the proxy."""
+
+    model_profile_path = "/profiles/current-model.json"
+
+    def failing_model_profile_reader(profile_path: str) -> str:
+        """Simulate an application profile-storage failure."""
+
+        raise ValueError(f"application storage rejected {profile_path!r}")
+
+    client = Client(
+        ClientConfig(
+            base_url=running_server.url,
+            secret="test-secret",
+            model_profile_path=model_profile_path,
+            model_profile_reader=failing_model_profile_reader,
+        )
+    )
+
+    with pytest.raises(LLMProxyModelProfileError, match="read model_profile") as error_info:
+        client.post_messages(ClientMessagesRequest(messages=(ClientMessage(role="user", content="Keep it typed"),)))
+
+    assert f"path={model_profile_path!r}" in str(error_info.value)
+    assert "application storage rejected" in str(error_info.value)
+    assert CapturingHandler.captured_requests == []
+
+
 def test_client_sends_unknown_model_profile_pair_to_proxy(running_server: RunningServer, tmp_path: Path) -> None:
     """The client leaves exact provider/model validation to the proxy boundary."""
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 import urllib.error
@@ -10,6 +11,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -21,6 +23,7 @@ from llm_proxy_client import (
     ClientMessage,
     LLMProxyClientError,
     LLMProxyHTTPError,
+    LLMProxyModelProfileError,
     LLMProxyTransportError,
 )
 
@@ -40,6 +43,7 @@ class CapturingHandler(BaseHTTPRequestHandler):
     """HTTP handler that captures the request and returns a configured body."""
 
     captured_request = CapturedRequest()
+    captured_requests: list[CapturedRequest] = []
     response_status = 200
     response_body = "reviewed"
     response_delay_seconds = 0.0
@@ -49,13 +53,15 @@ class CapturingHandler(BaseHTTPRequestHandler):
 
         body_length = int(self.headers.get("Content-Length", "0"))
         raw_body = self.rfile.read(body_length).decode("utf-8")
-        type(self).captured_request = CapturedRequest(
+        captured_request = CapturedRequest(
             method=self.command,
             path=self.path,
             accept=self.headers.get("Accept", ""),
             content_type=self.headers.get("Content-Type", ""),
             body=json.loads(raw_body),
         )
+        type(self).captured_request = captured_request
+        type(self).captured_requests.append(captured_request)
         if type(self).response_delay_seconds > 0:
             time.sleep(type(self).response_delay_seconds)
         self.send_response(type(self).response_status)
@@ -96,6 +102,7 @@ def running_server() -> RunningServer:
     """Start a local HTTP server for client contract tests."""
 
     CapturingHandler.captured_request = CapturedRequest()
+    CapturingHandler.captured_requests = []
     CapturingHandler.response_status = 200
     CapturingHandler.response_body = "reviewed"
     CapturingHandler.response_delay_seconds = 0.0
@@ -107,6 +114,20 @@ def running_server() -> RunningServer:
         yield running
     finally:
         running.close()
+
+
+def read_model_profile(profile_path: str) -> str:
+    """Read one application-owned model profile as UTF-8 text."""
+
+    return Path(profile_path).read_text(encoding="utf-8")
+
+
+def replace_model_profile(profile_path: Path, profile_document: str) -> None:
+    """Atomically replace one application-owned profile document."""
+
+    replacement_path = profile_path.with_name("next-model.json")
+    replacement_path.write_text(profile_document, encoding="utf-8")
+    os.replace(replacement_path, profile_path)
 
 
 def test_client_posts_v2_body_and_preserves_non_body_query(running_server: RunningServer) -> None:
@@ -175,6 +196,124 @@ def test_client_omits_model_when_request_uses_provider_default(running_server: R
         "messages": [{"role": "user", "content": "Use provider default"}],
         "web_search": False,
     }
+
+
+def test_client_reloads_atomically_replaced_model_profile(running_server: RunningServer, tmp_path: Path) -> None:
+    """One client reads the profile that exists at each outbound request."""
+
+    profile_path = tmp_path / "current-model.json"
+    replace_model_profile(profile_path, '{"provider":"gemini","model":"gemini-2.5-flash"}')
+    client = Client(
+        ClientConfig(
+            base_url=running_server.url,
+            secret="test-secret",
+            model_profile_path=str(profile_path),
+            model_profile_reader=read_model_profile,
+        )
+    )
+    request = ClientMessagesRequest(messages=(ClientMessage(role="user", content="Use my selected model"),))
+
+    assert client.post_messages(request) == "reviewed"
+    replace_model_profile(profile_path, '{"provider":"openai","model":"gpt-5-mini"}')
+    assert client.post_messages(request) == "reviewed"
+
+    assert [
+        (
+            urllib.parse.parse_qs(urllib.parse.urlparse(captured_request.path).query)["provider"],
+            captured_request.body,
+        )
+        for captured_request in CapturingHandler.captured_requests
+    ] == [
+        (
+            ["gemini"],
+            {
+                "messages": [{"role": "user", "content": "Use my selected model"}],
+                "web_search": False,
+                "model": "gemini-2.5-flash",
+            },
+        ),
+        (
+            ["openai"],
+            {
+                "messages": [{"role": "user", "content": "Use my selected model"}],
+                "web_search": False,
+                "model": "gpt-5-mini",
+            },
+        ),
+    ]
+
+
+def test_client_rejects_invalid_or_competing_model_profiles_before_http(
+    running_server: RunningServer, tmp_path: Path
+) -> None:
+    """Invalid profiles and a pinned request never reuse a prior profile or call the proxy."""
+
+    profile_path = tmp_path / "current-model.json"
+    valid_profile = '{"provider":"gemini","model":"gemini-2.5-flash"}'
+    replace_model_profile(profile_path, valid_profile)
+    client = Client(
+        ClientConfig(
+            base_url=running_server.url,
+            secret="test-secret",
+            model_profile_path=str(profile_path),
+            model_profile_reader=read_model_profile,
+        )
+    )
+    request = ClientMessagesRequest(messages=(ClientMessage(role="user", content="Keep the profile current"),))
+
+    assert client.post_messages(request) == "reviewed"
+    assert len(CapturingHandler.captured_requests) == 1
+    invalid_profiles = [
+        ('{"provider":"gemini"', "decode model_profile"),
+        ('{"provider":"gemini"}', "missing model"),
+        ('{"provider":"gemini","model":"gemini-2.5-flash","secret":"forbidden"}', "unsupported field"),
+        ('{"provider":"gemini","provider":"openai","model":"gpt-5-mini"}', "duplicate field"),
+    ]
+    for invalid_profile, expected_error in invalid_profiles:
+        replace_model_profile(profile_path, invalid_profile)
+        with pytest.raises(LLMProxyModelProfileError, match=expected_error):
+            client.post_messages(request)
+        assert len(CapturingHandler.captured_requests) == 1
+        replace_model_profile(profile_path, valid_profile)
+
+    profile_path.unlink()
+    with pytest.raises(LLMProxyModelProfileError, match="read model_profile"):
+        client.post_messages(request)
+    assert len(CapturingHandler.captured_requests) == 1
+    replace_model_profile(profile_path, valid_profile)
+
+    pinned_request = ClientMessagesRequest(
+        messages=(ClientMessage(role="user", content="Do not compete"),), model="gpt-5-mini"
+    )
+    with pytest.raises(LLMProxyModelProfileError, match="request model conflicts"):
+        client.post_messages(pinned_request)
+    assert len(CapturingHandler.captured_requests) == 1
+
+
+def test_client_sends_unknown_model_profile_pair_to_proxy(running_server: RunningServer, tmp_path: Path) -> None:
+    """The client leaves exact provider/model validation to the proxy boundary."""
+
+    profile_path = tmp_path / "current-model.json"
+    replace_model_profile(profile_path, '{"provider":"unknown","model":"unknown-model"}')
+    CapturingHandler.response_status = 400
+    CapturingHandler.response_body = "unknown provider/model pair"
+    client = Client(
+        ClientConfig(
+            base_url=running_server.url,
+            secret="test-secret",
+            model_profile_path=str(profile_path),
+            model_profile_reader=read_model_profile,
+        )
+    )
+
+    with pytest.raises(LLMProxyHTTPError) as error_info:
+        client.post_messages(ClientMessagesRequest(messages=(ClientMessage(role="user", content="Route this pair"),)))
+
+    parsed_path = urllib.parse.urlparse(CapturingHandler.captured_request.path)
+    assert error_info.value.status_code == 400
+    assert urllib.parse.parse_qs(parsed_path.query)["provider"] == ["unknown"]
+    assert CapturingHandler.captured_request.body is not None
+    assert CapturingHandler.captured_request.body["model"] == "unknown-model"
 
 
 def test_client_overrides_provider_and_sends_optional_v2_body_fields(running_server: RunningServer) -> None:
@@ -256,6 +395,55 @@ def test_client_posts_v2_messages_body(running_server: RunningServer) -> None:
         ({"base_url": "http://", "secret": "sekret"}, "base_url must include host"),
         ({"base_url": "http://example.test", "secret": ""}, "missing secret"),
         ({"base_url": "http://example.test", "secret": "sekret", "timeout_seconds": 0}, "timeout_seconds must be positive"),
+        (
+            {"base_url": "http://example.test", "secret": "sekret", "model_profile_path": "/profiles/user.json"},
+            "model_profile_path requires model_profile_reader",
+        ),
+        (
+            {
+                "base_url": "http://example.test",
+                "secret": "sekret",
+                "model_profile_reader": read_model_profile,
+            },
+            "model_profile_reader requires model_profile_path",
+        ),
+        (
+            {
+                "base_url": "http://example.test",
+                "secret": "sekret",
+                "model_profile_path": "/profiles/user.json",
+                "model_profile_reader": "not-a-reader",
+            },
+            "model_profile_reader must be callable",
+        ),
+        (
+            {
+                "base_url": "http://example.test",
+                "secret": "sekret",
+                "provider": "gemini",
+                "model_profile_path": "/profiles/user.json",
+                "model_profile_reader": read_model_profile,
+            },
+            "model_profile_path conflicts with provider",
+        ),
+        (
+            {
+                "base_url": "http://example.test?provider=gemini",
+                "secret": "sekret",
+                "model_profile_path": "/profiles/user.json",
+                "model_profile_reader": read_model_profile,
+            },
+            "base_url provider query",
+        ),
+        (
+            {
+                "base_url": "http://example.test?model=gpt-5-mini",
+                "secret": "sekret",
+                "model_profile_path": "/profiles/user.json",
+                "model_profile_reader": read_model_profile,
+            },
+            "base_url model query",
+        ),
     ],
 )
 def test_config_validation_errors(config_kwargs: dict[str, object], expected_error: str) -> None:


### PR DESCRIPTION
## Summary

This change introduces dynamic, reloadable model profiles for application-level user selection of provider/model pairs in both Go and Python LLM Proxy clients, as well as the CLI. It implements strict validation and atomic reload of a single JSON profile per client, enabling per-user or application-level dynamic routing without requiring code changes, process restarts, or redeployments.

## Key Changes

- Adds support for specifying a canonical JSON model profile containing the provider and model, validated and loaded at each request.
- Exposes a `--model-profile` option in the Go CLI for command-line configuration.
- Updates both Go and Python client libraries to support reading, edge-validating, and atomically reloading the profile; requests now fail eagerly for unreadable, invalid, or conflicting profile sources.
- Documents and enforces the rule that the model profile, if configured, is the exclusive source of provider/model selection—other config/request-level values are rejected in its presence.
- Provides example integrations and usage documentation distinguishing between tenant-based defaults and per-user/application profile selection.
- Adds comprehensive tests and documentation to prove profile reload, error handling, and mutual exclusivity with other selection sources.

## Motivation

This enables applications to integrate the client library once and offer dynamic model selection for their users