### PR TITLE
gix/make-per-request-timeout-explicit-contract-with-header

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -12,75 +12,210 @@ Format: `- [ ] [B042] (P1) {I007} Title`
 Resolved history: `.mprlab/ISSUES-ARCHIVE.md`; the complete original issue
 bodies, resolution notes, and validation records remain in `v0.2.43`.
 
-Triage, 2026-07-24: B069 is the immediate active regression. F014 has no
-remaining active prerequisites and unblocks I027 and P001. I029 is the
-remaining contract predecessor for I031; I031 also waits for F014. M019 is now
-independently ready because M018 is complete. M013 then M012 resolve the
-product-context governance path. Planning proceeds P002 -> P003 -> P004 ->
-P005, with M020 already satisfied; recurring maintenance remains scheduled
-work.
+Triage, 2026-07-24: B069 is the immediate active regression. Under the
+one-issue-at-a-time workflow, the selected P1 execution tranche is
+**B069 -> F014 -> I029**: B069 establishes the bounded per-request timeout and
+error contract for public upstream work, F014 replaces singular management
+routes with tenant-scoped routes, and I029 then freezes those final public and
+management contracts in OpenAPI. I031 is the next convergence item after I029
+and F014; I027 and P001 are independent F014 successors. M019 is independently
+ready because M018 is complete. M013 then M012 resolve the product-context
+governance path. Planning proceeds P002 -> P003 -> P004 -> P005, with M020
+already satisfied; recurring maintenance remains scheduled work.
 
 ## BugFixes
 
-- [ ] [B069] (P1) Restore the long v2 semantic-review completion contract after request-level effort rollout.
-  ### Summary
-  The redeployed production endpoint accepts the canonical optional `reasoning_effort` field, but a production-sized F001 source-world request still outlives the caller without returning either the final response or a structured proxy timeout. A small request using the same endpoint, credentials, model, and explicit `high` effort succeeds, so this is the long-request boundary previously covered by B016, B017, and B018 rather than request-shape rejection or total service unavailability.
+- [!] [B069] (P1) Make upstream request timeouts an explicit, bounded client-to-proxy contract.
+  Goal:
+  Let each client choose the exact bounded amount of time LLM Proxy may spend
+  on one upstream request, while keeping caller cancellation, provider work,
+  and gateway protection under distinct owners.
 
-  ### Impact
-  Kamu F001 cannot begin Bulgarian Creative Director source-world review. The failed one-shot request produced no durable response or safe completion receipt, so the caller cannot distinguish a still-running provider operation from a failed operation and must not retry it.
+  Problem:
+  A production-sized F001 `POST /v2` request reached the caller's independent
+  300-second HTTP deadline before LLM Proxy returned either a result or its own
+  360-second timeout. The owned gateway was staged with 420-second outer
+  deadlines. The Go CLI and Python package separately use 390 seconds, but that
+  number has no product, protocol, provider, or deployment significance.
 
-  ### Production evidence
-  - On 2026-07-24, after the effort-capable deployment, a sanitized `POST /v2` control using `gpt-5.5`, `reasoning_effort: "high"`, `max_tokens: 16`, and `Reply exactly: OK` returned `OK` in about 2.6 seconds.
-  - Creative Director was then upgraded to released `github.com/tyemirov/llm-proxy v0.2.42`. No-spend HTTP coverage proves the F001 delivery-profile value is serialized as canonical `reasoning_effort: "high"` and that omitted configuration remains absent.
-  - The exact F001 profile passed Creative Director validation at SHA-256 `eec521a661b9f64886bfb7bbc232752f0947c6067ffa33dddec15d5a5966e581`. The selected `neblagodarnost` canonical source is 15,845 bytes with SHA-256 `45da648ff5dd21d417c65ad8e022919e8f761d52ad628d017192bf5095f6d58d`.
-  - The canonical pipeline request started with inherited `LLM_PROXY_SECRET`, `LLM_PROXY_BASE_URL`, and `LLM_PROXY_MODEL` unset so the project-owned dotenv configuration was authoritative:
-    ```bash
-    env -u LLM_PROXY_SECRET -u LLM_PROXY_BASE_URL -u LLM_PROXY_MODEL \
-      /Users/tyemirov/Development/Smith/creative-director/bin/creative-director pipeline \
-      --project-profile /Users/tyemirov/Documents/Projects/Kamu/configs/creative-director/kamu-tales.json \
-      --story-id neblagodarnost \
-      --mode storyboard \
-      --delivery-profile kamu-storyboard \
-      --execute \
-      --from source-world \
-      --to source-world \
-      --confirm-provider-spend \
-      --json
-    ```
-  - At `2026-07-24T21:51:55Z`, after the configured 300-second caller deadline, the pipeline stopped with stable code `source_world_review_llm_proxy_http_error` and the sanitized error:
-    ```text
-    llm_proxy_client_http_failure: post request: Post "[redacted-url]": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
-    ```
-  - No source-world prompt, review, or manifest was promoted by the failed transaction. The pipeline wrote only its blocked execution state and did not retry the provider request.
-  - Public verification after the failure resolved `llm-proxy-api.mprlab.com` to the expected gateway and returned the expected Caddy-served `403` health response from `/` plus `200` from `/config-ui.yaml`; the service was not generally unavailable.
-  - Read-only inspection of the files staged on the gateway host confirms `request_timeout_seconds: 360`, `response_header_timeout 420s`, and `read_timeout 420s`. The running container image digest could not be inspected without the gateway sudo boundary, and no sudo or deployment command was attempted.
-  - The signed-in one-day usage dashboard records three `openai / gpt-5.5` requests but exposes only aggregate counts, so it cannot identify whether the abandoned long request later completed or reached the proxy deadline.
-  - Released `v0.2.43` contains only client-authentication documentation/site work and does not address this issue.
+  The defect is not that one of these constants is too small. The defect is
+  that the caller, proxy, provider adapters, and gateway each own an implicit
+  clock, so a client cannot ask LLM Proxy for the work budget its request needs
+  and cannot know which layer ended the request.
 
-  ### Confirmed boundary defect and remaining investigation
-  B016 and B017 established a one-request REST contract in which LLM Proxy owns OpenAI background polling, the proxy runtime owns the terminal or structured timeout, packaged clients wait longer than the server, and the gateway waits longer than clients. The deployed files preserve the 360-second server and 420-second gateway deadlines, but this existing product profile supplies a 300-second client deadline. That ordering guarantees the caller can abandon a valid in-flight proxy request before LLM Proxy owns completion or returns its structured timeout.
+  Consequence:
+  Kamu F001 cannot safely retry its Bulgarian source-world review. The failed
+  one-shot request produced no response or durable completion receipt, and the
+  available aggregate usage count cannot establish whether provider work later
+  completed or the proxy eventually reached its deadline.
 
-  The reusable Go package does not currently expose the documented 390-second supported-client deadline as a public constant or default. `llmproxyclient.ConfigInput` requires every application to supply a positive duration, while `390 * time.Second` exists only as a private `llm-proxy-client` command constant and a README example. Creative Director therefore cannot consume one owner-defined timeout contract; its package default is 120 seconds and the Kamu profile duplicates a 300-second product value.
+  Evidence:
+  - A small `gpt-5.5` request with explicit `reasoning_effort: "high"` returned
+    `200` in about 2.6 seconds, so the released field, route, credentials, and
+    basic service path work.
+  - The approximately 16 KB `neblagodarnost` source-world request ended after
+    300 seconds with `Client.Timeout exceeded while awaiting headers`; no
+    source-world artifact was promoted and the caller did not retry.
+  - The current runtime uses `server.request_timeout_seconds: 360`; staged
+    gateway `response_header_timeout` and `read_timeout` values are 420
+    seconds. The Go CLI, README example, and Python client introduce a separate
+    390-second convention, while the reusable Go package requires every caller
+    to invent its own positive HTTP timeout.
+  - LLM Proxy currently constructs a global timeout for provider clients,
+    creates another deadline in the text handler, and lets dictation rely on
+    provider-local deadlines. There is no single request-ingress deadline
+    shared consistently by every upstream operation.
 
-  Fix this contract defect first. Production-safe correlation must then establish whether the explicit-effort workload also reveals a provider/background-lifecycle regression after a supported client remains connected through the proxy deadline. Possible remaining failures are:
-  1. the deployed effort-capable route no longer completing the background polling lifecycle for this workload;
-  2. runtime/gateway timeout ordering drifting from the released contract; or
-  3. the provider legitimately reaching the proxy-owned deadline and LLM Proxy returning a structured timeout.
+  Contract:
+  Define one optional request header for every public operation that can start
+  upstream work:
+  ```text
+  X-LLM-Proxy-Request-Timeout-Seconds: <positive whole number>
+  ```
+  It applies to `GET /`, `POST /`, `POST /v2`, and `POST /dictate`; management
+  and static-site operations are out of scope.
 
-  The investigation must establish the terminal boundary from production-safe correlation evidence. Do not assume that merely raising a product-local timeout proves or repairs the owning defect.
+  The header is the maximum wall-clock budget LLM Proxy may spend on the
+  authenticated request. It begins before request-body parsing and includes
+  validation, admission/queue wait, the provider call, OpenAI background
+  polling, and response construction. It is a ceiling, not a promise that the
+  operation will run for that long: validation, queue saturation, provider
+  failure, or explicit caller cancellation may finish it earlier.
 
-  ### Requirements
-  1. Reproduce a production-comparable `POST /v2` request with an approximately 16 KB source-world prompt, `gpt-5.5`, and explicit `reasoning_effort: "high"` through the released public boundary.
-  2. Prove from safe request correlation that LLM Proxy received `high`, resolved the expected provider/model, entered the OpenAI background lifecycle, and either reached a terminal response or its own configured deadline.
-  3. Restore deterministic timeout ordering so the proxy returns the final body or a structured proxy/provider error before any supported caller or gateway closes the connection. Expose one canonical supported-client deadline from the Go client package so Creative Director can consume the owner contract and Kamu can remove its product-local magic number.
-  4. Preserve the one-shot public REST contract from B017. Do not add product-side retries, prompt chunking, tenant-default mutation, provider-specific fields, direct OpenAI calls, or a Kamu-only timeout exception.
-  5. Add production-comparable black-box coverage for the explicit-effort long-request path and retain the existing small-request behavior.
+  - If the header is omitted, use `server.request_timeout_seconds` as the
+    effective budget.
+  - Add `server.max_request_timeout_seconds` as the operator-owned capacity
+    limit. Accept a requested value exactly when it is within the inclusive
+    range `1..max`; never round, clamp, replace, or silently fall back.
+  - Reject a blank, repeated, signed, fractional, nonnumeric, zero, negative,
+    or over-limit value with `400` before queue admission or any provider call.
+    Return `application/json` with the exact safe envelope
+    `{"error":{"code":"invalid_request_timeout","max_request_timeout_seconds":M}}`.
+  - Return the effective value on every accepted response, including errors,
+    in `X-LLM-Proxy-Request-Timeout-Seconds`.
+  - When the accepted budget expires, cancel queued/provider/polling work and
+    return `504 application/json` with the exact safe envelope
+    `{"error":{"code":"request_timeout","request_timeout_seconds":N}}`, where
+    `N` is the effective timeout. Do not report it as a provider failure.
+  - Create the deadline once at authenticated request ingress and propagate
+    that context unchanged. Provider adapters must not start a fresh timeout or
+    extend the remaining budget.
 
-  ### Acceptance criteria
-  - The exact F001 `neblagodarnost` source-world canary returns a final review body or a structured, attributable proxy error; it never ends as an opaque client `awaiting headers` timeout.
-  - A small explicit-`high` v2 control continues to return HTTP 200.
-  - The effective server, supported-client, and gateway deadlines are verified at the deployed boundary.
-  - `make ci` passes and the released/deployed artifact is verified before F001 retries the request.
+  Caller cancellation is a separate concern. A Go context, process signal, or
+  explicitly configured transport policy may cancel a request sooner, in which
+  case no response is guaranteed. Bundled clients must not hide such a policy
+  behind the server-budget setting or impose an unrelated total-response
+  deadline by default.
+
+  The owned gateway is the final outer guard. Its response-header and read
+  deadlines must be strictly greater than
+  `server.max_request_timeout_seconds`, with the relationship validated from
+  deployment configuration. The gateway must not use a client-specific magic
+  number.
+
+  Requirements:
+  1. Validate the server default and maximum at startup: both effective values
+     are positive and the default does not exceed the maximum. An explicitly
+     invalid value fails startup rather than being reset.
+  2. Enforce the header and one ingress-owned context identically across all
+     four upstream public operations. Preserve the one-shot REST lifecycle:
+     no async receipt, retry, prompt chunking, provider-specific timeout field,
+     tenant mutation, direct provider call, or product-only exception.
+  3. Move timeout selection into each Go and Python messages request and
+     serialize it as the canonical header. Replace the CLI's ambiguous
+     `--timeout` with `--request-timeout-seconds`. Remove the 390-second
+     constants and config-level total-response timeout, and replace the
+     390-second README example. Continue to honor the Go caller's context and
+     injected transports as separate cancellation mechanisms.
+  4. Record the effective timeout and terminal outcome in safe structured
+     request evidence without prompts, audio, credentials, provider response
+     bodies, or free-form error text. Production correlation must distinguish
+     success, proxy deadline, provider failure, and caller cancellation.
+  5. Update the owning documentation in the same change:
+     - `README.md` defines the header, default/max behavior, client examples,
+       status codes, and the distinction between work budget and cancellation.
+     - `CHANGELOG.md` records the externally visible header, errors, client API
+       change, and removal of the arbitrary supported-client deadline.
+     - `configs/config.yml` declares the current operator-selected default and
+       maximum. The accepted request budget is at most the proxy maximum, which
+       remains strictly below the owned gateway's outer guard; caller
+       cancellation is independent of that ordering.
+     - This repository currently has no `PRD.md` or `ARCHITECTURE.md`. Do not
+       create partial timeout-only placeholders. M013 owns the product-context
+       document decision and must carry this final behavior into any canonical
+       documents it introduces. I029 will subsequently freeze the wire
+       contract in canonical OpenAPI.
+
+  Deployment dependency:
+  The current gateway schema-v1 `caddy_route` declaration cannot express
+  transport timeout values and rejects unknown fields. Do not invent an
+  llm-proxy-only manifest field or extend that obsolete shape. Production
+  activation requires a companion `mprlab-gateway` change or the forward-only
+  I204 `caddy_fragment` migration to make the edge guard greater than the
+  configured proxy maximum, plus non-deploying validation of the assembled
+  Caddy configuration. Production deployment itself remains user-owned.
+
+  Validation:
+  - Add black-box tests proving omission uses the server default; a shorter
+    accepted value times out and cancels work; a value longer than the default
+    can succeed after the default would have expired; and malformed, repeated,
+    or over-limit values return `400` without an upstream request.
+  - Exercise `GET /`, both JSON POST routes, and `/dictate`; prove queue time and
+    OpenAI background polling consume the same non-resetting budget.
+  - Exercise the Go package, Python package, and CLI against a real test server;
+    prove each sends the requested header, omits it when not requested, receives
+    the server's effective response header, and has no hidden 390-second
+    deadline.
+  - Validate startup invariants and reject a deployment whose gateway outer
+    deadline cannot outwait the configured server maximum.
+  - Re-run a production-comparable approximately 16 KB `gpt-5.5`,
+    explicit-`high` request with a deliberately selected budget above the
+    deployed default and within the deployed maximum. Correlate it through a
+    final body or the canonical proxy `504`; it must not end at an opaque
+    bundled-client `awaiting headers` timeout. Retain the small explicit-`high`
+    `200` control.
+  - Run the required baseline and final `make ci` pair, with the final run after
+    the last code edit. Verify the released artifact and deployed timeout
+    relationship before F001 retries the request.
+
+  Implemented 2026-07-24:
+  LLM Proxy now accepts the canonical request-scoped header on all four
+  upstream routes, validates the configured default and maximum, starts one
+  cause-preserving deadline before body parsing, echoes the effective budget,
+  and returns exact safe `400` and `504` envelopes. Queue wait, provider work,
+  dictation, and OpenAI background polling share that deadline without adapter
+  resets. Safe terminal evidence distinguishes success, proxy timeout, provider
+  failure, and caller cancellation.
+
+  The Go package, Go CLI, and Python package now serialize the budget per
+  request and impose no hidden total-response deadline. Go integrations move
+  `ConfigInput.Timeout` to
+  `MessagesRequestInput.RequestTimeoutSeconds`; Python client `0.2.0` moves
+  `ClientConfig.timeout_seconds` to
+  `ClientMessagesRequest.request_timeout_seconds`; the CLI uses only
+  `--request-timeout-seconds`. README, changelog, implementation plans,
+  generated public client guides, and upgrade commands document the migration.
+
+  The app deployment preflight reads its tracked maximum and supplies it to the
+  companion gateway verifier. The gateway parses only its own Caddy
+  configuration, rejects outer guards that are not strictly greater, and sets
+  the response-header, upstream-read, and client-write guards to 3660 seconds
+  for the current 3600-second service capacity. The connection-idle policy
+  remains independent. Focused Go coverage is 100%, Python checks pass, the
+  complete gateway test suite and pinned-container Caddy validation pass, and
+  no production deployment command was run.
+
+  The required pre-change and post-change `make ci` runs pass. The final run
+  followed the last code edit and passed exact 100% Go coverage, 33 Python
+  tests, 51 management-browser tests, the black-box authentication test,
+  release-contract checks, and the live-provider harness preflight.
+
+  Blocked:
+  Source implementation is complete, but resolution still requires the
+  execution chain to land and release the coordinated app and gateway changes,
+  the user-owned production deployment, verification of the deployed
+  max/outer-guard relationship, and the production-comparable approximately
+  16 KB explicit-`high` canary plus its small control before Kamu F001 retries.
 
 ## Improvements
 
@@ -181,7 +316,7 @@ work.
     `timeout -k 350s -s SIGKILL 350s make ci` pair, with the final run after the
     last code edit.
 
-- [ ] [I029] (P1) Publish one canonical OpenAPI contract and enforce server/client conformance.
+- [ ] [I029] (P1) {B069,F014} Publish one canonical OpenAPI contract and enforce server/client conformance.
   Goal:
   Make one committed OpenAPI 3.1 document the sole canonical HTTP wire
   contract for every llm-proxy-owned endpoint, publish that exact artifact on
@@ -196,6 +331,14 @@ work.
   - The published canonical-v2 prose page omits the request-level
     `reasoning_effort` field delivered by B068, demonstrating that independently
     maintained prose can drift from the live wire contract.
+
+  Dependencies:
+  - B069 must settle the final public per-request timeout and attributable
+    error boundary before this issue freezes its request/response
+    documentation and client conformance expectations.
+  - F014 replaces the singular management endpoints with tenant-scoped routes.
+    This contract must describe only that final management surface, rather than
+    documenting a shape that F014 immediately removes.
 
   Requirements:
   - Add exactly one hand-maintained canonical contract at
@@ -397,11 +540,15 @@ work.
   - Sample the open entries after the pass and confirm each has clear next actions and validation expectations.
   - Confirm no recurring runbook was marked complete.
   - Confirm duplicates were merged or explicitly cross-referenced.
-  Last run: 2026-07-23. Polished 14 non-recurring unresolved entries. B063 is
-  explicitly blocked on an operator-owned deployment; M018 is P0 after a
-  pinned-toolchain scan found reachable GO-2026-5970; F013, F014, and I027 now
-  have their implementation order recorded. Planning entries remain open but
-  deferred under the repository workflow.
+  Last run: 2026-07-24. Polished 13 non-recurring unresolved entries after the
+  resolved-history archive. Added I029 dependencies on B069 and F014: the
+  former settles the public per-request timeout/error contract and the latter
+  replaces singular management routes. B069 now records its external gateway
+  deployment dependency, and M013 waits for B069 so future product-context
+  documents cannot omit the resulting timeout contract. Selected the
+  sequential P1 tranche B069 -> F014 -> I029; I031 is the resulting convergence
+  item, while I027 and P001 remain independent F014 successors. Planning
+  entries remain open but deferred under the repository workflow.
 - [ ] [M003R] (P2) Architecture and policy review.
   Goal:
   Catch architecture, policy, and workflow drift before it becomes hidden maintenance debt.
@@ -534,12 +681,16 @@ work.
   - A reviewed governance normalization change with no unrelated product or runtime edits.
   Validation:
   - Run the MPR Lab governor in `--dry-run` and `--check` modes and require no pending managed-file changes.
-- [ ] [M013] (P2) Resolve missing product-context document references.
+- [ ] [M013] (P2) {B069} Resolve missing product-context document references.
   Goal:
   Keep the root governance entrypoint limited to product-context documents that exist and represent the current contract.
   Requirements:
   - Decide whether current `PRD.md` and `ARCHITECTURE.md` documents are required or whether their references are stale.
   - Add current canonical documents or remove the obsolete references; do not add placeholders or compatibility documents.
+  - Treat B069's final bounded client-selected request budget, ingress deadline
+    ownership, caller-cancellation distinction, and gateway outer-guard
+    invariant as required source material if canonical product or architecture
+    documents are added.
   Deliverables:
   - Root governance references that resolve to current product-context files.
   Validation:

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -184,8 +184,8 @@ already satisfied; recurring maintenance remains scheduled work.
   cause-preserving deadline before body parsing, echoes the effective budget,
   and returns exact safe `400` and `504` envelopes. Queue wait, provider work,
   dictation, and OpenAI background polling share that deadline without adapter
-  resets. Safe terminal evidence distinguishes success, proxy timeout, provider
-  failure, and caller cancellation.
+  resets. Safe terminal evidence distinguishes validation failure, success,
+  proxy timeout, proxy overload, provider failure, and caller cancellation.
 
   The Go package, Go CLI, and Python package now serialize the budget per
   request and impose no hidden total-response deadline. Go integrations move
@@ -206,9 +206,34 @@ already satisfied; recurring maintenance remains scheduled work.
   no production deployment command was run.
 
   The required pre-change and post-change `make ci` runs pass. The final run
-  followed the last code edit and passed exact 100% Go coverage, 33 Python
+  followed the last code edit and passed exact 100% Go coverage, 34 Python
   tests, 51 management-browser tests, the black-box authentication test,
   release-contract checks, and the live-provider harness preflight.
+
+  Review follow-up 2026-07-24:
+  Response bodies are now fully constructed and checked against the request
+  context before success is selected. Managed-usage persistence runs only
+  after the selected response is written and flushed; its store-lock
+  acquisition and GORM operations use the same request context. Cancellation
+  can therefore leave terminal log evidence without a managed-usage row, which
+  is documented in README, but persistence can no longer outwait the accepted
+  request budget or change the selected response.
+
+  Explicit YAML `null` and empty timeout values now fail startup instead of
+  selecting defaults, while true omission still selects the compiled default.
+  Queue saturation records `proxy_overload` rather than
+  `provider_failure`. The tracked Python distribution metadata now reports
+  client version `0.2.0`, with a package-metadata regression test. The required
+  review-follow-up baseline and final `make ci` runs pass; the final run follows
+  the last tracked edit.
+
+  Gateway review correction 2026-07-24:
+  The final `deploy-llm-proxy-backend` invocation now receives the same
+  app-owned maximum that was read once from the tracked configuration and
+  supplied to the early verifier. The gateway target itself requires that
+  value, so direct or aggregate gateway deployment cannot bypass the
+  request-capacity contract. The public deployment fixture and final
+  post-edit `make ci` pass without production contact.
 
   Blocked:
   Source implementation is complete, but resolution still requires the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Add the bounded `X-LLM-Proxy-Request-Timeout-Seconds` contract across text and dictation routes, including effective response headers and canonical `400 invalid_request_timeout` and `504 request_timeout` JSON errors.
 - Move Go and Python timeout selection from client configuration onto each messages request, replace the CLI `--timeout` flag with `--request-timeout-seconds`, and remove the arbitrary 390-second bundled-client deadline.
 - Add `server.max_request_timeout_seconds`, one ingress-owned deadline shared by body parsing, queue admission, provider calls, and OpenAI polling, plus safe terminal-outcome logging.
+- Keep response construction and managed-usage persistence under request cancellation, classify queue saturation as `proxy_overload`, reject explicit null timeout configuration, and synchronize Python client distribution metadata at `0.2.0`.
 - Make deployment pass the app-owned maximum request budget into the gateway contract verifier, which rejects outer response guards that cannot outwait it.
 
 ## [v0.2.43] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Declare the llm-proxy TAuth tenant requirements in the app-owned deployment manifest for gateway assembly.
+- Add the bounded `X-LLM-Proxy-Request-Timeout-Seconds` contract across text and dictation routes, including effective response headers and canonical `400 invalid_request_timeout` and `504 request_timeout` JSON errors.
+- Move Go and Python timeout selection from client configuration onto each messages request, replace the CLI `--timeout` flag with `--request-timeout-seconds`, and remove the arbitrary 390-second bundled-client deadline.
+- Add `server.max_request_timeout_seconds`, one ingress-owned deadline shared by body parsing, queue admission, provider calls, and OpenAI polling, plus safe terminal-outcome logging.
+- Make deployment pass the app-owned maximum request budget into the gateway contract verifier, which rejects outer response guards that cannot outwait it.
 
 ## [v0.2.43] - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,52 @@ know whether the selected upstream provider uses synchronous responses,
 background responses, or provider-specific polling internally. For OpenAI
 Responses, llm-proxy always owns the background-response lifecycle: it sends
 stored background requests upstream and polls OpenAI server-side until the answer
-is terminal or `server.request_timeout_seconds` expires.
+is terminal or the request's effective work budget expires.
 
 A `504 Gateway Timeout` means the overall proxy request deadline expired before
 the selected upstream provider produced a final answer. It is not a prompt for
 the client to poll llm-proxy.
+
+### Request work budgets
+
+Every authenticated operation that can start upstream work accepts one optional
+header:
+
+```text
+X-LLM-Proxy-Request-Timeout-Seconds: N
+```
+
+`N` is the positive whole-number wall-clock budget, in seconds, for that
+request. The budget begins before body parsing and covers validation, queue
+admission, every provider call, OpenAI background polling, and response
+construction for `GET /`, `POST /`, `POST /v2`, and `POST /dictate`.
+
+If the header is omitted, `server.request_timeout_seconds` is the effective
+budget. A supplied value must be in the inclusive range
+`1..server.max_request_timeout_seconds`; the proxy never rounds, clamps, or
+replaces it. A blank, repeated, signed, fractional, nonnumeric, zero, negative,
+or over-limit value returns this exact `400 application/json` response before
+queue admission:
+
+```json
+{"error":{"code":"invalid_request_timeout","max_request_timeout_seconds":3600}}
+```
+
+Every accepted response, including errors, echoes the effective value in
+`X-LLM-Proxy-Request-Timeout-Seconds`. If that budget expires, the proxy cancels
+the remaining queued, provider, or polling work and returns:
+
+```json
+{"error":{"code":"request_timeout","request_timeout_seconds":900}}
+```
+
+with `504 application/json`. The value shown is the effective budget for that
+request.
+
+This server work budget is not a client transport timeout. A caller may still
+cancel sooner with a Go context, a process signal, or an explicitly configured
+HTTP transport policy, and no response is guaranteed after caller cancellation.
+The bundled clients impose no separate total-response deadline by default.
 
 Internally, `server.workers` limits concurrent upstream provider HTTP
 operations and `server.queue_size` limits upstream HTTP operations waiting for a
@@ -69,6 +110,7 @@ server:
   workers: 4
   queue_size: 100
   request_timeout_seconds: 360
+  max_request_timeout_seconds: 3600
   max_prompt_bytes: 4194304
   max_input_audio_bytes: 26214400
   upstream_rate_limits: []
@@ -404,6 +446,12 @@ providers:
             efforts: ["minimal", "low", "medium", "high"]
 ```
 
+`server.request_timeout_seconds` and `server.max_request_timeout_seconds` must
+both be positive, and the default must not exceed the maximum. Invalid explicit
+values fail startup. The maximum is operator-owned service capacity and must
+remain strictly below the response-header and read deadlines of the outer
+gateway.
+
 Dictation-capable providers must also declare a dictation catalog:
 
 ```yaml
@@ -444,10 +492,10 @@ the stable proxy payload shape for that OpenAI model and must be one of:
 
 All OpenAI Responses text requests also send `background: true` and
 `store: true`. llm-proxy polls the stored OpenAI response server-side until it
-reaches a terminal state or the normal `server.request_timeout_seconds` deadline
-expires. Plain REST callers use one `GET /`, `POST /`, or `POST /v2` request and
-receive the final formatted answer; they do not stream, poll, or follow a
-separate resume endpoint.
+reaches a terminal state or the request's effective work budget expires. Plain
+REST callers use one `GET /`, `POST /`, or `POST /v2` request and receive the
+final formatted answer; they do not stream, poll, or follow a separate resume
+endpoint.
 
 Provider-specific details:
 
@@ -1068,7 +1116,12 @@ than treating a completed push as immediate public availability.
 `llm-proxy` is a gateway-local service in `mprlab-gateway`, so `make deploy`
 uses the sole gateway `deploy-llm-proxy-backend` target after the gateway-owned
 `verify-llm-proxy-deployment-contract` preflight proves the coupled TAuth
-service, runtime assets, and health checks. Override only the checkout with
+service, runtime assets, and health checks. That preflight reads
+`server.max_request_timeout_seconds` from the app-owned tracked config and
+passes it to the gateway verifier; deployment fails unless the gateway-owned
+response-header, upstream-read, and client-write guards are all strictly
+greater. Neither repository carries a fallback copy of the other's capacity.
+Override only the checkout with
 `GATEWAY_DIR=/path/to/mprlab-gateway`; the selected gateway checkout must be a
 clean, synchronized `origin/master`. Override Pages preparation and activation
 with `PAGES_DOMAIN=<domain>`, `PAGES_CONFIG_URL=<https-config-url>`,
@@ -1132,6 +1185,7 @@ llm-proxy-client \
   --secret "$SERVICE_SECRET" \
   --model gpt-5.5 \
   --reasoning-effort high \
+  --request-timeout-seconds 900 \
   --prompt "Summarize this"
 ```
 
@@ -1141,13 +1195,50 @@ such as `prompt` and `model`, and sends the prompt as a v2 `user` message.
 `--system-prompt` becomes a v2 `system` message. Optional `model`,
 `web_search`, `max_tokens`, and `reasoning_effort` values remain body fields.
 When `--model` is omitted, the body omits `model` so llm-proxy uses the selected
-provider's configured default model.
+provider's configured default model. `--request-timeout-seconds` is instead
+serialized as `X-LLM-Proxy-Request-Timeout-Seconds`; omitting the flag omits the
+header and selects the server default. The obsolete `--timeout` flag is not an
+alias and is rejected.
 
 The reusable Go package under `pkg/llmproxyclient` is v2-only: construct a
 `MessagesRequest` with `NewMessagesRequest` and send it with
 `Client.PostMessages`. `MessagesRequestInput.ReasoningEffort` is an optional
 nonblank request override; the proxy validates it against the exact resolved
 provider/model capability before it calls upstream.
+
+Set `MessagesRequestInput.RequestTimeoutSeconds` when one request needs a
+specific proxy work budget:
+
+```go
+requestTimeoutSeconds := 900
+request, err := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+    Messages: []llmproxyclient.MessageInput{
+        {Role: "user", Content: "Summarize this"},
+    },
+    RequestTimeoutSeconds: &requestTimeoutSeconds,
+})
+if err != nil {
+    return err
+}
+text, err := client.PostMessages(ctx, request)
+```
+
+The request value controls only the proxy budget header. `ctx` remains the Go
+caller's independent cancellation authority, and the injected `HTTPDoer` may
+have its own explicitly selected transport policy. The package does not add a
+total-response timeout.
+
+To upgrade the Go package and CLI:
+
+```shell
+go get github.com/tyemirov/llm-proxy/pkg/llmproxyclient@latest
+go install github.com/tyemirov/llm-proxy/llm-proxy-client@latest
+```
+
+Remove `ConfigInput.Timeout` from existing Go integrations and move the desired
+proxy budget to `MessagesRequestInput.RequestTimeoutSeconds`. Use a caller
+context only when the application intentionally needs an independent,
+potentially shorter cancellation deadline.
 
 #### Model selection without application redeployment
 
@@ -1201,7 +1292,6 @@ config, err := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
     Secret:             serviceSecret,
     ModelProfilePath:   userModelProfilePath,
     ModelProfileReader: os.ReadFile,
-    Timeout:            390 * time.Second,
 })
 if err != nil {
     return err
@@ -1232,8 +1322,11 @@ remains the separate normal contract.
 The same transport contract is available as an importable Python package:
 
 ```shell
-uv pip install "llm-proxy-client @ git+https://github.com/tyemirov/llm-proxy.git"
+uv pip install --upgrade "llm-proxy-client @ git+https://github.com/tyemirov/llm-proxy.git@master#subdirectory=python"
 ```
+
+For reproducible application builds, replace `master` with the desired released
+repository tag.
 
 ```python
 from llm_proxy_client import Client, ClientConfig, ClientMessagesRequest, ClientMessage
@@ -1249,6 +1342,7 @@ text = client.post_messages(
     ClientMessagesRequest(
         messages=(ClientMessage(role="user", content="Summarize this"),),
         max_tokens=512,
+        request_timeout_seconds=900,
     )
 )
 ```
@@ -1256,6 +1350,14 @@ text = client.post_messages(
 `ClientMessagesRequest.reasoning_effort` is the same optional per-request
 override. Supply a nonblank value only for a resolved provider/model route that
 declares it; omit the field to retain the tenant default.
+`ClientMessagesRequest.request_timeout_seconds` serializes the canonical proxy
+work-budget header. Omit it to use the server default.
+
+Python client `0.2.0` removes `ClientConfig.timeout_seconds`. Move that value to
+each `ClientMessagesRequest` that needs it. The default urllib transport is
+called without a total-response timeout; applications that intentionally need
+an independent transport deadline can continue to inject an opener that owns
+that policy.
 
 The Python package is v2-only. For chat-transcript callers, send the same
 `post_messages` request with multiple messages:
@@ -1561,6 +1663,11 @@ but are not returned in response metadata.
 
 ### LLM endpoint
 
+All four public upstream endpoints accept
+`X-LLM-Proxy-Request-Timeout-Seconds: N`. Omit it to use the configured server
+default. See [Request work budgets](#request-work-budgets) for validation,
+response-header, timeout-error, and cancellation semantics.
+
 ```text
 GET /
   ?prompt=STRING            # required
@@ -1734,12 +1841,12 @@ and [latest-model guide](https://developers.openai.com/api/docs/guides/latest-mo
 ### Status codes
 
 * `200 OK` - success
-* `400 Bad Request` - missing/invalid parameters, invalid multipart audio form, unknown provider/model, or unsupported provider capability
+* `400 Bad Request` - missing/invalid parameters, invalid request timeout, invalid multipart audio form, unknown provider/model, or unsupported provider capability. Invalid timeout headers return `{"error":{"code":"invalid_request_timeout","max_request_timeout_seconds":M}}`.
 * `403 Forbidden` - missing or invalid `key`
 * `413 Payload Too Large` - JSON prompt body exceeds `max_prompt_bytes`
 * `429 Too Many Requests` - upstream provider rate limit
 * `503 Service Unavailable` - selected provider credential is unavailable because that non-default provider is disabled or missing its API key
-* `504 Gateway Timeout` - the overall proxy request timed out before the selected upstream provider returned a final result
+* `504 Gateway Timeout` - the accepted proxy work budget expired; the response is `{"error":{"code":"request_timeout","request_timeout_seconds":N}}`
 * `502 Bad Gateway` - upstream provider API returned an error
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ cancel sooner with a Go context, a process signal, or an explicitly configured
 HTTP transport policy, and no response is guaranteed after caller cancellation.
 The bundled clients impose no separate total-response deadline by default.
 
+Accepted upstream requests emit safe terminal evidence with the effective
+budget and one of `validation_failure`, `success`, `proxy_timeout`,
+`proxy_overload`, `provider_failure`, or `caller_cancelled`. Queue-capacity
+rejection is proxy overload, not a provider failure.
+
+For managed tenants, usage persistence begins only after the selected response
+status and body have been written and the response writer has been flushed.
+The store lock and database calls use the same request context, so they stop
+when the accepted budget or caller cancellation ends the request. Consequently,
+a request canceled before its usage transaction commits may have terminal log
+evidence but no managed-usage row; usage persistence never changes an already
+selected response.
+
 Internally, `server.workers` limits concurrent upstream provider HTTP
 operations and `server.queue_size` limits upstream HTTP operations waiting for a
 worker. Long OpenAI background-response poll sleeps do not occupy a worker slot;
@@ -448,9 +461,10 @@ providers:
 
 `server.request_timeout_seconds` and `server.max_request_timeout_seconds` must
 both be positive, and the default must not exceed the maximum. Invalid explicit
-values fail startup. The maximum is operator-owned service capacity and must
-remain strictly below the response-header and read deadlines of the outer
-gateway.
+values fail startup, including YAML `null` and an explicitly empty YAML value;
+omitting either field selects its compiled default. The maximum is
+operator-owned service capacity and must remain strictly below the
+response-header and read deadlines of the outer gateway.
 
 Dictation-capable providers must also declare a dictation catalog:
 
@@ -1118,9 +1132,10 @@ uses the sole gateway `deploy-llm-proxy-backend` target after the gateway-owned
 `verify-llm-proxy-deployment-contract` preflight proves the coupled TAuth
 service, runtime assets, and health checks. That preflight reads
 `server.max_request_timeout_seconds` from the app-owned tracked config and
-passes it to the gateway verifier; deployment fails unless the gateway-owned
-response-header, upstream-read, and client-write guards are all strictly
-greater. Neither repository carries a fallback copy of the other's capacity.
+passes it to both the early gateway verifier and the protected gateway
+deployment target; deployment fails unless the gateway-owned response-header,
+upstream-read, and client-write guards are all strictly greater. Neither
+repository carries a fallback copy of the other's capacity.
 Override only the checkout with
 `GATEWAY_DIR=/path/to/mprlab-gateway`; the selected gateway checkout must be a
 clean, synchronized `origin/master`. Override Pages preparation and activation

--- a/cmd/cli/config_file.go
+++ b/cmd/cli/config_file.go
@@ -187,6 +187,9 @@ func loadRuntimeConfiguration(rawConfigPath string) (proxy.Configuration, error)
 	if readConfigError := configReader.ReadConfig(strings.NewReader(expandedConfig)); readConfigError != nil {
 		return proxy.Configuration{}, fmt.Errorf("%w: path=%s: %v", errConfigFileParse, configPath, readConfigError)
 	}
+	if timeoutValidationError := validateExplicitRequestTimeoutConfiguration(configReader); timeoutValidationError != nil {
+		return proxy.Configuration{}, fmt.Errorf("%w: path=%s: %v", errConfigInvalid, configPath, timeoutValidationError)
+	}
 
 	var parsedConfiguration fileConfiguration
 	if unmarshalError := configReader.UnmarshalExact(&parsedConfiguration); unmarshalError != nil {
@@ -197,6 +200,19 @@ func loadRuntimeConfiguration(rawConfigPath string) (proxy.Configuration, error)
 		return proxy.Configuration{}, fmt.Errorf("%w: path=%s: %v", errConfigInvalid, configPath, configError)
 	}
 	return runtimeConfig, nil
+}
+
+func validateExplicitRequestTimeoutConfiguration(configReader *viper.Viper) error {
+	timeoutFields := map[string]struct{}{
+		"server.request_timeout_seconds":     {},
+		"server.max_request_timeout_seconds": {},
+	}
+	for _, configuredField := range configReader.AllKeys() {
+		if _, isTimeoutField := timeoutFields[configuredField]; isTimeoutField && configReader.Get(configuredField) == nil {
+			return fmt.Errorf("invalid configuration: %s must be positive", configuredField)
+		}
+	}
+	return nil
 }
 
 func normalizedConfigPath(rawConfigPath string) string {

--- a/cmd/cli/config_file.go
+++ b/cmd/cli/config_file.go
@@ -53,14 +53,15 @@ type fileConfiguration struct {
 }
 
 type serverConfiguration struct {
-	Port                  int                              `mapstructure:"port"`
-	LogLevel              string                           `mapstructure:"log_level"`
-	Workers               int                              `mapstructure:"workers"`
-	QueueSize             int                              `mapstructure:"queue_size"`
-	RequestTimeoutSeconds int                              `mapstructure:"request_timeout_seconds"`
-	MaxPromptBytes        int64                            `mapstructure:"max_prompt_bytes"`
-	MaxInputAudioBytes    int64                            `mapstructure:"max_input_audio_bytes"`
-	UpstreamRateLimits    []upstreamRateLimitConfiguration `mapstructure:"upstream_rate_limits"`
+	Port                     int                              `mapstructure:"port"`
+	LogLevel                 string                           `mapstructure:"log_level"`
+	Workers                  int                              `mapstructure:"workers"`
+	QueueSize                int                              `mapstructure:"queue_size"`
+	RequestTimeoutSeconds    *int                             `mapstructure:"request_timeout_seconds"`
+	MaxRequestTimeoutSeconds *int                             `mapstructure:"max_request_timeout_seconds"`
+	MaxPromptBytes           int64                            `mapstructure:"max_prompt_bytes"`
+	MaxInputAudioBytes       int64                            `mapstructure:"max_input_audio_bytes"`
+	UpstreamRateLimits       []upstreamRateLimitConfiguration `mapstructure:"upstream_rate_limits"`
 }
 
 type upstreamRateLimitConfiguration struct {
@@ -272,6 +273,14 @@ func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configurati
 	if configurationValidationError := configuration.validateCompleteConfiguration(); configurationValidationError != nil {
 		return proxy.Configuration{}, configurationValidationError
 	}
+	requestTimeoutSeconds, timeoutError := configuredPositiveSeconds(configuration.Server.RequestTimeoutSeconds, proxy.DefaultRequestTimeoutSeconds, "server.request_timeout_seconds")
+	if timeoutError != nil {
+		return proxy.Configuration{}, timeoutError
+	}
+	maxRequestTimeoutSeconds, maxTimeoutError := configuredPositiveSeconds(configuration.Server.MaxRequestTimeoutSeconds, proxy.DefaultMaxRequestTimeoutSeconds, "server.max_request_timeout_seconds")
+	if maxTimeoutError != nil {
+		return proxy.Configuration{}, maxTimeoutError
+	}
 	return proxy.NewConfiguration(proxy.Configuration{
 		Tenants:                      tenantConfigurations(configuration.Tenants),
 		Management:                   managementProxyConfiguration(configuration.Management),
@@ -307,12 +316,23 @@ func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configurati
 		LogLevel:                     configuration.Server.LogLevel,
 		WorkerCount:                  configuration.Server.Workers,
 		QueueSize:                    configuration.Server.QueueSize,
-		RequestTimeoutSeconds:        configuration.Server.RequestTimeoutSeconds,
+		RequestTimeoutSeconds:        requestTimeoutSeconds,
+		MaxRequestTimeoutSeconds:     maxRequestTimeoutSeconds,
 		MaxPromptBytes:               configuration.Server.MaxPromptBytes,
 		MaxInputAudioBytes:           configuration.Server.MaxInputAudioBytes,
 		UpstreamRateLimits:           proxyUpstreamRateLimitConfigurations(configuration.Server.UpstreamRateLimits),
 		ProviderModels:               configuration.Providers.providerModelCatalogs(),
 	})
+}
+
+func configuredPositiveSeconds(configuredValue *int, defaultValue int, fieldName string) (int, error) {
+	if configuredValue == nil {
+		return defaultValue, nil
+	}
+	if *configuredValue <= 0 {
+		return 0, fmt.Errorf("invalid configuration: %s must be positive", fieldName)
+	}
+	return *configuredValue, nil
 }
 
 func proxyUpstreamRateLimitConfigurations(configurations []upstreamRateLimitConfiguration) []proxy.UpstreamRateLimitConfiguration {

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -57,6 +57,7 @@ server:
   workers: 2
   queue_size: 9
   request_timeout_seconds: 7
+  max_request_timeout_seconds: 11
   max_prompt_bytes: 1024
   max_input_audio_bytes: 2048
   upstream_rate_limits:
@@ -124,6 +125,13 @@ P411_LEGACY_TOKEN_OWNER_EMAIL=Legacy.Owner@Example.com
 	}
 	if capturedConfiguration.Port != 18080 {
 		t.Fatalf("port=%d", capturedConfiguration.Port)
+	}
+	if capturedConfiguration.RequestTimeoutSeconds != 7 || capturedConfiguration.MaxRequestTimeoutSeconds != 11 {
+		t.Fatalf(
+			"request timeout default=%d maximum=%d",
+			capturedConfiguration.RequestTimeoutSeconds,
+			capturedConfiguration.MaxRequestTimeoutSeconds,
+		)
 	}
 	if len(capturedConfiguration.UpstreamRateLimits) != 1 || capturedConfiguration.UpstreamRateLimits[0].Origin != "https://openai.example" || capturedConfiguration.UpstreamRateLimits[0].MaxRequests != 12 || capturedConfiguration.UpstreamRateLimits[0].Interval != "1m" {
 		t.Fatalf("upstreamRateLimits=%+v", capturedConfiguration.UpstreamRateLimits)
@@ -246,6 +254,47 @@ tenants:
 	executeError := executeRootCommand(t, "--config", configPath)
 	if executeError != nil {
 		t.Fatalf("ExecuteC error: %v", executeError)
+	}
+}
+
+func TestRootCommandRejectsInvalidRequestTimeoutConfiguration(t *testing.T) {
+	testCases := []struct {
+		name          string
+		serverYAML    string
+		expectedError string
+	}{
+		{
+			name:          "zero default",
+			serverYAML:    "  request_timeout_seconds: 0\n",
+			expectedError: "server.request_timeout_seconds must be positive",
+		},
+		{
+			name:          "zero maximum",
+			serverYAML:    "  max_request_timeout_seconds: 0\n",
+			expectedError: "server.max_request_timeout_seconds must be positive",
+		},
+		{
+			name:          "default exceeds maximum",
+			serverYAML:    "  request_timeout_seconds: 5\n  max_request_timeout_seconds: 4\n",
+			expectedError: "server.request_timeout_seconds exceeds server.max_request_timeout_seconds",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			configPath := writeTestConfig(subTest, subTest.TempDir(), `
+server:
+`+testCase.serverYAML+`tenants:
+  - id: default
+    secret: "sekret"
+`+completeLiteralProvidersYAML())
+			withServeProxy(subTest, failingServeProxy(subTest))
+
+			executeError := executeRootCommand(subTest, "--config", configPath)
+			if executeError == nil || !strings.Contains(executeError.Error(), testCase.expectedError) {
+				subTest.Fatalf("error=%v want contains %q", executeError, testCase.expectedError)
+			}
+		})
 	}
 }
 

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -269,8 +269,28 @@ func TestRootCommandRejectsInvalidRequestTimeoutConfiguration(t *testing.T) {
 			expectedError: "server.request_timeout_seconds must be positive",
 		},
 		{
+			name:          "null default",
+			serverYAML:    "  request_timeout_seconds: null\n",
+			expectedError: "server.request_timeout_seconds must be positive",
+		},
+		{
+			name:          "empty default",
+			serverYAML:    "  request_timeout_seconds:\n",
+			expectedError: "server.request_timeout_seconds must be positive",
+		},
+		{
 			name:          "zero maximum",
 			serverYAML:    "  max_request_timeout_seconds: 0\n",
+			expectedError: "server.max_request_timeout_seconds must be positive",
+		},
+		{
+			name:          "null maximum",
+			serverYAML:    "  max_request_timeout_seconds: null\n",
+			expectedError: "server.max_request_timeout_seconds must be positive",
+		},
+		{
+			name:          "empty maximum",
+			serverYAML:    "  max_request_timeout_seconds:\n",
 			expectedError: "server.max_request_timeout_seconds must be positive",
 		},
 		{

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -4,6 +4,7 @@ server:
   workers: 4
   queue_size: 32
   request_timeout_seconds: 360
+  max_request_timeout_seconds: 3600
   max_prompt_bytes: 4194304
   max_input_audio_bytes: 26214400
   upstream_rate_limits: []

--- a/docs/implementation/dictation-endpoint-plan.md
+++ b/docs/implementation/dictation-endpoint-plan.md
@@ -9,6 +9,8 @@ Provide an authenticated audio-transcription endpoint in `llm-proxy` so downstre
 - `POST /dictate?key=SERVICE_SECRET[&model=MODEL_ID]`
 - `Content-Type: multipart/form-data`
 - request audio part name: `audio` (alias `file` for compatibility)
+- optional `X-LLM-Proxy-Request-Timeout-Seconds` header: the same bounded,
+  ingress-owned work budget used by every public text route
 - success response: JSON `{ "text": "..." }`
 
 ## Implementation Path
@@ -27,7 +29,9 @@ Provide an authenticated audio-transcription endpoint in `llm-proxy` so downstre
    - register `POST /dictate` route
    - reuse `secretMiddleware` (query `key`)
    - enforce multipart/size limits and missing-file validation
-   - return proxy-mapped status codes (`400`, `502`, `504`)
+   - apply the shared request-timeout header before multipart parsing and
+     return its canonical `400`/`504` JSON envelopes
+   - return other proxy-mapped status codes (`400`, `502`)
 5. Update README endpoint docs and curl examples for `/dictate`.
 
 ## Test Plan

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -23,6 +23,19 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 - Omitted `max_tokens` means the proxy omits provider max-token fields and lets the selected provider/model default apply, except Anthropic Messages where the upstream API requires `max_tokens` and the proxy sends the selected model's configured synchronous output limit.
 - Known provider-specific output-token ceilings are validated before upstream calls; MiniMax M2.7 rejects `max_tokens` above `2048`, Gemini text models reject values above `65536`, and Claude models reject values above their configured synchronous Messages output limits with `400 Bad Request`.
 - `reasoning_effort` is optional on `GET /` as a query parameter and on JSON `POST /` and `POST /v2` as a body field. Omission retains the resolved tenant default. A supplied value must be nonblank and supported by the exact resolved text provider/model route; blank, `null`, or unsupported values return `400 Bad Request` before a provider call.
+- `X-LLM-Proxy-Request-Timeout-Seconds` is an optional positive whole-number
+  header on `GET /`, `POST /`, `POST /v2`, and `POST /dictate`. Omission uses
+  `server.request_timeout_seconds`; a supplied value must be in the inclusive
+  range `1..server.max_request_timeout_seconds`.
+- The effective request budget begins at authenticated ingress before body
+  parsing and covers validation, queue admission, provider work, OpenAI
+  background polling, and response construction. Provider adapters propagate
+  the ingress context and never start a replacement deadline.
+- Accepted responses echo the effective timeout header. Invalid values return
+  the canonical `400 invalid_request_timeout` JSON envelope before upstream
+  admission, and budget expiry returns the canonical `504 request_timeout`
+  JSON envelope. Caller cancellation remains independent and may end the
+  request sooner without a response.
 - For JSON `POST /`, query `model` may override the body only when the body omits `model` or provides the same value.
 - Conflicting query/body `model` values return `400 Bad Request`.
 - JSON `POST /` bodies that provide both `prompt` and `messages`, neither field, empty messages, unsupported roles, empty content, a missing user message, partially specified `order`, duplicate `order`, or negative `order` return `400 Bad Request`.
@@ -97,6 +110,7 @@ Shared config fields:
 - `server.workers`
 - `server.queue_size`
 - `server.request_timeout_seconds`
+- `server.max_request_timeout_seconds`
 - `server.max_prompt_bytes`
 - `server.max_input_audio_bytes`
 - `server.upstream_rate_limits[].origin`
@@ -200,9 +214,9 @@ OpenAI `request_profile` values select stable payload shapes:
 
 Every OpenAI Responses text request includes `background: true` and
 `store: true`; the proxy polls the returned response id server-side until a
-terminal status or `server.request_timeout_seconds`. Callers use one normal
-`GET /`, `POST /`, or `POST /v2` request and receive the final formatted answer;
-there is no streaming or client-side polling contract.
+terminal status or the request's effective ingress-owned budget. Callers use
+one normal `GET /`, `POST /`, or `POST /v2` request and receive the final
+formatted answer; there is no streaming or client-side polling contract.
 
 Bundled clients intentionally expose only the canonical `POST /v2` text
 contract. The installable Go CLI maps prompt flags or stdin into v2 `system` and
@@ -211,6 +225,13 @@ messages-request constructors and `PostMessages`/`post_messages` send methods.
 Their optional `reasoning_effort` input serializes the same canonical field;
 the clients reject only blank local input and leave exact model-capability
 validation to the proxy edge.
+Their optional request-timeout input serializes
+`X-LLM-Proxy-Request-Timeout-Seconds` on each messages request. The Go CLI uses
+`--request-timeout-seconds`; the Go and Python packages expose
+`RequestTimeoutSeconds` and `request_timeout_seconds` on their request types.
+Omission delegates to the server default. Bundled transports add no unrelated
+total-response timeout; Go contexts and explicitly injected transports remain
+independent caller-owned cancellation mechanisms.
 When a bundled-client request omits `model`, it deliberately sends no model
 field and delegates selection to the authenticated tenant or selected provider.
 The server keeps `GET /` and compatibility JSON `POST /` available for direct

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/subosito/gotenv v1.6.0
 	github.com/tyemirov/tauth v1.1.8
 	go.uber.org/zap v1.27.1
+	golang.org/x/sync v0.22.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )
@@ -64,7 +65,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/tyemirov/llm-proxy/internal/constants"
 	"github.com/tyemirov/llm-proxy/internal/utils"
@@ -21,8 +20,7 @@ const (
 )
 
 type anthropicMessagesClient struct {
-	httpClient     HTTPDoer
-	requestTimeout time.Duration
+	httpClient HTTPDoer
 }
 
 type anthropicMessagesRequest struct {
@@ -47,10 +45,9 @@ type anthropicContentBlock struct {
 	Text string `json:"text"`
 }
 
-func newAnthropicMessagesClient(httpClient HTTPDoer, requestTimeout time.Duration) *anthropicMessagesClient {
+func newAnthropicMessagesClient(httpClient HTTPDoer) *anthropicMessagesClient {
 	return &anthropicMessagesClient{
-		httpClient:     httpClient,
-		requestTimeout: requestTimeout,
+		httpClient: httpClient,
 	}
 }
 
@@ -64,10 +61,8 @@ func (client *anthropicMessagesClient) generateText(parentContext context.Contex
 	}
 	payloadBytes, _ := json.Marshal(payload)
 
-	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
-	defer cancelRequest()
 	requestURL := strings.TrimRight(baseURL, "/") + "/v1/messages"
-	httpRequest, buildError := http.NewRequestWithContext(requestContext, http.MethodPost, requestURL, bytes.NewReader(payloadBytes))
+	httpRequest, buildError := http.NewRequestWithContext(parentContext, http.MethodPost, requestURL, bytes.NewReader(payloadBytes))
 	if buildError != nil {
 		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
 		return textGenerationResult{}, buildError

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -25,8 +25,10 @@ const (
 	// DefaultDictationProvider is the provider used when /dictate does not supply one.
 	DefaultDictationProvider = ProviderNameOpenAI
 
-	// DefaultRequestTimeoutSeconds is the overall app-side request timeout.
+	// DefaultRequestTimeoutSeconds is the request work budget used when the client omits one.
 	DefaultRequestTimeoutSeconds = 360
+	// DefaultMaxRequestTimeoutSeconds is the one-hour operator capacity ceiling for a request.
+	DefaultMaxRequestTimeoutSeconds = 60 * 60
 	// DefaultMaxPromptBytes limits JSON LLM request bodies accepted by POST /.
 	DefaultMaxPromptBytes      = 4 * 1024 * 1024
 	DefaultDictationModel      = "gpt-4o-mini-transcribe"
@@ -77,6 +79,7 @@ type Configuration struct {
 	WorkerCount                  int
 	QueueSize                    int
 	RequestTimeoutSeconds        int
+	MaxRequestTimeoutSeconds     int
 	MaxPromptBytes               int64
 	MaxInputAudioBytes           int64
 	UpstreamRateLimits           []UpstreamRateLimitConfiguration
@@ -85,6 +88,7 @@ type Configuration struct {
 	upstreamRateLimits           upstreamRateLimits
 	tenants                      tenantRegistry
 	managementSessionValidator   *managementSessionValidator
+	requestTimeoutPolicy         requestTimeoutPolicy
 	validated                    bool
 }
 
@@ -123,6 +127,10 @@ type LegacyTokenMigrationConfiguration struct {
 // NewConfiguration returns a normalized runtime configuration after validating startup invariants.
 func NewConfiguration(configuration Configuration) (Configuration, error) {
 	configuration.ApplyTunables()
+	timeoutPolicy, timeoutPolicyError := newRequestTimeoutPolicy(configuration.RequestTimeoutSeconds, configuration.MaxRequestTimeoutSeconds)
+	if timeoutPolicyError != nil {
+		return Configuration{}, timeoutPolicyError
+	}
 	upstreamRateLimits, rateLimitError := newUpstreamRateLimits(configuration.UpstreamRateLimits)
 	if rateLimitError != nil {
 		return Configuration{}, rateLimitError
@@ -142,6 +150,7 @@ func NewConfiguration(configuration Configuration) (Configuration, error) {
 	configuration.upstreamRateLimits = upstreamRateLimits
 	configuration.tenants = tenants
 	configuration.managementSessionValidator = sessionValidator
+	configuration.requestTimeoutPolicy = timeoutPolicy
 	configuration.validated = true
 	return configuration, nil
 }
@@ -222,8 +231,11 @@ func (configuration *Configuration) ApplyTunables() {
 	if configuration.QueueSize <= 0 {
 		configuration.QueueSize = DefaultQueueSize
 	}
-	if configuration.RequestTimeoutSeconds <= 0 {
+	if configuration.RequestTimeoutSeconds == 0 {
 		configuration.RequestTimeoutSeconds = DefaultRequestTimeoutSeconds
+	}
+	if configuration.MaxRequestTimeoutSeconds == 0 {
+		configuration.MaxRequestTimeoutSeconds = DefaultMaxRequestTimeoutSeconds
 	}
 	if configuration.MaxPromptBytes <= 0 {
 		configuration.MaxPromptBytes = DefaultMaxPromptBytes

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -1390,8 +1390,8 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		request = request.WithContext(requestContext)
 		responseRecorder := httptest.NewRecorder()
 		router.ServeHTTP(responseRecorder, request)
-		if responseRecorder.Code != http.StatusGatewayTimeout {
-			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusGatewayTimeout, responseRecorder.Body.String())
+		if responseRecorder.Code != 499 {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, 499, responseRecorder.Body.String())
 		}
 	})
 
@@ -1697,8 +1697,8 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		queryParameters := url.Values{}
 		queryParameters.Set("provider", proxy.ProviderNameDeepSeek)
 		statusCode, _, _ := performCoverageTextRequestWithTimeout(subTest, router, queryParameters, "", coverageShortRequestTimeout)
-		if statusCode != http.StatusGatewayTimeout {
-			subTest.Fatalf("status=%d want=%d", statusCode, http.StatusGatewayTimeout)
+		if statusCode != 499 {
+			subTest.Fatalf("status=%d want=%d", statusCode, 499)
 		}
 	})
 
@@ -1749,8 +1749,8 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		queryParameters := url.Values{}
 		queryParameters.Set("provider", proxy.ProviderNameDeepSeek)
 		statusCode, _, _ := performCoverageTextRequestWithTimeout(subTest, router, queryParameters, "", coverageShortRequestTimeout)
-		if statusCode != http.StatusGatewayTimeout {
-			subTest.Fatalf("status=%d want=%d", statusCode, http.StatusGatewayTimeout)
+		if statusCode != 499 {
+			subTest.Fatalf("status=%d want=%d", statusCode, 499)
 		}
 		close(releaseUpstream)
 		select {
@@ -2125,8 +2125,8 @@ func TestCoverageHTTPUtilityReadFailure(t *testing.T) {
 	})
 	queryParameters := url.Values{}
 	statusCode, _, _ := performCoverageTextRequestWithTimeout(t, router, queryParameters, "", coverageShortRequestTimeout)
-	if statusCode != http.StatusGatewayTimeout {
-		t.Fatalf("status=%d want=%d", statusCode, http.StatusGatewayTimeout)
+	if statusCode != 499 {
+		t.Fatalf("status=%d want=%d", statusCode, 499)
 	}
 }
 

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/tyemirov/llm-proxy/internal/constants"
 	"github.com/tyemirov/llm-proxy/internal/utils"
@@ -23,8 +22,7 @@ const (
 type geminiFinishReason string
 
 type geminiGenerateContentClient struct {
-	httpClient     HTTPDoer
-	requestTimeout time.Duration
+	httpClient HTTPDoer
 }
 
 type geminiGenerateContentRequest struct {
@@ -71,10 +69,9 @@ type geminiUsageMetadata struct {
 	TotalTokenCount      *int `json:"totalTokenCount"`
 }
 
-func newGeminiGenerateContentClient(httpClient HTTPDoer, requestTimeout time.Duration) *geminiGenerateContentClient {
+func newGeminiGenerateContentClient(httpClient HTTPDoer) *geminiGenerateContentClient {
 	return &geminiGenerateContentClient{
-		httpClient:     httpClient,
-		requestTimeout: requestTimeout,
+		httpClient: httpClient,
 	}
 }
 
@@ -90,9 +87,7 @@ func (client *geminiGenerateContentClient) generateText(parentContext context.Co
 	payloadBytes, _ := json.Marshal(payload)
 
 	requestURL := geminiGenerateContentURL(baseURL, modelIdentifier)
-	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
-	defer cancelRequest()
-	httpRequest, buildError := http.NewRequestWithContext(requestContext, http.MethodPost, requestURL, bytes.NewReader(payloadBytes))
+	httpRequest, buildError := http.NewRequestWithContext(parentContext, http.MethodPost, requestURL, bytes.NewReader(payloadBytes))
 	if buildError != nil {
 		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
 		return textGenerationResult{}, buildError

--- a/internal/proxy/management_internal_test.go
+++ b/internal/proxy/management_internal_test.go
@@ -1387,6 +1387,7 @@ func TestProviderKeyRejectionInternalEdges(t *testing.T) {
 	ginContext, _ := gin.CreateTestContext(response)
 	ginContext.Request = httptest.NewRequest(http.MethodPost, "/", nil)
 	ginContext.Request.Body = failingReadCloser{}
+	ginContext.Set(contextKeyRequestTimeoutState, &requestTimeoutState{})
 	if _, ok := readJSONProxyBody(ginContext); ok || response.Code != http.StatusBadRequest {
 		t.Fatalf("readJSONProxyBody ok=%v status=%d", ok, response.Code)
 	}

--- a/internal/proxy/management_internal_test.go
+++ b/internal/proxy/management_internal_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -376,10 +377,10 @@ func TestManagedTenantStoreUsageEdges(t *testing.T) {
 
 	noOpDatabase := newFakeManagedTenantDatabase()
 	noOpStore := newManagedTenantStoreWithDatabase(noOpDatabase)
-	if recordError := noOpStore.recordUsage(tenant{identifier: tenantID("static-usage")}, managedUsageEvent{statusCode: http.StatusOK}); recordError != nil {
+	if recordError := noOpStore.recordUsage(context.Background(), tenant{identifier: tenantID("static-usage")}, managedUsageEvent{statusCode: http.StatusOK}); recordError != nil {
 		t.Fatalf("unmanaged record usage error=%v", recordError)
 	}
-	if recordError := noOpStore.recordUsage(tenant{identifier: tenantID("missing-user"), managed: true}, managedUsageEvent{statusCode: http.StatusOK}); recordError != nil {
+	if recordError := noOpStore.recordUsage(context.Background(), tenant{identifier: tenantID("missing-user"), managed: true}, managedUsageEvent{statusCode: http.StatusOK}); recordError != nil {
 		t.Fatalf("missing user record usage error=%v", recordError)
 	}
 	if len(noOpDatabase.usageEvents) != 0 {
@@ -393,7 +394,7 @@ func TestManagedTenantStoreUsageEdges(t *testing.T) {
 	createErrorDatabase.createUsageEventError = errInternalTestDatabase
 	createErrorStore := newManagedTenantStoreWithDatabase(createErrorDatabase)
 	createErrorStore.now = func() time.Time { return fixedTime }
-	recordError := createErrorStore.recordUsage(managedTenant, managedUsageEvent{
+	recordError := createErrorStore.recordUsage(context.Background(), managedTenant, managedUsageEvent{
 		endpoint:            usageEndpointText,
 		providerIdentifier:  ProviderNameOpenAI,
 		modelIdentifier:     ModelNameGPT41,
@@ -408,7 +409,7 @@ func TestManagedTenantStoreUsageEdges(t *testing.T) {
 	ownerQueryErrorDatabase := newFakeManagedTenantDatabase()
 	ownerQueryErrorDatabase.userQueryErrors = []error{errInternalTestDatabase}
 	ownerQueryErrorStore := newManagedTenantStoreWithDatabase(ownerQueryErrorDatabase)
-	if recordError := ownerQueryErrorStore.recordUsage(managedTenant, managedUsageEvent{statusCode: http.StatusOK}); !errors.Is(recordError, errManagedTenantStorePersist) {
+	if recordError := ownerQueryErrorStore.recordUsage(context.Background(), managedTenant, managedUsageEvent{statusCode: http.StatusOK}); !errors.Is(recordError, errManagedTenantStorePersist) {
 		t.Fatalf("owner query usage error=%v want %v", recordError, errManagedTenantStorePersist)
 	}
 
@@ -417,7 +418,7 @@ func TestManagedTenantStoreUsageEdges(t *testing.T) {
 	unownedRecord.TenantID = managedTenant.identifier.string()
 	unownedDatabase.records[unownedRecord.UserID] = unownedRecord
 	unownedStore := newManagedTenantStoreWithDatabase(unownedDatabase)
-	if recordError := unownedStore.recordUsage(managedTenant, managedUsageEvent{statusCode: http.StatusOK}); !errors.Is(recordError, errManagedLegacyTokenUnowned) {
+	if recordError := unownedStore.recordUsage(context.Background(), managedTenant, managedUsageEvent{statusCode: http.StatusOK}); !errors.Is(recordError, errManagedLegacyTokenUnowned) {
 		t.Fatalf("unowned usage error=%v want %v", recordError, errManagedLegacyTokenUnowned)
 	}
 
@@ -466,9 +467,32 @@ func TestManagedTenantStoreUsageEdges(t *testing.T) {
 	}
 
 	observedCore, observedLogs := observer.New(zapcore.WarnLevel)
-	recordManagedUsage(createErrorStore, zap.New(observedCore).Sugar(), managedTenant, usageEndpointText, ProviderNameOpenAI, ModelNameGPT41, http.StatusOK, nil, fixedTime.Add(-time.Second))
+	usageRecorder := httptest.NewRecorder()
+	usageContext, _ := gin.CreateTestContext(usageRecorder)
+	usageContext.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	usageContext.Status(http.StatusOK)
+	recordManagedUsage(createErrorStore, zap.New(observedCore).Sugar(), usageContext, managedTenant, usageEndpointText, ProviderNameOpenAI, ModelNameGPT41, http.StatusOK, nil, fixedTime.Add(-time.Second))
 	if observedLogs.Len() != 1 || observedLogs.All()[0].Message != logEventUsageRecordFailed {
 		t.Fatalf("usage record logs=%+v", observedLogs.All())
+	}
+	if !usageRecorder.Flushed {
+		t.Fatal("managed usage persistence must run after the response writer is flushed")
+	}
+
+	cancelledRequestContext, cancelRequest := context.WithCancel(context.Background())
+	cancelRequest()
+	cancelledRecordError := createErrorStore.recordUsage(cancelledRequestContext, managedTenant, managedUsageEvent{statusCode: http.StatusOK})
+	if !errors.Is(cancelledRecordError, context.Canceled) || !errors.Is(cancelledRecordError, errManagedTenantStorePersist) {
+		t.Fatalf("cancelled usage error=%v", cancelledRecordError)
+	}
+	cancelledRecorder := httptest.NewRecorder()
+	cancelledGinContext, _ := gin.CreateTestContext(cancelledRecorder)
+	cancelledGinContext.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(cancelledRequestContext)
+	cancelledGinContext.Status(http.StatusOK)
+	cancelledCore, cancelledLogs := observer.New(zapcore.WarnLevel)
+	recordManagedUsage(createErrorStore, zap.New(cancelledCore).Sugar(), cancelledGinContext, managedTenant, usageEndpointText, ProviderNameOpenAI, ModelNameGPT41, http.StatusOK, nil, fixedTime.Add(-time.Second))
+	if cancelledLogs.Len() != 0 || !cancelledRecorder.Flushed {
+		t.Fatalf("cancelled usage logs=%+v flushed=%t", cancelledLogs.All(), cancelledRecorder.Flushed)
 	}
 
 	service := newInternalManagementService(t, queryUsageErrorDatabase)
@@ -500,6 +524,80 @@ func TestManagedTenantStoreUsageEdges(t *testing.T) {
 	adminSnapshots, adminSnapshotsError := newManagedTenantStoreWithDatabase(adminOrderingDatabase).adminUsersSummary()
 	if adminSnapshotsError != nil || len(adminSnapshots) != 2 || adminSnapshots[0].userID != "admin-user-a" {
 		t.Fatalf("admin snapshots=%+v error=%v", adminSnapshots, adminSnapshotsError)
+	}
+}
+
+func TestResponseConstructionHonorsRequestDeadline(t *testing.T) {
+	testCases := []struct {
+		name     string
+		complete func(*gin.Context)
+	}{
+		{
+			name: "text",
+			complete: func(ginContext *gin.Context) {
+				completeChatRequest(
+					ginContext,
+					chatRequestParameters{},
+					textGenerationResult{text: "late response"},
+					tenant{},
+					usageEndpointText,
+					nil,
+					zap.NewNop().Sugar(),
+					time.Now(),
+				)
+			},
+		},
+		{
+			name: "dictation",
+			complete: func(ginContext *gin.Context) {
+				completeDictationRequest(
+					ginContext,
+					"late transcription",
+					tenant{},
+					providerDefinition{},
+					modelID(""),
+					nil,
+					zap.NewNop().Sugar(),
+					time.Now(),
+				)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			requestContext, cancelRequest := context.WithCancelCause(context.Background())
+			cancelRequest(errRequestTimeoutBudgetExpired)
+			responseRecorder := httptest.NewRecorder()
+			ginContext, _ := gin.CreateTestContext(responseRecorder)
+			ginContext.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(requestContext)
+			timeoutState := &requestTimeoutState{
+				budget:  newRequestTimeoutBudget(7),
+				outcome: requestOutcomeValidation,
+			}
+			ginContext.Set(contextKeyRequestTimeoutState, timeoutState)
+
+			testCase.complete(ginContext)
+
+			if responseRecorder.Code != http.StatusGatewayTimeout {
+				subTest.Fatalf("status=%d want=%d", responseRecorder.Code, http.StatusGatewayTimeout)
+			}
+			if responseRecorder.Body.String() != `{"error":{"code":"request_timeout","request_timeout_seconds":7}}` {
+				subTest.Fatalf("body=%q", responseRecorder.Body.String())
+			}
+			if timeoutState.outcome != requestOutcomeProxyTimeout {
+				subTest.Fatalf("outcome=%q want=%q", timeoutState.outcome, requestOutcomeProxyTimeout)
+			}
+		})
+	}
+}
+
+func TestRequestFailureOutcomeClassifiesProxyOverload(t *testing.T) {
+	if outcome := requestFailureOutcome(errQueueFull); outcome != requestOutcomeProxyOverload {
+		t.Fatalf("queue outcome=%q want=%q", outcome, requestOutcomeProxyOverload)
+	}
+	if outcome := requestFailureOutcome(errInternalTestDatabase); outcome != requestOutcomeProviderFailure {
+		t.Fatalf("provider outcome=%q want=%q", outcome, requestOutcomeProviderFailure)
 	}
 }
 
@@ -869,7 +967,7 @@ func TestGORMManagedLegacyTenantClaimStateAndFailures(t *testing.T) {
 				}
 			} else {
 				orphanUsage := managedUsageEventRecord{UserID: claim.targetUserID, TenantID: claim.tenantID, CreatedAt: time.Now().UTC()}
-				if createError := database.createUsageEvent(orphanUsage); createError != nil {
+				if createError := database.createUsageEvent(context.Background(), orphanUsage); createError != nil {
 					subTest.Fatalf("create orphan usage: %v", createError)
 				}
 			}
@@ -1492,7 +1590,7 @@ func newGORMManagedLegacyClaimFixture(t *testing.T, withProvider bool, withUsage
 	}
 	if withUsage {
 		usageRecord := managedUsageEventRecord{UserID: sourceUserID, TenantID: "legacy", Endpoint: usageEndpointText, StatusCode: http.StatusOK, Success: true, CreatedAt: fixedTime}
-		if createError := database.createUsageEvent(usageRecord); createError != nil {
+		if createError := database.createUsageEvent(context.Background(), usageRecord); createError != nil {
 			t.Fatalf("create source usage: %v", createError)
 		}
 	}
@@ -1556,7 +1654,7 @@ func (database *fakeManagedTenantDatabase) tenantByUserID(userID string) (manage
 	return cloneManagedTenantRecord(record), nil
 }
 
-func (database *fakeManagedTenantDatabase) tenantByTenantID(tenantID string) (managedTenantRecord, error) {
+func (database *fakeManagedTenantDatabase) tenantByTenantID(_ context.Context, tenantID string) (managedTenantRecord, error) {
 	if queryError, hasQueryError := database.popUserQueryError(); hasQueryError {
 		return managedTenantRecord{}, queryError
 	}
@@ -1667,7 +1765,7 @@ func (database *fakeManagedTenantDatabase) deleteProviderKey(record managedProvi
 	return nil
 }
 
-func (database *fakeManagedTenantDatabase) createUsageEvent(record managedUsageEventRecord) error {
+func (database *fakeManagedTenantDatabase) createUsageEvent(_ context.Context, record managedUsageEventRecord) error {
 	if database.createUsageEventError != nil {
 		return database.createUsageEventError
 	}

--- a/internal/proxy/management_store.go
+++ b/internal/proxy/management_store.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -11,11 +12,11 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/glebarez/sqlite"
 	"github.com/tyemirov/llm-proxy/internal/constants"
+	"golang.org/x/sync/semaphore"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -41,6 +42,7 @@ const (
 	maskedSecretSuffixLength            = 4
 	managedUsageSummaryDays             = 30
 	managedUsageReadBatchSize           = 256
+	managedTenantStoreLockCapacity      = int64(1 << 30)
 )
 
 var (
@@ -58,7 +60,7 @@ var (
 )
 
 type managedTenantStore struct {
-	mutex             sync.RWMutex
+	mutex             *managedTenantStoreMutex
 	database          managedTenantDatabase
 	providerKeyCipher managedProviderKeyCipher
 	routingDefaults   *providerRegistry
@@ -67,11 +69,39 @@ type managedTenantStore struct {
 	now               func() time.Time
 }
 
+type managedTenantStoreMutex struct {
+	weighted *semaphore.Weighted
+}
+
+func newManagedTenantStoreMutex() *managedTenantStoreMutex {
+	return &managedTenantStoreMutex{weighted: semaphore.NewWeighted(managedTenantStoreLockCapacity)}
+}
+
+func (mutex *managedTenantStoreMutex) Lock() {
+	_ = mutex.weighted.Acquire(context.Background(), managedTenantStoreLockCapacity)
+}
+
+func (mutex *managedTenantStoreMutex) LockContext(requestContext context.Context) error {
+	return mutex.weighted.Acquire(requestContext, managedTenantStoreLockCapacity)
+}
+
+func (mutex *managedTenantStoreMutex) Unlock() {
+	mutex.weighted.Release(managedTenantStoreLockCapacity)
+}
+
+func (mutex *managedTenantStoreMutex) RLock() {
+	_ = mutex.weighted.Acquire(context.Background(), 1)
+}
+
+func (mutex *managedTenantStoreMutex) RUnlock() {
+	mutex.weighted.Release(1)
+}
+
 type managedUsageEventVisitor func(managedUsageEventRecord)
 
 type managedTenantDatabase interface {
 	tenantByUserID(userID string) (managedTenantRecord, error)
-	tenantByTenantID(tenantID string) (managedTenantRecord, error)
+	tenantByTenantID(requestContext context.Context, tenantID string) (managedTenantRecord, error)
 	tenantBySecretDigest(secretDigest string) (managedTenantRecord, error)
 	tenants() ([]managedTenantRecord, error)
 	providerKeys() ([]managedProviderAPIKeyRecord, error)
@@ -79,7 +109,7 @@ type managedTenantDatabase interface {
 	saveTenant(record managedTenantRecord) error
 	saveProviderKey(record managedProviderAPIKeyRecord) error
 	deleteProviderKey(record managedProviderAPIKeyRecord) error
-	createUsageEvent(record managedUsageEventRecord) error
+	createUsageEvent(requestContext context.Context, record managedUsageEventRecord) error
 	earliestUsageEventByUserIDThrough(userID string, periodEnd time.Time) (time.Time, error)
 	streamUsageEventsByUserIDBetween(userID string, periodStart time.Time, periodEnd time.Time, visit managedUsageEventVisitor) error
 	streamUsageEventsByUserIDThrough(userID string, periodEnd time.Time, visit managedUsageEventVisitor) error
@@ -242,6 +272,7 @@ func newManagedTenantStoreWithDatabase(database managedTenantDatabase) *managedT
 
 func newManagedTenantStoreWithDatabaseAndCipher(database managedTenantDatabase, providerKeyCipher managedProviderKeyCipher) *managedTenantStore {
 	return &managedTenantStore{
+		mutex:             newManagedTenantStoreMutex(),
 		database:          database,
 		providerKeyCipher: providerKeyCipher,
 		randomReader:      rand.Reader,
@@ -359,9 +390,9 @@ func (database *gormManagedTenantDatabase) tenantByUserID(userID string) (manage
 	return record, queryError
 }
 
-func (database *gormManagedTenantDatabase) tenantByTenantID(tenantID string) (managedTenantRecord, error) {
+func (database *gormManagedTenantDatabase) tenantByTenantID(requestContext context.Context, tenantID string) (managedTenantRecord, error) {
 	var record managedTenantRecord
-	queryError := database.database.
+	queryError := database.database.WithContext(requestContext).
 		Where(&managedTenantRecord{TenantID: tenantID}).
 		First(&record).
 		Error
@@ -414,8 +445,8 @@ func (database *gormManagedTenantDatabase) deleteProviderKey(record managedProvi
 	return database.database.Where(&record).Delete(&managedProviderAPIKeyRecord{}).Error
 }
 
-func (database *gormManagedTenantDatabase) createUsageEvent(record managedUsageEventRecord) error {
-	return database.database.Create(&record).Error
+func (database *gormManagedTenantDatabase) createUsageEvent(requestContext context.Context, record managedUsageEventRecord) error {
+	return database.database.WithContext(requestContext).Create(&record).Error
 }
 
 func (database *gormManagedTenantDatabase) earliestUsageEventByUserIDThrough(userID string, periodEnd time.Time) (time.Time, error) {

--- a/internal/proxy/management_usage.go
+++ b/internal/proxy/management_usage.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -139,15 +140,17 @@ func (interval usageInterval) finiteWindow() (time.Duration, int, usageBucketUni
 	}
 }
 
-func (store *managedTenantStore) recordUsage(requestTenant tenant, event managedUsageEvent) error {
+func (store *managedTenantStore) recordUsage(requestContext context.Context, requestTenant tenant, event managedUsageEvent) error {
 	if !requestTenant.managed || requestTenant.userID == constants.EmptyString {
 		return nil
 	}
-	store.mutex.Lock()
+	if lockError := store.mutex.LockContext(requestContext); lockError != nil {
+		return fmt.Errorf("%w: tenant_id=%s: %w", errManagedTenantStorePersist, requestTenant.identifier.string(), lockError)
+	}
 	defer store.mutex.Unlock()
-	ownerRecord, ownerError := store.database.tenantByTenantID(requestTenant.identifier.string())
+	ownerRecord, ownerError := store.database.tenantByTenantID(requestContext, requestTenant.identifier.string())
 	if ownerError != nil {
-		return fmt.Errorf("%w: tenant_id=%s: %v", errManagedTenantStorePersist, requestTenant.identifier.string(), ownerError)
+		return fmt.Errorf("%w: tenant_id=%s: %w", errManagedTenantStorePersist, requestTenant.identifier.string(), ownerError)
 	}
 	if strings.HasPrefix(ownerRecord.UserID, legacyStaticTenantUserIDPrefix) {
 		return fmt.Errorf("%w: tenant_id=%s", errManagedLegacyTokenUnowned, requestTenant.identifier.string())
@@ -169,8 +172,8 @@ func (store *managedTenantStore) recordUsage(requestTenant tenant, event managed
 		usageRecord.ResponseTokens = event.usage.ResponseTokens
 		usageRecord.TotalTokens = event.usage.TotalTokens
 	}
-	if persistError := store.database.createUsageEvent(usageRecord); persistError != nil {
-		return fmt.Errorf("%w: user_id=%s: %v", errManagedTenantStorePersist, ownerRecord.UserID, persistError)
+	if persistError := store.database.createUsageEvent(requestContext, usageRecord); persistError != nil {
+		return fmt.Errorf("%w: user_id=%s: %w", errManagedTenantStorePersist, ownerRecord.UserID, persistError)
 	}
 	return nil
 }

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -30,17 +30,15 @@ var (
 // OpenAIClient provides access to the OpenAI responses API with configurable
 // endpoints and tunable parameters.
 type OpenAIClient struct {
-	httpClient     HTTPDoer
-	endpoints      *Endpoints
-	requestTimeout time.Duration
+	httpClient HTTPDoer
+	endpoints  *Endpoints
 }
 
 // NewOpenAIClient constructs an OpenAIClient initialized with the supplied components.
-func NewOpenAIClient(httpClient HTTPDoer, endpoints *Endpoints, requestTimeout time.Duration) *OpenAIClient {
+func NewOpenAIClient(httpClient HTTPDoer, endpoints *Endpoints) *OpenAIClient {
 	return &OpenAIClient{
-		httpClient:     httpClient,
-		endpoints:      endpoints,
-		requestTimeout: requestTimeout,
+		httpClient: httpClient,
+		endpoints:  endpoints,
 	}
 }
 
@@ -82,9 +80,7 @@ func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIK
 	payload := BuildRequestPayload(modelIdentifier.string(), modelIdentifier.requestProfile.string(), messages.openAIResponsesInput(), webSearchEnabled, maxTokens, reasoningEffort)
 	payloadBytes, _ := json.Marshal(payload)
 
-	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
-	defer cancelRequest()
-	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodPost, client.endpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
+	httpRequest, buildError := buildAuthorizedJSONRequest(parentContext, http.MethodPost, client.endpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
 	if buildError != nil {
 		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
 		return textGenerationResult{}, buildError
@@ -119,7 +115,7 @@ func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIK
 		return textGenerationResult{}, errors.New(errorOpenAIAPI)
 	}
 
-	return client.resolveOpenAIResponse(requestContext, openAIKey, modelIdentifier, webSearchEnabled, maxTokens, reasoningEffort, responseSnapshot, structuredLogger)
+	return client.resolveOpenAIResponse(parentContext, openAIKey, modelIdentifier, webSearchEnabled, maxTokens, reasoningEffort, responseSnapshot, structuredLogger)
 }
 
 type openAIResponseSnapshot struct {
@@ -307,9 +303,7 @@ func (client *OpenAIClient) startIncompleteContinuation(parentContext context.Co
 func (client *OpenAIClient) startContinuationResponse(parentContext context.Context, openAIKey string, payload map[string]any, structuredLogger *zap.SugaredLogger) (string, error) {
 	payloadBytes, _ := json.Marshal(payload)
 
-	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
-	defer cancelRequest()
-	request, _ := buildAuthorizedJSONRequest(requestContext, http.MethodPost, client.endpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
+	request, _ := buildAuthorizedJSONRequest(parentContext, http.MethodPost, client.endpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
 
 	statusCode, responseBytes, _, requestError := client.performResponsesRequest(request, structuredLogger, logEventOpenAIRequestError)
 	if requestError != nil {
@@ -376,10 +370,7 @@ func (client *OpenAIClient) pollResponseUntilDone(parentContext context.Context,
 // fetchResponseByID retrieves a response by identifier and reports whether the response is complete.
 func (client *OpenAIClient) fetchResponseByID(parentContext context.Context, openAIKey string, responseIdentifier string, structuredLogger *zap.SugaredLogger) (openAIResponseSnapshot, bool, error) {
 	resourceURL := client.endpoints.GetResponsesURL() + "/" + responseIdentifier
-	requestContext, cancel := context.WithTimeout(parentContext, client.requestTimeout)
-	defer cancel()
-
-	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodGet, resourceURL, openAIKey, nil)
+	httpRequest, buildError := buildAuthorizedJSONRequest(parentContext, http.MethodGet, resourceURL, openAIKey, nil)
 	if buildError != nil {
 		return openAIResponseSnapshot{}, false, buildError
 	}

--- a/internal/proxy/openai_compatible_chat.go
+++ b/internal/proxy/openai_compatible_chat.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/tyemirov/llm-proxy/internal/constants"
 	"github.com/tyemirov/llm-proxy/internal/utils"
@@ -16,8 +15,7 @@ import (
 )
 
 type openAICompatibleChatClient struct {
-	httpClient     HTTPDoer
-	requestTimeout time.Duration
+	httpClient HTTPDoer
 }
 
 type chatCompletionMessage struct {
@@ -46,10 +44,9 @@ type chatCompletionResponseMessage struct {
 	ReasoningContent string `json:"reasoning_content"`
 }
 
-func newOpenAICompatibleChatClient(httpClient HTTPDoer, requestTimeout time.Duration) *openAICompatibleChatClient {
+func newOpenAICompatibleChatClient(httpClient HTTPDoer) *openAICompatibleChatClient {
 	return &openAICompatibleChatClient{
-		httpClient:     httpClient,
-		requestTimeout: requestTimeout,
+		httpClient: httpClient,
 	}
 }
 
@@ -68,10 +65,8 @@ func (client *openAICompatibleChatClient) generateText(parentContext context.Con
 	}
 	payloadBytes, _ := json.Marshal(payload)
 
-	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
-	defer cancelRequest()
 	requestURL := strings.TrimRight(baseURL, "/") + "/chat/completions"
-	httpRequest, buildError := buildAuthorizedJSONRequest(requestContext, http.MethodPost, requestURL, apiKey, bytes.NewReader(payloadBytes))
+	httpRequest, buildError := buildAuthorizedJSONRequest(parentContext, http.MethodPost, requestURL, apiKey, bytes.NewReader(payloadBytes))
 	if buildError != nil {
 		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
 		return textGenerationResult{}, buildError

--- a/internal/proxy/openai_dictation.go
+++ b/internal/proxy/openai_dictation.go
@@ -41,11 +41,8 @@ func (client *OpenAIClient) transcribeAudioWithURL(parentContext context.Context
 
 	_ = multipartWriter.Close()
 
-	requestContext, cancelRequest := context.WithTimeout(parentContext, client.requestTimeout)
-	defer cancelRequest()
-
 	requestBody := bytes.NewReader(payloadBuffer.Bytes())
-	httpRequest, buildError := http.NewRequestWithContext(requestContext, http.MethodPost, transcriptionsURL, requestBody)
+	httpRequest, buildError := http.NewRequestWithContext(parentContext, http.MethodPost, transcriptionsURL, requestBody)
 	if buildError != nil {
 		return constants.EmptyString, buildError
 	}

--- a/internal/proxy/openai_dictation_test.go
+++ b/internal/proxy/openai_dictation_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"testing"
-	"time"
 )
 
 type transcriptionFailingReader struct{}
@@ -78,7 +77,7 @@ func TestParseTranscriptionText(t *testing.T) {
 }
 
 func TestTranscribeAudioWithURLReturnsReaderError(t *testing.T) {
-	client := NewOpenAIClient(http.DefaultClient, NewEndpoints(), time.Second)
+	client := NewOpenAIClient(http.DefaultClient, NewEndpoints())
 	_, transcriptionError := client.transcribeAudioWithURL(context.Background(), "key", "http://example.test", keyModel, DefaultDictationModel, "audio.webm", transcriptionFailingReader{}, nil)
 	if transcriptionError == nil {
 		t.Fatalf("transcriptionError=nil want non-nil")

--- a/internal/proxy/provider_key_rejection.go
+++ b/internal/proxy/provider_key_rejection.go
@@ -49,6 +49,9 @@ func rejectClientProviderCredentialsFromQuery(ginContext *gin.Context) bool {
 func readJSONProxyBody(ginContext *gin.Context) ([]byte, bool) {
 	bodyBytes, readError := io.ReadAll(ginContext.Request.Body)
 	if readError != nil {
+		if requestContextEnded(ginContext) {
+			return nil, false
+		}
 		var maxBytesError *http.MaxBytesError
 		if errors.As(readError, &maxBytesError) {
 			ginContext.String(http.StatusRequestEntityTooLarge, errorPromptPayloadTooLarge)

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -2103,8 +2103,8 @@ func TestProviderRoutingMapsGeminiTransportErrors(t *testing.T) {
 		defer cancelRequest()
 		responseRecorder := httptest.NewRecorder()
 		router.ServeHTTP(responseRecorder, request.WithContext(requestContext))
-		if responseRecorder.Code != http.StatusGatewayTimeout {
-			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusGatewayTimeout, responseRecorder.Body.String())
+		if responseRecorder.Code != 499 {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, 499, responseRecorder.Body.String())
 		}
 	})
 }
@@ -2207,8 +2207,8 @@ func TestProviderRoutingMapsAnthropicTransportErrors(t *testing.T) {
 		defer cancelRequest()
 		responseRecorder := httptest.NewRecorder()
 		router.ServeHTTP(responseRecorder, request.WithContext(requestContext))
-		if responseRecorder.Code != http.StatusGatewayTimeout {
-			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusGatewayTimeout, responseRecorder.Body.String())
+		if responseRecorder.Code != 499 {
+			subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, 499, responseRecorder.Body.String())
 		}
 	})
 }

--- a/internal/proxy/request_timeout.go
+++ b/internal/proxy/request_timeout.go
@@ -22,6 +22,7 @@ const (
 	requestOutcomeValidation      = "validation_failure"
 	requestOutcomeSuccess         = "success"
 	requestOutcomeProxyTimeout    = "proxy_timeout"
+	requestOutcomeProxyOverload   = "proxy_overload"
 	requestOutcomeProviderFailure = "provider_failure"
 	requestOutcomeCallerCancelled = "caller_cancelled"
 	statusClientClosedRequest     = 499
@@ -152,6 +153,13 @@ func requestTimeoutHandler(policy requestTimeoutPolicy, structuredLogger *zap.Su
 
 func markRequestOutcome(ginContext *gin.Context, outcome string) {
 	requestTimeoutStateFromContext(ginContext).outcome = outcome
+}
+
+func requestFailureOutcome(requestError error) string {
+	if errors.Is(requestError, errQueueFull) {
+		return requestOutcomeProxyOverload
+	}
+	return requestOutcomeProviderFailure
 }
 
 func requestTimeoutStateFromContext(ginContext *gin.Context) *requestTimeoutState {

--- a/internal/proxy/request_timeout.go
+++ b/internal/proxy/request_timeout.go
@@ -1,0 +1,201 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
+	"go.uber.org/zap"
+)
+
+const (
+	contextKeyRequestTimeoutState = "request_timeout_state"
+	logEventUpstreamRequestEnded  = "upstream request ended"
+	logFieldRequestTimeoutSeconds = "request_timeout_seconds"
+	logFieldOutcome               = "outcome"
+	requestOutcomeValidation      = "validation_failure"
+	requestOutcomeSuccess         = "success"
+	requestOutcomeProxyTimeout    = "proxy_timeout"
+	requestOutcomeProviderFailure = "provider_failure"
+	requestOutcomeCallerCancelled = "caller_cancelled"
+	statusClientClosedRequest     = 499
+)
+
+var errRequestTimeoutBudgetExpired = errors.New("request timeout budget expired")
+
+type requestTimeoutPolicy struct {
+	defaultBudget requestTimeoutBudget
+	maximum       int
+}
+
+type requestTimeoutBudget struct {
+	seconds  int
+	duration time.Duration
+}
+
+type requestTimeoutState struct {
+	budget  requestTimeoutBudget
+	outcome string
+}
+
+func newRequestTimeoutPolicy(defaultSeconds int, maximumSeconds int) (requestTimeoutPolicy, error) {
+	if defaultSeconds <= 0 {
+		return requestTimeoutPolicy{}, fmt.Errorf("invalid request timeout configuration: server.request_timeout_seconds must be positive")
+	}
+	if maximumSeconds <= 0 {
+		return requestTimeoutPolicy{}, fmt.Errorf("invalid request timeout configuration: server.max_request_timeout_seconds must be positive")
+	}
+	if defaultSeconds > maximumSeconds {
+		return requestTimeoutPolicy{}, fmt.Errorf("invalid request timeout configuration: server.request_timeout_seconds exceeds server.max_request_timeout_seconds")
+	}
+	if int64(maximumSeconds) > int64(^uint64(0)>>1)/int64(time.Second) {
+		return requestTimeoutPolicy{}, fmt.Errorf("invalid request timeout configuration: server.max_request_timeout_seconds exceeds supported duration")
+	}
+	return requestTimeoutPolicy{
+		defaultBudget: newRequestTimeoutBudget(defaultSeconds),
+		maximum:       maximumSeconds,
+	}, nil
+}
+
+func newRequestTimeoutBudget(seconds int) requestTimeoutBudget {
+	return requestTimeoutBudget{
+		seconds:  seconds,
+		duration: time.Duration(seconds) * time.Second,
+	}
+}
+
+func (policy requestTimeoutPolicy) resolve(headerValues []string) (requestTimeoutBudget, bool) {
+	if len(headerValues) == 0 {
+		return policy.defaultBudget, true
+	}
+	if len(headerValues) != 1 || headerValues[0] == "" {
+		return requestTimeoutBudget{}, false
+	}
+	for _, character := range headerValues[0] {
+		if character < '0' || character > '9' {
+			return requestTimeoutBudget{}, false
+		}
+	}
+	requestedSeconds, parseError := strconv.Atoi(headerValues[0])
+	if parseError != nil || requestedSeconds <= 0 || requestedSeconds > policy.maximum {
+		return requestTimeoutBudget{}, false
+	}
+	return newRequestTimeoutBudget(requestedSeconds), true
+}
+
+func requestTimeoutHandler(policy requestTimeoutPolicy, structuredLogger *zap.SugaredLogger, handler gin.HandlerFunc) gin.HandlerFunc {
+	return func(ginContext *gin.Context) {
+		budget, valid := policy.resolve(ginContext.Request.Header.Values(llmproxycontract.HeaderRequestTimeoutSeconds))
+		if !valid {
+			ginContext.Data(
+				http.StatusBadRequest,
+				mimeApplicationJSON,
+				[]byte(fmt.Sprintf(
+					`{"error":{"code":"%s","max_request_timeout_seconds":%d}}`,
+					llmproxycontract.ErrorCodeInvalidRequestTimeout,
+					policy.maximum,
+				)),
+			)
+			return
+		}
+
+		ginContext.Header(llmproxycontract.HeaderRequestTimeoutSeconds, strconv.Itoa(budget.seconds))
+		callerContext := ginContext.Request.Context()
+		requestContext, cancelRequest := context.WithTimeoutCause(
+			callerContext,
+			budget.duration,
+			errRequestTimeoutBudgetExpired,
+		)
+		requestBody := ginContext.Request.Body
+		stopBodyClose := context.AfterFunc(requestContext, func() {
+			if requestBody != nil {
+				_ = requestBody.Close()
+			}
+		})
+		state := &requestTimeoutState{
+			budget:  budget,
+			outcome: requestOutcomeValidation,
+		}
+		ginContext.Set(contextKeyRequestTimeoutState, state)
+		ginContext.Request = ginContext.Request.WithContext(requestContext)
+		if requestBody != nil {
+			ginContext.Request.Body = contextReadCloser{
+				Reader: contextReader{contextValue: requestContext, reader: requestBody},
+				Closer: requestBody,
+			}
+		}
+
+		handler(ginContext)
+
+		_ = stopBodyClose()
+		cancelRequest()
+		if structuredLogger != nil {
+			requestTenant := authenticatedTenantFromContext(ginContext)
+			structuredLogger.Infow(
+				logEventUpstreamRequestEnded,
+				logFieldMethod, ginContext.Request.Method,
+				logFieldEndpoint, requestLogPath(ginContext.Request.URL),
+				logFieldTenantID, requestTenant.identifier.string(),
+				logFieldRequestTimeoutSeconds, budget.seconds,
+				logFieldOutcome, state.outcome,
+				logFieldStatus, ginContext.Writer.Status(),
+			)
+		}
+	}
+}
+
+func markRequestOutcome(ginContext *gin.Context, outcome string) {
+	requestTimeoutStateFromContext(ginContext).outcome = outcome
+}
+
+func requestTimeoutStateFromContext(ginContext *gin.Context) *requestTimeoutState {
+	return ginContext.MustGet(contextKeyRequestTimeoutState).(*requestTimeoutState)
+}
+
+func requestContextEnded(ginContext *gin.Context) bool {
+	state := requestTimeoutStateFromContext(ginContext)
+	requestCause := context.Cause(ginContext.Request.Context())
+	if requestCause == nil {
+		return false
+	}
+	if !errors.Is(requestCause, errRequestTimeoutBudgetExpired) {
+		state.outcome = requestOutcomeCallerCancelled
+		ginContext.Status(statusClientClosedRequest)
+		return true
+	}
+	state.outcome = requestOutcomeProxyTimeout
+	ginContext.Data(
+		http.StatusGatewayTimeout,
+		mimeApplicationJSON,
+		[]byte(fmt.Sprintf(
+			`{"error":{"code":"%s","request_timeout_seconds":%d}}`,
+			llmproxycontract.ErrorCodeRequestTimeout,
+			state.budget.seconds,
+		)),
+	)
+	return true
+}
+
+type contextReader struct {
+	contextValue context.Context
+	reader       io.Reader
+}
+
+func (reader contextReader) Read(buffer []byte) (int, error) {
+	readBytes, readError := reader.reader.Read(buffer)
+	if contextError := reader.contextValue.Err(); contextError != nil {
+		return readBytes, contextError
+	}
+	return readBytes, readError
+}
+
+type contextReadCloser struct {
+	io.Reader
+	io.Closer
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -506,25 +506,33 @@ func submitChatRequest(ginContext *gin.Context, upstreamProviders *providerRoute
 	generation, requestError := upstreamProviders.generateText(ginContext.Request.Context(), chatRequest, structuredLogger)
 	if requestError != nil {
 		if requestContextEnded(ginContext) {
-			recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
+			recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
 			return
 		}
-		markRequestOutcome(ginContext, requestOutcomeProviderFailure)
+		markRequestOutcome(ginContext, requestFailureOutcome(requestError))
 		statusCode := statusCodeForError(requestError)
-		recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), statusCode, nil, requestStart)
 		ginContext.String(statusCode, responseMessageForError(requestError))
+		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), statusCode, nil, requestStart)
 		return
 	}
 	if requestContextEnded(ginContext) {
-		recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
+		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
+		return
+	}
+	completeChatRequest(ginContext, chatRequest, generation, requestTenant, usageEndpoint, managedTenants, structuredLogger, requestStart)
+}
+
+func completeChatRequest(ginContext *gin.Context, chatRequest chatRequestParameters, generation textGenerationResult, requestTenant tenant, usageEndpoint string, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger, requestStart time.Time) {
+	mime := preferredMime(ginContext)
+	formattedBody, contentType := formatResponse(generation.text, mime, chatRequest, generation.usage)
+	if requestContextEnded(ginContext) {
+		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
 		return
 	}
 	markRequestOutcome(ginContext, requestOutcomeSuccess)
-	mime := preferredMime(ginContext)
 	writeTokenUsageHeaders(ginContext.Writer.Header(), generation.usage)
-	formattedBody, contentType := formatResponse(generation.text, mime, chatRequest, generation.usage)
-	recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), http.StatusOK, generation.usage, requestStart)
 	ginContext.Data(http.StatusOK, contentType, []byte(formattedBody))
+	recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), http.StatusOK, generation.usage, requestStart)
 }
 
 func dictateHandler(upstreamProviders *providerRouter, providers *providerRegistry, maxInputAudioBytes int64, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
@@ -591,31 +599,42 @@ func dictateHandler(upstreamProviders *providerRouter, providers *providerRegist
 		transcribedText, requestError := upstreamProviders.transcribeAudio(ginContext.Request.Context(), dictationRequest, structuredLogger)
 		if requestError != nil {
 			if requestContextEnded(ginContext) {
-				recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), ginContext.Writer.Status(), nil, requestStart)
+				recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), ginContext.Writer.Status(), nil, requestStart)
 				return
 			}
-			markRequestOutcome(ginContext, requestOutcomeProviderFailure)
+			markRequestOutcome(ginContext, requestFailureOutcome(requestError))
 			statusCode := statusCodeForError(requestError)
-			recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), statusCode, nil, requestStart)
 			ginContext.String(statusCode, responseMessageForError(requestError))
+			recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), statusCode, nil, requestStart)
 			return
 		}
 		if requestContextEnded(ginContext) {
-			recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), ginContext.Writer.Status(), nil, requestStart)
+			recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), ginContext.Writer.Status(), nil, requestStart)
 			return
 		}
 
-		markRequestOutcome(ginContext, requestOutcomeSuccess)
-		recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), http.StatusOK, nil, requestStart)
-		ginContext.JSON(http.StatusOK, gin.H{keyText: transcribedText})
+		completeDictationRequest(ginContext, transcribedText, requestTenant, providerDefinition, modelIdentifier, managedTenants, structuredLogger, requestStart)
 	}
 }
 
-func recordManagedUsage(managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger, requestTenant tenant, endpoint string, providerIdentifier string, modelIdentifier string, statusCode int, usage *tokenUsage, requestStart time.Time) {
+func completeDictationRequest(ginContext *gin.Context, transcribedText string, requestTenant tenant, providerDefinition providerDefinition, modelIdentifier modelID, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger, requestStart time.Time) {
+	responseBody, _ := json.Marshal(gin.H{keyText: transcribedText})
+	if requestContextEnded(ginContext) {
+		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), ginContext.Writer.Status(), nil, requestStart)
+		return
+	}
+	markRequestOutcome(ginContext, requestOutcomeSuccess)
+	ginContext.Data(http.StatusOK, mimeApplicationJSON, responseBody)
+	recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), http.StatusOK, nil, requestStart)
+}
+
+func recordManagedUsage(managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger, ginContext *gin.Context, requestTenant tenant, endpoint string, providerIdentifier string, modelIdentifier string, statusCode int, usage *tokenUsage, requestStart time.Time) {
 	if managedTenants == nil || !requestTenant.managed {
 		return
 	}
-	recordError := managedTenants.recordUsage(requestTenant, managedUsageEvent{
+	ginContext.Writer.Flush()
+	requestContext := ginContext.Request.Context()
+	recordError := managedTenants.recordUsage(requestContext, requestTenant, managedUsageEvent{
 		endpoint:            endpoint,
 		providerIdentifier:  providerIdentifier,
 		modelIdentifier:     modelIdentifier,
@@ -624,6 +643,9 @@ func recordManagedUsage(managedTenants *managedTenantStore, structuredLogger *za
 		usage:               usage,
 	})
 	if recordError != nil {
+		if context.Cause(requestContext) != nil {
+			return
+		}
 		structuredLogger.Warnw(
 			logEventUsageRecordFailed,
 			logFieldTenantID, requestTenant.identifier.string(),
@@ -638,7 +660,7 @@ func recordManagedUsage(managedTenants *managedTenantStore, structuredLogger *za
 
 func recordManagedUsageValidationFailure(managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger, ginContext *gin.Context, requestTenant tenant, endpoint string, providerIdentifier string, modelIdentifier string, requestStart time.Time) {
 	statusCode := ginContext.Writer.Status()
-	recordManagedUsage(managedTenants, structuredLogger, requestTenant, endpoint, providerIdentifier, modelIdentifier, statusCode, nil, requestStart)
+	recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, endpoint, providerIdentifier, modelIdentifier, statusCode, nil, requestStart)
 }
 
 func usageTextProviderIdentifier(ginContext *gin.Context, defaults tenantDefaults) string {

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -16,13 +16,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// result holds the outcome returned by a provider goroutine, including the text response
-// and any error encountered during the upstream provider request.
-type result struct {
-	generation   textGenerationResult
-	requestError error
-}
-
 // chatRequestPayload is the JSON contract for POST / LLM requests.
 // Client authentication stays outside this body on the key query parameter; provider credentials are loaded from server configuration.
 type chatRequestPayload struct {
@@ -108,12 +101,11 @@ func buildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 		router.Use(requestResponseLogger(structuredLogger))
 	}
 
-	requestTimeout := time.Duration(configuration.RequestTimeoutSeconds) * time.Second
 	upstreamHTTPClient := newLimitedHTTPDoer(HTTPClient, configuration.WorkerCount, configuration.QueueSize, configuration.upstreamRateLimits, structuredLogger, systemUpstreamRateLimitClock{})
-	openAIClient := NewOpenAIClient(upstreamHTTPClient, configuration.Endpoints, requestTimeout)
-	chatClient := newOpenAICompatibleChatClient(upstreamHTTPClient, requestTimeout)
-	geminiClient := newGeminiGenerateContentClient(upstreamHTTPClient, requestTimeout)
-	anthropicClient := newAnthropicMessagesClient(upstreamHTTPClient, requestTimeout)
+	openAIClient := NewOpenAIClient(upstreamHTTPClient, configuration.Endpoints)
+	chatClient := newOpenAICompatibleChatClient(upstreamHTTPClient)
+	geminiClient := newGeminiGenerateContentClient(upstreamHTTPClient)
+	anthropicClient := newAnthropicMessagesClient(upstreamHTTPClient)
 	upstreamProviders := newProviderRouter(openAIClient, chatClient, geminiClient, anthropicClient)
 	var managedTenants *managedTenantStore
 	runtimeStaticTenants := configuration.tenants
@@ -134,15 +126,19 @@ func buildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	tenantAuthenticator := newTenantAuthenticator(runtimeStaticTenants, managedTenants)
 
 	router.Use(gin.Recovery())
-	rootProxyHandler := tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, chatHandler(upstreamProviders, providers, requestTimeout, managedTenants, structuredLogger))
+	rootProxyHandler := tenantAuthenticatedHandler(
+		tenantAuthenticator,
+		structuredLogger,
+		requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatHandler(upstreamProviders, providers, managedTenants, structuredLogger)),
+	)
 	if configuration.Management.Enabled {
 		managementService := newManagementService(configuration.Management, configuration.managementSessionValidator, managedTenants, providers, tenantAuthenticator, structuredLogger)
 		managementService.registerRoutes(router)
 	}
 	router.GET(rootPath, rootProxyHandler)
-	router.POST(rootPath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, chatJSONHandler(upstreamProviders, providers, requestTimeout, configuration.MaxPromptBytes, managedTenants, structuredLogger)))
-	router.POST(v2Path, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, chatV2JSONHandler(upstreamProviders, providers, requestTimeout, configuration.MaxPromptBytes, managedTenants, structuredLogger)))
-	router.POST(dictatePath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, dictateHandler(upstreamProviders, providers, configuration.MaxInputAudioBytes, managedTenants, structuredLogger)))
+	router.POST(rootPath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatJSONHandler(upstreamProviders, providers, configuration.MaxPromptBytes, managedTenants, structuredLogger))))
+	router.POST(v2Path, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatV2JSONHandler(upstreamProviders, providers, configuration.MaxPromptBytes, managedTenants, structuredLogger))))
+	router.POST(dictatePath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, dictateHandler(upstreamProviders, providers, configuration.MaxInputAudioBytes, managedTenants, structuredLogger))))
 	return router, nil
 }
 
@@ -156,7 +152,7 @@ func Serve(configuration Configuration, structuredLogger *zap.SugaredLogger) err
 }
 
 // chatHandler returns a handler that forwards query-string requests to upstream providers.
-func chatHandler(upstreamProviders *providerRouter, providers *providerRegistry, requestTimeout time.Duration, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+func chatHandler(upstreamProviders *providerRouter, providers *providerRegistry, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
 		requestStart := time.Now()
 		requestTenant := authenticatedTenantFromContext(ginContext)
@@ -171,12 +167,12 @@ func chatHandler(upstreamProviders *providerRouter, providers *providerRegistry,
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
 			return
 		}
-		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointText, requestTimeout, managedTenants, structuredLogger)
+		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointText, managedTenants, structuredLogger)
 	}
 }
 
 // chatJSONHandler accepts large prompt bodies while preserving the same model validation and response formatting used by GET /.
-func chatJSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, requestTimeout time.Duration, maxPromptBytes int64, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+func chatJSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, maxPromptBytes int64, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
 		requestStart := time.Now()
 		requestTenant := authenticatedTenantFromContext(ginContext)
@@ -210,11 +206,11 @@ func chatJSONHandler(upstreamProviders *providerRouter, providers *providerRegis
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, payload.Model, requestTenant.defaults), requestStart)
 			return
 		}
-		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointText, requestTimeout, managedTenants, structuredLogger)
+		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointText, managedTenants, structuredLogger)
 	}
 }
 
-func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, requestTimeout time.Duration, maxPromptBytes int64, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, maxPromptBytes int64, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
 		requestStart := time.Now()
 		requestTenant := authenticatedTenantFromContext(ginContext)
@@ -248,7 +244,7 @@ func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerReg
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, payload.Model, requestTenant.defaults), requestStart)
 			return
 		}
-		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointV2, requestTimeout, managedTenants, structuredLogger)
+		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointV2, managedTenants, structuredLogger)
 	}
 }
 
@@ -505,33 +501,30 @@ func requestReasoningEffortForResolvedTextRoute(provider providerDefinition, mod
 	return *requestedEffort.value, nil
 }
 
-func submitChatRequest(ginContext *gin.Context, upstreamProviders *providerRouter, chatRequest chatRequestParameters, requestTenant tenant, usageEndpoint string, requestTimeout time.Duration, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) {
+func submitChatRequest(ginContext *gin.Context, upstreamProviders *providerRouter, chatRequest chatRequestParameters, requestTenant tenant, usageEndpoint string, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) {
 	requestStart := time.Now()
-	replyChannel := make(chan result, 1)
-	requestContext, requestCancel := context.WithTimeout(ginContext.Request.Context(), requestTimeout)
-	defer requestCancel()
-	go func() {
-		generation, requestError := upstreamProviders.generateText(requestContext, chatRequest, structuredLogger)
-		replyChannel <- result{generation: generation, requestError: requestError}
-	}()
-
-	select {
-	case outcome := <-replyChannel:
-		if outcome.requestError != nil {
-			statusCode := statusCodeForError(outcome.requestError)
-			recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), statusCode, nil, requestStart)
-			ginContext.String(statusCode, responseMessageForError(outcome.requestError))
+	generation, requestError := upstreamProviders.generateText(ginContext.Request.Context(), chatRequest, structuredLogger)
+	if requestError != nil {
+		if requestContextEnded(ginContext) {
+			recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
 			return
 		}
-		mime := preferredMime(ginContext)
-		writeTokenUsageHeaders(ginContext.Writer.Header(), outcome.generation.usage)
-		formattedBody, contentType := formatResponse(outcome.generation.text, mime, chatRequest, outcome.generation.usage)
-		recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), http.StatusOK, outcome.generation.usage, requestStart)
-		ginContext.Data(http.StatusOK, contentType, []byte(formattedBody))
-	case <-requestContext.Done():
-		recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), http.StatusGatewayTimeout, nil, requestStart)
-		ginContext.String(http.StatusGatewayTimeout, errorRequestTimedOut)
+		markRequestOutcome(ginContext, requestOutcomeProviderFailure)
+		statusCode := statusCodeForError(requestError)
+		recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), statusCode, nil, requestStart)
+		ginContext.String(statusCode, responseMessageForError(requestError))
+		return
 	}
+	if requestContextEnded(ginContext) {
+		recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
+		return
+	}
+	markRequestOutcome(ginContext, requestOutcomeSuccess)
+	mime := preferredMime(ginContext)
+	writeTokenUsageHeaders(ginContext.Writer.Header(), generation.usage)
+	formattedBody, contentType := formatResponse(generation.text, mime, chatRequest, generation.usage)
+	recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), http.StatusOK, generation.usage, requestStart)
+	ginContext.Data(http.StatusOK, contentType, []byte(formattedBody))
 }
 
 func dictateHandler(upstreamProviders *providerRouter, providers *providerRegistry, maxInputAudioBytes int64, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
@@ -544,6 +537,10 @@ func dictateHandler(upstreamProviders *providerRouter, providers *providerRegist
 		}
 		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxInputAudioBytes+2*1024*1024)
 		if parseError := ginContext.Request.ParseMultipartForm(maxInputAudioBytes); parseError != nil {
+			if requestContextEnded(ginContext) {
+				recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointDictation, usageDictationProviderIdentifier(ginContext, requestTenant.defaults), usageDictationModelIdentifier(ginContext, requestTenant.defaults), requestStart)
+				return
+			}
 			ginContext.String(http.StatusBadRequest, errorInvalidAudioForm)
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointDictation, usageDictationProviderIdentifier(ginContext, requestTenant.defaults), usageDictationModelIdentifier(ginContext, requestTenant.defaults), requestStart)
 			return
@@ -589,16 +586,26 @@ func dictateHandler(upstreamProviders *providerRouter, providers *providerRegist
 			provider:    providerDefinition,
 			model:       modelIdentifier,
 			fileName:    fileName,
-			audioReader: audioFile,
+			audioReader: contextReader{contextValue: ginContext.Request.Context(), reader: audioFile},
 		}
 		transcribedText, requestError := upstreamProviders.transcribeAudio(ginContext.Request.Context(), dictationRequest, structuredLogger)
 		if requestError != nil {
+			if requestContextEnded(ginContext) {
+				recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), ginContext.Writer.Status(), nil, requestStart)
+				return
+			}
+			markRequestOutcome(ginContext, requestOutcomeProviderFailure)
 			statusCode := statusCodeForError(requestError)
 			recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), statusCode, nil, requestStart)
 			ginContext.String(statusCode, responseMessageForError(requestError))
 			return
 		}
+		if requestContextEnded(ginContext) {
+			recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), ginContext.Writer.Status(), nil, requestStart)
+			return
+		}
 
+		markRequestOutcome(ginContext, requestOutcomeSuccess)
 		recordManagedUsage(managedTenants, structuredLogger, requestTenant, usageEndpointDictation, providerDefinition.identifier.string(), modelIdentifier.string(), http.StatusOK, nil, requestStart)
 		ginContext.JSON(http.StatusOK, gin.H{keyText: transcribedText})
 	}

--- a/llm-proxy-client/main.go
+++ b/llm-proxy-client/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/tyemirov/llm-proxy/pkg/llmproxyclient"
@@ -17,41 +16,39 @@ const (
 	commandUse   = "llm-proxy-client"
 	commandShort = "Send a v2 JSON POST request through llm-proxy"
 
-	flagBaseURL         = "base-url"
-	flagSecret          = "secret"
-	flagProvider        = "provider"
-	flagModel           = "model"
-	flagModelProfile    = "model-profile"
-	flagPrompt          = "prompt"
-	flagPromptFile      = "prompt-file"
-	flagWebSearch       = "web-search"
-	flagSystemPrompt    = "system-prompt"
-	flagMaxTokens       = "max-tokens"
-	flagReasoningEffort = "reasoning-effort"
-	flagTimeout         = "timeout"
+	flagBaseURL               = "base-url"
+	flagSecret                = "secret"
+	flagProvider              = "provider"
+	flagModel                 = "model"
+	flagModelProfile          = "model-profile"
+	flagPrompt                = "prompt"
+	flagPromptFile            = "prompt-file"
+	flagWebSearch             = "web-search"
+	flagSystemPrompt          = "system-prompt"
+	flagMaxTokens             = "max-tokens"
+	flagReasoningEffort       = "reasoning-effort"
+	flagRequestTimeoutSeconds = "request-timeout-seconds"
 
 	envNameBaseURL = "LLM_PROXY_BASE_URL"
 	envNameSecret  = "LLM_PROXY_SECRET"
-
-	defaultTimeout = 390 * time.Second
 )
 
 type commandOptions struct {
-	baseURL          string
-	secret           string
-	provider         string
-	model            string
-	modelProfilePath string
-	prompt           string
-	promptFile       string
-	webSearch        bool
-	systemPrompt     string
-	maxTokens        int
-	reasoningEffort  string
-	timeout          time.Duration
+	baseURL               string
+	secret                string
+	provider              string
+	model                 string
+	modelProfilePath      string
+	prompt                string
+	promptFile            string
+	webSearch             bool
+	systemPrompt          string
+	maxTokens             int
+	reasoningEffort       string
+	requestTimeoutSeconds int
 }
 
-type httpClientFactory func(timeout time.Duration) llmproxyclient.HTTPDoer
+type httpClientFactory func() llmproxyclient.HTTPDoer
 
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr, defaultHTTPClientFactory))
@@ -107,7 +104,6 @@ func newRootCommand(
 				Secret:           configuredString(command, flagSecret, envNameSecret, options.secret),
 				Provider:         options.provider,
 				ModelProfilePath: options.modelProfilePath,
-				Timeout:          options.timeout,
 			}
 			if options.modelProfilePath != "" {
 				configInput.ModelProfileReader = os.ReadFile
@@ -132,11 +128,14 @@ func newRootCommand(
 			if command.Flags().Changed(flagReasoningEffort) {
 				requestInput.ReasoningEffort = &options.reasoningEffort
 			}
+			if command.Flags().Changed(flagRequestTimeoutSeconds) {
+				requestInput.RequestTimeoutSeconds = &options.requestTimeoutSeconds
+			}
 			request, requestError := llmproxyclient.NewMessagesRequest(requestInput)
 			if requestError != nil {
 				return fmt.Errorf("llm_proxy_client_request_failed: %w", requestError)
 			}
-			client, clientError := llmproxyclient.NewClient(config, httpClientFactoryValue(config.Timeout()))
+			client, clientError := llmproxyclient.NewClient(config, httpClientFactoryValue())
 			if clientError != nil {
 				return fmt.Errorf("llm_proxy_client_create_failed: %w", clientError)
 			}
@@ -164,7 +163,7 @@ func newRootCommand(
 	flagSet.StringVar(&options.systemPrompt, flagSystemPrompt, "", "v2 system message content")
 	flagSet.IntVar(&options.maxTokens, flagMaxTokens, 0, "positive output token cap")
 	flagSet.StringVar(&options.reasoningEffort, flagReasoningEffort, "", "model-supported reasoning effort")
-	flagSet.DurationVar(&options.timeout, flagTimeout, defaultTimeout, "request timeout")
+	flagSet.IntVar(&options.requestTimeoutSeconds, flagRequestTimeoutSeconds, 0, "positive proxy work budget in whole seconds")
 
 	return rootCommand
 }
@@ -197,6 +196,6 @@ func readPrompt(stdin io.Reader, promptValue string, promptFile string) (string,
 	return string(promptBytes), nil
 }
 
-func defaultHTTPClientFactory(timeout time.Duration) llmproxyclient.HTTPDoer {
-	return &http.Client{Timeout: timeout}
+func defaultHTTPClientFactory() llmproxyclient.HTTPDoer {
+	return &http.Client{}
 }

--- a/llm-proxy-client/main_test.go
+++ b/llm-proxy-client/main_test.go
@@ -11,17 +11,18 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/tyemirov/llm-proxy/pkg/llmproxyclient"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
 )
 
 type capturedProxyRequest struct {
-	method      string
-	path        string
-	contentType string
-	accept      string
-	body        string
+	method         string
+	path           string
+	contentType    string
+	accept         string
+	requestTimeout string
+	body           string
 }
 
 type failingHTTPDoer struct {
@@ -68,11 +69,12 @@ func TestCommandPostsPromptAsV2UserMessage(t *testing.T) {
 			t.Fatalf("read body: %v", readError)
 		}
 		capturedRequest = capturedProxyRequest{
-			method:      httpRequest.Method,
-			path:        httpRequest.URL.RequestURI(),
-			contentType: httpRequest.Header.Get("Content-Type"),
-			accept:      httpRequest.Header.Get("Accept"),
-			body:        string(bodyBytes),
+			method:         httpRequest.Method,
+			path:           httpRequest.URL.RequestURI(),
+			contentType:    httpRequest.Header.Get("Content-Type"),
+			accept:         httpRequest.Header.Get("Accept"),
+			requestTimeout: httpRequest.Header.Get(llmproxycontract.HeaderRequestTimeoutSeconds),
+			body:           string(bodyBytes),
 		}
 		responseWriter.WriteHeader(http.StatusOK)
 		_, _ = responseWriter.Write([]byte("reviewed"))
@@ -108,6 +110,9 @@ func TestCommandPostsPromptAsV2UserMessage(t *testing.T) {
 	}
 	if capturedRequest.accept != "text/plain" {
 		t.Fatalf("accept=%q", capturedRequest.accept)
+	}
+	if capturedRequest.requestTimeout != "" {
+		t.Fatalf("request timeout header should be omitted: %q", capturedRequest.requestTimeout)
 	}
 	parsedRequestURL, parseError := url.Parse(capturedRequest.path)
 	if parseError != nil {
@@ -152,7 +157,11 @@ func TestCommandReadsEnvironmentAndStdin(t *testing.T) {
 		if readError != nil {
 			t.Fatalf("read body: %v", readError)
 		}
-		capturedRequest = capturedProxyRequest{path: httpRequest.URL.RequestURI(), body: string(bodyBytes)}
+		capturedRequest = capturedProxyRequest{
+			path:           httpRequest.URL.RequestURI(),
+			requestTimeout: httpRequest.Header.Get(llmproxycontract.HeaderRequestTimeoutSeconds),
+			body:           string(bodyBytes),
+		}
 		responseWriter.WriteHeader(http.StatusOK)
 		_, _ = responseWriter.Write([]byte("stdin-ok"))
 	}))
@@ -197,7 +206,11 @@ func TestCommandReadsPromptFileAndOptionalBodyFields(t *testing.T) {
 		if readError != nil {
 			t.Fatalf("read body: %v", readError)
 		}
-		capturedRequest = capturedProxyRequest{path: httpRequest.URL.RequestURI(), body: string(bodyBytes)}
+		capturedRequest = capturedProxyRequest{
+			path:           httpRequest.URL.RequestURI(),
+			requestTimeout: httpRequest.Header.Get(llmproxycontract.HeaderRequestTimeoutSeconds),
+			body:           string(bodyBytes),
+		}
 		responseWriter.WriteHeader(http.StatusOK)
 		_, _ = responseWriter.Write([]byte("file-ok"))
 	}))
@@ -215,7 +228,7 @@ func TestCommandReadsPromptFileAndOptionalBodyFields(t *testing.T) {
 			"--system-prompt", "Be terse.",
 			"--max-tokens", "42",
 			"--reasoning-effort", "high",
-			"--timeout", "2s",
+			"--request-timeout-seconds", "2",
 		},
 		strings.NewReader(""),
 		&stdout,
@@ -234,6 +247,9 @@ func TestCommandReadsPromptFileAndOptionalBodyFields(t *testing.T) {
 	}
 	if strings.Contains(capturedRequest.path, "model=") {
 		t.Fatalf("path must omit model query: %q", capturedRequest.path)
+	}
+	if capturedRequest.requestTimeout != "2" {
+		t.Fatalf("request timeout header=%q", capturedRequest.requestTimeout)
 	}
 	parsedRequestURL, parseError := url.Parse(capturedRequest.path)
 	if parseError != nil {
@@ -447,10 +463,16 @@ func TestCommandRejectsInvalidInputs(t *testing.T) {
 			errorString: "missing secret",
 		},
 		{
-			name:        "invalid timeout",
-			arguments:   []string{"--base-url", "http://example.test", "--secret", "sekret", "--prompt", "prompt", "--timeout", "0s"},
+			name:        "invalid request timeout",
+			arguments:   []string{"--base-url", "http://example.test", "--secret", "sekret", "--prompt", "prompt", "--request-timeout-seconds", "0"},
 			stdin:       strings.NewReader(""),
-			errorString: "timeout must be positive",
+			errorString: "request_timeout_seconds must be positive",
+		},
+		{
+			name:        "obsolete timeout flag",
+			arguments:   []string{"--base-url", "http://example.test", "--secret", "sekret", "--prompt", "prompt", "--timeout", "1s"},
+			stdin:       strings.NewReader(""),
+			errorString: "unknown flag: --timeout",
 		},
 		{
 			name:        "missing prompt",
@@ -530,7 +552,7 @@ func TestCommandReportsProxyAndIOErrors(t *testing.T) {
 			strings.NewReader(""),
 			&stdout,
 			&stderr,
-			func(timeout time.Duration) llmproxyclient.HTTPDoer {
+			func() llmproxyclient.HTTPDoer {
 				return failingHTTPDoer{err: errors.New("transport failed")}
 			},
 		)
@@ -549,7 +571,7 @@ func TestCommandReportsProxyAndIOErrors(t *testing.T) {
 			strings.NewReader(""),
 			&stdout,
 			&stderr,
-			func(timeout time.Duration) llmproxyclient.HTTPDoer {
+			func() llmproxyclient.HTTPDoer {
 				return readFailHTTPDoer{}
 			},
 		)
@@ -568,7 +590,7 @@ func TestCommandReportsProxyAndIOErrors(t *testing.T) {
 			strings.NewReader(""),
 			&stdout,
 			&stderr,
-			func(timeout time.Duration) llmproxyclient.HTTPDoer {
+			func() llmproxyclient.HTTPDoer {
 				return nil
 			},
 		)

--- a/pkg/llmproxyclient/client.go
+++ b/pkg/llmproxyclient/client.go
@@ -11,8 +11,10 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
-	"time"
+
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
 )
 
 const (
@@ -66,7 +68,6 @@ type ConfigInput struct {
 	Provider           string
 	ModelProfilePath   string
 	ModelProfileReader ModelProfileReader
-	Timeout            time.Duration
 }
 
 // Config is validated llm-proxy client configuration.
@@ -76,7 +77,6 @@ type Config struct {
 	provider           string
 	modelProfilePath   string
 	modelProfileReader ModelProfileReader
-	timeout            time.Duration
 }
 
 // NewConfig validates external client configuration.
@@ -119,22 +119,13 @@ func NewConfig(input ConfigInput) (Config, error) {
 	if trimmedSecret == "" {
 		return Config{}, fmt.Errorf("%w: missing secret", ErrInvalidClientConfig)
 	}
-	if input.Timeout <= 0 {
-		return Config{}, fmt.Errorf("%w: timeout must be positive", ErrInvalidClientConfig)
-	}
 	return Config{
 		baseURL:            parsedBaseURL,
 		secret:             trimmedSecret,
 		provider:           trimmedProvider,
 		modelProfilePath:   trimmedModelProfilePath,
 		modelProfileReader: input.ModelProfileReader,
-		timeout:            input.Timeout,
 	}, nil
-}
-
-// Timeout returns the validated client timeout.
-func (config Config) Timeout() time.Duration {
-	return config.timeout
 }
 
 // MessagesPostURL builds the authenticated v2 JSON POST URL for this config.
@@ -210,15 +201,18 @@ type MessagesRequestInput struct {
 	WebSearch       bool
 	MaxTokens       *int
 	ReasoningEffort *string
+	// RequestTimeoutSeconds optionally selects the proxy-owned wall-clock work budget.
+	RequestTimeoutSeconds *int
 }
 
 // MessagesRequest is a validated v2 messages-only JSON POST request.
 type MessagesRequest struct {
-	messages        []message
-	model           string
-	webSearch       bool
-	maxTokens       *int
-	reasoningEffort *string
+	messages              []message
+	model                 string
+	webSearch             bool
+	maxTokens             *int
+	reasoningEffort       *string
+	requestTimeoutSeconds *int
 }
 
 // NewMessagesRequest validates v2 messages-only request input.
@@ -232,16 +226,25 @@ func NewMessagesRequest(input MessagesRequestInput) (MessagesRequest, error) {
 	if input.ReasoningEffort != nil && strings.TrimSpace(*input.ReasoningEffort) == "" {
 		return MessagesRequest{}, fmt.Errorf("%w: reasoning_effort must be nonblank", ErrInvalidClientRequest)
 	}
+	if input.RequestTimeoutSeconds != nil && *input.RequestTimeoutSeconds <= 0 {
+		return MessagesRequest{}, fmt.Errorf("%w: request_timeout_seconds must be positive", ErrInvalidClientRequest)
+	}
+	var requestTimeoutSeconds *int
+	if input.RequestTimeoutSeconds != nil {
+		copiedRequestTimeoutSeconds := *input.RequestTimeoutSeconds
+		requestTimeoutSeconds = &copiedRequestTimeoutSeconds
+	}
 	messages, messageError := newMessages(input.Messages)
 	if messageError != nil {
 		return MessagesRequest{}, messageError
 	}
 	return MessagesRequest{
-		messages:        messages,
-		model:           strings.TrimSpace(input.Model),
-		webSearch:       input.WebSearch,
-		maxTokens:       input.MaxTokens,
-		reasoningEffort: input.ReasoningEffort,
+		messages:              messages,
+		model:                 strings.TrimSpace(input.Model),
+		webSearch:             input.WebSearch,
+		maxTokens:             input.MaxTokens,
+		reasoningEffort:       input.ReasoningEffort,
+		requestTimeoutSeconds: requestTimeoutSeconds,
 	}, nil
 }
 
@@ -357,7 +360,7 @@ func (client Client) PostMessages(contextValue context.Context, request Messages
 	if requestError != nil {
 		return "", requestError
 	}
-	return client.postPayload(contextValue, requestURL, requestBody)
+	return client.postPayload(contextValue, requestURL, requestBody, request.requestTimeoutSeconds)
 }
 
 func (client Client) messagesPostRequest(request MessagesRequest) (url.URL, []byte, error) {
@@ -378,7 +381,7 @@ func (client Client) messagesPostRequest(request MessagesRequest) (url.URL, []by
 	return client.config.messagesPostURLForProvider(modelProfile.provider), request.payloadBody(modelProfile.model), nil
 }
 
-func (client Client) postPayload(contextValue context.Context, requestURL url.URL, requestBody []byte) (string, error) {
+func (client Client) postPayload(contextValue context.Context, requestURL url.URL, requestBody []byte, requestTimeoutSeconds *int) (string, error) {
 	httpRequest := (&http.Request{
 		Method:        http.MethodPost,
 		URL:           &requestURL,
@@ -388,6 +391,9 @@ func (client Client) postPayload(contextValue context.Context, requestURL url.UR
 	}).WithContext(contextValue)
 	httpRequest.Header.Set(headerAccept, formatQueryValueTextPlain)
 	httpRequest.Header.Set(headerContentType, jsonContentType)
+	if requestTimeoutSeconds != nil {
+		httpRequest.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, strconv.Itoa(*requestTimeoutSeconds))
+	}
 
 	httpResponse, httpError := client.httpClient.Do(httpRequest)
 	if httpError != nil {

--- a/pkg/llmproxyclient/client_test.go
+++ b/pkg/llmproxyclient/client_test.go
@@ -12,9 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/tyemirov/llm-proxy/pkg/llmproxyclient"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
 )
 
 func TestConfigMessagesPostURLShapesAuthenticatedV2JSONPostURL(testingInstance *testing.T) {
@@ -22,7 +22,6 @@ func TestConfigMessagesPostURLShapesAuthenticatedV2JSONPostURL(testingInstance *
 		BaseURL:  "https://proxy.example/review?prompt=old&model=old&max_tokens=9&reasoning_effort=old&web_search=true&provider=gemini&keep=1",
 		Secret:   "sekret",
 		Provider: "deepseek",
-		Timeout:  time.Second,
 	})
 	if configError != nil {
 		testingInstance.Fatalf("config error: %v", configError)
@@ -42,7 +41,6 @@ func TestConfigMessagesPostURLShapesAuthenticatedV2JSONPostURL(testingInstance *
 	v2Config, v2ConfigError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
 		BaseURL: "https://proxy.example/v2?prompt=old",
 		Secret:  "sekret",
-		Timeout: time.Second,
 	})
 	if v2ConfigError != nil {
 		testingInstance.Fatalf("v2 config error: %v", v2ConfigError)
@@ -82,9 +80,11 @@ func TestClientPostMessagesSendsV2MessagesBody(testingInstance *testing.T) {
 	firstOrder := messageOrder(1)
 	secondOrder := messageOrder(2)
 	var capturedPath string
+	var capturedTimeout string
 	var capturedBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		capturedPath = httpRequest.URL.Path
+		capturedTimeout = httpRequest.Header.Get(llmproxycontract.HeaderRequestTimeoutSeconds)
 		bodyBytes, readError := io.ReadAll(httpRequest.Body)
 		if readError != nil {
 			testingInstance.Fatalf("read body: %v", readError)
@@ -99,7 +99,6 @@ func TestClientPostMessagesSendsV2MessagesBody(testingInstance *testing.T) {
 	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
 		BaseURL: server.URL,
 		Secret:  "sekret",
-		Timeout: time.Second,
 	})
 	if configError != nil {
 		testingInstance.Fatalf("config error: %v", configError)
@@ -109,20 +108,23 @@ func TestClientPostMessagesSendsV2MessagesBody(testingInstance *testing.T) {
 		testingInstance.Fatalf("client error: %v", clientError)
 	}
 	maxTokens := messageOrder(5)
+	requestTimeoutSeconds := 12
 	reasoningEffort := "high"
 	request, requestError := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
 		Messages: []llmproxyclient.MessageInput{
 			{Role: "assistant", Content: "Hi", Order: secondOrder},
 			{Role: "user", Content: "Hello", Order: firstOrder},
 		},
-		Model:           "deepseek-v4-flash",
-		WebSearch:       true,
-		MaxTokens:       maxTokens,
-		ReasoningEffort: &reasoningEffort,
+		Model:                 "deepseek-v4-flash",
+		WebSearch:             true,
+		MaxTokens:             maxTokens,
+		ReasoningEffort:       &reasoningEffort,
+		RequestTimeoutSeconds: &requestTimeoutSeconds,
 	})
 	if requestError != nil {
 		testingInstance.Fatalf("request error: %v", requestError)
 	}
+	requestTimeoutSeconds = 99
 
 	responseText, postError := client.PostMessages(context.Background(), request)
 
@@ -131,6 +133,9 @@ func TestClientPostMessagesSendsV2MessagesBody(testingInstance *testing.T) {
 	}
 	if responseText != "ok" || capturedPath != "/v2" {
 		testingInstance.Fatalf("response=%q path=%q", responseText, capturedPath)
+	}
+	if capturedTimeout != "12" {
+		testingInstance.Fatalf("request timeout header=%q", capturedTimeout)
 	}
 	if capturedBody["prompt"] != nil || capturedBody["system_prompt"] != nil {
 		testingInstance.Fatalf("legacy fields must be omitted for v2 messages body: %v", capturedBody)
@@ -150,6 +155,7 @@ func TestClientPostMessagesSendsV2MessagesBody(testingInstance *testing.T) {
 
 func TestClientOmitsModelWhenRequestUsesProviderDefault(testingInstance *testing.T) {
 	var capturedPath string
+	var capturedTimeout string
 	var capturedBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		bodyBytes, readError := io.ReadAll(httpRequest.Body)
@@ -160,6 +166,7 @@ func TestClientOmitsModelWhenRequestUsesProviderDefault(testingInstance *testing
 			testingInstance.Fatalf("decode body: %v", decodeError)
 		}
 		capturedPath = httpRequest.URL.RequestURI()
+		capturedTimeout = httpRequest.Header.Get(llmproxycontract.HeaderRequestTimeoutSeconds)
 		_, _ = responseWriter.Write([]byte("ok"))
 	}))
 	defer server.Close()
@@ -167,7 +174,6 @@ func TestClientOmitsModelWhenRequestUsesProviderDefault(testingInstance *testing
 	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
 		BaseURL: server.URL + "/review?provider=gemini&model=stale&keep=1",
 		Secret:  "sekret",
-		Timeout: time.Second,
 	})
 	if configError != nil {
 		testingInstance.Fatalf("config error: %v", configError)
@@ -200,6 +206,9 @@ func TestClientOmitsModelWhenRequestUsesProviderDefault(testingInstance *testing
 	}
 	if _, hasModel := capturedBody["model"]; hasModel {
 		testingInstance.Fatalf("body must omit model when using provider default: %v", capturedBody)
+	}
+	if capturedTimeout != "" {
+		testingInstance.Fatalf("request timeout header should be omitted: %q", capturedTimeout)
 	}
 }
 
@@ -238,7 +247,6 @@ func TestClientReloadsAtomicallyReplacedModelProfile(testingInstance *testing.T)
 		Secret:             "sekret",
 		ModelProfilePath:   profilePath,
 		ModelProfileReader: os.ReadFile,
-		Timeout:            time.Second,
 	})
 	if configError != nil {
 		testingInstance.Fatalf("config error: %v", configError)
@@ -284,7 +292,6 @@ func TestConfigMessagesPostURLReloadsModelProfile(testingInstance *testing.T) {
 		Secret:             "sekret",
 		ModelProfilePath:   profilePath,
 		ModelProfileReader: os.ReadFile,
-		Timeout:            time.Second,
 	})
 	if configError != nil {
 		testingInstance.Fatalf("config error: %v", configError)
@@ -338,7 +345,6 @@ func TestClientRejectsInvalidOrCompetingModelProfilesBeforeHTTP(testingInstance 
 		Secret:             "sekret",
 		ModelProfilePath:   profilePath,
 		ModelProfileReader: os.ReadFile,
-		Timeout:            time.Second,
 	})
 	if configError != nil {
 		testingInstance.Fatalf("config error: %v", configError)
@@ -506,7 +512,6 @@ func TestConfigRejectsModelProfileSourceConflicts(testingInstance *testing.T) {
 				BaseURL:            "https://proxy.example",
 				Secret:             "sekret",
 				ModelProfileReader: profileReader,
-				Timeout:            time.Second,
 			},
 			errorString: "model_profile_reader requires model_profile_path",
 		},
@@ -516,7 +521,6 @@ func TestConfigRejectsModelProfileSourceConflicts(testingInstance *testing.T) {
 				BaseURL:          "https://proxy.example",
 				Secret:           "sekret",
 				ModelProfilePath: "/profiles/user.json",
-				Timeout:          time.Second,
 			},
 			errorString: "model_profile_path requires model_profile_reader",
 		},
@@ -528,7 +532,6 @@ func TestConfigRejectsModelProfileSourceConflicts(testingInstance *testing.T) {
 				Provider:           "gemini",
 				ModelProfilePath:   "/profiles/user.json",
 				ModelProfileReader: profileReader,
-				Timeout:            time.Second,
 			},
 			errorString: "conflicts with provider",
 		},
@@ -539,7 +542,6 @@ func TestConfigRejectsModelProfileSourceConflicts(testingInstance *testing.T) {
 				Secret:             "sekret",
 				ModelProfilePath:   "/profiles/user.json",
 				ModelProfileReader: profileReader,
-				Timeout:            time.Second,
 			},
 			errorString: "base_url provider query",
 		},
@@ -550,7 +552,6 @@ func TestConfigRejectsModelProfileSourceConflicts(testingInstance *testing.T) {
 				Secret:             "sekret",
 				ModelProfilePath:   "/profiles/user.json",
 				ModelProfileReader: profileReader,
-				Timeout:            time.Second,
 			},
 			errorString: "base_url model query",
 		},
@@ -594,7 +595,6 @@ func TestClientSendsUnknownModelProfilePairToProxy(testingInstance *testing.T) {
 		Secret:             "sekret",
 		ModelProfilePath:   profilePath,
 		ModelProfileReader: os.ReadFile,
-		Timeout:            time.Second,
 	})
 	if configError != nil {
 		testingInstance.Fatalf("config error: %v", configError)
@@ -639,6 +639,11 @@ func TestMessagesRequestRejectsInvalidInputs(testingInstance *testing.T) {
 			name:        "blank reasoning effort",
 			input:       llmproxyclient.MessagesRequestInput{Messages: []llmproxyclient.MessageInput{{Role: "user", Content: "prompt"}}, ReasoningEffort: &emptyReasoningEffort},
 			errorString: "reasoning_effort must be nonblank",
+		},
+		{
+			name:        "invalid request timeout",
+			input:       llmproxyclient.MessagesRequestInput{Messages: []llmproxyclient.MessageInput{{Role: "user", Content: "prompt"}}, RequestTimeoutSeconds: messageOrder(0)},
+			errorString: "request_timeout_seconds must be positive",
 		},
 		{
 			name:        "unsupported role",

--- a/pkg/llmproxycontract/contract.go
+++ b/pkg/llmproxycontract/contract.go
@@ -1,0 +1,11 @@
+// Package llmproxycontract exposes canonical llm-proxy wire-contract literals.
+package llmproxycontract
+
+const (
+	// HeaderRequestTimeoutSeconds carries the accepted proxy work budget for one upstream request.
+	HeaderRequestTimeoutSeconds = "X-LLM-Proxy-Request-Timeout-Seconds"
+	// ErrorCodeInvalidRequestTimeout identifies a rejected request-timeout header.
+	ErrorCodeInvalidRequestTimeout = "invalid_request_timeout"
+	// ErrorCodeRequestTimeout identifies expiration of the accepted proxy work budget.
+	ErrorCodeRequestTimeout = "request_timeout"
+)

--- a/python/llm_proxy_client/client.py
+++ b/python/llm_proxy_client/client.py
@@ -15,6 +15,7 @@ FORMAT_QUERY_KEY = "format"
 FORMAT_QUERY_VALUE_TEXT_PLAIN = "text/plain"
 JSON_CONTENT_TYPE = "application/json; charset=utf-8"
 KEY_QUERY_KEY = "key"
+REQUEST_TIMEOUT_HEADER = "X-LLM-Proxy-Request-Timeout-Seconds"
 PROVIDER_QUERY_KEY = "provider"
 MODEL_PROFILE_MODEL_KEY = "model"
 MODEL_PROFILE_SUBJECT = "model_profile"
@@ -63,7 +64,7 @@ class LLMProxyTransportError(RuntimeError):
 class ResponseOpener(Protocol):
     """Callable that executes a prepared urllib request."""
 
-    def __call__(self, request: urllib.request.Request, timeout: float) -> str:
+    def __call__(self, request: urllib.request.Request) -> str:
         """Return decoded response text for the prepared request."""
 
 
@@ -92,7 +93,6 @@ class ClientConfig:
     base_url: str
     secret: str
     provider: str = ""
-    timeout_seconds: float = 390.0
     model_profile_path: str = ""
     model_profile_reader: ModelProfileReader | None = None
 
@@ -106,9 +106,6 @@ class ClientConfig:
             raise LLMProxyClientError("llm_proxy_client_invalid_config: base_url must include host")
         if not self.secret.strip():
             raise LLMProxyClientError("llm_proxy_client_invalid_config: missing secret")
-        if self.timeout_seconds <= 0:
-            raise LLMProxyClientError("llm_proxy_client_invalid_config: timeout_seconds must be positive")
-
         model_profile_path = self.model_profile_path.strip()
         if not model_profile_path and self.model_profile_reader is not None:
             raise LLMProxyClientError(
@@ -303,6 +300,7 @@ class ClientMessagesRequest:
     web_search: bool = False
     max_tokens: int | None = None
     reasoning_effort: str | None = None
+    request_timeout_seconds: int | None = None
 
     def __post_init__(self) -> None:
         if len(self.messages) == 0:
@@ -312,6 +310,14 @@ class ClientMessagesRequest:
             raise LLMProxyClientError("llm_proxy_client_invalid_request: max_tokens must be positive")
         if self.reasoning_effort is not None and not self.reasoning_effort.strip():
             raise LLMProxyClientError("llm_proxy_client_invalid_request: reasoning_effort must be nonblank")
+        if self.request_timeout_seconds is not None and (
+            isinstance(self.request_timeout_seconds, bool)
+            or not isinstance(self.request_timeout_seconds, int)
+            or self.request_timeout_seconds <= 0
+        ):
+            raise LLMProxyClientError(
+                "llm_proxy_client_invalid_request: request_timeout_seconds must be a positive whole number"
+            )
 
     def body(self) -> dict[str, Any]:
         """Return the JSON body payload for this v2 request."""
@@ -375,26 +381,32 @@ class Client:
             return self._post_json(
                 request._body_with_model(model_profile.model),
                 self.config._messages_post_url_for_provider(model_profile.provider),
+                request.request_timeout_seconds,
             )
-        return self._post_json(request.body(), self.config.messages_post_url())
+        return self._post_json(request.body(), self.config.messages_post_url(), request.request_timeout_seconds)
 
-    def _post_json(self, request_payload: dict[str, Any], request_url: str) -> str:
+    def _post_json(
+        self, request_payload: dict[str, Any], request_url: str, request_timeout_seconds: int | None
+    ) -> str:
         """Send a JSON POST request payload and return the response text."""
 
         request_body = json.dumps(request_payload, ensure_ascii=False).encode("utf-8")
+        request_headers = {
+            ACCEPT_HEADER: FORMAT_QUERY_VALUE_TEXT_PLAIN,
+            CONTENT_TYPE_HEADER: JSON_CONTENT_TYPE,
+        }
+        if request_timeout_seconds is not None:
+            request_headers[REQUEST_TIMEOUT_HEADER] = str(request_timeout_seconds)
         prepared_request = urllib.request.Request(
             request_url,
             data=request_body,
-            headers={
-                ACCEPT_HEADER: FORMAT_QUERY_VALUE_TEXT_PLAIN,
-                CONTENT_TYPE_HEADER: JSON_CONTENT_TYPE,
-            },
+            headers=request_headers,
             method="POST",
         )
         opener = self.opener or default_response_opener
-        failure_context = request_failure_context(request_payload, request_url, self.config.timeout_seconds)
+        failure_context = request_failure_context(request_payload, request_url, request_timeout_seconds)
         try:
-            return opener(prepared_request, self.config.timeout_seconds)
+            return opener(prepared_request)
         except urllib.error.HTTPError as error:
             body = error.read().decode("utf-8", errors="replace")
             raise LLMProxyHTTPError(error.code, body, str(error.reason), failure_context) from error
@@ -412,7 +424,9 @@ class Client:
             ) from error
 
 
-def request_failure_context(request_payload: dict[str, Any], request_url: str, timeout_seconds: float) -> str:
+def request_failure_context(
+    request_payload: dict[str, Any], request_url: str, request_timeout_seconds: int | None
+) -> str:
     """Return non-secret request context for HTTP and transport failures."""
 
     parsed_url = urllib.parse.urlparse(request_url)
@@ -420,7 +434,8 @@ def request_failure_context(request_payload: dict[str, Any], request_url: str, t
     provider = first_query_value(query_values, PROVIDER_QUERY_KEY, "omitted")
     model_value = request_payload.get("model")
     model = model_value if isinstance(model_value, str) and model_value.strip() else "omitted"
-    return f"provider={provider} model={model} timeout_seconds={timeout_seconds:g}"
+    timeout_value = request_timeout_seconds if request_timeout_seconds is not None else "omitted"
+    return f"provider={provider} model={model} request_timeout_seconds={timeout_value}"
 
 
 def first_query_value(query_values: dict[str, list[str]], key: str, default: str) -> str:
@@ -435,9 +450,9 @@ def first_query_value(query_values: dict[str, list[str]], key: str, default: str
     return value
 
 
-def default_response_opener(request: urllib.request.Request, timeout: float) -> str:
+def default_response_opener(request: urllib.request.Request) -> str:
     """Execute a prepared urllib request and return decoded text."""
 
-    with urllib.request.urlopen(request, timeout=timeout) as response:
+    with urllib.request.urlopen(request) as response:
         response_body = cast(bytes, response.read())
         return response_body.decode("utf-8")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-proxy-client"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python client for llm-proxy JSON POST text requests."
 requires-python = ">=3.11"
 dependencies = []

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -36,6 +36,7 @@ class CapturedRequest:
     path: str = ""
     accept: str = ""
     content_type: str = ""
+    request_timeout: str = ""
     body: dict[str, Any] | None = None
 
 
@@ -58,6 +59,7 @@ class CapturingHandler(BaseHTTPRequestHandler):
             path=self.path,
             accept=self.headers.get("Accept", ""),
             content_type=self.headers.get("Content-Type", ""),
+            request_timeout=self.headers.get("X-LLM-Proxy-Request-Timeout-Seconds", ""),
             body=json.loads(raw_body),
         )
         type(self).captured_request = captured_request
@@ -147,6 +149,7 @@ def test_client_posts_v2_body_and_preserves_non_body_query(running_server: Runni
         ClientMessagesRequest(
             messages=(ClientMessage(role="user", content="Проверить текст"),),
             model="gpt-5.5",
+            request_timeout_seconds=27,
         )
     )
 
@@ -157,6 +160,7 @@ def test_client_posts_v2_body_and_preserves_non_body_query(running_server: Runni
     assert captured_request.method == "POST"
     assert captured_request.accept == "text/plain"
     assert captured_request.content_type == "application/json; charset=utf-8"
+    assert captured_request.request_timeout == "27"
     assert parsed_path.path == "/review/v2"
     assert query_values["key"] == ["test-secret"]
     assert query_values["format"] == ["text/plain"]
@@ -192,6 +196,7 @@ def test_client_omits_model_when_request_uses_provider_default(running_server: R
     assert parsed_path.path == "/review/v2"
     assert query_values["provider"] == ["gemini"]
     assert "model" not in query_values
+    assert captured_request.request_timeout == ""
     assert captured_request.body == {
         "messages": [{"role": "user", "content": "Use provider default"}],
         "web_search": False,
@@ -423,7 +428,6 @@ def test_client_posts_v2_messages_body(running_server: RunningServer) -> None:
         ({"base_url": "ftp://example.test", "secret": "sekret"}, "base_url must use http or https"),
         ({"base_url": "http://", "secret": "sekret"}, "base_url must include host"),
         ({"base_url": "http://example.test", "secret": ""}, "missing secret"),
-        ({"base_url": "http://example.test", "secret": "sekret", "timeout_seconds": 0}, "timeout_seconds must be positive"),
         (
             {"base_url": "http://example.test", "secret": "sekret", "model_profile_path": "/profiles/user.json"},
             "model_profile_path requires model_profile_reader",
@@ -512,6 +516,18 @@ def test_config_validation_errors(config_kwargs: dict[str, object], expected_err
             {"messages": (ClientMessage(role="user", content="prompt"),), "reasoning_effort": ""},
             "reasoning_effort must be nonblank",
         ),
+        (
+            {"messages": (ClientMessage(role="user", content="prompt"),), "request_timeout_seconds": 0},
+            "request_timeout_seconds must be a positive whole number",
+        ),
+        (
+            {"messages": (ClientMessage(role="user", content="prompt"),), "request_timeout_seconds": 1.5},
+            "request_timeout_seconds must be a positive whole number",
+        ),
+        (
+            {"messages": (ClientMessage(role="user", content="prompt"),), "request_timeout_seconds": True},
+            "request_timeout_seconds must be a positive whole number",
+        ),
     ],
 )
 def test_messages_request_validation_errors(request_kwargs: dict[str, object], expected_error: str) -> None:
@@ -545,7 +561,6 @@ def test_http_error_exposes_status_and_body(running_server: RunningServer) -> No
         ClientConfig(
             base_url=f"{running_server.url}/?provider=gemini",
             secret="test-secret",
-            timeout_seconds=12,
         )
     )
 
@@ -554,80 +569,83 @@ def test_http_error_exposes_status_and_body(running_server: RunningServer) -> No
             ClientMessagesRequest(
                 messages=(ClientMessage(role="user", content="prompt"),),
                 model="gpt-5-mini",
+                request_timeout_seconds=12,
             )
         )
 
     assert error_info.value.status_code == 502
     assert error_info.value.body == "upstream failed"
-    assert error_info.value.request_context == "provider=gemini model=gpt-5-mini timeout_seconds=12"
-    assert "provider=gemini model=gpt-5-mini timeout_seconds=12" in str(error_info.value)
+    assert error_info.value.request_context == "provider=gemini model=gpt-5-mini request_timeout_seconds=12"
+    assert "provider=gemini model=gpt-5-mini request_timeout_seconds=12" in str(error_info.value)
 
 
 def test_transport_error_is_typed() -> None:
     """Transport errors are surfaced separately from HTTP status errors."""
 
-    def failing_opener(request: urllib.request.Request, timeout: float) -> str:
+    def failing_opener(request: urllib.request.Request) -> str:
         raise urllib.error.URLError("network unavailable")
 
     client = Client(
         ClientConfig(
             base_url="http://example.test/?provider=gemini",
             secret="test-secret",
-            timeout_seconds=9,
         ),
         opener=failing_opener,
     )
 
     with pytest.raises(
         LLMProxyTransportError,
-        match="provider=gemini model=gpt-5-mini timeout_seconds=9.*network unavailable",
+        match="provider=gemini model=gpt-5-mini request_timeout_seconds=9.*network unavailable",
     ):
         client.post_messages(
             ClientMessagesRequest(
                 messages=(ClientMessage(role="user", content="prompt"),),
                 model="gpt-5-mini",
+                request_timeout_seconds=9,
             )
         )
 
 
-def test_read_timeout_is_typed_transport_error(running_server: RunningServer) -> None:
-    """Socket read timeouts are surfaced through the transport-error contract."""
+def test_transport_owned_timeout_is_typed_transport_error() -> None:
+    """An injected transport may still enforce its independently owned cancellation policy."""
 
-    CapturingHandler.response_delay_seconds = 0.3
+    def timing_out_opener(request: urllib.request.Request) -> str:
+        raise TimeoutError("transport timed out")
+
     client = Client(
-        ClientConfig(
-            base_url=running_server.url,
-            secret="test-secret",
-            timeout_seconds=0.05,
-        )
+        ClientConfig(base_url="http://example.test", secret="test-secret"),
+        opener=timing_out_opener,
     )
 
-    with pytest.raises(LLMProxyTransportError, match="provider=omitted model=omitted timeout_seconds=0.05.*timed out"):
+    with pytest.raises(
+        LLMProxyTransportError,
+        match="provider=omitted model=omitted request_timeout_seconds=omitted.*transport timed out",
+    ):
         client.post_messages(ClientMessagesRequest(messages=(ClientMessage(role="user", content="prompt"),)))
 
 
 def test_ssl_failure_is_typed_transport_error() -> None:
     """Raw socket and SSL style failures are surfaced through the transport-error contract."""
 
-    def failing_opener(request: urllib.request.Request, timeout: float) -> str:
+    def failing_opener(request: urllib.request.Request) -> str:
         raise OSError("record layer failure")
 
     client = Client(
         ClientConfig(
             base_url="http://example.test/?provider=openai",
             secret="test-secret",
-            timeout_seconds=240,
         ),
         opener=failing_opener,
     )
 
     with pytest.raises(
         LLMProxyTransportError,
-        match="provider=openai model=gpt-5.5 timeout_seconds=240.*record layer failure",
+        match="provider=openai model=gpt-5.5 request_timeout_seconds=240.*record layer failure",
     ):
         client.post_messages(
             ClientMessagesRequest(
                 messages=(ClientMessage(role="user", content="prompt"),),
                 model="gpt-5.5",
+                request_timeout_seconds=240,
             )
         )

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -11,6 +11,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 
@@ -130,6 +131,12 @@ def replace_model_profile(profile_path: Path, profile_document: str) -> None:
     replacement_path = profile_path.with_name("next-model.json")
     replacement_path.write_text(profile_document, encoding="utf-8")
     os.replace(replacement_path, profile_path)
+
+
+def test_distribution_metadata_matches_public_package_version() -> None:
+    """The source-tree distribution metadata exposes the released client version."""
+
+    assert version("llm-proxy-client") == "0.2.0"
 
 
 def test_client_posts_v2_body_and_preserves_non_body_query(running_server: RunningServer) -> None:

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "llm-proxy-client"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -246,7 +246,8 @@ fi
 
 if [[ "${SKIP_GATEWAY}" != "true" ]]; then
   echo "==> [deploy] Deploying llm-proxy through mprlab-gateway target ${GATEWAY_TARGET}"
-  timeout --foreground -k 1200s -s SIGKILL 1200s make -C "${GATEWAY_DIR}" "${GATEWAY_TARGET}"
+  LLM_PROXY_MAX_REQUEST_TIMEOUT_SECONDS="${max_request_timeout_seconds}" \
+    timeout --foreground -k 1200s -s SIGKILL 1200s make -C "${GATEWAY_DIR}" "${GATEWAY_TARGET}"
 fi
 
 if [[ "${SKIP_PAGES}" != "true" && "${SKIP_GATEWAY}" != "true" ]]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -136,6 +136,8 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "${repo_root}"
 release_helper="${RELEASE_HELPER:-${repo_root}/tools/gitrelease/scripts/release_helper.py}"
 [[ -f "${release_helper}" ]] || { echo "error: release helper is missing: ${release_helper}" >&2; exit 1; }
+request_timeout_capacity_reader="${repo_root}/scripts/read-request-timeout-capacity.sh"
+[[ -x "${request_timeout_capacity_reader}" ]] || { echo "error: request-timeout capacity reader is missing or not executable: ${request_timeout_capacity_reader}" >&2; exit 1; }
 
 resolve_gateway_dir() {
   if [[ -n "${GATEWAY_DIR}" ]]; then
@@ -146,6 +148,7 @@ resolve_gateway_dir() {
 }
 
 if [[ "${SKIP_GATEWAY}" != "true" ]]; then
+  max_request_timeout_seconds="$("${request_timeout_capacity_reader}" "${repo_root}/configs/config.yml")"
   GATEWAY_DIR="$(resolve_gateway_dir)"
   [[ -n "${GATEWAY_DIR}" ]] || { echo "error: gateway checkout not found; set GATEWAY_DIR=/path/to/mprlab-gateway or pass --gateway-dir" >&2; exit 1; }
   [[ -d "${GATEWAY_DIR}" ]] || { echo "error: gateway checkout not found: ${GATEWAY_DIR}" >&2; exit 1; }
@@ -161,9 +164,9 @@ if [[ "${SKIP_GATEWAY}" != "true" ]]; then
     exit 1
   fi
 
-  echo "==> [deploy] Verifying coupled llm-proxy/TAuth gateway contract"
-  if ! timeout -k 180s -s SIGKILL 180s make -C "${GATEWAY_DIR}" "${GATEWAY_CONTRACT_TARGET}"; then
-    echo "error: gateway checkout does not satisfy the coupled llm-proxy/TAuth deployment contract" >&2
+  echo "==> [deploy] Verifying coupled llm-proxy/TAuth gateway contract and ${max_request_timeout_seconds}s request capacity"
+  if ! LLM_PROXY_MAX_REQUEST_TIMEOUT_SECONDS="${max_request_timeout_seconds}" timeout -k 180s -s SIGKILL 180s make -C "${GATEWAY_DIR}" "${GATEWAY_CONTRACT_TARGET}"; then
+    echo "error: gateway checkout does not satisfy the coupled llm-proxy/TAuth deployment and request-capacity contract" >&2
     exit 1
   fi
 

--- a/scripts/generate_seo_resources.mjs
+++ b/scripts/generate_seo_resources.mjs
@@ -357,7 +357,7 @@ if (!this.hasSecret) {
     features: [
       ["One-shot REST contract", "Clients do not stream, poll, or follow resume endpoints.", "The final answer arrives in the original response."],
       ["Server-side polling", "The backend polls stored OpenAI response IDs internally.", "Provider lifecycle details stay out of product code."],
-      ["Timeout ownership", "server.request_timeout_seconds bounds the overall proxy request.", "A timeout becomes a documented 504."],
+      ["Timeout ownership", "Each request can select a bounded proxy work budget; omission uses server.request_timeout_seconds.", "A budget expiry becomes a canonical 504."],
     ],
     examples: [
       ["Semantic review", "A workflow sends a long JSON-only review prompt and waits on one proxy request."],
@@ -952,17 +952,20 @@ export function revokeSecret() {
       "Configure base URL and tenant secret.",
       "Let omitted model stay omitted when provider defaults should apply.",
       "Set MessagesRequestInput.ReasoningEffort only for a nonblank value the resolved route declares.",
+      "Set MessagesRequestInput.RequestTimeoutSeconds only when this request needs a specific proxy work budget.",
     ],
     features: [
       ["v2-only API", "The reusable package exposes messages requests rather than multiple text shapes.", "Callers standardize on POST /v2."],
       ["Provider query preservation", "Base URLs can include non-payload query parameters such as provider.", "Provider-selected requests still use the canonical body."],
       ["Omitted-model behavior", "The client omits model unless the caller specifies it.", "Server-side defaults remain authoritative."],
       ["Reasoning-effort override", "MessagesRequestInput serializes an optional nonblank ReasoningEffort value.", "The proxy, not the client, validates exact model capability."],
+      ["Per-request work budget", "RequestTimeoutSeconds serializes the canonical timeout header.", "Go context cancellation remains separate and caller-owned."],
     ],
     examples: [
       ["Backend service", "A Go service sends system and user messages through Client.PostMessages."],
       ["Provider-specific base URL", "The base URL includes ?provider=gemini while the request body omits model."],
       ["Max-token override", "A caller adds max_tokens for one request without changing provider defaults."],
+      ["Long review", "A caller requests a larger bounded proxy work budget without changing the HTTP client's total timeout."],
     ],
     limitations: [
       "The Go client is for text messages, not /dictate multipart uploads.",
@@ -977,7 +980,6 @@ export function revokeSecret() {
     Secret:             serviceSecret,
     ModelProfilePath:   userModelProfilePath,
     ModelProfileReader: os.ReadFile,
-    Timeout:            390 * time.Second,
 })
 if err != nil {
     return err
@@ -985,7 +987,14 @@ if err != nil {
 client, err := llmproxyclient.NewClient(config, http.DefaultClient)
 if err != nil {
     return err
-}`,
+}
+requestTimeoutSeconds := 900
+request, err := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+    Messages: []llmproxyclient.MessageInput{
+        {Role: "user", Content: "Summarize this"},
+    },
+    RequestTimeoutSeconds: &requestTimeoutSeconds,
+})`,
     },
   }),
   page({
@@ -1003,12 +1012,14 @@ if err != nil {
       "Create ClientConfig with base_url and secret.",
       "Build ClientMessagesRequest with one or more ClientMessage values.",
       "Set reasoning_effort only for a nonblank value declared by the resolved route, or omit it to retain the tenant default.",
+      "Set request_timeout_seconds only when this request needs a specific proxy work budget.",
       "Call post_messages and let the proxy route provider details.",
     ],
     features: [
       ["Messages request object", "Callers send system, user, and assistant messages in one typed request shape.", "Chat workflows avoid ad hoc JSON."],
       ["Optional order", "Messages can include order values when array order is not enough.", "The proxy sorts before routing."],
       ["Reasoning-effort override", "ClientMessagesRequest serializes an optional nonblank reasoning_effort value.", "The proxy validates it against the exact resolved provider/model capability."],
+      ["Per-request work budget", "ClientMessagesRequest serializes request_timeout_seconds as the canonical timeout header.", "The default urllib transport adds no unrelated total-response deadline."],
       ["Transport context", "Python client errors include non-secret provider, model, and timeout context.", "Debugging avoids leaking credentials."],
     ],
     examples: [
@@ -1039,6 +1050,7 @@ text = client.post_messages(
         model="gpt-5.5",
         max_tokens=512,
         reasoning_effort="high",
+        request_timeout_seconds=900,
     )
 )`,
     },
@@ -1057,18 +1069,20 @@ text = client.post_messages(
       "Install with go install github.com/tyemirov/llm-proxy/llm-proxy-client@latest.",
       "Set --base-url and --secret, or use LLM_PROXY_BASE_URL and LLM_PROXY_SECRET.",
       "Send --prompt, --prompt-file, or stdin content.",
-      "Optionally include --system-prompt, --model, --max-tokens, or --reasoning-effort; keep provider in the base URL.",
+      "Optionally include --system-prompt, --model, --max-tokens, --reasoning-effort, or --request-timeout-seconds; keep provider in the base URL.",
     ],
     features: [
       ["Canonical POST /v2", "The CLI sends prompt input as v2 messages.", "CLI behavior matches reusable client behavior."],
       ["Environment support", "Base URL and secret can come from env for shell workflows.", "Prompt content can flow from stdin."],
       ["Reasoning-effort flag", "The CLI serializes --reasoning-effort in the v2 JSON body.", "The server validates it against the resolved route rather than accepting a global option list."],
+      ["Request-timeout flag", "The CLI serializes --request-timeout-seconds as the canonical proxy work-budget header.", "Omission selects the server default without a hidden CLI deadline."],
       ["Payload/query cleanup", "The client strips body-owned query fields and preserves non-payload query parameters.", "Provider selection can stay in the base URL."],
     ],
     examples: [
       ["Quick summary", "Pipe text into llm-proxy-client with a configured base URL and secret."],
       ["Provider route", "Use a base URL with ?provider=gemini to test Gemini without changing the body."],
       ["System instruction", "Pass --system-prompt so the CLI sends a v2 system message."],
+      ["Long request", "Pass --request-timeout-seconds for a bounded proxy budget chosen for that prompt."],
     ],
     limitations: [
       "The CLI is a text client; it does not upload audio to /dictate.",
@@ -1083,6 +1097,7 @@ text = client.post_messages(
   --secret "$SERVICE_SECRET" \\
   --model "gpt-5.5" \\
   --reasoning-effort "high" \\
+  --request-timeout-seconds 900 \\
   --prompt "Summarize this"`,
     },
   }),
@@ -1139,7 +1154,7 @@ text = client.post_messages(
     ],
     examples: [
       ["Disabled provider", "A selected non-default provider without an API key returns 503 provider not configured."],
-      ["Long provider work", "A request exceeding server.request_timeout_seconds returns 504."],
+      ["Long provider work", "A request exceeding its accepted proxy work budget returns the canonical request_timeout 504 envelope."],
       ["Provider outage", "A non-rate-limit upstream provider failure maps to bad gateway behavior."],
     ],
     limitations: [
@@ -1632,7 +1647,7 @@ text = client.post_messages(
     ],
     features: [
       ["Queue status", "The shared upstream operation queue returns service-unavailable behavior when full.", "Callers can back off before adding more pressure."],
-      ["Deadline status", "Long requests that exceed server.request_timeout_seconds return 504.", "Clients should not poll llm-proxy after a timeout."],
+      ["Deadline status", "Long requests that exceed their accepted proxy work budget return a canonical 504.", "Clients should not poll llm-proxy after a timeout."],
       ["Provider error mapping", "Rate limits and provider failures map to distinct statuses.", "Retry logic can be status-aware."],
     ],
     examples: [

--- a/scripts/read-request-timeout-capacity.sh
+++ b/scripts/read-request-timeout-capacity.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  printf '%s\n' 'usage: read-request-timeout-capacity.sh <config-path>' >&2
+  exit 2
+fi
+
+config_path="$1"
+if [[ ! -f "${config_path}" || -L "${config_path}" ]]; then
+  printf 'error: server config must be a regular, non-symlink file: %s\n' "${config_path}" >&2
+  exit 1
+fi
+
+maximum="$(
+  awk '
+    {
+      line = $0
+      sub(/[[:space:]]*#.*/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+
+      if (line ~ /^server:[[:space:]]*$/) {
+        server_count++
+        in_server = 1
+        next
+      }
+      if (line ~ /^[^[:space:]][^:]*:[[:space:]]*/) {
+        in_server = 0
+      }
+      if (in_server && line ~ /^[[:space:]]+max_request_timeout_seconds:[[:space:]]*/) {
+        maximum_count++
+        sub(/^[[:space:]]+max_request_timeout_seconds:[[:space:]]*/, "", line)
+        maximum = line
+      }
+    }
+
+    END {
+      if (server_count != 1) {
+        printf "error: expected exactly one top-level server mapping, found %d\n", server_count > "/dev/stderr"
+        exit 1
+      }
+      if (maximum_count != 1) {
+        printf "error: expected exactly one server.max_request_timeout_seconds, found %d\n", maximum_count > "/dev/stderr"
+        exit 1
+      }
+      print maximum
+    }
+  ' "${config_path}"
+)"
+
+if [[ ! "${maximum}" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'error: server.max_request_timeout_seconds must be a positive whole number (got: %s)\n' "${maximum}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${maximum}"

--- a/site/resources/go-client-v2-only-llm-proxy/index.html
+++ b/site/resources/go-client-v2-only-llm-proxy/index.html
@@ -71,6 +71,7 @@
 <li>Configure base URL and tenant secret.</li>
 <li>Let omitted model stay omitted when provider defaults should apply.</li>
 <li>Set MessagesRequestInput.ReasoningEffort only for a nonblank value the resolved route declares.</li>
+<li>Set MessagesRequestInput.RequestTimeoutSeconds only when this request needs a specific proxy work budget.</li>
             </ol>
           </section>
 
@@ -114,6 +115,13 @@
                           <td>The proxy, not the client, validates exact model capability.</td>
                         </tr>
 
+
+                        <tr>
+                          <td>Per-request work budget</td>
+                          <td>RequestTimeoutSeconds serializes the canonical timeout header.</td>
+                          <td>Go context cancellation remains separate and caller-owned.</td>
+                        </tr>
+
                 </tbody>
               </table>
             </div>
@@ -140,6 +148,12 @@
                       <p>A caller adds max_tokens for one request without changing provider defaults.</p>
                     </section>
 
+
+                    <section class="resource-card">
+                      <h3>Long review</h3>
+                      <p>A caller requests a larger bounded proxy work budget without changing the HTTP client's total timeout.</p>
+                    </section>
+
             </div>
           </section>
 
@@ -159,7 +173,6 @@
     Secret:             serviceSecret,
     ModelProfilePath:   userModelProfilePath,
     ModelProfileReader: os.ReadFile,
-    Timeout:            390 * time.Second,
 })
 if err != nil {
     return err
@@ -167,7 +180,14 @@ if err != nil {
 client, err := llmproxyclient.NewClient(config, http.DefaultClient)
 if err != nil {
     return err
-}</code></pre>
+}
+requestTimeoutSeconds := 900
+request, err := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+    Messages: []llmproxyclient.MessageInput{
+        {Role: &quot;user&quot;, Content: &quot;Summarize this&quot;},
+    },
+    RequestTimeoutSeconds: &amp;requestTimeoutSeconds,
+})</code></pre>
             <p>Verified 2026-07-24 by <a href="https://github.com/tyemirov" rel="author">Tyemirov on GitHub</a> against <code>README.md</code>.</p>
           </section>
 

--- a/site/resources/installable-llm-proxy-cli/index.html
+++ b/site/resources/installable-llm-proxy-cli/index.html
@@ -69,7 +69,7 @@
               <li>Install with go install github.com/tyemirov/llm-proxy/llm-proxy-client@latest.</li>
 <li>Set --base-url and --secret, or use LLM_PROXY_BASE_URL and LLM_PROXY_SECRET.</li>
 <li>Send --prompt, --prompt-file, or stdin content.</li>
-<li>Optionally include --system-prompt, --model, --max-tokens, or --reasoning-effort; keep provider in the base URL.</li>
+<li>Optionally include --system-prompt, --model, --max-tokens, --reasoning-effort, or --request-timeout-seconds; keep provider in the base URL.</li>
             </ol>
           </section>
 
@@ -108,6 +108,13 @@
 
 
                         <tr>
+                          <td>Request-timeout flag</td>
+                          <td>The CLI serializes --request-timeout-seconds as the canonical proxy work-budget header.</td>
+                          <td>Omission selects the server default without a hidden CLI deadline.</td>
+                        </tr>
+
+
+                        <tr>
                           <td>Payload/query cleanup</td>
                           <td>The client strips body-owned query fields and preserves non-payload query parameters.</td>
                           <td>Provider selection can stay in the base URL.</td>
@@ -139,6 +146,12 @@
                       <p>Pass --system-prompt so the CLI sends a v2 system message.</p>
                     </section>
 
+
+                    <section class="resource-card">
+                      <h3>Long request</h3>
+                      <p>Pass --request-timeout-seconds for a bounded proxy budget chosen for that prompt.</p>
+                    </section>
+
             </div>
           </section>
 
@@ -158,6 +171,7 @@
   --secret &quot;$SERVICE_SECRET&quot; \
   --model &quot;gpt-5.5&quot; \
   --reasoning-effort &quot;high&quot; \
+  --request-timeout-seconds 900 \
   --prompt &quot;Summarize this&quot;</code></pre>
             <p>Verified 2026-07-24 by <a href="https://github.com/tyemirov" rel="author">Tyemirov on GitHub</a> against <code>README.md</code>.</p>
           </section>

--- a/site/resources/llm-proxy-status-code-map/index.html
+++ b/site/resources/llm-proxy-status-code-map/index.html
@@ -123,7 +123,7 @@
 
                     <section class="resource-card">
                       <h3>Long provider work</h3>
-                      <p>A request exceeding server.request_timeout_seconds returns 504.</p>
+                      <p>A request exceeding its accepted proxy work budget returns the canonical request_timeout 504 envelope.</p>
                     </section>
 
 

--- a/site/resources/openai-background-response-polling/index.html
+++ b/site/resources/openai-background-response-polling/index.html
@@ -102,8 +102,8 @@
 
                         <tr>
                           <td>Timeout ownership</td>
-                          <td>server.request_timeout_seconds bounds the overall proxy request.</td>
-                          <td>A timeout becomes a documented 504.</td>
+                          <td>Each request can select a bounded proxy work budget; omission uses server.request_timeout_seconds.</td>
+                          <td>A budget expiry becomes a canonical 504.</td>
                         </tr>
 
                 </tbody>

--- a/site/resources/provider-overload-timeout-handling/index.html
+++ b/site/resources/provider-overload-timeout-handling/index.html
@@ -96,7 +96,7 @@
 
                         <tr>
                           <td>Deadline status</td>
-                          <td>Long requests that exceed server.request_timeout_seconds return 504.</td>
+                          <td>Long requests that exceed their accepted proxy work budget return a canonical 504.</td>
                           <td>Clients should not poll llm-proxy after a timeout.</td>
                         </tr>
 

--- a/site/resources/python-client-v2-only-llm-proxy/index.html
+++ b/site/resources/python-client-v2-only-llm-proxy/index.html
@@ -70,6 +70,7 @@
 <li>Create ClientConfig with base_url and secret.</li>
 <li>Build ClientMessagesRequest with one or more ClientMessage values.</li>
 <li>Set reasoning_effort only for a nonblank value declared by the resolved route, or omit it to retain the tenant default.</li>
+<li>Set request_timeout_seconds only when this request needs a specific proxy work budget.</li>
 <li>Call post_messages and let the proxy route provider details.</li>
             </ol>
           </section>
@@ -105,6 +106,13 @@
                           <td>Reasoning-effort override</td>
                           <td>ClientMessagesRequest serializes an optional nonblank reasoning_effort value.</td>
                           <td>The proxy validates it against the exact resolved provider/model capability.</td>
+                        </tr>
+
+
+                        <tr>
+                          <td>Per-request work budget</td>
+                          <td>ClientMessagesRequest serializes request_timeout_seconds as the canonical timeout header.</td>
+                          <td>The default urllib transport adds no unrelated total-response deadline.</td>
                         </tr>
 
 
@@ -169,6 +177,7 @@ text = client.post_messages(
         model=&quot;gpt-5.5&quot;,
         max_tokens=512,
         reasoning_effort=&quot;high&quot;,
+        request_timeout_seconds=900,
     )
 )</code></pre>
             <p>Verified 2026-07-24 by <a href="https://github.com/tyemirov" rel="author">Tyemirov on GitHub</a> against <code>README.md</code>.</p>

--- a/tests/integration/request_timeout_test.go
+++ b/tests/integration/request_timeout_test.go
@@ -1,18 +1,23 @@
 package integration_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tyemirov/llm-proxy/internal/proxy"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -20,6 +25,7 @@ import (
 
 const (
 	timeoutExpectedStatusCode       = http.StatusGatewayTimeout
+	callerCancellationStatusCode    = 499
 	timeoutRequestTimeout           = 1
 	timeoutUpstreamDelay            = 3 * time.Second
 	timeoutHTTPClientTimeout        = timeoutUpstreamDelay + 2*time.Second
@@ -137,20 +143,20 @@ func TestIntegrationGatewayContextTimeoutCancelsUpstreamRequest(testingInstance 
 		testingInstance.Fatalf(getFailedFormat, requestError)
 	}
 	defer httpResponse.Body.Close()
-	if httpResponse.StatusCode != timeoutExpectedStatusCode {
+	if httpResponse.StatusCode != callerCancellationStatusCode {
 		responseBody, _ := io.ReadAll(httpResponse.Body)
-		testingInstance.Fatalf(statusWantBodyFormat, httpResponse.StatusCode, timeoutExpectedStatusCode, string(responseBody))
+		testingInstance.Fatalf(statusWantBodyFormat, httpResponse.StatusCode, callerCancellationStatusCode, string(responseBody))
 	}
 
 	select {
 	case <-upstreamRequestCanceled:
 	case <-lateUsableOpenAIResponse:
-		testingInstance.Fatal("upstream produced a late usable OpenAI API response after proxy sent 504")
+		testingInstance.Fatal("upstream produced a late usable OpenAI API response after caller cancellation")
 	case <-time.After(gatewayContextAssertionTimeout):
-		testingInstance.Fatal("upstream request context was not canceled after proxy sent 504")
+		testingInstance.Fatal("upstream request context was not canceled after caller cancellation")
 	}
 	if observedLogs.FilterMessage(openAIAPIResponseLogMessage).Len() != 0 {
-		testingInstance.Fatal("observed late OpenAI API response log after proxy sent 504")
+		testingInstance.Fatal("observed late OpenAI API response log after caller cancellation")
 	}
 }
 
@@ -185,6 +191,550 @@ func TestIntegrationUpstreamRequestTimeoutTriggersGatewayTimeout(testingInstance
 			}
 			if elapsedDuration >= timeoutUpstreamDelay {
 				subTest.Fatalf("elapsed=%v exceeds upstream delay %v", elapsedDuration, timeoutUpstreamDelay)
+			}
+		})
+	}
+}
+
+type requestTimeoutHTTPDoer func(*http.Request) (*http.Response, error)
+
+func (doer requestTimeoutHTTPDoer) Do(request *http.Request) (*http.Response, error) {
+	return doer(request)
+}
+
+type closeAwareBlockingBody struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newCloseAwareBlockingBody() *closeAwareBlockingBody {
+	return &closeAwareBlockingBody{closed: make(chan struct{})}
+}
+
+func (body *closeAwareBlockingBody) Read([]byte) (int, error) {
+	<-body.closed
+	return 0, errors.New("body closed")
+}
+
+func (body *closeAwareBlockingBody) Close() error {
+	body.once.Do(func() { close(body.closed) })
+	return nil
+}
+
+func timeoutContractConfiguration(defaultSeconds int, maximumSeconds int) proxy.Configuration {
+	return proxy.Configuration{
+		Tenants:                  proxy.SingleTenantConfigurations("integration", serviceSecretValue),
+		OpenAIKey:                openAIKeyValue,
+		LogLevel:                 proxy.LogLevelInfo,
+		WorkerCount:              1,
+		QueueSize:                4,
+		RequestTimeoutSeconds:    defaultSeconds,
+		MaxRequestTimeoutSeconds: maximumSeconds,
+	}
+}
+
+func timeoutContractRouter(testingInstance *testing.T, doer proxy.HTTPDoer, configuration proxy.Configuration, logger *zap.SugaredLogger) *gin.Engine {
+	testingInstance.Helper()
+	previousHTTPClient := proxy.HTTPClient
+	proxy.HTTPClient = doer
+	testingInstance.Cleanup(func() { proxy.HTTPClient = previousHTTPClient })
+	router, buildError := proxy.BuildRouter(integrationConfiguration(testingInstance, configuration), logger)
+	if buildError != nil {
+		testingInstance.Fatalf("BuildRouter failed: %v", buildError)
+	}
+	return router
+}
+
+func completedTimeoutContractResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func timeoutContractMultipartBody(testingInstance *testing.T) (*bytes.Buffer, string) {
+	testingInstance.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	filePart, createError := writer.CreateFormFile("audio", "sample.webm")
+	if createError != nil {
+		testingInstance.Fatalf("create audio form: %v", createError)
+	}
+	if _, writeError := filePart.Write([]byte("audio")); writeError != nil {
+		testingInstance.Fatalf("write audio form: %v", writeError)
+	}
+	if closeError := writer.Close(); closeError != nil {
+		testingInstance.Fatalf("close audio form: %v", closeError)
+	}
+	return body, writer.FormDataContentType()
+}
+
+func TestIntegrationRequestTimeoutHeaderValidationAndEcho(testingInstance *testing.T) {
+	var upstreamCalls atomic.Int64
+	router := timeoutContractRouter(
+		testingInstance,
+		requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			upstreamCalls.Add(1)
+			return completedTimeoutContractResponse(`{"id":"complete","status":"completed","output_text":"ok"}`), nil
+		}),
+		timeoutContractConfiguration(2, 3),
+		zap.NewNop().Sugar(),
+	)
+	invalidHeaders := []struct {
+		name   string
+		values []string
+	}{
+		{name: "blank", values: []string{""}},
+		{name: "repeated", values: []string{"1", "2"}},
+		{name: "signed", values: []string{"+1"}},
+		{name: "fractional", values: []string{"1.5"}},
+		{name: "nonnumeric", values: []string{"later"}},
+		{name: "zero", values: []string{"0"}},
+		{name: "negative", values: []string{"-1"}},
+		{name: "over limit", values: []string{"4"}},
+		{name: "overflow", values: []string{strings.Repeat("9", 64)}},
+	}
+	for _, testCase := range invalidHeaders {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=hello", nil)
+			for _, value := range testCase.values {
+				request.Header.Add(llmproxycontract.HeaderRequestTimeoutSeconds, value)
+			}
+			responseRecorder := httptest.NewRecorder()
+
+			router.ServeHTTP(responseRecorder, request)
+
+			if responseRecorder.Code != http.StatusBadRequest {
+				subTest.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+			}
+			if responseRecorder.Header().Get("Content-Type") != contentTypeJSON {
+				subTest.Fatalf("content type=%q", responseRecorder.Header().Get("Content-Type"))
+			}
+			expectedBody := `{"error":{"code":"invalid_request_timeout","max_request_timeout_seconds":3}}`
+			if responseRecorder.Body.String() != expectedBody {
+				subTest.Fatalf("body=%q want=%q", responseRecorder.Body.String(), expectedBody)
+			}
+			if responseRecorder.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds) != "" {
+				subTest.Fatalf("rejected response must not echo an effective timeout")
+			}
+		})
+	}
+	if upstreamCalls.Load() != 0 {
+		testingInstance.Fatalf("invalid headers reached upstream: calls=%d", upstreamCalls.Load())
+	}
+
+	acceptedHeaders := []struct {
+		name           string
+		requestedValue string
+		effectiveValue string
+	}{
+		{name: "omitted uses default", effectiveValue: "2"},
+		{name: "explicit value", requestedValue: "3", effectiveValue: "3"},
+	}
+	for _, testCase := range acceptedHeaders {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=hello", nil)
+			if testCase.requestedValue != "" {
+				request.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, testCase.requestedValue)
+			}
+			responseRecorder := httptest.NewRecorder()
+
+			router.ServeHTTP(responseRecorder, request)
+
+			if responseRecorder.Code != http.StatusOK {
+				subTest.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+			}
+			if responseRecorder.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds) != testCase.effectiveValue {
+				subTest.Fatalf(
+					"effective timeout=%q want=%q",
+					responseRecorder.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds),
+					testCase.effectiveValue,
+				)
+			}
+		})
+	}
+	if upstreamCalls.Load() != int64(len(acceptedHeaders)) {
+		testingInstance.Fatalf("accepted upstream calls=%d want=%d", upstreamCalls.Load(), len(acceptedHeaders))
+	}
+}
+
+func TestIntegrationRequestTimeoutAppliesToEveryUpstreamRoute(testingInstance *testing.T) {
+	router := timeoutContractRouter(
+		testingInstance,
+		requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			if strings.Contains(request.URL.Path, "transcriptions") {
+				return completedTimeoutContractResponse(`{"text":"dictated"}`), nil
+			}
+			return completedTimeoutContractResponse(`{"id":"complete","status":"completed","output_text":"ok"}`), nil
+		}),
+		timeoutContractConfiguration(1, 3),
+		zap.NewNop().Sugar(),
+	)
+	multipartBody, multipartContentType := timeoutContractMultipartBody(testingInstance)
+	testCases := []struct {
+		name        string
+		method      string
+		path        string
+		body        io.Reader
+		contentType string
+	}{
+		{name: "get root", method: http.MethodGet, path: "/?key=" + serviceSecretValue + "&prompt=hello"},
+		{name: "post root", method: http.MethodPost, path: "/?key=" + serviceSecretValue, body: strings.NewReader(`{"prompt":"hello"}`), contentType: contentTypeJSON},
+		{name: "post v2", method: http.MethodPost, path: "/v2?key=" + serviceSecretValue, body: strings.NewReader(`{"messages":[{"role":"user","content":"hello"}]}`), contentType: contentTypeJSON},
+		{name: "post dictate", method: http.MethodPost, path: "/dictate?key=" + serviceSecretValue, body: multipartBody, contentType: multipartContentType},
+	}
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			request := httptest.NewRequest(testCase.method, testCase.path, testCase.body)
+			request.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "3")
+			if testCase.contentType != "" {
+				request.Header.Set("Content-Type", testCase.contentType)
+			}
+			responseRecorder := httptest.NewRecorder()
+
+			router.ServeHTTP(responseRecorder, request)
+
+			if responseRecorder.Code != http.StatusOK {
+				subTest.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+			}
+			if responseRecorder.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds) != "3" {
+				subTest.Fatalf("effective timeout=%q", responseRecorder.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds))
+			}
+		})
+	}
+}
+
+func TestIntegrationRequestTimeoutReturnsCanonicalErrorAndSafeOutcome(testingInstance *testing.T) {
+	upstreamCanceled := make(chan struct{})
+	var cancelOnce sync.Once
+	callerContext, cancelCaller := context.WithCancel(context.Background())
+	defer cancelCaller()
+	observedCore, observedLogs := observer.New(zapcore.InfoLevel)
+	router := timeoutContractRouter(
+		testingInstance,
+		requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			<-request.Context().Done()
+			cancelCaller()
+			cancelOnce.Do(func() { close(upstreamCanceled) })
+			return nil, request.Context().Err()
+		}),
+		timeoutContractConfiguration(2, 3),
+		zap.New(observedCore).Sugar(),
+	)
+	request := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=secret-prompt", nil).WithContext(callerContext)
+	request.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "1")
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusGatewayTimeout {
+		testingInstance.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+	}
+	if responseRecorder.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds) != "1" {
+		testingInstance.Fatalf("effective timeout=%q", responseRecorder.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds))
+	}
+	if responseRecorder.Header().Get("Content-Type") != contentTypeJSON {
+		testingInstance.Fatalf("content type=%q", responseRecorder.Header().Get("Content-Type"))
+	}
+	expectedBody := `{"error":{"code":"request_timeout","request_timeout_seconds":1}}`
+	if responseRecorder.Body.String() != expectedBody {
+		testingInstance.Fatalf("body=%q want=%q", responseRecorder.Body.String(), expectedBody)
+	}
+	select {
+	case <-upstreamCanceled:
+	default:
+		testingInstance.Fatal("upstream context was not canceled")
+	}
+	outcomeEntries := observedLogs.FilterMessage("upstream request ended").All()
+	if len(outcomeEntries) != 1 {
+		testingInstance.Fatalf("outcome log entries=%d", len(outcomeEntries))
+	}
+	outcomeFields := outcomeEntries[0].ContextMap()
+	if outcomeFields["request_timeout_seconds"] != int64(1) || outcomeFields["outcome"] != "proxy_timeout" {
+		testingInstance.Fatalf("outcome fields=%v", outcomeFields)
+	}
+	for _, forbiddenField := range []string{"prompt", "audio", "credential", "response_body", "error"} {
+		if _, exists := outcomeFields[forbiddenField]; exists {
+			testingInstance.Fatalf("unsafe outcome field %q=%v", forbiddenField, outcomeFields[forbiddenField])
+		}
+	}
+}
+
+func TestIntegrationExplicitRequestTimeoutIncludesQueueWait(testingInstance *testing.T) {
+	upstreamStarted := make(chan struct{})
+	releaseUpstream := make(chan struct{})
+	var upstreamCalls atomic.Int64
+	var startOnce sync.Once
+	router := timeoutContractRouter(
+		testingInstance,
+		requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			upstreamCalls.Add(1)
+			startOnce.Do(func() { close(upstreamStarted) })
+			select {
+			case <-request.Context().Done():
+				return nil, request.Context().Err()
+			case <-releaseUpstream:
+				return completedTimeoutContractResponse(`{"id":"complete","status":"completed","output_text":"ok"}`), nil
+			}
+		}),
+		timeoutContractConfiguration(2, 3),
+		zap.NewNop().Sugar(),
+	)
+
+	firstResponse := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		request := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=first", nil)
+		request.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "3")
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, request)
+		firstResponse <- responseRecorder
+	}()
+	select {
+	case <-upstreamStarted:
+	case <-time.After(time.Second):
+		testingInstance.Fatal("first upstream request did not start")
+	}
+
+	queuedRequest := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=queued", nil)
+	queuedRequest.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "1")
+	queuedResponse := httptest.NewRecorder()
+	router.ServeHTTP(queuedResponse, queuedRequest)
+
+	if queuedResponse.Code != http.StatusGatewayTimeout {
+		testingInstance.Fatalf("queued status=%d body=%s", queuedResponse.Code, queuedResponse.Body.String())
+	}
+	if queuedResponse.Body.String() != `{"error":{"code":"request_timeout","request_timeout_seconds":1}}` {
+		testingInstance.Fatalf("queued body=%q", queuedResponse.Body.String())
+	}
+	if queuedResponse.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds) != "1" {
+		testingInstance.Fatalf(
+			"queued effective timeout=%q",
+			queuedResponse.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds),
+		)
+	}
+	if upstreamCalls.Load() != 1 {
+		testingInstance.Fatalf("queued request reached upstream: calls=%d", upstreamCalls.Load())
+	}
+
+	close(releaseUpstream)
+	select {
+	case responseRecorder := <-firstResponse:
+		if responseRecorder.Code != http.StatusOK {
+			testingInstance.Fatalf("first status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+		}
+	case <-time.After(time.Second):
+		testingInstance.Fatal("first request did not finish after upstream release")
+	}
+}
+
+func TestIntegrationRequestTimeoutLogsTerminalOutcomes(testingInstance *testing.T) {
+	var upstreamCall atomic.Int64
+	observedCore, observedLogs := observer.New(zapcore.InfoLevel)
+	router := timeoutContractRouter(
+		testingInstance,
+		requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			if upstreamCall.Add(1) == 1 {
+				return completedTimeoutContractResponse(`{"id":"complete","status":"completed","output_text":"ok"}`), nil
+			}
+			providerFailure := completedTimeoutContractResponse(`{"error":{"message":"provider failed"}}`)
+			providerFailure.StatusCode = http.StatusBadRequest
+			return providerFailure, nil
+		}),
+		timeoutContractConfiguration(2, 3),
+		zap.New(observedCore).Sugar(),
+	)
+
+	successRequest := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=success", nil)
+	successResponse := httptest.NewRecorder()
+	router.ServeHTTP(successResponse, successRequest)
+	if successResponse.Code != http.StatusOK {
+		testingInstance.Fatalf("success status=%d body=%s", successResponse.Code, successResponse.Body.String())
+	}
+
+	failureRequest := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=failure", nil)
+	failureResponse := httptest.NewRecorder()
+	router.ServeHTTP(failureResponse, failureRequest)
+	if failureResponse.Code != http.StatusBadGateway {
+		testingInstance.Fatalf("failure status=%d body=%s", failureResponse.Code, failureResponse.Body.String())
+	}
+
+	callerContext, cancelCaller := context.WithCancel(context.Background())
+	cancelCaller()
+	canceledRequest := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=canceled", nil).WithContext(callerContext)
+	canceledResponse := httptest.NewRecorder()
+	router.ServeHTTP(canceledResponse, canceledRequest)
+	if canceledResponse.Code != callerCancellationStatusCode {
+		testingInstance.Fatalf("canceled status=%d body=%s", canceledResponse.Code, canceledResponse.Body.String())
+	}
+
+	outcomeEntries := observedLogs.FilterMessage("upstream request ended").All()
+	if len(outcomeEntries) != 3 {
+		testingInstance.Fatalf("outcome log entries=%d", len(outcomeEntries))
+	}
+	expectedOutcomes := []string{"success", "provider_failure", "caller_cancelled"}
+	for entryIndex, expectedOutcome := range expectedOutcomes {
+		outcomeFields := outcomeEntries[entryIndex].ContextMap()
+		if outcomeFields["outcome"] != expectedOutcome {
+			testingInstance.Fatalf("outcome[%d]=%v want=%q", entryIndex, outcomeFields, expectedOutcome)
+		}
+	}
+}
+
+func TestIntegrationRequestedTimeoutCanOutliveDefault(testingInstance *testing.T) {
+	router := timeoutContractRouter(
+		testingInstance,
+		requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			time.Sleep(1100 * time.Millisecond)
+			return completedTimeoutContractResponse(`{"id":"complete","status":"completed","output_text":"late success"}`), nil
+		}),
+		timeoutContractConfiguration(1, 2),
+		zap.NewNop().Sugar(),
+	)
+
+	defaultRequest := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=hello", nil)
+	defaultResponse := httptest.NewRecorder()
+	router.ServeHTTP(defaultResponse, defaultRequest)
+	if defaultResponse.Code != http.StatusGatewayTimeout {
+		testingInstance.Fatalf("default status=%d body=%s", defaultResponse.Code, defaultResponse.Body.String())
+	}
+
+	extendedRequest := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=hello", nil)
+	extendedRequest.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "2")
+	extendedResponse := httptest.NewRecorder()
+	router.ServeHTTP(extendedResponse, extendedRequest)
+	if extendedResponse.Code != http.StatusOK {
+		testingInstance.Fatalf("extended status=%d body=%s", extendedResponse.Code, extendedResponse.Body.String())
+	}
+	if extendedResponse.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds) != "2" {
+		testingInstance.Fatalf("effective timeout=%q", extendedResponse.Header().Get(llmproxycontract.HeaderRequestTimeoutSeconds))
+	}
+}
+
+func TestIntegrationRequestTimeoutIncludesBodyParsingAndDictation(testingInstance *testing.T) {
+	var upstreamCalls atomic.Int64
+	waitForDeadline := requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+		upstreamCalls.Add(1)
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	})
+	router := timeoutContractRouter(testingInstance, waitForDeadline, timeoutContractConfiguration(2, 3), zap.NewNop().Sugar())
+
+	blockingJSONBody := newCloseAwareBlockingBody()
+	jsonRequest := httptest.NewRequest(http.MethodPost, "/v2?key="+serviceSecretValue, nil)
+	jsonRequest.Body = blockingJSONBody
+	jsonRequest.Header.Set("Content-Type", contentTypeJSON)
+	jsonRequest.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "1")
+	jsonResponse := httptest.NewRecorder()
+	router.ServeHTTP(jsonResponse, jsonRequest)
+	if jsonResponse.Code != http.StatusGatewayTimeout {
+		testingInstance.Fatalf("body parsing status=%d body=%s", jsonResponse.Code, jsonResponse.Body.String())
+	}
+	if upstreamCalls.Load() != 0 {
+		testingInstance.Fatalf("body parsing timeout reached upstream")
+	}
+
+	blockingMultipartBody := newCloseAwareBlockingBody()
+	dictationParsingRequest := httptest.NewRequest(http.MethodPost, "/dictate?key="+serviceSecretValue, nil)
+	dictationParsingRequest.Body = blockingMultipartBody
+	dictationParsingRequest.Header.Set("Content-Type", "multipart/form-data; boundary=blocking")
+	dictationParsingRequest.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "1")
+	dictationParsingResponse := httptest.NewRecorder()
+	router.ServeHTTP(dictationParsingResponse, dictationParsingRequest)
+	if dictationParsingResponse.Code != http.StatusGatewayTimeout {
+		testingInstance.Fatalf("dictation parsing status=%d body=%s", dictationParsingResponse.Code, dictationParsingResponse.Body.String())
+	}
+	if upstreamCalls.Load() != 0 {
+		testingInstance.Fatalf("dictation parsing timeout reached upstream")
+	}
+
+	audioBody, contentType := timeoutContractMultipartBody(testingInstance)
+	dictationRequest := httptest.NewRequest(http.MethodPost, "/dictate?key="+serviceSecretValue, audioBody)
+	dictationRequest.Header.Set("Content-Type", contentType)
+	dictationRequest.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "1")
+	dictationResponse := httptest.NewRecorder()
+	router.ServeHTTP(dictationResponse, dictationRequest)
+	if dictationResponse.Code != http.StatusGatewayTimeout {
+		testingInstance.Fatalf("dictation provider status=%d body=%s", dictationResponse.Code, dictationResponse.Body.String())
+	}
+	if upstreamCalls.Load() != 1 {
+		testingInstance.Fatalf("dictation upstream calls=%d want=1", upstreamCalls.Load())
+	}
+}
+
+func TestIntegrationDictationSuccessAfterDeadlineIsRejected(testingInstance *testing.T) {
+	router := timeoutContractRouter(
+		testingInstance,
+		requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			time.Sleep(1100 * time.Millisecond)
+			return completedTimeoutContractResponse(`{"text":"late dictation"}`), nil
+		}),
+		timeoutContractConfiguration(1, 2),
+		zap.NewNop().Sugar(),
+	)
+	audioBody, contentType := timeoutContractMultipartBody(testingInstance)
+	request := httptest.NewRequest(http.MethodPost, "/dictate?key="+serviceSecretValue, audioBody)
+	request.Header.Set("Content-Type", contentType)
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusGatewayTimeout {
+		testingInstance.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+	}
+}
+
+func TestIntegrationOpenAIPollingConsumesOneRequestBudget(testingInstance *testing.T) {
+	var pollCalls atomic.Int64
+	router := timeoutContractRouter(
+		testingInstance,
+		requestTimeoutHTTPDoer(func(request *http.Request) (*http.Response, error) {
+			if request.Method == http.MethodPost {
+				return completedTimeoutContractResponse(`{"id":"background","status":"queued"}`), nil
+			}
+			pollCalls.Add(1)
+			return completedTimeoutContractResponse(`{"id":"background","status":"in_progress"}`), nil
+		}),
+		timeoutContractConfiguration(2, 3),
+		zap.NewNop().Sugar(),
+	)
+	request := httptest.NewRequest(http.MethodGet, "/?key="+serviceSecretValue+"&prompt=hello", nil)
+	request.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "1")
+	responseRecorder := httptest.NewRecorder()
+
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusGatewayTimeout {
+		testingInstance.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+	}
+	if pollCalls.Load() < 2 {
+		testingInstance.Fatalf("poll calls=%d want at least 2", pollCalls.Load())
+	}
+}
+
+func TestIntegrationRequestTimeoutConfigurationInvariants(testingInstance *testing.T) {
+	testCases := []struct {
+		name          string
+		defaultValue  int
+		maximumValue  int
+		expectedError string
+	}{
+		{name: "negative default", defaultValue: -1, maximumValue: 3, expectedError: "request_timeout_seconds must be positive"},
+		{name: "negative maximum", defaultValue: 1, maximumValue: -1, expectedError: "max_request_timeout_seconds must be positive"},
+		{name: "default exceeds maximum", defaultValue: 3, maximumValue: 2, expectedError: "request_timeout_seconds exceeds"},
+		{name: "unsupported duration", defaultValue: 1, maximumValue: int(10_000_000_000), expectedError: "exceeds supported duration"},
+	}
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			_, buildError := proxy.BuildRouter(
+				proxy.Configuration{
+					RequestTimeoutSeconds:    testCase.defaultValue,
+					MaxRequestTimeoutSeconds: testCase.maximumValue,
+				},
+				zap.NewNop().Sugar(),
+			)
+			if buildError == nil || !strings.Contains(buildError.Error(), testCase.expectedError) {
+				subTest.Fatalf("error=%v want contains %q", buildError, testCase.expectedError)
 			}
 		})
 	}

--- a/tests/integration/upstream_rate_limit_test.go
+++ b/tests/integration/upstream_rate_limit_test.go
@@ -345,8 +345,8 @@ func TestIntegrationCanceledWorkerAcquisitionsDoNotReserveRateSlots(testingInsta
 		httpRequest := httptest.NewRequest(http.MethodGet, requestPath, nil).WithContext(requestContext)
 		responseRecorder := httptest.NewRecorder()
 		router.ServeHTTP(responseRecorder, httpRequest)
-		if responseRecorder.Code != http.StatusGatewayTimeout {
-			testingInstance.Fatalf("canceled request %d status=%d want=%d", requestIndex, responseRecorder.Code, http.StatusGatewayTimeout)
+		if responseRecorder.Code != 499 {
+			testingInstance.Fatalf("canceled request %d status=%d want=%d", requestIndex, responseRecorder.Code, 499)
 		}
 	}
 
@@ -527,7 +527,7 @@ func TestIntegrationUpstreamRateLimitCancellationReturnsGatewayTimeoutAndLogs(te
 	}))
 	testingInstance.Cleanup(cancelingGateway.Close)
 	secondStatus, secondError := performRateLimitTextRequest(cancelingGateway.Client(), cancelingGateway.URL, proxy.ProviderNameDeepSeek)
-	if secondError != nil || secondStatus != http.StatusGatewayTimeout {
+	if secondError != nil || secondStatus != 499 {
 		testingInstance.Fatalf("canceled status=%d error=%v", secondStatus, secondError)
 	}
 

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -811,14 +811,90 @@ func TestOperationalDeployRejectsNoncanonicalTag(testingInstance *testing.T) {
 	}
 }
 
+func TestOperationalRequestTimeoutCapacityReader(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	readerPath := filepath.Join(repositoryRoot, operationalScriptsDirectory, "read-request-timeout-capacity.sh")
+	testCases := []struct {
+		name           string
+		configuration  string
+		expectedOutput string
+		expectedError  string
+	}{
+		{
+			name: "valid",
+			configuration: "server:\n" +
+				"  request_timeout_seconds: 360\n" +
+				"  max_request_timeout_seconds: 3600\n",
+			expectedOutput: "3600\n",
+		},
+		{
+			name: "commented",
+			configuration: "server:\n" +
+				"  max_request_timeout_seconds: 900 # operator capacity\n",
+			expectedOutput: "900\n",
+		},
+		{
+			name:          "missing",
+			configuration: "server:\n  request_timeout_seconds: 360\n",
+			expectedError: "expected exactly one server.max_request_timeout_seconds, found 0",
+		},
+		{
+			name: "duplicate",
+			configuration: "server:\n" +
+				"  max_request_timeout_seconds: 900\n" +
+				"  max_request_timeout_seconds: 1200\n",
+			expectedError: "expected exactly one server.max_request_timeout_seconds, found 2",
+		},
+		{
+			name:          "invalid",
+			configuration: "server:\n  max_request_timeout_seconds: 0\n",
+			expectedError: "must be a positive whole number",
+		},
+		{
+			name: "nested-lookalike",
+			configuration: "provider:\n" +
+				"  max_request_timeout_seconds: 900\n" +
+				"server:\n" +
+				"  max_request_timeout_seconds: 3600\n",
+			expectedOutput: "3600\n",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(testingInstance *testing.T) {
+			configPath := filepath.Join(testingInstance.TempDir(), "config.yml")
+			writeOperationalFile(testingInstance, configPath, testCase.configuration, 0o644)
+			command := exec.Command(readerPath, configPath)
+			output, commandError := command.CombinedOutput()
+			if testCase.expectedError == "" {
+				if commandError != nil {
+					testingInstance.Fatalf("read request-timeout capacity: %v\n%s", commandError, output)
+				}
+				if string(output) != testCase.expectedOutput {
+					testingInstance.Fatalf("unexpected request-timeout capacity: %q", output)
+				}
+				return
+			}
+			if commandError == nil {
+				testingInstance.Fatalf("capacity reader accepted invalid config: %s", output)
+			}
+			if !strings.Contains(string(output), testCase.expectedError) {
+				testingInstance.Fatalf("unexpected capacity-reader error: %s", output)
+			}
+		})
+	}
+}
+
 func TestOperationalDeployPreflightsPagesBeforeGatewayMutation(testingInstance *testing.T) {
 	repositoryRoot := operationalRepositoryRoot(testingInstance)
 	fixtureRoot := testingInstance.TempDir()
 	copyOperationalFile(testingInstance, filepath.Join(repositoryRoot, operationalScriptsDirectory, "deploy.sh"), filepath.Join(fixtureRoot, operationalScriptsDirectory, "deploy.sh"))
+	copyOperationalFile(testingInstance, filepath.Join(repositoryRoot, operationalScriptsDirectory, "read-request-timeout-capacity.sh"), filepath.Join(fixtureRoot, operationalScriptsDirectory, "read-request-timeout-capacity.sh"))
+	copyOperationalFile(testingInstance, filepath.Join(repositoryRoot, "configs", "config.yml"), filepath.Join(fixtureRoot, "configs", "config.yml"))
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "init")
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "config", "user.name", "Operational Test")
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "config", "user.email", "operational-test@example.invalid")
-	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "add", operationalScriptsDirectory)
+	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "add", operationalScriptsDirectory, "configs")
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "commit", "-m", "Fixture")
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "branch", "-M", "master")
 	remoteRoot := filepath.Join(testingInstance.TempDir(), "origin.git")
@@ -834,7 +910,7 @@ func TestOperationalDeployPreflightsPagesBeforeGatewayMutation(testingInstance *
 	writeOperationalFile(
 		testingInstance,
 		filepath.Join(toolDirectory, "make"),
-		"#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\t%s\\n' \"$*\" \"${DEPLOY_PAGES_ARGS:-}\" >>\"${MAKE_CAPTURE}\"\nif [[ \"$*\" == *pages-deploy* && \"${DEPLOY_PAGES_ARGS:-}\" == *--verify-only* ]]; then exit 42; fi\nif [[ \"${1:-}\" == \"-C\" && \"$*\" == *deploy-llm-proxy-backend* ]]; then : >\"${GATEWAY_SENTINEL}\"; fi\n",
+		"#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\t%s\\t%s\\n' \"$*\" \"${DEPLOY_PAGES_ARGS:-}\" \"${LLM_PROXY_MAX_REQUEST_TIMEOUT_SECONDS:-}\" >>\"${MAKE_CAPTURE}\"\nif [[ \"$*\" == *pages-deploy* && \"${DEPLOY_PAGES_ARGS:-}\" == *--verify-only* ]]; then exit 42; fi\nif [[ \"${1:-}\" == \"-C\" && \"$*\" == *deploy-llm-proxy-backend* ]]; then : >\"${GATEWAY_SENTINEL}\"; fi\n",
 		0o755,
 	)
 	gatewayDirectory := filepath.Join(testingInstance.TempDir(), "gateway")
@@ -872,16 +948,21 @@ func TestOperationalDeployPreflightsPagesBeforeGatewayMutation(testingInstance *
 	if !strings.Contains(string(captureBytes), "pages-deploy\t--verify-only") {
 		testingInstance.Fatalf("Pages verify-only preflight was not invoked: %s", captureBytes)
 	}
+	if !strings.Contains(string(captureBytes), "verify-llm-proxy-deployment-contract\t\t3600") {
+		testingInstance.Fatalf("gateway verification did not receive the configured request capacity: %s", captureBytes)
+	}
 }
 
 func TestOperationalDeployForwardsSelectedRemoteToPages(testingInstance *testing.T) {
 	repositoryRoot := operationalRepositoryRoot(testingInstance)
 	fixtureRoot := testingInstance.TempDir()
 	copyOperationalFile(testingInstance, filepath.Join(repositoryRoot, operationalScriptsDirectory, "deploy.sh"), filepath.Join(fixtureRoot, operationalScriptsDirectory, "deploy.sh"))
+	copyOperationalFile(testingInstance, filepath.Join(repositoryRoot, operationalScriptsDirectory, "read-request-timeout-capacity.sh"), filepath.Join(fixtureRoot, operationalScriptsDirectory, "read-request-timeout-capacity.sh"))
+	copyOperationalFile(testingInstance, filepath.Join(repositoryRoot, "configs", "config.yml"), filepath.Join(fixtureRoot, "configs", "config.yml"))
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "init")
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "config", "user.name", "Operational Test")
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "config", "user.email", "operational-test@example.invalid")
-	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "add", operationalScriptsDirectory)
+	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "add", operationalScriptsDirectory, "configs")
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "commit", "-m", "Fixture")
 	runOperationalCommand(testingInstance, fixtureRoot, nil, "git", "branch", "-M", "master")
 	remoteRoot := filepath.Join(testingInstance.TempDir(), "upstream.git")

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -977,7 +977,7 @@ func TestOperationalDeployForwardsSelectedRemoteToPages(testingInstance *testing
 	writeOperationalFile(
 		testingInstance,
 		filepath.Join(toolDirectory, "make"),
-		"#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\t%s\\n' \"$*\" \"${PUBLISH_REMOTE:-}\" >>\"${MAKE_CAPTURE}\"\n",
+		"#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\t%s\\t%s\\n' \"$*\" \"${PUBLISH_REMOTE:-}\" \"${LLM_PROXY_MAX_REQUEST_TIMEOUT_SECONDS:-}\" >>\"${MAKE_CAPTURE}\"\n",
 		0o755,
 	)
 	gatewayDirectory := filepath.Join(testingInstance.TempDir(), "gateway")
@@ -1007,6 +1007,9 @@ func TestOperationalDeployForwardsSelectedRemoteToPages(testingInstance *testing
 	}
 	if !strings.Contains(string(captureBytes), "--no-print-directory pages-deploy\tupstream") {
 		testingInstance.Fatalf("Pages deployment did not receive selected remote: %s", captureBytes)
+	}
+	if !strings.Contains(string(captureBytes), "deploy-llm-proxy-backend\t\t3600") {
+		testingInstance.Fatalf("gateway deployment did not receive the configured request capacity: %s", captureBytes)
 	}
 }
 

--- a/tools/gitrelease/tests/test_deploy_contract.py
+++ b/tools/gitrelease/tests/test_deploy_contract.py
@@ -11,7 +11,9 @@ DEPLOY_SCRIPT = REPOSITORY_ROOT / "scripts" / "deploy.sh"
 
 
 class DeployContractTests(unittest.TestCase):
-    def test_deploy_rejects_gateway_without_coupled_tauth_contract(self) -> None:
+    def test_deploy_rejects_gateway_without_coupled_deployment_and_capacity_contract(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             gateway_directory = self.initialize_gateway(
                 Path(temporary_directory),
@@ -24,7 +26,8 @@ class DeployContractTests(unittest.TestCase):
 
             self.assertNotEqual(result.returncode, 0)
             self.assertIn(
-                "gateway checkout does not satisfy the coupled llm-proxy/TAuth deployment contract",
+                "gateway checkout does not satisfy the coupled llm-proxy/TAuth "
+                "deployment and request-capacity contract",
                 result.stderr,
             )
             self.assertFalse((gateway_directory / "deployed").exists())


### PR DESCRIPTION
### Summary

This change introduces and enforces an explicit, bounded per-request timeout contract between clients and the LLM Proxy. It enables each client to specify, via a dedicated header, the maximum time the proxy may spend on a single upstream request.

### Key Changes

- **Explicit Header**: Introduces the `X-LLM-Proxy-Request-Timeout-Seconds` header to all public upstream endpoints (`GET /`, `POST /`, `POST /v2`, `POST /dictate`).
    - If set, the header value (bounded integer) defines the request work budget.
    - If omitted, the configurable server default is used.
    - Values are strictly validated: blank, repeated, non-integer, zero, negative, or exceeding the server's maximum are rejected with a structured `400` error.
- **Centralized Enforcement**: Moves timeout budget selection and enforcement into a unified router-level mechanism, ensuring provider clients and background polling cannot overrun the budget.
- **Structured Errors and Evidence**:
    - When the timeout is exceeded, returns a structured `504` `application/json` envelope indicating a proxy-enforced timeout, not a provider or client transport error.
    - All responses echo the effective timeout in the response header.