### PR TITLE
fix(logging): keep web search query values out of logs

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -656,6 +656,21 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   Resolved:
   Structured request logs now use the canonical escaped path without a query component. Black-box router coverage sends distinct prompt, system prompt, tenant-secret, and rejected provider-key query values, then verifies none reach any emitted structured log field. README documents the query-free logging boundary. Baseline and final `timeout -k 350s -s SIGKILL 350s make ci` runs passed.
 
+- [x] [B040] (P1) Keep invalid web-search query values out of structured logs.
+  Goal:
+  Preserve the query-free logging contract when the public `GET /` parser receives an invalid `web_search` value.
+  Requirements:
+  - Emit only stable parser metadata; do not log the raw query value or an error string that embeds it.
+  - Preserve the current request-authentication and invalid-web-search handling semantics.
+  - Extend router-level log coverage with an authenticated invalid `web_search` sentinel and prove it is absent from every emitted log entry.
+  Deliverables:
+  - A query-free invalid-web-search parser warning.
+  - Regression coverage for the full authenticated HTTP path.
+  Validation:
+  - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci` pair after the final code edit.
+  Resolved:
+  The invalid `web_search` warning now emits only its stable event and no query-derived fields or error values. Router-level black-box coverage drives an authenticated invalid-web-search sentinel through the existing request flow and verifies it, prompts, tenant keys, and rejected credential-shaped values remain absent from every structured log entry. Baseline and final `timeout -k 350s -s SIGKILL 350s make ci` runs passed.
+
 ## Improvements
 
 - [x] [I024] (P1) Add Qwen 3.8 Token Plan and MiniMax M2.7 providers.

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -157,7 +157,6 @@ const (
 	logFieldMethod       = "method"
 	logFieldClientIP     = "client_ip"
 	logFieldStatus       = "status"
-	logFieldValue        = "value"
 	logFieldTenantID     = "tenant_id"
 	logFieldEndpoint     = "endpoint"
 	logFieldProvider     = "provider"

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -281,11 +281,7 @@ func chatRequestFromQuery(ginContext *gin.Context, defaults textRequestDefaults,
 	webSearchQuery := strings.TrimSpace(ginContext.Query(queryParameterWebSearch))
 	webSearchEnabled, webSearchParseError := parseWebSearchParameter(webSearchQuery)
 	if webSearchParseError != nil {
-		structuredLogger.Warnw(
-			logEventParseWebSearchParameterFailed,
-			logFieldValue, webSearchQuery,
-			constants.LogFieldError, webSearchParseError,
-		)
+		structuredLogger.Warnw(logEventParseWebSearchParameterFailed)
 	}
 	maxTokens, maxTokensError := parseMaxTokensParameter(ginContext.Query(queryParameterMaxTokens))
 	if maxTokensError != nil {

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -26,12 +26,18 @@ type chatHandlerScenario struct {
 
 func TestRequestLogsExcludeQueryContent(testingInstance *testing.T) {
 	const (
+		finalResponse                 = `{"status":"completed", "output":[{"type":"message", "role":"assistant", "content":[{"type":"text","text":"ok"}]}]}`
 		promptQueryValue              = "prompt-log-sentinel"
 		systemPromptQueryValue        = "system-prompt-log-sentinel"
 		tenantSecretQueryValue        = "tenant-secret-log-sentinel"
 		rejectedProviderKeyQueryValue = "provider-key-log-sentinel"
+		invalidWebSearchQueryValue    = "web-search-log-sentinel"
 	)
 
+	mockServer := NewSessionMockServer(finalResponse)
+	testingInstance.Cleanup(mockServer.Close)
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(mockServer.URL)
 	observedCore, observedLogs := observer.New(zapcore.DebugLevel)
 	loggerInstance := zap.New(observedCore)
 	testingInstance.Cleanup(func() { _ = loggerInstance.Sync() })
@@ -42,26 +48,41 @@ func TestRequestLogsExcludeQueryContent(testingInstance *testing.T) {
 		WorkerCount:           1,
 		QueueSize:             1,
 		RequestTimeoutSeconds: TestTimeout,
+		Endpoints:             endpoints,
 	}, loggerInstance.Sugar())
 	if buildError != nil {
 		testingInstance.Fatalf(messageBuildRouterError, buildError)
 	}
 
-	requestPath := fmt.Sprintf("/?prompt=%s&system_prompt=%s&key=%s&api_key=%s", promptQueryValue, systemPromptQueryValue, tenantSecretQueryValue, rejectedProviderKeyQueryValue)
-	request := httptest.NewRequest(http.MethodGet, requestPath, nil)
-	responseRecorder := httptest.NewRecorder()
-
-	router.ServeHTTP(responseRecorder, request)
-
-	if responseRecorder.Code != http.StatusBadRequest {
-		testingInstance.Fatalf("status=%d want=%d", responseRecorder.Code, http.StatusBadRequest)
+	requestScenarios := []struct {
+		requestPath        string
+		expectedStatusCode int
+	}{
+		{
+			requestPath:        fmt.Sprintf("/?prompt=%s&system_prompt=%s&key=%s&api_key=%s", promptQueryValue, systemPromptQueryValue, tenantSecretQueryValue, rejectedProviderKeyQueryValue),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			requestPath:        fmt.Sprintf("/?prompt=%s&system_prompt=%s&key=%s&web_search=%s", promptQueryValue, systemPromptQueryValue, tenantSecretQueryValue, invalidWebSearchQueryValue),
+			expectedStatusCode: http.StatusOK,
+		},
 	}
-	if observedLogs.FilterField(zap.String(constants.LogFieldPath, "/")).Len() != 1 {
+	for _, requestScenario := range requestScenarios {
+		request := httptest.NewRequest(http.MethodGet, requestScenario.requestPath, nil)
+		responseRecorder := httptest.NewRecorder()
+
+		router.ServeHTTP(responseRecorder, request)
+
+		if responseRecorder.Code != requestScenario.expectedStatusCode {
+			testingInstance.Fatalf("status=%d want=%d", responseRecorder.Code, requestScenario.expectedStatusCode)
+		}
+	}
+	if observedLogs.FilterField(zap.String(constants.LogFieldPath, "/")).Len() != len(requestScenarios) {
 		testingInstance.Fatal("request log does not contain the query-free root path")
 	}
 	for _, loggedEntry := range observedLogs.All() {
 		loggedContent := loggedEntry.Message + fmt.Sprint(loggedEntry.ContextMap())
-		for _, sensitiveQueryValue := range []string{promptQueryValue, systemPromptQueryValue, tenantSecretQueryValue, rejectedProviderKeyQueryValue} {
+		for _, sensitiveQueryValue := range []string{promptQueryValue, systemPromptQueryValue, tenantSecretQueryValue, rejectedProviderKeyQueryValue, invalidWebSearchQueryValue} {
 			if strings.Contains(loggedContent, sensitiveQueryValue) {
 				testingInstance.Fatal("request logs contain query content")
 			}


### PR DESCRIPTION
## Summary

- remove raw invalid `web_search` values and error strings from parser warnings
- preserve the existing invalid-web-search request handling
- extend router-level log privacy coverage through an authenticated invalid-web-search request
- record B040 as resolved

## Validation

- `timeout -k 350s -s SIGKILL 350s make ci` (baseline and final)

Stacked on #204.