### PR TITLE
gix/isolate-live-harness-from-unrelated-listeners-and-add

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1194,6 +1194,47 @@ Format: `- [ ] [B042] (P1) {I007} Title`
   timed-out stdin-mode probe unless it receives `--prompt`. Baseline and final
   `make ci` runs passed.
 
+- [x] [B049] (P1) {M005R,B048} Isolate the disposable live-provider harness from unrelated local listeners.
+  Goal:
+  Keep `make ci` and `make release` deterministic when an unrelated local
+  service, including Docker Desktop, owns the historical harness port 18080.
+
+  Current failure:
+  `scripts/test_live_providers.sh --preflight` starts a disposable static-mode
+  proxy but defaults it to port 18080. On 2026-07-22, that address belonged to
+  Docker Desktop's `com.docker.backend`, not a prior harness child. The harness
+  correctly rejected the occupied address, but asking it to kill a listener by
+  port would terminate unrelated software and can make later container release
+  work fail.
+
+  Requirements:
+  - Default the disposable harness to a freshly allocated loopback TCP port;
+    retain `LLM_PROXY_LIVE_PORT` as an exact explicit override for operators.
+  - Generate the temporary config and make all readiness, preflight, and smoke
+    requests use that one selected port.
+  - On normal exit or termination, remove only the temporary files and the
+    exact proxy child the harness started; never kill a process discovered only
+    by its listening port.
+  - Add black-box operational coverage proving the default generated config no
+    longer uses 18080, an explicit port remains exact, and a completed preflight
+    releases its selected port.
+  - Update the local-automation contract and run the required baseline and
+    final `timeout -k 350s -s SIGKILL 350s make ci` pair, with the final run
+    after the last code edit.
+
+  ### Resolution
+
+  The live-provider harness now asks the operating system for a fresh loopback
+  TCP port unless `LLM_PROXY_LIVE_PORT` is explicitly set. Its EXIT cleanup
+  preserves the command status, removes the temporary directory, and sends
+  `TERM` only to its tracked proxy child; HUP, INT, and TERM first exit through
+  that cleanup. It never terminates a process merely because it listens on a
+  port. Black-box operational coverage proves the default config no longer
+  emits 18080, explicit ports remain exact, and both normal completion and a
+  forced harness TERM reap the owned child. A real preflight also passed while a
+  separate listener held 18080. Baseline and final `make ci` runs passed with
+  100.0% Go coverage.
+
 
 ## Improvements
 

--- a/README.md
+++ b/README.md
@@ -955,7 +955,10 @@ disabled, a temporary tenant, and placeholder values for unused provider keys,
 so live checks never open the configured management database or reuse its
 migration state. Inspect that generated contract without building or calling a
 paid provider with `./scripts/test_live_providers.sh --write-config
-/tmp/llm-proxy-live.yml`.
+/tmp/llm-proxy-live.yml`. Unless `LLM_PROXY_LIVE_PORT` explicitly selects a
+port, each harness run allocates a fresh loopback port. It removes only the
+temporary proxy child it started and never terminates an unrelated local
+listener.
 
 `make release` and `make deploy` run the local `make ci` gate with the standard
 350-second timeout. Override both with

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -278,7 +278,10 @@ tenant config with management disabled and placeholder values for unused
 providers. It therefore cannot open or mutate the configured management
 database. The `--write-config` option exposes that generated contract without
 building the proxy or making a paid provider call; `--preflight` starts it and
-proves authenticated routing without an upstream call.
+proves authenticated routing without an upstream call. Each run allocates a
+fresh loopback port unless `LLM_PROXY_LIVE_PORT` explicitly provides one, and
+cleanup terminates only the proxy child started by the harness rather than a
+process discovered through a shared port.
 
 Startup validates configured tenants, rejects duplicate tenant ids and duplicate secrets, requires API keys for each configured static tenant's default text and dictation providers when management mode is disabled, allows non-default provider API keys to be blank so those providers are disabled until configured, requires every configured provider base URL, requires transcription URLs for dictation-capable providers, requires text model catalogs for every provider, requires dictation model catalogs for dictation-capable providers, rejects blank or duplicate model ids, rejects defaults not listed in their model catalog, rejects `web_search` outside OpenAI text model entries, validates OpenAI request profiles, validates exact model-owned reasoning-effort lists, validates each configured static tenant's default text provider/model and effort, and validates endpoint/credential support for each configured static tenant's default dictation provider/model. When `management.enabled` is false, at least one static tenant is required. When `management.enabled` is true, static tenants and nonblank config-level provider API keys are rejected because managed tokens and provider credentials are user-owned database state.
 

--- a/scripts/test_live_providers.sh
+++ b/scripts/test_live_providers.sh
@@ -31,7 +31,8 @@ Optional environment:
   LIVE_ENV_FILE              Path to a dotenv file to parse before discovery.
   LLM_PROXY_LIVE_PROVIDERS   Comma or space separated provider list. If set,
                              every listed provider must have its key.
-  LLM_PROXY_LIVE_PORT        Local port for the temporary proxy. Default: 18080.
+  LLM_PROXY_LIVE_PORT        Local port for the temporary proxy. Default: a
+                             freshly allocated loopback port.
   LLM_PROXY_LIVE_TIMEOUT     Per-request curl timeout in seconds. Default: 45.
   SERVICE_SECRET             Tenant secret. Generated when omitted.
   GO                         Go binary. Default: go.
@@ -69,6 +70,18 @@ env_or_default() {
   else
     printf "%s\n" "${fallback}"
   fi
+}
+
+allocate_loopback_port() {
+  command -v python3 >/dev/null 2>&1 || { echo "error: python3 is required to allocate a live-provider harness port" >&2; exit 1; }
+  python3 -c '
+import socket
+
+listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+listener.bind(("127.0.0.1", 0))
+print(listener.getsockname()[1])
+listener.close()
+'
 }
 
 load_env_file() {
@@ -376,13 +389,19 @@ TMP_DIR="$(mktemp -d)"
 PROXY_PID=""
 
 cleanup() {
+  local exit_status=$?
+  trap - EXIT HUP INT TERM
   if [[ -n "${PROXY_PID}" ]] && kill -0 "${PROXY_PID}" >/dev/null 2>&1; then
-    kill "${PROXY_PID}" >/dev/null 2>&1 || true
+    kill -TERM "${PROXY_PID}" >/dev/null 2>&1 || true
     wait "${PROXY_PID}" >/dev/null 2>&1 || true
   fi
   rm -rf "${TMP_DIR}"
+  return "${exit_status}"
 }
 trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 if [[ -n "${LIVE_ENV_FILE:-}" ]]; then
   [[ -f "${LIVE_ENV_FILE}" ]] || { echo "error: LIVE_ENV_FILE not found: ${LIVE_ENV_FILE}" >&2; exit 1; }
@@ -397,7 +416,11 @@ if [[ "${PREFLIGHT_ONLY}" != "true" && -z "${WRITE_CONFIG_PATH}" ]]; then
   fi
 fi
 
-PORT="$(env_or_default LLM_PROXY_LIVE_PORT 18080)"
+if [[ -n "${LLM_PROXY_LIVE_PORT:-}" ]]; then
+  PORT="${LLM_PROXY_LIVE_PORT}"
+else
+  PORT="$(allocate_loopback_port)"
+fi
 LIVE_TIMEOUT="$(env_or_default LLM_PROXY_LIVE_TIMEOUT 45)"
 if [[ -n "${WRITE_CONFIG_PATH}" ]]; then
   mkdir -p "$(dirname "${WRITE_CONFIG_PATH}")"

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -3,11 +3,14 @@ package tests_test
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -518,6 +521,201 @@ func TestOperationalLiveConfigWritesWithoutProviderKeys(testingInstance *testing
 	}
 	if !strings.Contains(configuration, "management:\n  enabled: false") {
 		testingInstance.Fatalf("generated live config did not disable management: %s", configuration)
+	}
+}
+
+func TestOperationalLiveConfigAllocatesDefaultHarnessPort(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	configurationOutput := filepath.Join(testingInstance.TempDir(), "live-config.yml")
+	environment := append(
+		os.Environ(),
+		"LLM_PROXY_LIVE_PORT=",
+		"GO=/does/not/exist",
+	)
+	runOperationalCommand(
+		testingInstance,
+		repositoryRoot,
+		environment,
+		filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"),
+		"--write-config", configurationOutput,
+	)
+	configurationBytes, readError := os.ReadFile(configurationOutput)
+	if readError != nil {
+		testingInstance.Fatalf("read generated default-port live config: %v", readError)
+	}
+	allocatedPort := operationalLiveConfigPort(testingInstance, string(configurationBytes))
+	if allocatedPort == 18080 {
+		testingInstance.Fatalf("default live config retained shared port 18080: %s", configurationBytes)
+	}
+	if allocatedPort < 1024 {
+		testingInstance.Fatalf("default live config did not allocate an unprivileged port: %d", allocatedPort)
+	}
+}
+
+func TestOperationalLiveHarnessReapsOwnedProxyChild(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	reservedPort := operationalLoopbackPort(testingInstance)
+	fixture := newOperationalLiveHarnessFixture(testingInstance)
+	environment := fixture.environment(reservedPort)
+	runOperationalCommand(
+		testingInstance,
+		repositoryRoot,
+		environment,
+		filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"),
+		"--preflight",
+	)
+	assertOperationalProxyChildStopped(testingInstance, fixture.proxyPIDPath)
+}
+
+func TestOperationalLiveHarnessReapsOwnedProxyChildAfterTermination(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixture := newOperationalLiveHarnessFixture(testingInstance)
+	preflightBlockPath := filepath.Join(testingInstance.TempDir(), "preflight-blocked")
+	command := exec.Command(filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), "--preflight")
+	command.Dir = repositoryRoot
+	command.Env = fixture.environment(
+		operationalLoopbackPort(testingInstance),
+		"CURL_PREFLIGHT_BLOCK_PATH="+preflightBlockPath,
+		"CURL_PREFLIGHT_BLOCK_SECONDS=2",
+	)
+	if startError := command.Start(); startError != nil {
+		testingInstance.Fatalf("start live harness: %v", startError)
+	}
+	waitForOperationalFile(testingInstance, preflightBlockPath)
+	if signalError := command.Process.Signal(syscall.SIGTERM); signalError != nil {
+		testingInstance.Fatalf("terminate live harness: %v", signalError)
+	}
+	if waitError := command.Wait(); waitError == nil {
+		testingInstance.Fatal("live harness succeeded after termination")
+	}
+	assertOperationalProxyChildStopped(testingInstance, fixture.proxyPIDPath)
+}
+
+func operationalLiveConfigPort(testingInstance *testing.T, configuration string) int {
+	testingInstance.Helper()
+	portMatch := regexp.MustCompile(`(?m)^  port: ([0-9]+)$`).FindStringSubmatch(configuration)
+	if len(portMatch) != 2 {
+		testingInstance.Fatalf("generated live config omitted port: %s", configuration)
+	}
+	port, parseError := strconv.Atoi(portMatch[1])
+	if parseError != nil {
+		testingInstance.Fatalf("parse generated live config port: %v", parseError)
+	}
+	return port
+}
+
+type operationalLiveHarnessFixture struct {
+	proxyPIDPath  string
+	toolDirectory string
+}
+
+func newOperationalLiveHarnessFixture(testingInstance *testing.T) operationalLiveHarnessFixture {
+	testingInstance.Helper()
+	fixtureRoot := testingInstance.TempDir()
+	toolDirectory := filepath.Join(fixtureRoot, "tools")
+	proxyPIDPath := filepath.Join(fixtureRoot, "proxy.pid")
+	writeOperationalFile(testingInstance, filepath.Join(toolDirectory, "go"), `#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${1:?}" == "build" ]]
+shift
+output_path=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output_path="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+[[ -n "${output_path}" ]]
+builtin printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'builtin printf "%s\n" "$$" >"${PROXY_PID_CAPTURE:?}"' \
+  'exec sleep 60' >"${output_path}"
+chmod +x "${output_path}"
+`, 0o755)
+	writeOperationalFile(testingInstance, filepath.Join(toolDirectory, "curl"), `#!/usr/bin/env bash
+set -euo pipefail
+
+for argument in "$@"; do
+  case "${argument}" in
+    *provider=unsupported-live-preflight*)
+      if [[ -n "${CURL_PREFLIGHT_BLOCK_PATH:-}" ]]; then
+        builtin printf '%s\n' ready >"${CURL_PREFLIGHT_BLOCK_PATH}"
+        sleep "${CURL_PREFLIGHT_BLOCK_SECONDS:-1}"
+      fi
+      builtin printf '%s' 400
+      exit 0
+      ;;
+  esac
+done
+builtin printf '%s' 403
+`, 0o755)
+	return operationalLiveHarnessFixture{
+		proxyPIDPath:  proxyPIDPath,
+		toolDirectory: toolDirectory,
+	}
+}
+
+func (fixture operationalLiveHarnessFixture) environment(port int, extraEnvironment ...string) []string {
+	environment := append(
+		os.Environ(),
+		"PATH="+fixture.toolDirectory+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GO="+filepath.Join(fixture.toolDirectory, "go"),
+		"LLM_PROXY_LIVE_PORT="+strconv.Itoa(port),
+		"PROXY_PID_CAPTURE="+fixture.proxyPIDPath,
+	)
+	return append(environment, extraEnvironment...)
+}
+
+func operationalLoopbackPort(testingInstance *testing.T) int {
+	testingInstance.Helper()
+	listener, listenError := net.Listen("tcp", "127.0.0.1:0")
+	if listenError != nil {
+		testingInstance.Fatalf("reserve loopback port: %v", listenError)
+	}
+	reservedAddress, addressOK := listener.Addr().(*net.TCPAddr)
+	if !addressOK {
+		testingInstance.Fatalf("reserved address type=%T", listener.Addr())
+	}
+	if closeError := listener.Close(); closeError != nil {
+		testingInstance.Fatalf("release loopback port: %v", closeError)
+	}
+	return reservedAddress.Port
+}
+
+func waitForOperationalFile(testingInstance *testing.T, path string) {
+	testingInstance.Helper()
+	deadline := time.Now().Add(operationalHelpTimeout)
+	for {
+		if _, statError := os.Stat(path); statError == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			testingInstance.Fatalf("timed out waiting for operational file: %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertOperationalProxyChildStopped(testingInstance *testing.T, proxyPIDPath string) {
+	testingInstance.Helper()
+	proxyPIDBytes, readError := os.ReadFile(proxyPIDPath)
+	if readError != nil {
+		testingInstance.Fatalf("read proxy pid: %v", readError)
+	}
+	proxyPID, parseError := strconv.Atoi(strings.TrimSpace(string(proxyPIDBytes)))
+	if parseError != nil {
+		testingInstance.Fatalf("parse proxy pid: %v", parseError)
+	}
+	if killError := exec.Command("kill", "-0", strconv.Itoa(proxyPID)).Run(); killError == nil {
+		_ = exec.Command("kill", "-TERM", strconv.Itoa(proxyPID)).Run()
+		testingInstance.Fatalf("live harness left proxy child running: pid=%d", proxyPID)
 	}
 }
 


### PR DESCRIPTION
This update improves the robustness and isolation of the live-provider harness used in testing:

- The live harness now dynamically allocates a free loopback TCP port unless LLM_PROXY_LIVE_PORT is explicitly set, rather than defaulting to a commonly used static port (18080). This prevents collisions with unrelated local services such as Docker Desktop.
- Cleanup routines have been strengthened: on exit (including signals), the harness cleans up only its own temporary files and reliably terminates only the proxy child process it started, avoiding accidental interference with unrelated processes merely listening on the selected port.
- New and improved operational tests verify that:
  - The harness allocates a non-privileged, dynamically chosen port by default, and never uses 18080 unless specifically requested.
  - The harness process reliably reaps its child proxy process after both normal completion and forced termination.
- Documentation and issue tracking have been updated to describe this improved behavior, clarify the port allocation and cleanup guarantees, and record the resolution of the related robustness issue.

These changes ensure deterministic testing and release flows, even in environments where the historical default port may already be in use by unrelated processes.