### PR TITLE
gix/add-paid-credential-safe-live-test-for-default-tenant

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -22,8 +22,237 @@ canonical account-wide and tenant-filtered operations and response headers. M019
 ready because M018 is complete. M013 then M012 resolve the product-context
 governance path. Planning proceeds P002 -> P003 -> P004 -> P005, with M020
 already satisfied; recurring maintenance remains scheduled work.
+I036 is an independently ready P1 improvement that verifies every newly
+supplied provider credential before it can be persisted or become routing
+eligible.
+I035 is an independent B076 successor that persists only the authenticated
+user's selected Usage interval across sessions.
+F016 is independently ready and adds the canonical v2 client contract for
+server-side Node.js applications.
+B077 publication and both public serving boundaries are now verified at
+v0.2.47. It remains operator-blocked only on the direct production-container
+image receipt and the post-release Terra/max canary required by its completion
+contract. The dominant active Meta 502 path is separately reproduced as
+explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
+
+- [x] [B086] (P1) Make Default-tenant production live tests repeatable.
+  Goal:
+  Provide one paid, production-boundary command that proves the Default tenant
+  can route text through its saved provider credentials without putting any
+  upstream credential in the local test environment.
+
+  Requirements:
+  - Add `make live-test`, separate from the disposable local provider harness
+    and excluded from `make ci`.
+  - Require only the canonical `LLM_PROXY_SECRET` tenant client secret. The
+    command must call `https://llm-proxy-api.mprlab.com`, must not load a dotenv
+    file, and must never read, accept, or send local provider API keys.
+  - Use that secret to select the Default tenant and test exactly OpenAI,
+    Anthropic, Meta, Gemini, and Moonshot through canonical `POST /v2` calls
+    with each provider's saved Default-tenant model.
+  - For every listed provider, send one short echo-marker request. Also send
+    the same deterministic, large completion request through OpenAI,
+    Anthropic, and Meta. The OpenAI Responses case must remain open through
+    the server-owned background polling lifecycle before returning its final
+    marker; the Anthropic and Meta cases must wait for their canonical
+    synchronous provider completions.
+  - Run every case even after a failure, redact all credentials and response
+    bodies from output, and return nonzero when any case does not return the
+    expected completed response.
+
+  Validation:
+  - Add black-box operational coverage for `make live-test` using a fake curl
+    boundary. Prove all eight canonical requests use the production origin,
+    Default-tenant secret query authentication, exact provider selection, no
+    explicit model, and all three large-completion request shapes.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair, then execute the paid
+    `make live-test` command and record its exact safe provider outcomes.
+
+  Resolution:
+  - Extended the production-only harness to eight cases: five echo requests
+    plus the identical large completion request through OpenAI, Anthropic, and
+    Meta. The OpenAI result retains its explicit background-polling case name;
+    Anthropic and Meta retain explicit long-completion case names.
+  - The fake-curl operational boundary proves all eight calls use only the
+    production origin, Default-tenant client secret, saved provider default
+    model, required request budget, and final completion marker.
+  - The required baseline and final `make ci` checks passed. The paid run
+    returned `200` for the OpenAI, Anthropic, and Meta echoes; Gemini echo
+    returned `502`, Moonshot echo returned `429`, OpenAI long completion
+    returned `504`, and Anthropic and Meta long completions returned `502`.
+    The harness completed all eight cases, redacted their bodies, and correctly
+    returned nonzero. The echo failures remain B087; the long-completion
+    failures are tracked in B088.
+
+- [ ] [B087] (P1) Restore Default-tenant Gemini and Moonshot production routing.
+  Goal:
+  Restore successful text generation for the Default tenant's saved Gemini and
+  Moonshot provider routes without weakening the production live-test contract.
+
+  Evidence:
+  - The current eight-case `make live-test` production run returned `200` for
+    OpenAI, Anthropic, and Meta echo cases using the same Default-tenant client
+    secret. Gemini echo returned safe HTTP `502`; Moonshot echo returned safe
+    HTTP `429`. The independent long-completion failures are tracked in B088.
+
+  Requirements:
+  - Diagnose the exact Default-tenant Gemini `502` and Moonshot `429` at the
+    public proxy/provider boundary without exposing secrets, prompts, response
+    bodies, or client credentials.
+  - Restore the affected provider routes through their canonical saved tenant
+    credentials and provider configuration; do not add a local provider-key
+    path, fallback provider, retry loop, or test-only bypass.
+  - Preserve `make live-test` as an honest production boundary: it must retain
+    all five providers, the short marker requests, the OpenAI polling case, and
+    the Anthropic and Meta long-completion cases.
+
+  Validation:
+  - Run `make live-test` with the Default-tenant client secret and prove the
+    Gemini and Moonshot echo cases return HTTP `200` with their required
+    completion markers while retaining the complete eight-case matrix.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair for any code change.
+
+- [ ] [B088] (P1) Restore Default-tenant long completion routing for OpenAI, Anthropic, and Meta.
+  Goal:
+  Make the Default tenant complete the production live test's deterministic
+  large request through OpenAI, Anthropic, and Meta without a local provider
+  credential, fallback provider, or client-side polling path.
+
+  Evidence:
+  - The expanded `make live-test` run returned HTTP `200` for the three
+    providers' short echo requests using their saved Default-tenant models.
+  - The same run gave OpenAI's named background-polling case its full
+    900-second budget before a safe HTTP `504`; Anthropic and Meta long
+    completion cases each returned safe HTTP `502`.
+  - The harness sent the same request larger than 16 KiB to all three cases,
+    required normalized output for all 120 fictional portfolio records before
+    the final marker, printed no response body or credential, and continued
+    through the complete eight-case matrix.
+
+  Requirements:
+  - Diagnose and restore the exact production route for each failed long
+    completion through the saved Default-tenant provider configuration. Retain
+    OpenAI's server-owned Responses polling and the canonical blocking request
+    contract for Anthropic and Meta.
+  - Do not weaken, skip, shorten, special-case, retry, or replace the
+    large-completion live-test cases to conceal a provider, continuation, or
+    request-deadline failure.
+  - Do not add local provider keys, a client polling endpoint, a fallback
+    provider, or an unbounded timeout. Keep request and response data redacted
+    from user-facing failures and issue evidence.
+
+  Validation:
+  - Run `make live-test` with only the Default-tenant client secret and prove
+    the named OpenAI background-polling, Anthropic long-completion, and Meta
+    long-completion cases return HTTP `200` with their final marker.
+  - For any source change, run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+
+- [x] [B085] (P1) {B080} Complete truncated provider output through one shared coordinator.
+  Goal:
+  Make every configured text provider recover from output-budget truncation
+  inside the caller's existing blocking request, using one provider-neutral
+  completion lifecycle instead of recording a recoverable partial result as an
+  upstream failure.
+
+  Evidence:
+  - The production Meta Muse Spark path returns HTTP `200` with
+    `finish_reason=length` when the caller selects a 256-token completion
+    budget, while the same prompt completes with `finish_reason=stop` at 1200
+    tokens. B080 currently converts the recoverable first response into a
+    public `502` and a failed managed usage event.
+  - The configured provider catalog contains 12 text providers implemented by
+    four transports: OpenAI Responses; shared OpenAI-compatible Chat
+    Completions for Meta, DeepSeek, DashScope, Qwen Cloud, Moonshot, MiniMax,
+    SiliconFlow, Zhipu, and Grok; Gemini `generateContent`; and Anthropic
+    Messages.
+  - Each transport reports output-budget exhaustion explicitly:
+    OpenAI `status=incomplete` with `reason=max_output_tokens`, Chat
+    `finish_reason=length`, Gemini `finishReason=MAX_TOKENS`, and Anthropic
+    `stop_reason=max_tokens`.
+  - The current adapters classify those four signals independently as terminal
+    errors. OpenAI pending-response polling is also embedded in its adapter, so
+    there is no shared owner for completion state, continuation accounting, or
+    the request deadline.
+
+  Requirements:
+  - Introduce one provider-neutral completion coordinator used by every
+    configured text provider. It must keep the original public request open and
+    continue provider work until the normalized state is complete, the request
+    context ends, or a non-recoverable provider state occurs.
+  - Normalize only exact output-budget exhaustion as recoverable:
+    OpenAI `incomplete/max_output_tokens`, Chat `length`, Gemini `MAX_TOKENS`,
+    and Anthropic `max_tokens`. Safety/content filtering, refusals, tool calls,
+    context-window exhaustion, missing or unknown states, failed/cancelled
+    work, malformed responses, and provider HTTP failures remain canonical
+    upstream failures.
+  - Use one continuation transcript contract for every transport: retain the
+    original messages, append any accumulated assistant output, and request
+    only the missing suffix. Provider adapters may translate that canonical
+    transcript to their wire format but must not own separate retry loops or
+    provider-name-specific continuation policy.
+  - Treat public `max_tokens` as the initial per-attempt output budget for this
+    completion lifecycle, not permission to return a truncated answer. Reuse
+    it for suffix-producing attempts. When an incomplete attempt produces no
+    visible progress, increase the next attempt budget generically, bounded by
+    the configured model output limit when one is known and by integer safety;
+    the overall request timeout remains the hard lifecycle bound.
+  - Keep upstream worker admission and configured origin rate limits on every
+    provider operation. Waiting between explicit incomplete observations must
+    not occupy a worker.
+  - Aggregate token usage across distinct continuation attempts while retaining
+    cumulative-snapshot replacement for repeated observations of one OpenAI
+    response id. A recovered lifecycle produces one successful managed usage
+    event and no failure row. A request that exhausts its overall deadline
+    produces one canonical `504 request_timeout` event with usage accumulated
+    before the deadline.
+  - Never expose an intermediate partial response, raw provider body, provider
+    error, prompt, response, or credential through the public error or managed
+    failure-detail contract.
+  - Supersede B080's terminal-incomplete and no-hidden-continuation decision in
+    README, the canonical OpenAPI contract, the generated API reference, and
+    provider-routing documentation. Keep the client-facing operation blocking;
+    do not add a client polling endpoint, durable job queue, compatibility
+    path, or provider-specific public option.
+
+  Validation:
+  - Exercise every canonical text provider selector through the public
+    `POST /v2` boundary with an output-budget truncation followed by a complete
+    suffix, and prove each returns one complete HTTP `200` result.
+  - Prove the four transport families use the same coordinator contract,
+    preserve ordered/system/user/assistant messages, concatenate suffixes
+    without returning an intermediate response, and aggregate exact usage.
+  - Reproduce the Meta no-visible-output case and prove the generic progress
+    budget increases before the next attempt without exceeding a configured
+    model limit.
+  - Prove repeated incomplete observations continue until an explicit complete
+    signal, while deadline expiry returns the canonical `504` and a safety,
+    refusal, tool, context-window, missing, or unknown state still returns
+    `502` without another continuation request.
+  - Prove recovered managed requests add only one successful usage event and do
+    not appear in account-wide or tenant failure details.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+
+  Resolution:
+  - Resolved 2026-07-27: one provider-neutral coordinator now continues exact
+    output-budget signals across all 12 configured providers and all four
+    transports until canonical completion or the public request deadline.
+    Adapters only normalize native provider state and translate the shared
+    continuation transcript.
+  - A recovered lifecycle records one success with usage aggregated across
+    distinct attempts; repeated OpenAI snapshots for one response id replace
+    prior snapshots. Deadline expiry records one canonical `504` with usage
+    accumulated before the deadline. Non-recoverable states remain `502`
+    failures and never expose partial text.
+  - The required baseline and post-change `make ci` runs passed. Public
+    black-box coverage exercises every configured provider, repeated and
+    zero-progress continuations, transcript and suffix assembly, exact usage
+    accounting, deadline expiry, and representative non-recoverable states.
 
 - [x] [B084] (P1) {I029} Restore the generated API reference after OpenAPI contract merges.
   Goal:
@@ -380,9 +609,37 @@ already satisfied; recurring maintenance remains scheduled work.
     to classify any subsequent provider failure before resuming the full F001
     batch.
 
-  Blocked: production release publication and activation are operator-owned;
-  F001 provider execution remains stopped until the new immutable release,
-  backend route, and matching Pages UI are all verified live.
+  Verified 2026-07-27:
+  - Release `v0.2.47` points to release commit
+    `943a9b5b582534c11526a5242c145a2d234f6f09`; its immutable source commit is
+    `63763e70c20db0dad311e95d654aa67a6f076e13`.
+  - `ghcr.io/tyemirov/llm-proxy:v0.2.47` and `:latest` both resolve through the
+    standard Docker client to
+    `sha256:986fb7cb1a3dc50d49d53678121452e28acb503458e70d107f45f98f3dfa4121`.
+  - The public Pages marker reports `release_version=v0.2.47` and source
+    `63763e70c20db0dad311e95d654aa67a6f076e13`. The deployed UI assets contain
+    the failed-request action and account/tenant failure clients.
+  - Unauthenticated requests to both canonical failure-details operations now
+    return `401`, proving the live backend reaches the authentication boundary
+    instead of the obsolete router-level `404`.
+  - The dominant active Meta failure path is not evidence of stale B077
+    activation.
+    One repository-owned live smoke without an explicit output ceiling
+    completed successfully. A controlled `muse-spark-1.1` request with the
+    caller's explicit 256-token ceiling returned provider HTTP `200`,
+    `finish_reason=length`, and no visible answer; the same request at 1200
+    tokens returned `finish_reason=stop` with visible text. The public
+    production proxy reproduced the same split: 256 returned safe `502`
+    `chat completion finish_reason=length`, while 1200 returned exact success.
+    B080 correctly maps the incomplete 256-token result without leaking partial
+    output. The current Gix commit-message path owns that 256-token ceiling and
+    fails over to its lower-priority OpenAI connection.
+
+  Blocked: direct inspection of the running production container image still
+  requires the gateway operator's sudo authority, and the required post-release
+  Terra/max 900-second Creative Director canary has not been rerun. Keep B077
+  blocked until the operator records the running container's image ID and
+  matching repo digest, then completes the single normalized Terra canary.
 
 - [x] [B079] (P1) {B074,B076,F014} Consolidate tenant and client-key lifecycle into one Settings row.
   Goal:
@@ -1103,6 +1360,198 @@ already satisfied; recurring maintenance remains scheduled work.
   - Kamu F001 can therefore resume with the declared 900-second budget; no retry, direct-provider path, prompt chunking, or tenant mutation is required.
 
 ## Improvements
+
+- [ ] [I036] (P1) {F014,B081} Verify pasted provider API keys before persisting them.
+  Goal:
+  Make a provider connected and routing-eligible only after LLM Proxy
+  automatically proves that a newly supplied credential is operational for
+  the exact selected provider and text model.
+
+  Evidence:
+  - The Settings API-key input currently marks the provider draft dirty on
+    input and submits it only on change, provider switch, or Settings close. A
+    paste has no immediate verification state or provider request.
+  - `PUT /api/management/tenants/:tenant_id/provider-keys/:provider` currently
+    validates the body, provider, and model, then encrypts and persists any
+    nonblank key without contacting the selected provider. The real-router
+    suite proves that an arbitrary short value such as `skhort` returns `200`
+    and masked saved-key state.
+  - A successful save sets `providers[].has_key`, makes that provider eligible
+    for routing defaults, and may establish the tenant's first default route.
+    An unusable credential can therefore appear connected until the user's
+    first real proxy request fails upstream.
+
+  Requirements:
+  - Treat every nonempty `api_key` submitted to the existing provider-settings
+    operation as an unverified new or replacement credential. Verify it
+    server-side before any provider-key, provider-settings, or routing-default
+    database mutation. An empty `api_key` remains the exact retain-existing-key
+    operation for model or system-prompt updates and does not reverify the
+    stored credential.
+  - Add one provider-neutral verification boundary covering every canonical
+    provider. Each provider adapter must perform its exact documented,
+    authenticated, non-user-content operation and report success only when the
+    supplied credential is accepted and the selected text model is available
+    to it. Key shape, encryption success, catalog membership, a global
+    credential, or another provider must never count as verification.
+  - A paste into the selected provider's API-key field must start verification
+    automatically without waiting for blur, Settings close, provider switch,
+    or a separate Verify/Save action. Any non-paste replacement submitted
+    through the canonical operation receives the same server-side verification
+    guarantee.
+  - Show one explicit `Verifying key` pending state and lock conflicting
+    provider, tenant, model, reveal, remove, and Settings-close actions until
+    that attempt settles. A newer paste, authentication reset, tenant switch,
+    provider switch, model change, or editor replacement must cancel or
+    invalidate the prior attempt so a stale result cannot mutate or render in
+    the new context.
+  - On verification success, encrypt and persist the credential together with
+    the submitted provider model and system prompt, reconcile routing defaults,
+    and return the complete profile in one atomic mutation. Only that response
+    may set `has_key`, unlock mandatory setup, or expose the provider in routing
+    selectors. Clear the raw pasted value from browser state and return to the
+    existing masked-key presentation.
+  - On verification rejection, keep a new provider unkeyed. For a failed
+    replacement, retain the prior verified encrypted credential, provider
+    settings, and routing defaults unchanged. Keep the rejected draft available
+    only in the current editor for correction or retry, and state visibly
+    whether no key was saved or the previous key remains active.
+  - Distinguish a provider credential/model rejection from an unconfirmed
+    timeout, rate limit, or provider outage through stable, documented,
+    provider-neutral management errors. None of those outcomes may save the
+    candidate key. Never return, persist, log, or render the key, authenticated
+    URL, raw provider body, probe response, prompt, or provider-specific
+    free-form error.
+  - Run verification under the request context and the existing shared
+    upstream admission and origin-rate-limit boundaries. Make exactly one
+    documented verification operation per submitted candidate; add no hidden
+    retry, alternate endpoint, generation fallback, background continuation,
+    or deferred save. Verification attempts do not create managed usage events.
+  - Update the canonical OpenAPI source and generated reference, README,
+    provider-routing documentation, frontend types and copy, and CHANGELOG in
+    the same implementation.
+
+  Deliverables:
+  - One provider-neutral operational credential verifier with exact adapters
+    for all canonical providers, wired into the existing authenticated
+    provider-settings mutation before its database transaction.
+  - Automatic paste-triggered verification with explicit pending, success,
+    rejection, transient-failure, retry, and stale-response behavior in
+    Settings.
+  - Canonical and generated documentation for the verify-before-persist
+    contract and its safe failure statuses.
+
+  Validation:
+  - Exercise every canonical provider through the real management router and
+    its actual transport shape against controlled upstream servers. Prove an
+    accepted credential/model pair performs exactly one verification operation
+    and only then returns a keyed profile and eligible defaults.
+  - For every transport family, prove authentication rejection, model-access
+    rejection, rate limiting, upstream failure, timeout, malformed success, and
+    cancellation leave the database and routing defaults unchanged and expose
+    only the documented safe management error.
+  - Prove a rejected first key leaves mandatory setup locked, while a rejected
+    replacement leaves the prior key operational and selected defaults
+    unchanged. Prove no verification attempt creates a managed usage event or
+    leaks candidate material through responses, logs, profile data, or the DOM.
+  - Add rendered Playwright coverage showing that paste starts verification
+    before blur, displays and announces the pending state, locks conflicting
+    actions, applies success once, retains a failed draft for retry, and rejects
+    stale completions after every tenant/provider/model/auth context change.
+  - Extend the opt-in live-provider harness to verify each available real key
+    through the same operational verifier before its provider smoke request;
+    keep paid live calls and secrets outside `make ci`.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair for the implementation, with
+    the final run after the last code edit.
+
+- [ ] [I035] (P2) {B076} Persist each user's selected Usage interval across sessions.
+  Goal:
+  Make the Usage Overview reopen with the last interval the authenticated user
+  successfully selected. A user who selects `7 days` must start the next login
+  at `7 days`; after changing to `1 day`, subsequent logins must start at
+  `1 day`.
+
+  Evidence:
+  - The frontend initializes `selectedUsageInterval` from the hard-coded
+    `30d` default. Selecting another interval changes only the mounted Alpine
+    component and requests that interval's usage summary.
+  - Authentication reset explicitly restores `30d`, and a full page reload
+    constructs the same default before the authenticated workspace loads.
+  - The managed user record and `GET /api/management/account` response contain
+    no dashboard preference, so the current selection cannot survive logout,
+    reload, session restoration, or another browser/device.
+
+  Requirements:
+  - Persist exactly one canonical account-owned `usage_interval` preference for
+    each authenticated managed user. Accepted values are `all`, `30d`, `7d`,
+    and `1d`; a newly created user defaults to `30d`.
+  - Keep this preference independent of the `Usage tenant` filter and Settings
+    tenant. The same saved interval initializes both account-wide and explicitly
+    tenant-filtered Usage Overview queries. Do not persist the Usage tenant,
+    dashboard view, admin view, failure-dialog state, or any other local UI
+    state as part of this issue.
+  - Extend the canonical `GET /api/management/account` response with a required
+    `preferences` object containing the exact saved `usage_interval`. Add one
+    owner-only `PUT /api/management/account/preferences` operation whose strict
+    request and response contain that same complete preference object. Reject
+    a missing, blank, unknown, or additional field with `400`; never normalize,
+    infer, or silently replace an invalid value.
+  - Store the preference on the managed user through the existing GORM database
+    boundary. Add one bounded, all-or-nothing schema migration that initializes
+    every existing user to `30d`, verifies the migrated rows, and records the
+    new current schema version. After migration, keep only the current schema
+    and reject invalid persisted values at startup without a read-time fallback,
+    nullable legacy shape, dual read/write, or compatibility response.
+  - Apply the account response's saved interval before issuing the initial
+    Usage Overview request so login, session restoration, and full reload make
+    exactly the saved-interval request without first rendering or requesting
+    `30d`.
+  - On interval selection, persist the exact new value before treating it as
+    the confirmed selection and loading its usage summary. Keep interval
+    controls blocked through the preference mutation and selected-interval load.
+    A failed preference mutation must retain the prior confirmed interval and
+    snapshot, show the existing explicit request-failure treatment, and never
+    imply that an unsaved choice will survive the next login.
+  - Preserve request identity and authentication isolation. A late preference
+    or usage response cannot overwrite a newer interval, authentication reset,
+    another user, Usage tenant change, or dashboard-view change.
+  - Keep the preference server-side. Do not add localStorage, sessionStorage,
+    cookies, URL/history state, a tenant field, a client-library preference
+    file, or a browser-only fallback. The fixed administrator dashboard remains
+    a separate 30-day contract and does not read or mutate this preference.
+  - Update the canonical OpenAPI source, generated API reference, frontend
+    types, README, CHANGELOG.md, and
+    `docs/implementation/provider-routing-plan.md` in the same implementation.
+
+  Deliverables:
+  - One typed Usage-interval preference contract, forward-only managed-user
+    schema migration, owner-isolated read/update store path, canonical account
+    response and preference update operation, and race-safe frontend hydration
+    and mutation flow.
+  - Updated canonical and generated documentation describing the account-owned
+    persistence boundary and the unchanged local-only state outside this
+    preference.
+
+  Validation:
+  - Exercise the real management router and a disposable SQLite database to
+    prove a new user starts at `30d`, can save each supported interval, retains
+    the latest value after database restart and a new authenticated session,
+    and cannot read or change another user's preference.
+  - Prove the bounded migration initializes existing users once, preserves all
+    account/tenant/provider/usage data, and rejects an invalid current-schema
+    preference at startup without mutation or fallback.
+  - Add OpenAPI conformance coverage for the required account preference and
+    strict authenticated update operation, including invalid bodies,
+    authorization, owner isolation, and stable error responses.
+  - Add Playwright coverage showing `7 days` selected after a full reload and
+    later login, then `1 day` after the next successful change and login.
+    Prove the first usage request uses only the saved interval, failed saves
+    retain the prior confirmed view, rapid/stale responses cannot regress it,
+    and no preference is written to browser storage.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair for the implementation, with
+    the final run after the last code edit.
 
 - [x] [I034] (P2) {B079} Minimize Settings system-prompt editors by default.
   Goal:
@@ -1957,6 +2406,136 @@ already satisfied; recurring maintenance remains scheduled work.
     coverage, the real SQLite migrations, 33 Python tests,
     package installation, 59 browser scenarios, the real two-user TAuth
     black-box test, release checks, and live-provider harness preflight.
+
+- [ ] [F016] (P1) Add an installable Node.js client for canonical v2 messages.
+  Goal:
+  Let server-side Node.js applications install `llm-proxy-client`, create one
+  validated client from an application-supplied LLM Proxy base URL and tenant
+  secret, and await canonical `/v2` message requests without duplicating
+  authentication, URL, model-profile, timeout, or error-handling logic.
+
+  Evidence:
+  - `pkg/llmproxyclient` is the reusable Go client, `python/llm_proxy_client` is
+    the installable Python package, and `llm-proxy-client` is the standalone Go
+    CLI. Their public tests exercise the same v2-only messages transport.
+  - The root npm project is private frontend/test tooling. The repository has
+    no installable Node.js package, Node import surface, package declaration,
+    or packed-consumer validation.
+  - `docs/openapi.yaml` is the sole public HTTP contract, and repository CI
+    already uses Node.js 22. The Node package can therefore use the built-in
+    Fetch API without adding a runtime dependency or another wire schema.
+
+  Requirements:
+  - Add exactly one package project under `node/`, named
+    `llm-proxy-client`, initially versioned `0.1.0`, with
+    `"type": "module"`, a strict public `exports` map, and
+    `"engines": {"node": ">=22"}`. Keep the root frontend package private and
+    separate; do not add alternate package names, scopes, entrypoints, or
+    registry fallbacks.
+  - Author the runtime directly as vanilla ESM JavaScript with `// @ts-check`,
+    complete JSDoc, descriptive identifiers, immutable validated values, and
+    no runtime dependencies. Generate one TypeScript declaration surface from
+    that source for consumers. Do not add a CommonJS build, dual-package
+    condition, transpiled runtime copy, browser bundle, provider SDK, or legacy
+    prompt/GET client.
+  - Export only the canonical public surface: `Client`, `ClientConfig`,
+    `ClientMessage`, `ClientMessagesRequest`, `LLMProxyClientError`,
+    `LLMProxyModelProfileError`, `LLMProxyHTTPError`, and
+    `LLMProxyTransportError`. `Client.postMessages(request, {signal})` returns
+    `Promise<string>`; the constructor accepts an explicitly injected Fetch
+    implementation or uses Node's built-in `globalThis.fetch`.
+  - Validate configuration and request input exactly once at their constructors.
+    Require an absolute HTTP(S) base URL and nonblank tenant secret; accept an
+    optional provider. Require at least one message and one `user` message,
+    allow only `system`, `user`, and `assistant` roles with nonempty content,
+    and require optional `order` values to be all-or-none, unique,
+    non-negative integers. Accept only optional `model`, `webSearch`,
+    `maxTokens`, `reasoningEffort`, and `requestTimeoutSeconds` values matching
+    the canonical v2 contract; a request timeout is a positive whole number.
+  - Build the request with the standard `URL` API. Append `/v2` exactly once,
+    replace `key` and `format`, preserve unrelated query values, preserve a
+    base-URL provider unless the validated config explicitly overrides it, and
+    remove body-owned query fields. Send `format=text/plain`,
+    `Accept: text/plain`, `Content-Type: application/json; charset=utf-8`, and
+    the exact canonical JSON body. Omit `model`, `max_tokens`, and
+    `reasoning_effort` when not selected; serialize `web_search` as a boolean.
+  - Serialize `requestTimeoutSeconds` only as
+    `X-LLM-Proxy-Request-Timeout-Seconds`. Add no client-owned total-response
+    deadline, retry, polling, streaming, or fallback transport. A supplied
+    `AbortSignal` is the caller's independent cancellation authority.
+  - Match F015's application-user model-profile contract. A configured
+    `modelProfilePath` requires one application-injected asynchronous text
+    reader; reread and strictly decode its complete JSON document before every
+    request. Accept exactly one nonblank `provider` and `model` string, reject
+    unknown or duplicate fields, and reject profile mode combined with a
+    configured/base-URL provider, base-URL model, or request model. A read,
+    decode, validation, or conflict failure must stop before Fetch and must
+    never reuse a prior profile, tenant default, or alternate source.
+  - Return successful response text unchanged. Map every non-2xx response to
+    `LLMProxyHTTPError` with status, response body, status text, and bounded
+    provider/model/request-timeout context. Map network failures and caller
+    cancellation to `LLMProxyTransportError` while retaining the original
+    error as `cause`. No error name, message, field, cause wrapper, log, or
+    package example may expose the tenant secret, authenticated URL, request
+    messages, or response text from another request.
+  - Keep the package server-side only. Do not read environment variables,
+    dotenv files, service `config.yml`, browser storage, TAuth state, or
+    upstream provider keys. Applications supply configuration and secrets
+    explicitly; the package never sends a provider API key.
+  - Add repository-owned package lint, declaration, black-box test, pack, and
+    temporary-consumer install targets to the root Makefile and `make ci`.
+    Extend CI path filters for `node/**`. Package only the ESM runtime,
+    declarations, package README, and MIT license through an explicit `files`
+    allowlist; exclude tests, coverage, repository tooling, and local files.
+  - Produce one deterministic `npm pack` tarball and an explicit
+    operator-owned npm publication command. Validate package name, version,
+    contents, registry target, and an unpublished version before mutation.
+    CI and implementation work use `npm publish --dry-run` only; no PR,
+    `make ci`, deploy, or implicit release step may publish externally, and
+    there is no alternate registry/package-name fallback.
+  - Add Node.js installation and ESM/TypeScript usage to the package README and
+    root README. Update `CHANGELOG.md`,
+    `docs/implementation/provider-routing-plan.md`, the client-authentication
+    documentation, and the generated Clients resource family with one
+    Node.js-client page and examples. Do not change the public HTTP contract to
+    accommodate the client; prove the package conforms to the existing
+    `docs/openapi.yaml`.
+
+  Deliverables:
+  - One installable zero-runtime-dependency Node.js ESM package with generated
+    declarations, validated public request/config types, injectable Fetch
+    transport, model-profile support, and stable typed errors.
+  - Root Makefile/CI integration, packed-consumer validation, deterministic
+    package artifact, and explicit operator-owned publication path.
+  - Updated product, client-authentication, provider-routing, package, and
+    generated public documentation for the Node.js integration.
+
+  Validation:
+  - Pack the package, install only that tarball into disposable JavaScript and
+    TypeScript consumer projects, import only its public export, compile the
+    typed example, and make real requests through a loopback HTTP server.
+    Never validate by importing unpublished source paths.
+  - Through the installed public client, prove exact method, `/v2` path,
+    authentication/format/provider query behavior, unrelated-query
+    preservation, body-field stripping, headers, Unicode messages, explicit
+    ordering, optional-field omission, response text, and conformance with the
+    canonical OpenAPI request and documented response statuses.
+  - Cover every configuration/message/request invariant; provider
+    preserve/override behavior; profile reload after atomic replacement;
+    malformed, duplicate, incomplete, unreadable, and conflicting profiles;
+    timeout-header omission/presence; caller abort; transport failure; every
+    documented non-2xx status; and proof that one call occurs with no hidden
+    retry or client deadline.
+  - Assert HTTP and transport errors preserve their typed fields and cause
+    while their string/object representations exclude the tenant secret,
+    authenticated URL, request content, and unrelated response state.
+  - Verify `npm pack --dry-run` and `npm publish --dry-run` contain only the
+    allowlisted files, use exact `llm-proxy-client@0.1.0` metadata, require
+    Node.js 22 or newer, expose only ESM plus declarations, and leave no packed,
+    installed, credential, or coverage artifacts in the worktree.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair for the implementation, with
+    the final run after the last code edit.
 
 ## Planning
 *do not implement yet*

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GATEWAY_DIR ?=
 
 GO_SOURCES := $(shell find . -name '*.go' -not -path './vendor/*')
 
-.PHONY: fmt check-format lint go-lint python-lint frontend-lint test go-test python-test python-package-install-test frontend-test test-openapi-pages-artifact test-management-auth-blackbox release-test test-live-provider-harness test-live-providers test-live-gemini build clean ci up release container-artifacts pages-artifact publish-release publish pages-deploy deploy
+.PHONY: fmt check-format lint go-lint python-lint frontend-lint test go-test python-test python-package-install-test frontend-test test-openapi-pages-artifact test-management-auth-blackbox release-test test-live-provider-harness test-live-providers test-live-gemini live-test build clean ci up release container-artifacts pages-artifact publish-release publish pages-deploy deploy
 
 fmt:
 	$(GOFMT) -w $(GO_SOURCES)
@@ -85,6 +85,9 @@ test-live-providers:
 
 test-live-gemini:
 	@GO="$(GO)" ./scripts/test_live_gemini.sh
+
+live-test:
+	@./scripts/live_test.sh
 
 build:
 	mkdir -p $(BIN_DIR)

--- a/README.md
+++ b/README.md
@@ -58,12 +58,16 @@ immediately, and a missing or unknown status is rejected rather than polled.
 The response id remains in the active request lifecycle; llm-proxy has no
 durable provider-job queue or later resume endpoint.
 
-The current Chat Completions, Gemini `generateContent`, and Anthropic Messages
-routes are synchronous. Their text is successful only when the same response
-reports a complete provider-specific stop signal: Chat
-`finish_reason=stop`, Gemini `finishReason=STOP`, or Anthropic
-`stop_reason=end_turn|stop_sequence`. Missing, truncated, tool/intermediate, or
-unknown stop signals return `502` without partial text.
+Every current text route uses one provider-neutral completion coordinator.
+When an upstream attempt exhausts its output budget—OpenAI Responses
+`status=incomplete` with `reason=max_output_tokens`, Chat Completions
+`finish_reason=length`, Gemini `finishReason=MAX_TOKENS`, or Anthropic
+`stop_reason=max_tokens`—the coordinator retains the original messages,
+appends the accumulated assistant output and one missing-suffix instruction,
+and calls the same selected provider again. It repeats until the adapter
+reports its complete stop signal or the overall request deadline expires.
+Safety filters, refusals, tool/intermediate states, malformed responses, and
+missing or unknown signals remain `502` failures and never trigger this loop.
 
 A `504 Gateway Timeout` means the overall proxy request deadline expired before
 the selected upstream provider produced a final answer. It is not a prompt for
@@ -548,9 +552,10 @@ Provider-specific details:
   dictation uses `providers.openai.transcriptions_url`.
 * OpenAI-compatible text providers send chat completion requests with
   `Authorization: Bearer <api_key>` and the selected provider base URL. The
-  shared adapter accepts text only with `finish_reason=stop`; `length`,
-  `content_filter`, `tool_calls`, missing, and provider-specific non-stop
-  reasons are upstream failures.
+  shared adapter normalizes `finish_reason=length` into the common
+  missing-suffix loop and accepts the assembled text only after
+  `finish_reason=stop`; `content_filter`, `tool_calls`, missing, and
+  provider-specific non-stop reasons are upstream failures.
 * Qwen Cloud Token Plan uses selector `qwencloud`, exact model
   `qwen3.8-max-preview`, `${QWEN_CLOUD_TOKEN_PLAN_API_KEY}`, and
   `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`.
@@ -585,15 +590,17 @@ Provider-specific details:
   `providers.grok.transcriptions_url`.
 * Gemini text requests use the native `generateContent` route and normalize
   Gemini usage metadata into the same response headers and JSON `usage` object
-  used by the other text providers. Only `finishReason=STOP` can return text.
+  used by the other text providers. `finishReason=MAX_TOKENS` enters the common
+  missing-suffix loop and only `finishReason=STOP` completes the assembled
+  answer.
 * Anthropic text requests use `POST /v1/messages` with `x-api-key` and
   `anthropic-version: 2023-06-01`. System messages are translated to
   Anthropic's top-level `system` field. Anthropic requires `max_tokens`, so
   when the client omits it the proxy sends the selected Claude model's
-  configured output limit. Only `stop_reason=end_turn` or `stop_sequence` can
-  return text; truncation, tool use, paused turns, refusals, and unknown reasons
-  are upstream failures because this adapter exposes no continuation or tool
-  loop.
+  configured output limit. `stop_reason=max_tokens` enters the common
+  missing-suffix loop; `end_turn` or `stop_sequence` completes the assembled
+  answer. Tool use, paused turns, refusals, and unknown reasons remain upstream
+  failures because this adapter exposes no tool loop.
 * Zhipu dictation uses Z.AI GLM-ASR through
   `providers.zhipu.transcriptions_url` with the selected configured dictation
   model.
@@ -1070,10 +1077,13 @@ to the static frontend.
 
 Web search is per request and currently supported only on OpenAI models that
 support the OpenAI web search tool.
-Text output length is also per request: pass `max_tokens` when a client wants
-to cap one generation. When omitted, the proxy does not send a provider
-max-token field, except Anthropic Messages where `max_tokens` is required
-upstream and the proxy sends the selected model's configured output limit.
+Text output length is per upstream attempt: pass `max_tokens` to set the
+initial attempt's budget, which is reused for missing-suffix attempts. If an
+output-budget stop contains no visible progress and the model has a configured
+output limit, the coordinator increases the next attempt's budget toward that
+limit. When omitted, the proxy does not send a provider max-token field, except
+Anthropic Messages where `max_tokens` is required upstream and the proxy sends
+the selected model's configured output limit.
 Provider-specific output-token limits are enforced at the request edge when
 known. MiniMax M2.7 rejects `max_tokens` above `2048`; Gemini text models
 currently reject values above `65536`; Claude models reject values above the
@@ -1239,6 +1249,7 @@ This repository exposes the standard local targets used by MPR app repos:
 | `make test-live-provider-harness` | Generate the temporary static-mode live-test config and verify authenticated routing without an upstream call. |
 | `make test-live-providers` | Generate a complete temporary static-mode config and run live text smoke tests for every provider whose API key is present; use `LIVE_ENV_FILE=/path/to/env` to load interpolation values. |
 | `make test-live-gemini` | Compatibility wrapper for `make test-live-providers` with `LLM_PROXY_LIVE_PROVIDERS=gemini`. |
+| `make live-test` | Send paid production `POST /v2` requests through the Default tenant using only `LLM_PROXY_SECRET`: echo checks for OpenAI, Anthropic, Meta, Gemini, and Moonshot, plus one large OpenAI background-polling request. |
 | `make release` | Run CI and prepare the local tag, container archives, and validated Pages archive under `.git/mprlab-release` without remote writes. |
 | `make publish` | Publish the exact prepared Git refs, GitHub Release assets, and container archives without rebuilding or deploying; wait for each GHCR manifest to become readable. |
 | `make deploy` | Verify and deploy the published backend through the sibling gateway, then activate the Pages archive and verify the matching Pages build and public marker. |
@@ -1289,6 +1300,40 @@ paid provider with `./scripts/test_live_providers.sh --write-config
 port, each harness run allocates a fresh loopback port. It removes only the
 temporary proxy child it started and never terminates an unrelated local
 listener.
+
+### Production Default-tenant live test
+
+`make live-test` is a separate paid production check. It calls only
+`https://llm-proxy-api.mprlab.com` and requires exactly one local credential:
+`LLM_PROXY_SECRET`, the Default tenant's generated client secret. It neither
+loads a dotenv file nor reads, accepts, or sends a local upstream-provider key.
+The saved provider credentials and per-provider default models remain entirely
+on the production tenant.
+
+The command sends canonical `POST /v2` requests with an explicit provider and
+no model, so it exercises each saved Default-tenant provider model. It runs a
+small echo-marker request for OpenAI, Anthropic, Meta, Gemini, and Moonshot,
+then the same deterministic request larger than 16 KiB through OpenAI,
+Anthropic, and Meta. The long request requires normalized output for every
+portfolio record before its final marker and uses a 900-second request budget.
+OpenAI keeps the blocking caller request open while the Responses adapter
+performs server-owned background polling. Anthropic and Meta use their canonical
+synchronous completion paths (including shared output-continuation work when
+needed); the test client never polls a provider or llm-proxy itself. Each case
+verifies HTTP `200`, the echoed request budget, and a completion marker without
+printing the response body or tenant secret. It runs all eight cases before
+returning nonzero for any failed case.
+
+Set only the Default-tenant client secret before invoking it:
+
+```shell
+export LLM_PROXY_SECRET='...'
+make live-test
+```
+
+This target is intentionally outside `make ci`: it has a real production cost
+and is expected to fail honestly for a disabled, rate-limited, or failing
+provider.
 
 `make release` and `make deploy` run the local `make ci` gate with the standard
 350-second timeout. Override both with

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -23,9 +23,9 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 - `messages[]` items contain `role` and string `content`. Supported roles are `system`, `user`, and `assistant`; at least one `user` message is required.
 - `messages[].order` is optional. When any submitted message includes `order`, every submitted message must include a unique non-negative integer `order`; the proxy sorts submitted messages by ascending `order` before adding a request or tenant system prompt and before routing upstream.
 - With `messages[]` on `POST /`, body `system_prompt` is prepended as a system message only when the transcript does not already contain a `system` message. A body containing both `system_prompt` and a system message is invalid. With `POST /v2`, callers send system instructions as `system` role messages.
-- `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies.
+- `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies. It is the initial per-attempt output budget and is reused for missing-suffix attempts.
 - Provided `max_tokens` maps to OpenAI Responses `max_output_tokens`, Meta, Moonshot, and MiniMax Chat Completions `max_completion_tokens`, other OpenAI-compatible chat completions `max_tokens`, Anthropic Messages `max_tokens`, and Gemini `generationConfig.maxOutputTokens`.
-- Omitted `max_tokens` means the proxy omits provider max-token fields and lets the selected provider/model default apply, except Anthropic Messages where the upstream API requires `max_tokens` and the proxy sends the selected model's configured synchronous output limit.
+- Omitted `max_tokens` means the proxy omits provider max-token fields and lets the selected provider/model default apply, except Anthropic Messages where the upstream API requires `max_tokens` and the proxy sends the selected model's configured synchronous output limit. After an output-budget stop with no visible progress, a configured model output limit becomes the generic ceiling for increasing the next attempt.
 - Known provider-specific output-token ceilings are validated before upstream calls; MiniMax M2.7 rejects `max_tokens` above `2048`, Gemini text models reject values above `65536`, and Claude models reject values above their configured synchronous Messages output limits with `400 Bad Request`.
 - `reasoning_effort` is optional on `GET /` as a query parameter and on JSON `POST /` and `POST /v2` as a body field. Omission retains the resolved tenant default. A supplied value must be nonblank and supported by the exact resolved text provider/model route; blank, `null`, or unsupported values return `400 Bad Request` before a provider call.
 - `X-LLM-Proxy-Request-Timeout-Seconds` is an optional positive whole-number
@@ -220,26 +220,39 @@ documented `queued` and `in_progress` pending states or for a proxy-initiated
 stored background synthesis. Documented terminal states are resolved
 immediately, and missing or unknown states are rejected rather than guessed.
 Only `status=completed` is a successful terminal response.
-`status=incomplete`, including `reason=max_output_tokens`, returns the
-canonical `502` upstream failure without partial text, continuation, or another
-paid generation; any reported token usage remains attached only to the failed
-normalized usage event. Usage objects observed while polling one response id
-are cumulative snapshots, so the newest nonempty snapshot replaces earlier
-observations. Usage is summed only when completed-response synthesis creates a
-distinct response id. Callers use one normal `GET /`, `POST /`, or `POST /v2`
-request and receive a complete formatted answer or a non-2xx response; there is
-no streaming, client-side polling, durable provider-job queue, or later resume
-contract.
+`status=incomplete` with `reason=max_output_tokens` is normalized into the
+same provider-neutral missing-suffix lifecycle used by every text transport.
+Other incomplete reasons are canonical `502` upstream failures. Usage objects
+observed while polling one response id are cumulative snapshots, so the newest
+nonempty snapshot replaces earlier observations. Usage is summed across
+distinct missing-suffix attempts and completed-response synthesis requests.
+Callers use one normal `GET /`, `POST /`, or `POST /v2` request and receive a
+complete formatted answer or a non-2xx response; there is no streaming,
+client-side polling, durable provider-job queue, or later resume contract.
 
-All other current text transports are synchronous and validate their native
-completion evidence before returning text. The shared OpenAI-compatible Chat
-Completions adapter requires `finish_reason=stop`; Gemini
-`generateContent` requires `finishReason=STOP`; Anthropic Messages requires
-`stop_reason=end_turn` or `stop_sequence`. Missing, truncated,
-tool/intermediate, refused, or unknown reasons return `502` without partial
-text. Provider-specific deferred, batch, and asynchronous APIs are separate
-transports outside the configured routes; an arbitrary response `id` never
-activates generic polling.
+One completion coordinator owns output-budget recovery for all transports.
+Adapters normalize only their exact recoverable signal: OpenAI
+`incomplete/max_output_tokens`, Chat Completions `length`, Gemini
+`MAX_TOKENS`, and Anthropic `max_tokens`. The coordinator preserves the
+original messages, appends all accumulated assistant text plus one
+missing-suffix user instruction, repeats the selected provider call, and joins
+the returned suffixes until OpenAI reports `completed`, Chat reports `stop`,
+Gemini reports `STOP`, or Anthropic reports `end_turn`/`stop_sequence`. The
+overall request deadline is the hard bound. Safety/filter, refusal,
+tool/intermediate, failed/cancelled, malformed, missing, and unknown signals
+return the canonical failure without exposing partial text. Provider-specific
+deferred, batch, and asynchronous APIs remain separate transports; an
+arbitrary response `id` never activates polling.
+
+The caller's `max_tokens` value is the initial per-attempt budget and is reused
+for suffix attempts. When an output-budget response has no visible text and
+the model catalog declares an output limit, the next attempt increases the
+budget toward that limit. Each provider call independently passes through the
+shared worker, queue, and upstream-rate-limit controls; the coordinator's wait
+does not retain a worker. Distinct attempt usage is summed into one final
+managed event, while successive OpenAI snapshots for one response id replace
+one another. A recovered request records one success and no failure; a request
+deadline records one `504` with all usage observed before the deadline.
 
 Bundled clients intentionally expose only the canonical `POST /v2` text
 contract. The installable Go CLI maps prompt flags or stdin into v2 `system` and
@@ -343,6 +356,22 @@ fresh loopback port unless `LLM_PROXY_LIVE_PORT` explicitly provides one, and
 cleanup terminates only the proxy child started by the harness rather than a
 process discovered through a shared port.
 
+`make live-test` is deliberately a different boundary: it calls only the
+production API origin with `LLM_PROXY_SECRET`, the Default tenant client
+secret. It never loads a dotenv file or local provider credential. The command
+uses canonical `POST /v2` calls with explicit OpenAI, Anthropic, Meta, Gemini,
+and Moonshot providers and no explicit model, so managed production provider
+settings remain authoritative. Five echo-marker requests verify those routes;
+matching deterministic requests larger than 16 KiB target OpenAI, Anthropic,
+and Meta with a 900-second request budget and a required normalized line for
+each portfolio record before the final marker. OpenAI keeps one blocking request
+open while the proxy owns its Responses background polling. Anthropic and Meta
+exercise their canonical synchronous completion paths, including shared
+output-continuation work when needed. The client validates only the final
+marker, status, and resolved timeout header. This paid check remains outside
+`make ci`, runs all eight cases even after an earlier failure, and never prints
+a tenant secret or response body.
+
 Startup validates configured tenants, rejects duplicate tenant ids and duplicate secrets, requires API keys for each configured static tenant's default text and dictation providers when management mode is disabled, allows non-default provider API keys to be blank so those providers are disabled until configured, requires every configured provider base URL, requires transcription URLs for dictation-capable providers, requires text model catalogs for every provider, requires dictation model catalogs for dictation-capable providers, rejects blank or duplicate model ids, rejects defaults not listed in their model catalog, rejects `web_search` outside OpenAI text model entries, validates OpenAI request profiles, validates exact model-owned reasoning-effort lists, validates each configured static tenant's default text provider/model and effort, and validates endpoint/credential support for each configured static tenant's default dictation provider/model. When `management.enabled` is false, at least one static tenant is required. When `management.enabled` is true, static tenants and nonblank config-level provider API keys are rejected because managed tokens and provider credentials are user-owned database state.
 
 The repository owns the immutable release implementation under
@@ -401,19 +430,20 @@ When the selected Usage snapshot contains failures, the success-rate card expose
 - `429`: upstream provider rate limiting.
 - `503`: registered non-default provider credential is unavailable, so the selected provider is disabled until its API key is configured.
 - `504`: the overall proxy request timed out before the selected upstream provider returned a final result.
-- `502`: upstream provider failure, including OpenAI Responses
-  `status=incomplete`, Chat Completions non-`stop` finish reasons, Gemini
-  non-`STOP` finish reasons, and Anthropic non-complete stop reasons; partial
-  provider text is never returned.
+- `502`: upstream provider failure, including non-budget OpenAI incomplete
+  reasons, Chat Completions reasons other than `stop` or `length`, Gemini
+  reasons other than `STOP` or `MAX_TOKENS`, and Anthropic reasons other than
+  `end_turn`, `stop_sequence`, or `max_tokens`; partial provider text is never
+  returned.
 
 ## Implementation Notes
 
 - Provider/model validation happens at the HTTP edge through a provider registry built from the configured model catalogs.
-- OpenAI keeps the existing Responses API adapter and derives Responses and Models URLs from `providers.openai.base_url`; audio transcription uses `providers.openai.transcriptions_url`. The adapter accepts text only from `status=completed`, polls only the documented pending states, and rejects failed, cancelled, incomplete, missing, or unknown states.
-- Non-OpenAI text providers use a shared OpenAI-compatible Chat Completions adapter. It requires `finish_reason=stop` before returning content or reasoning text.
+- OpenAI keeps the existing Responses API adapter and derives Responses and Models URLs from `providers.openai.base_url`; audio transcription uses `providers.openai.transcriptions_url`. The adapter polls documented pending states, normalizes only `incomplete/max_output_tokens` for shared continuation, and rejects failed, cancelled, other incomplete, missing, or unknown states.
+- Non-OpenAI compatible text providers use a shared Chat Completions adapter. It normalizes `finish_reason=length` for shared continuation and requires `finish_reason=stop` to complete content or reasoning text.
 - Meta uses the shared OpenAI-compatible Chat Completions adapter against `providers.meta.base_url`; its proxy contract is text-only and has no Responses fallback.
-- Anthropic uses a native Messages adapter, translating proxy `system` messages to the top-level Anthropic `system` parameter and `user`/`assistant` messages to Anthropic `messages[]`; only `end_turn` and `stop_sequence` are complete text stops.
-- Gemini uses a native generateContent adapter against `providers.gemini.base_url`; only `STOP` is a complete text finish reason.
+- Anthropic uses a native Messages adapter, translating proxy `system` messages to the top-level Anthropic `system` parameter and `user`/`assistant` messages to Anthropic `messages[]`; `max_tokens` continues through the shared coordinator, while `end_turn` and `stop_sequence` are complete text stops.
+- Gemini uses a native generateContent adapter against `providers.gemini.base_url`; `MAX_TOKENS` continues through the shared coordinator, while `STOP` is the complete text finish reason.
 - Grok uses the shared OpenAI-compatible Chat Completions adapter against `providers.grok.base_url`.
 - OpenAI-compatible chat providers receive validated and sorted `messages[]` as provider-supported `role` and `content` items.
 - OpenAI Responses payload shape comes from the selected configured model's stable `request_profile`; model-specific web-search support comes from the selected model catalog entry. OpenAI Responses text calls run in background mode with stored responses so long provider work can be polled by llm-proxy while the caller waits on one REST request.
@@ -427,14 +457,17 @@ When the selected Usage snapshot contains failures, the success-rate card expose
 Black-box router tests cover:
 
 - OpenAI omitted-provider regression.
-- OpenAI completed-only success and incomplete-response rejection through the
-  public `POST /v2` handler, including safe failed usage counts and no hidden
-  continuation.
+- OpenAI output-budget recovery through the public `POST /v2` handler,
+  including pending-response snapshots, repeated suffix attempts, exact text
+  assembly, aggregated usage, and one successful managed event.
 - OpenAI polling only for documented pending states, with missing and unknown
   states rejected without another provider call.
-- Shared Chat Completions, Gemini, and Anthropic partial-response rejection
-  through public `POST /v2`, including retained failed usage counts and no
-  client-visible token headers or partial text.
+- Every configured provider through its public text route, proving the same
+  shared continuation transcript, completion order, suffix assembly, and usage
+  aggregation for Chat Completions, Gemini, Anthropic, and OpenAI.
+- Deadline exhaustion and nonrecoverable safety, refusal, tool, malformed,
+  missing, and unknown signals, proving partial text is never exposed as a
+  failure response.
 - Explicit Meta Muse Spark 1.1 routing through `GET /`, compatibility `POST /`, and canonical `POST /v2`.
 - Unsupported Meta `web_search` and dictation paths.
 - Explicit DeepSeek chat-completions routing.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1080,6 +1080,7 @@
         "name": "max_tokens",
         "in": "query",
         "required": false,
+        "description": "Initial per-attempt output budget. The same budget is reused when the proxy requests a missing suffix; after a zero-text output-budget stop, a configured model output limit bounds any generic increase.",
         "schema": {
           "type": "integer",
           "minimum": 1
@@ -1286,7 +1287,7 @@
     },
     "responses": {
       "TextSuccess": {
-        "description": "Complete generated text in the selected representation. HTTP 200 requires the selected transport's canonical completion signal: OpenAI Responses status=completed, OpenAI-compatible Chat Completions finish_reason=stop, Gemini finishReason=STOP, or Anthropic stop_reason=end_turn|stop_sequence. Incomplete, intermediate, missing, or unknown provider states never return text as success.",
+        "description": "Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.",
         "headers": {
           "X-LLM-Proxy-Request-Timeout-Seconds": {
             "$ref": "#/components/headers/ResolvedRequestTimeout"
@@ -1404,7 +1405,7 @@
         "description": "The caller canceled or closed the request."
       },
       "ProxyBadGateway": {
-        "description": "The selected upstream provider failed or returned an incomplete, intermediate, missing, or unknown completion signal. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.",
+        "description": "The selected upstream provider failed or returned a nonrecoverable completion signal. Output-budget stops are continued internally and do not create this response. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.",
         "headers": {
           "X-LLM-Proxy-Request-Timeout-Seconds": {
             "$ref": "#/components/headers/ResolvedRequestTimeout"
@@ -1712,7 +1713,8 @@
           },
           "max_tokens": {
             "type": "integer",
-            "minimum": 1
+            "minimum": 1,
+            "description": "Initial per-attempt output budget. Reused for missing-suffix attempts, with any zero-progress increase bounded by the configured model output limit."
           },
           "reasoning_effort": {
             "type": "string",
@@ -1746,7 +1748,8 @@
           },
           "max_tokens": {
             "type": "integer",
-            "minimum": 1
+            "minimum": 1,
+            "description": "Initial per-attempt output budget. Reused for missing-suffix attempts, with any zero-progress increase bounded by the configured model output limit."
           },
           "reasoning_effort": {
             "type": "string",

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -19,6 +19,7 @@ const (
 	anthropicVersionValue           = "2023-06-01"
 	anthropicStopReasonEndTurn      = "end_turn"
 	anthropicStopReasonStopSequence = "stop_sequence"
+	anthropicStopReasonMaxTokens    = "max_tokens"
 )
 
 type anthropicMessagesClient struct {
@@ -121,24 +122,27 @@ func parseAnthropicMessagesResponse(responseBytes []byte) (textGenerationResult,
 		return textGenerationResult{}, usageError
 	}
 	generation := textGenerationResult{usage: usage}
-	stopReason := response.StopReason
-	if strings.TrimSpace(stopReason) == constants.EmptyString {
-		return generation, fmt.Errorf("%w: anthropic Messages missing stop_reason", ErrProviderAPI)
-	}
-	if stopReason != anthropicStopReasonEndTurn && stopReason != anthropicStopReasonStopSequence {
-		return generation, fmt.Errorf("%w: anthropic Messages stop_reason=%s", ErrProviderAPI, strings.TrimSpace(stopReason))
-	}
 	var textBuilder strings.Builder
 	for _, contentBlock := range response.Content {
 		if contentBlock.Type == textPartType && strings.TrimSpace(contentBlock.Text) != constants.EmptyString {
 			textBuilder.WriteString(contentBlock.Text)
 		}
 	}
-	trimmedText := strings.TrimSpace(textBuilder.String())
-	if trimmedText == constants.EmptyString {
+	visibleText := textBuilder.String()
+	stopReason := strings.TrimSpace(response.StopReason)
+	if stopReason == constants.EmptyString {
+		return generation, fmt.Errorf("%w: anthropic Messages missing stop_reason", ErrProviderAPI)
+	}
+	if stopReason == anthropicStopReasonMaxTokens {
+		return textGenerationResult{text: visibleText, usage: usage}, errProviderOutputLimitReached
+	}
+	if stopReason != anthropicStopReasonEndTurn && stopReason != anthropicStopReasonStopSequence {
+		return generation, fmt.Errorf("%w: anthropic Messages stop_reason=%s", ErrProviderAPI, stopReason)
+	}
+	if utils.IsBlank(visibleText) {
 		return generation, fmt.Errorf("%w: anthropic Messages returned no text", ErrProviderAPI)
 	}
-	return textGenerationResult{text: trimmedText, usage: usage}, nil
+	return textGenerationResult{text: visibleText, usage: usage}, nil
 }
 
 func parseAnthropicTokenUsage(usage *upstreamTokenUsage) (*tokenUsage, error) {

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -193,9 +193,7 @@ func validateTenantDefaultRuntime(providers *providerRegistry, validator *modelV
 	return nil
 }
 
-// ErrUpstreamIncomplete indicates that the upstream provider returned an incomplete response before the request deadline.
-var ErrUpstreamIncomplete = errors.New(errorUpstreamIncomplete)
-
+var errProviderOutputLimitReached = errors.New("provider output limit reached")
 var errQueueFull = errors.New(errorQueueFull)
 
 // ApplyTunables ensures tunable configuration values have sensible defaults.

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -74,8 +74,6 @@ const (
 	errorInvalidAudioForm           = "invalid audio form"
 	errorMissingAudioFile           = "missing audio file"
 	errorAudioPayloadTooLarge       = "audio payload too large"
-	// errorUpstreamIncomplete indicates that the upstream provider returned an incomplete response.
-	errorUpstreamIncomplete = "OpenAI API error (incomplete response)"
 	// errorUnknownModel indicates that a model identifier is not recognized.
 	errorUnknownModel = "unknown model"
 	// errorQueueFull indicates that the internal request queue cannot accept additional tasks.

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -730,15 +730,31 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("initial incomplete response with text maps to bad gateway", func(subTest *testing.T) {
+	t.Run("initial incomplete response with text continues to completion", func(subTest *testing.T) {
+		requestCount := 0
+		var finalContinuationPayload map[string]any
 		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			requestCount++
 			responseWriter.Header().Set("Content-Type", "application/json")
+			if requestCount == 3 {
+				requestBytes, _ := io.ReadAll(httpRequest.Body)
+				_ = json.Unmarshal(requestBytes, &finalContinuationPayload)
+				_, _ = responseWriter.Write([]byte(`{"id":"complete","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":" recovered"}]}]}`))
+				return
+			}
+			if requestCount == 2 {
+				_, _ = responseWriter.Write([]byte(`{"id":"partial-again","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":" then"}]}]}`))
+				return
+			}
 			_, _ = responseWriter.Write([]byte(`{"id":"partial","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial answer"}]}]}`))
 		})
 		queryParameters := url.Values{}
 		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
-		if statusCode != http.StatusBadGateway || body != proxy.ErrUpstreamIncomplete.Error() {
+		if statusCode != http.StatusOK || body != "partial answer then recovered" {
 			subTest.Fatalf("status=%d body=%q", statusCode, body)
+		}
+		if !strings.Contains(finalContinuationPayload["input"].(string), "assistant:\npartial answer then") {
+			subTest.Fatalf("final continuation input=%v", finalContinuationPayload["input"])
 		}
 	})
 
@@ -795,8 +811,9 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("initial incomplete response does not start continuation", func(subTest *testing.T) {
+	t.Run("initial incomplete response without text continues without inventing an unknown model limit", func(subTest *testing.T) {
 		requestCount := 0
+		var continuationPayload map[string]any
 		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")
 			if httpRequest.Method != http.MethodPost || httpRequest.URL.Path != "/" {
@@ -804,15 +821,36 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 				return
 			}
 			requestCount++
+			if requestCount == 2 {
+				requestBytes, _ := io.ReadAll(httpRequest.Body)
+				_ = json.Unmarshal(requestBytes, &continuationPayload)
+				_, _ = responseWriter.Write([]byte(`{"id":"complete","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"complete after empty partial"}]}]}`))
+				return
+			}
 			_, _ = responseWriter.Write([]byte(`{"id":"partial","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
 		})
 		queryParameters := url.Values{}
 		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
-		if statusCode != http.StatusBadGateway || body != proxy.ErrUpstreamIncomplete.Error() {
+		if statusCode != http.StatusOK || body != "complete after empty partial" {
 			subTest.Fatalf("status=%d body=%q", statusCode, body)
 		}
-		if requestCount != 1 {
-			subTest.Fatalf("upstream requests=%d want=1", requestCount)
+		if requestCount != 2 {
+			subTest.Fatalf("upstream requests=%d want=2", requestCount)
+		}
+		if continuationPayload["max_output_tokens"] != nil {
+			subTest.Fatalf("continuation payload invented an unconfigured model limit: %v", continuationPayload)
+		}
+	})
+
+	t.Run("caller cancellation ends shared continuation polling", func(subTest *testing.T) {
+		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"id":"partial","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+		})
+		queryParameters := url.Values{}
+		statusCode, _, _ := performCoverageTextRequestWithTimeout(subTest, router, queryParameters, "", coverageShortRequestTimeout)
+		if statusCode != 499 {
+			subTest.Fatalf("status=%d want=499", statusCode)
 		}
 	})
 
@@ -1114,11 +1152,17 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("poll incomplete response with text maps to bad gateway", func(subTest *testing.T) {
+	t.Run("poll incomplete response with text continues to completion", func(subTest *testing.T) {
+		postRequestCount := 0
 		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")
 			switch {
 			case httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/":
+				postRequestCount++
+				if postRequestCount == 2 {
+					_, _ = responseWriter.Write([]byte(`{"id":"complete","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":" recovered"}]}]}`))
+					return
+				}
 				_, _ = responseWriter.Write([]byte(`{"id":"partial","status":"queued"}`))
 			case httpRequest.Method == http.MethodGet && httpRequest.URL.Path == "/partial":
 				_, _ = responseWriter.Write([]byte(`{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial poll answer"}]}]}`))
@@ -1128,16 +1172,22 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		})
 		queryParameters := url.Values{}
 		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
-		if statusCode != http.StatusBadGateway || body != proxy.ErrUpstreamIncomplete.Error() {
+		if statusCode != http.StatusOK || body != "partial poll answer recovered" {
 			subTest.Fatalf("status=%d body=%q", statusCode, body)
 		}
 	})
 
-	t.Run("poll incomplete response without text maps to bad gateway", func(subTest *testing.T) {
+	t.Run("poll incomplete response without text continues to completion", func(subTest *testing.T) {
+		postRequestCount := 0
 		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")
 			switch {
 			case httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/":
+				postRequestCount++
+				if postRequestCount == 2 {
+					_, _ = responseWriter.Write([]byte(`{"id":"complete","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"complete after poll"}]}]}`))
+					return
+				}
 				_, _ = responseWriter.Write([]byte(`{"id":"partial","status":"queued"}`))
 			case httpRequest.Method == http.MethodGet && httpRequest.URL.Path == "/partial":
 				_, _ = responseWriter.Write([]byte(`{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[]}`))
@@ -1146,13 +1196,13 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 			}
 		})
 		queryParameters := url.Values{}
-		statusCode, _, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
-		if statusCode != http.StatusBadGateway {
-			subTest.Fatalf("status=%d want=%d", statusCode, http.StatusBadGateway)
+		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
+		if statusCode != http.StatusOK || body != "complete after poll" {
+			subTest.Fatalf("status=%d body=%q", statusCode, body)
 		}
 	})
 
-	t.Run("polled incomplete response does not start continuation", func(subTest *testing.T) {
+	t.Run("polled incomplete response starts shared continuation", func(subTest *testing.T) {
 		postRequestCount := 0
 		router := textRouterWithResponsesHandler(subTest, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 			responseWriter.Header().Set("Content-Type", "application/json")
@@ -1163,7 +1213,7 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 					_, _ = responseWriter.Write([]byte(`{"id":"polled_partial","status":"queued"}`))
 					return
 				}
-				http.Error(responseWriter, "unexpected continuation", http.StatusInternalServerError)
+				_, _ = responseWriter.Write([]byte(`{"id":"complete","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"continued"}]}]}`))
 			case httpRequest.Method == http.MethodGet && httpRequest.URL.Path == "/polled_partial":
 				_, _ = responseWriter.Write([]byte(`{"id":"polled_partial","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[],"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}`))
 			default:
@@ -1172,11 +1222,11 @@ func TestCoverageOpenAILifecycleBranches(t *testing.T) {
 		})
 		queryParameters := url.Values{}
 		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
-		if statusCode != http.StatusBadGateway || body != proxy.ErrUpstreamIncomplete.Error() {
+		if statusCode != http.StatusOK || body != "continued" {
 			subTest.Fatalf("status=%d body=%q", statusCode, body)
 		}
-		if postRequestCount != 1 {
-			subTest.Fatalf("post requests=%d want=1", postRequestCount)
+		if postRequestCount != 2 {
+			subTest.Fatalf("post requests=%d want=2", postRequestCount)
 		}
 	})
 
@@ -1580,7 +1630,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 			{name: "malformed json", statusCode: http.StatusOK, body: `{`, wantStatus: http.StatusBadGateway},
 			{name: "negative usage", statusCode: http.StatusOK, body: `{"choices":[{"message":{"content":"bad usage"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":-1}}`, wantStatus: http.StatusBadGateway},
 			{name: "missing finish reason", statusCode: http.StatusOK, body: `{"choices":[{"message":{"content":"unfinished text"}}]}`, wantStatus: http.StatusBadGateway},
-			{name: "length finish reason", statusCode: http.StatusOK, body: `{"choices":[{"message":{"content":"partial text"},"finish_reason":"length"}]}`, wantStatus: http.StatusBadGateway},
+			{name: "filtered finish reason", statusCode: http.StatusOK, body: `{"choices":[{"message":{"content":"filtered text"},"finish_reason":"content_filter"}]}`, wantStatus: http.StatusBadGateway},
 			{name: "missing text", statusCode: http.StatusOK, body: `{"choices":[{"message":{},"finish_reason":"stop"}]}`, wantStatus: http.StatusBadGateway},
 		}
 		for _, testCase := range testCases {

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	geminiAPIKeyHeader     = "x-goog-api-key"
-	geminiFinishReasonStop = geminiFinishReason("STOP")
+	geminiAPIKeyHeader          = "x-goog-api-key"
+	geminiFinishReasonStop      = geminiFinishReason("STOP")
+	geminiFinishReasonMaxTokens = geminiFinishReason("MAX_TOKENS")
 )
 
 type geminiFinishReason string
@@ -151,12 +152,12 @@ func parseGeminiGenerateContentResponse(responseBytes []byte) (textGenerationRes
 	}
 	generation := textGenerationResult{usage: usage}
 	for _, candidate := range response.Candidates {
+		visibleText := visibleGeminiCandidateText(candidate)
 		if finishReasonError := validateGeminiFinishReason(candidate.FinishReason); finishReasonError != nil {
-			return generation, finishReasonError
+			return textGenerationResult{text: visibleText, usage: usage}, finishReasonError
 		}
-		trimmedText := visibleGeminiCandidateText(candidate)
-		if trimmedText != constants.EmptyString {
-			return textGenerationResult{text: trimmedText, usage: usage}, nil
+		if !utils.IsBlank(visibleText) {
+			return textGenerationResult{text: visibleText, usage: usage}, nil
 		}
 	}
 	return generation, fmt.Errorf("%w: gemini generateContent returned no text", ErrProviderAPI)
@@ -165,6 +166,9 @@ func parseGeminiGenerateContentResponse(responseBytes []byte) (textGenerationRes
 func validateGeminiFinishReason(reason geminiFinishReason) error {
 	if reason == geminiFinishReasonStop {
 		return nil
+	}
+	if reason == geminiFinishReasonMaxTokens {
+		return errProviderOutputLimitReached
 	}
 	normalizedReason := strings.TrimSpace(string(reason))
 	if normalizedReason == constants.EmptyString {
@@ -180,7 +184,7 @@ func visibleGeminiCandidateText(candidate geminiCandidate) string {
 			textBuilder.WriteString(part.Text)
 		}
 	}
-	return strings.TrimSpace(textBuilder.String())
+	return textBuilder.String()
 }
 
 func parseGeminiTokenUsage(usage *geminiUsageMetadata) (*tokenUsage, error) {

--- a/internal/proxy/management_failures_test.go
+++ b/internal/proxy/management_failures_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/glebarez/sqlite"
 	"github.com/tyemirov/llm-proxy/internal/proxy"
@@ -49,11 +50,12 @@ type managementAccountUsageFailureTestItem struct {
 	managementUsageFailureTestItem
 }
 
-func TestOpenAIResponsesRequireCompletedStatusAtPublicV2Boundary(testingInstance *testing.T) {
+func TestOpenAIResponsesCompleteTruncatedOutputAndRecordOneSuccessAtPublicV2Boundary(testingInstance *testing.T) {
 	const (
 		incompletePrompt = "b080-incomplete"
 		completedPrompt  = "b080-completed"
 		partialText      = "provider-truncated partial text"
+		completionText   = " and recovered suffix"
 		completedText    = "complete response text"
 	)
 	upstreamRequestCount := 0
@@ -66,6 +68,8 @@ func TestOpenAIResponsesRequireCompletedStatusAtPublicV2Boundary(testingInstance
 		}
 		responseWriter.Header().Set("Content-Type", "application/json")
 		switch {
+		case bytes.Contains(requestBody, []byte(incompletePrompt)) && bytes.Contains(requestBody, []byte("Return only the missing suffix")):
+			_, _ = responseWriter.Write([]byte(`{"id":"b080-recovered-response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"` + completionText + `"}]}],"usage":{"input_tokens":5,"output_tokens":7,"total_tokens":12}}`))
 		case bytes.Contains(requestBody, []byte(incompletePrompt)):
 			_, _ = responseWriter.Write([]byte(`{"id":"b080-incomplete-response","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"` + partialText + `"}]}],"usage":{"input_tokens":1599,"output_tokens":2048,"total_tokens":3647}}`))
 		case bytes.Contains(requestBody, []byte(completedPrompt)):
@@ -100,16 +104,13 @@ func TestOpenAIResponsesRequireCompletedStatusAtPublicV2Boundary(testingInstance
 	}
 
 	incompleteResponse := requestV2(incompletePrompt, 2048)
-	if incompleteResponse.Code != http.StatusBadGateway || incompleteResponse.Body.String() != proxy.ErrUpstreamIncomplete.Error() {
+	if incompleteResponse.Code != http.StatusOK || incompleteResponse.Body.String() != partialText+completionText {
 		testingInstance.Fatalf("incomplete status=%d body=%q", incompleteResponse.Code, incompleteResponse.Body.String())
 	}
-	if strings.Contains(incompleteResponse.Body.String(), partialText) {
-		testingInstance.Fatalf("incomplete response leaked partial text: %q", incompleteResponse.Body.String())
-	}
-	for _, tokenHeader := range []string{testHeaderLLMProxyRequestTokens, testHeaderLLMProxyResponseTokens, testHeaderLLMProxyTotalTokens} {
-		if incompleteResponse.Header().Get(tokenHeader) != "" {
-			testingInstance.Fatalf("incomplete response exposed %s=%q", tokenHeader, incompleteResponse.Header().Get(tokenHeader))
-		}
+	if incompleteResponse.Header().Get(testHeaderLLMProxyRequestTokens) != "1604" ||
+		incompleteResponse.Header().Get(testHeaderLLMProxyResponseTokens) != "2055" ||
+		incompleteResponse.Header().Get(testHeaderLLMProxyTotalTokens) != "3659" {
+		testingInstance.Fatalf("recovered token headers=%v", incompleteResponse.Header())
 	}
 
 	completedResponse := requestV2(completedPrompt, 2048)
@@ -121,8 +122,8 @@ func TestOpenAIResponsesRequireCompletedStatusAtPublicV2Boundary(testingInstance
 		completedResponse.Header().Get(testHeaderLLMProxyTotalTokens) != "18" {
 		testingInstance.Fatalf("completed token headers=%v", completedResponse.Header())
 	}
-	if upstreamRequestCount != 2 {
-		testingInstance.Fatalf("upstream requests=%d want=2", upstreamRequestCount)
+	if upstreamRequestCount != 3 {
+		testingInstance.Fatalf("upstream requests=%d want=3", upstreamRequestCount)
 	}
 
 	type persistedOpenAIUsageEvent struct {
@@ -150,7 +151,7 @@ func TestOpenAIResponsesRequireCompletedStatusAtPublicV2Boundary(testingInstance
 		testingInstance.Fatalf("load OpenAI usage events: %v", queryError)
 	}
 	expectedUsageEvents := []persistedOpenAIUsageEvent{
-		{Endpoint: "v2", Provider: proxy.ProviderNameOpenAI, Model: proxy.ModelNameGPT41, StatusCode: http.StatusBadGateway, Success: false, OutcomeCode: "upstream_error", RequestTokens: 1599, ResponseTokens: 2048, TotalTokens: 3647},
+		{Endpoint: "v2", Provider: proxy.ProviderNameOpenAI, Model: proxy.ModelNameGPT41, StatusCode: http.StatusOK, Success: true, OutcomeCode: "success", RequestTokens: 1604, ResponseTokens: 2055, TotalTokens: 3659},
 		{Endpoint: "v2", Provider: proxy.ProviderNameOpenAI, Model: proxy.ModelNameGPT41, StatusCode: http.StatusOK, Success: true, OutcomeCode: "success", RequestTokens: 7, ResponseTokens: 11, TotalTokens: 18},
 	}
 	if !reflect.DeepEqual(usageEvents, expectedUsageEvents) {
@@ -158,17 +159,23 @@ func TestOpenAIResponsesRequireCompletedStatusAtPublicV2Boundary(testingInstance
 	}
 }
 
-func TestOpenAIPolledFailureKeepsLatestUsageSnapshotAtPublicV2Boundary(testingInstance *testing.T) {
+func TestOpenAIPolledIncompleteUsesLatestSnapshotThenCompletesAtPublicV2Boundary(testingInstance *testing.T) {
 	const (
 		responseIdentifier = "b080-polled-usage"
 		partialText        = "polled provider-truncated partial text"
 	)
 	upstreamRequestCount := 0
+	postRequestCount := 0
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		upstreamRequestCount++
 		responseWriter.Header().Set("Content-Type", "application/json")
 		switch {
 		case request.Method == http.MethodPost:
+			postRequestCount++
+			if postRequestCount == 2 {
+				_, _ = responseWriter.Write([]byte(`{"id":"b085-polled-complete","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":" recovered suffix"}]}],"usage":{"input_tokens":5,"output_tokens":7,"total_tokens":12}}`))
+				return
+			}
 			_, _ = responseWriter.Write([]byte(`{"id":"` + responseIdentifier + `","status":"queued","usage":{"input_tokens":11,"output_tokens":13,"total_tokens":24}}`))
 		case request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/"+responseIdentifier):
 			_, _ = responseWriter.Write([]byte(`{"id":"` + responseIdentifier + `","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"` + partialText + `"}]}],"usage":{"input_tokens":17,"output_tokens":19,"total_tokens":36}}`))
@@ -190,19 +197,16 @@ func TestOpenAIPolledFailureKeepsLatestUsageSnapshotAtPublicV2Boundary(testingIn
 	request.Header.Set("Content-Type", "application/json")
 	response := httptest.NewRecorder()
 	router.ServeHTTP(response, request)
-	if response.Code != http.StatusBadGateway || response.Body.String() != proxy.ErrUpstreamIncomplete.Error() {
+	if response.Code != http.StatusOK || response.Body.String() != partialText+" recovered suffix" {
 		testingInstance.Fatalf("status=%d body=%q", response.Code, response.Body.String())
 	}
-	if strings.Contains(response.Body.String(), partialText) {
-		testingInstance.Fatalf("response leaked partial text: %q", response.Body.String())
+	if response.Header().Get(testHeaderLLMProxyRequestTokens) != "22" ||
+		response.Header().Get(testHeaderLLMProxyResponseTokens) != "26" ||
+		response.Header().Get(testHeaderLLMProxyTotalTokens) != "48" {
+		testingInstance.Fatalf("token headers=%v", response.Header())
 	}
-	for _, tokenHeader := range []string{testHeaderLLMProxyRequestTokens, testHeaderLLMProxyResponseTokens, testHeaderLLMProxyTotalTokens} {
-		if response.Header().Get(tokenHeader) != "" {
-			testingInstance.Fatalf("response exposed %s=%q", tokenHeader, response.Header().Get(tokenHeader))
-		}
-	}
-	if upstreamRequestCount != 2 {
-		testingInstance.Fatalf("upstream requests=%d want=2", upstreamRequestCount)
+	if upstreamRequestCount != 3 {
+		testingInstance.Fatalf("upstream requests=%d want=3", upstreamRequestCount)
 	}
 
 	type persistedUsageEvent struct {
@@ -227,32 +231,49 @@ func TestOpenAIPolledFailureKeepsLatestUsageSnapshotAtPublicV2Boundary(testingIn
 		testingInstance.Fatalf("load usage events: %v", queryError)
 	}
 	expectedUsageEvents := []persistedUsageEvent{{
-		StatusCode:     http.StatusBadGateway,
-		Success:        false,
-		OutcomeCode:    "upstream_error",
-		RequestTokens:  17,
-		ResponseTokens: 19,
-		TotalTokens:    36,
+		StatusCode:     http.StatusOK,
+		Success:        true,
+		OutcomeCode:    "success",
+		RequestTokens:  22,
+		ResponseTokens: 26,
+		TotalTokens:    48,
 	}}
 	if !reflect.DeepEqual(usageEvents, expectedUsageEvents) {
 		testingInstance.Fatalf("usage events=%+v want=%+v", usageEvents, expectedUsageEvents)
 	}
 }
 
-func TestProviderCompletionSignalsRejectPartialTextAndRetainUsageAtPublicV2Boundary(testingInstance *testing.T) {
+func TestProviderCompletionSignalsRecoverPartialTextAndAggregateUsageAtPublicV2Boundary(testingInstance *testing.T) {
 	const (
 		chatPartialText      = "chat completion partial text"
 		geminiPartialText    = "gemini partial text"
 		anthropicPartialText = "anthropic partial text"
+		completionText       = " recovered suffix"
 	)
+	upstreamRequestCounts := map[string]int{}
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		responseWriter.Header().Set("Content-Type", "application/json")
 		switch {
 		case request.URL.Path == "/chat/completions":
+			upstreamRequestCounts["chat"]++
+			if upstreamRequestCounts["chat"] == 2 {
+				_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"` + completionText + `"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}}`))
+				return
+			}
 			_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"` + chatPartialText + `"},"finish_reason":"length"}],"usage":{"prompt_tokens":31,"completion_tokens":47,"total_tokens":78}}`))
 		case strings.HasSuffix(request.URL.Path, ":generateContent"):
+			upstreamRequestCounts["gemini"]++
+			if upstreamRequestCounts["gemini"] == 2 {
+				_, _ = responseWriter.Write([]byte(`{"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"` + completionText + `"}]}}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":7,"totalTokenCount":12}}`))
+				return
+			}
 			_, _ = responseWriter.Write([]byte(`{"candidates":[{"finishReason":"MAX_TOKENS","content":{"parts":[{"text":"` + geminiPartialText + `"}]}}],"usageMetadata":{"promptTokenCount":41,"candidatesTokenCount":53,"totalTokenCount":94}}`))
 		case request.URL.Path == "/v1/messages":
+			upstreamRequestCounts["anthropic"]++
+			if upstreamRequestCounts["anthropic"] == 2 {
+				_, _ = responseWriter.Write([]byte(`{"content":[{"type":"text","text":"` + completionText + `"}],"stop_reason":"end_turn","usage":{"input_tokens":7,"output_tokens":9}}`))
+				return
+			}
 			_, _ = responseWriter.Write([]byte(`{"content":[{"type":"text","text":"` + anthropicPartialText + `"}],"stop_reason":"max_tokens","usage":{"input_tokens":59,"output_tokens":61}}`))
 		default:
 			http.NotFound(responseWriter, request)
@@ -309,16 +330,8 @@ func TestProviderCompletionSignalsRejectPartialTextAndRetainUsageAtPublicV2Bound
 		request.Header.Set("Content-Type", "application/json")
 		response := httptest.NewRecorder()
 		router.ServeHTTP(response, request)
-		if response.Code != http.StatusBadGateway {
+		if response.Code != http.StatusOK || response.Body.String() != testCase.partialText+completionText {
 			testingInstance.Fatalf("provider=%s status=%d body=%q", testCase.provider, response.Code, response.Body.String())
-		}
-		if strings.Contains(response.Body.String(), testCase.partialText) {
-			testingInstance.Fatalf("provider=%s leaked partial text: %q", testCase.provider, response.Body.String())
-		}
-		for _, tokenHeader := range []string{testHeaderLLMProxyRequestTokens, testHeaderLLMProxyResponseTokens, testHeaderLLMProxyTotalTokens} {
-			if response.Header().Get(tokenHeader) != "" {
-				testingInstance.Fatalf("provider=%s exposed %s=%q", testCase.provider, tokenHeader, response.Header().Get(tokenHeader))
-			}
 		}
 	}
 
@@ -347,10 +360,96 @@ func TestProviderCompletionSignalsRejectPartialTextAndRetainUsageAtPublicV2Bound
 		testingInstance.Fatalf("load provider usage events: %v", queryError)
 	}
 	expectedUsageEvents := []persistedProviderUsageEvent{
-		{Endpoint: "v2", Provider: proxy.ProviderNameDeepSeek, Model: proxy.ModelNameDeepSeekV4Flash, StatusCode: http.StatusBadGateway, Success: false, OutcomeCode: "upstream_error", RequestTokens: 31, ResponseTokens: 47, TotalTokens: 78},
-		{Endpoint: "v2", Provider: proxy.ProviderNameGemini, Model: proxy.ModelNameGemini25Flash, StatusCode: http.StatusBadGateway, Success: false, OutcomeCode: "upstream_error", RequestTokens: 41, ResponseTokens: 53, TotalTokens: 94},
-		{Endpoint: "v2", Provider: proxy.ProviderNameAnthropic, Model: proxy.ModelNameClaudeSonnet46, StatusCode: http.StatusBadGateway, Success: false, OutcomeCode: "upstream_error", RequestTokens: 59, ResponseTokens: 61, TotalTokens: 120},
+		{Endpoint: "v2", Provider: proxy.ProviderNameDeepSeek, Model: proxy.ModelNameDeepSeekV4Flash, StatusCode: http.StatusOK, Success: true, OutcomeCode: "success", RequestTokens: 36, ResponseTokens: 54, TotalTokens: 90},
+		{Endpoint: "v2", Provider: proxy.ProviderNameGemini, Model: proxy.ModelNameGemini25Flash, StatusCode: http.StatusOK, Success: true, OutcomeCode: "success", RequestTokens: 46, ResponseTokens: 60, TotalTokens: 106},
+		{Endpoint: "v2", Provider: proxy.ProviderNameAnthropic, Model: proxy.ModelNameClaudeSonnet46, StatusCode: http.StatusOK, Success: true, OutcomeCode: "success", RequestTokens: 66, ResponseTokens: 70, TotalTokens: 136},
 	}
+	if !reflect.DeepEqual(usageEvents, expectedUsageEvents) {
+		testingInstance.Fatalf("usage events=%+v want=%+v", usageEvents, expectedUsageEvents)
+	}
+}
+
+func TestCompletionCoordinatorDeadlineRecordsAccumulatedUsageAsOneTimeout(testingInstance *testing.T) {
+	upstreamRequestCount := 0
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		upstreamRequestCount++
+		if upstreamRequestCount == 1 {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"partial text"},"finish_reason":"length"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`))
+			return
+		}
+		select {
+		case <-request.Context().Done():
+		case <-time.After(750 * time.Millisecond):
+		}
+	}))
+	defer upstreamServer.Close()
+
+	databasePath := filepath.Join(testingInstance.TempDir(), "completion-timeout.db")
+	router := newManagementRouterWithDatabasePath(testingInstance, proxy.Configuration{DeepSeekBaseURL: upstreamServer.URL}, databasePath)
+	ownerCookie := managementSessionCookie(testingInstance, "completion-timeout-owner")
+	tenantIdentifier := managementDefaultTenantTestID(testingInstance, router, ownerCookie)
+	saveProviderRequest := authenticatedJSONRequest(
+		http.MethodPut,
+		managementTenantTestPath(tenantIdentifier, "/provider-keys/"+proxy.ProviderNameDeepSeek),
+		managementProviderKeyRequestBody(testingInstance, testManagementDeepSeekKey, proxy.ModelNameDeepSeekV4Flash, ""),
+		ownerCookie,
+	)
+	saveProviderResponse := httptest.NewRecorder()
+	router.ServeHTTP(saveProviderResponse, saveProviderRequest)
+	if saveProviderResponse.Code != http.StatusOK {
+		testingInstance.Fatalf("save DeepSeek provider status=%d body=%q", saveProviderResponse.Code, saveProviderResponse.Body.String())
+	}
+	secret := generateManagementTenantSecret(testingInstance, router, ownerCookie, tenantIdentifier)
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v2?key="+url.QueryEscape(secret)+"&provider="+proxy.ProviderNameDeepSeek,
+		bytes.NewBufferString(`{"messages":[{"role":"user","content":"complete before the deadline"}]}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "1")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusGatewayTimeout || !strings.Contains(response.Body.String(), `"code":"request_timeout"`) {
+		testingInstance.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "partial text") {
+		testingInstance.Fatalf("timeout leaked partial text: %q", response.Body.String())
+	}
+	if upstreamRequestCount != 2 {
+		testingInstance.Fatalf("upstream requests=%d want=2", upstreamRequestCount)
+	}
+
+	type persistedTimeoutUsageEvent struct {
+		StatusCode     int    `gorm:"column:status_code"`
+		Success        bool   `gorm:"column:success"`
+		OutcomeCode    string `gorm:"column:outcome_code"`
+		RequestTokens  int    `gorm:"column:request_tokens"`
+		ResponseTokens int    `gorm:"column:response_tokens"`
+		TotalTokens    int    `gorm:"column:total_tokens"`
+	}
+	database, openError := gorm.Open(sqlite.Open(databasePath), &gorm.Config{})
+	if openError != nil {
+		testingInstance.Fatalf("open usage database: %v", openError)
+	}
+	var usageEvents []persistedTimeoutUsageEvent
+	if queryError := database.
+		Table("managed_usage_event_records").
+		Select("status_code", "success", "outcome_code", "request_tokens", "response_tokens", "total_tokens").
+		Order("id").
+		Find(&usageEvents).
+		Error; queryError != nil {
+		testingInstance.Fatalf("load timeout usage events: %v", queryError)
+	}
+	expectedUsageEvents := []persistedTimeoutUsageEvent{{
+		StatusCode:     http.StatusGatewayTimeout,
+		Success:        false,
+		OutcomeCode:    "request_timeout",
+		RequestTokens:  3,
+		ResponseTokens: 5,
+		TotalTokens:    8,
+	}}
 	if !reflect.DeepEqual(usageEvents, expectedUsageEvents) {
 		testingInstance.Fatalf("usage events=%+v want=%+v", usageEvents, expectedUsageEvents)
 	}

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -120,6 +120,7 @@ func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIK
 type openAIResponseSnapshot struct {
 	identifier            string
 	status                string
+	incompleteReason      string
 	text                  string
 	usage                 *tokenUsage
 	hasFinalMessage       bool
@@ -129,10 +130,15 @@ type openAIResponseSnapshot struct {
 func newOpenAIResponseSnapshot(responseBytes []byte) (openAIResponseSnapshot, error) {
 	var decodedObject map[string]any
 	decodeError := json.Unmarshal(responseBytes, &decodedObject)
+	incompleteReason := constants.EmptyString
+	if incompleteDetails, ok := decodedObject["incomplete_details"].(map[string]any); ok {
+		incompleteReason = utils.GetString(incompleteDetails, "reason")
+	}
 	usage, usageError := parseResponsesTokenUsage(responseBytes)
 	responseSnapshot := openAIResponseSnapshot{
 		identifier:            utils.GetString(decodedObject, jsonFieldID),
 		status:                utils.GetString(decodedObject, jsonFieldStatus),
+		incompleteReason:      incompleteReason,
 		text:                  extractTextFromAny(responseBytes),
 		usage:                 usage,
 		hasFinalMessage:       hasFinalMessage(responseBytes),
@@ -178,18 +184,20 @@ func (client *OpenAIClient) resolveOpenAIResponse(parentContext context.Context,
 		return client.resolveTerminalOpenAIResponse(parentContext, openAIKey, modelIdentifier, webSearchEnabled, maxTokens, reasoningEffort, responseSnapshot, structuredLogger)
 	}
 	if !responseSnapshot.isPending() {
-		return textGenerationResult{usage: responseSnapshot.usage}, errors.New(errorOpenAIAPI)
+		return client.resolveTerminalOpenAIResponse(parentContext, openAIKey, modelIdentifier, webSearchEnabled, maxTokens, reasoningEffort, responseSnapshot, structuredLogger)
 	}
 	if utils.IsBlank(responseSnapshot.identifier) {
 		return textGenerationResult{usage: responseSnapshot.usage}, errors.New(errorOpenAIAPI)
 	}
 	finalGeneration, pollError := client.pollResponseUntilDone(parentContext, openAIKey, responseSnapshot.identifier, responseSnapshot.usage, modelIdentifier, webSearchEnabled, maxTokens, reasoningEffort, structuredLogger)
 	if pollError != nil {
-		structuredLogger.Errorw(
-			logEventOpenAIPollError,
-			logFieldID, responseSnapshot.identifier,
-			constants.LogFieldError, pollError,
-		)
+		if !errors.Is(pollError, errProviderOutputLimitReached) {
+			structuredLogger.Errorw(
+				logEventOpenAIPollError,
+				logFieldID, responseSnapshot.identifier,
+				constants.LogFieldError, pollError,
+			)
+		}
 		return finalGeneration, openAIStageError(pollError)
 	}
 	return finalGeneration, nil
@@ -201,8 +209,13 @@ func (client *OpenAIClient) resolveTerminalOpenAIResponse(parentContext context.
 		return client.resolveCompleteOpenAIResponse(parentContext, openAIKey, modelIdentifier, webSearchEnabled, maxTokens, reasoningEffort, responseSnapshot, structuredLogger)
 	case statusCancelled, statusFailed:
 		return textGenerationResult{usage: responseSnapshot.usage}, errors.New(errorOpenAIFailedStatus)
+	case statusIncomplete:
+		if responseSnapshot.incompleteReason != "max_output_tokens" {
+			return textGenerationResult{usage: responseSnapshot.usage}, fmt.Errorf("%w: Responses incomplete reason=%s", ErrProviderAPI, responseSnapshot.incompleteReason)
+		}
+		return responseSnapshot.generation(), errProviderOutputLimitReached
 	}
-	return textGenerationResult{usage: responseSnapshot.usage}, ErrUpstreamIncomplete
+	return textGenerationResult{usage: responseSnapshot.usage}, errors.New(errorOpenAIAPI)
 }
 
 func (client *OpenAIClient) resolveCompleteOpenAIResponse(parentContext context.Context, openAIKey string, modelIdentifier textModelDefinition, webSearchEnabled bool, maxTokens *int, reasoningEffort string, responseSnapshot openAIResponseSnapshot, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
@@ -220,11 +233,13 @@ func (client *OpenAIClient) resolveCompleteOpenAIResponse(parentContext context.
 		finalGeneration, pollError := client.pollResponseUntilDone(parentContext, openAIKey, continuedResponseID, nil, modelIdentifier, webSearchEnabled, maxTokens, reasoningEffort, structuredLogger)
 		finalGeneration.usage = mergeTokenUsage(responseSnapshot.usage, finalGeneration.usage)
 		if pollError != nil {
-			structuredLogger.Errorw(
-				logEventOpenAIPollError,
-				logFieldID, continuedResponseID,
-				constants.LogFieldError, pollError,
-			)
+			if !errors.Is(pollError, errProviderOutputLimitReached) {
+				structuredLogger.Errorw(
+					logEventOpenAIPollError,
+					logFieldID, continuedResponseID,
+					constants.LogFieldError, pollError,
+				)
+			}
 			return finalGeneration, openAIStageError(pollError)
 		}
 		return finalGeneration, nil
@@ -236,7 +251,7 @@ func (client *OpenAIClient) resolveCompleteOpenAIResponse(parentContext context.
 }
 
 func openAIStageError(stageError error) error {
-	if errors.Is(stageError, context.Canceled) || errors.Is(stageError, context.DeadlineExceeded) || errors.Is(stageError, ErrUpstreamIncomplete) {
+	if errors.Is(stageError, context.Canceled) || errors.Is(stageError, context.DeadlineExceeded) || errors.Is(stageError, errProviderOutputLimitReached) {
 		return stageError
 	}
 	return errors.New(errorOpenAIAPI)
@@ -373,18 +388,17 @@ type searchAction struct {
 	Query string `json:"query"`
 }
 
-// joinParts creates a single string by joining the trimmed text from each
-// provided content part using a line break when multiple parts contain text.
+// joinParts creates a single string from visible content while preserving each
+// part's boundary whitespace for the completion coordinator.
 func joinParts(parts []contentPart) string {
 	var builder strings.Builder
 	for _, part := range parts {
 		if part.Type == outputPartType || part.Type == textPartType {
-			text := strings.TrimSpace(part.Text)
-			if text != constants.EmptyString {
+			if !utils.IsBlank(part.Text) {
 				if builder.Len() > 0 {
 					builder.WriteString(constants.LineBreak)
 				}
-				builder.WriteString(text)
+				builder.WriteString(part.Text)
 			}
 		}
 	}

--- a/internal/proxy/openai_compatible_chat.go
+++ b/internal/proxy/openai_compatible_chat.go
@@ -108,20 +108,23 @@ func parseChatCompletionResponse(responseBytes []byte) (textGenerationResult, er
 	}
 	generation := textGenerationResult{usage: usage}
 	for _, choice := range response.Choices {
-		finishReason := choice.FinishReason
-		if strings.TrimSpace(finishReason) == constants.EmptyString {
+		finishReason := strings.TrimSpace(choice.FinishReason)
+		if finishReason == constants.EmptyString {
 			return generation, fmt.Errorf("%w: chat completion missing finish_reason", ErrProviderAPI)
 		}
+		visibleText := choice.Message.Content
+		if utils.IsBlank(visibleText) {
+			visibleText = choice.Message.ReasoningContent
+		}
+		choiceGeneration := textGenerationResult{text: visibleText, usage: usage}
+		if finishReason == "length" {
+			return choiceGeneration, errProviderOutputLimitReached
+		}
 		if finishReason != finishReasonStop {
-			return generation, fmt.Errorf("%w: chat completion finish_reason=%s", ErrProviderAPI, strings.TrimSpace(finishReason))
+			return generation, fmt.Errorf("%w: chat completion finish_reason=%s", ErrProviderAPI, finishReason)
 		}
-		trimmedContent := strings.TrimSpace(choice.Message.Content)
-		if trimmedContent != constants.EmptyString {
-			return textGenerationResult{text: trimmedContent, usage: usage}, nil
-		}
-		trimmedReasoning := strings.TrimSpace(choice.Message.ReasoningContent)
-		if trimmedReasoning != constants.EmptyString {
-			return textGenerationResult{text: trimmedReasoning, usage: usage}, nil
+		if !utils.IsBlank(visibleText) {
+			return choiceGeneration, nil
 		}
 	}
 	return generation, errors.New(errorProviderNoText)

--- a/internal/proxy/provider_router.go
+++ b/internal/proxy/provider_router.go
@@ -2,9 +2,15 @@ package proxy
 
 import (
 	"context"
+	"errors"
+	"strings"
+	"time"
 
+	"github.com/tyemirov/llm-proxy/internal/utils"
 	"go.uber.org/zap"
 )
+
+const completionContinuationInstruction = "Continue exactly where the previous response stopped. Return only the missing suffix without repeating any completed text."
 
 type providerRouter struct {
 	openAIClient    *OpenAIClient
@@ -23,6 +29,34 @@ func newProviderRouter(openAIClient *OpenAIClient, chatClient *openAICompatibleC
 }
 
 func (router *providerRouter) generateText(requestContext context.Context, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	originalMessages := request.messages
+	accumulatedText := strings.Builder{}
+	var accumulatedUsage *tokenUsage
+	for {
+		generation, generationError := router.generateTextAttempt(requestContext, request, structuredLogger)
+		accumulatedText.WriteString(generation.text)
+		accumulatedUsage = mergeTokenUsage(accumulatedUsage, generation.usage)
+		if !errors.Is(generationError, errProviderOutputLimitReached) {
+			return textGenerationResult{
+				text:  strings.TrimSpace(accumulatedText.String()),
+				usage: accumulatedUsage,
+			}, generationError
+		}
+
+		request.messages = completionContinuationMessages(originalMessages, accumulatedText.String())
+		request.maxTokens = continuationMaxTokens(request.maxTokens, request.model, generation.text)
+		select {
+		case <-time.After(responsePollInterval):
+		case <-requestContext.Done():
+			return textGenerationResult{
+				text:  strings.TrimSpace(accumulatedText.String()),
+				usage: accumulatedUsage,
+			}, requestContext.Err()
+		}
+	}
+}
+
+func (router *providerRouter) generateTextAttempt(requestContext context.Context, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
 	if request.provider.textTransport == textTransportOpenAIResponses {
 		return router.openAIClient.openAIRequest(
 			requestContext,
@@ -67,6 +101,25 @@ func (router *providerRouter) generateText(requestContext context.Context, reque
 		request.provider.chatTokenLimitParameter,
 		structuredLogger,
 	)
+}
+
+func completionContinuationMessages(originalMessages chatMessages, accumulatedText string) chatMessages {
+	continuationMessages := append(chatMessages(nil), originalMessages...)
+	if !utils.IsBlank(accumulatedText) {
+		continuationMessages = append(continuationMessages, chatMessage{role: chatRoleAssistant, content: accumulatedText})
+	}
+	return append(continuationMessages, chatMessage{role: chatRoleUser, content: completionContinuationInstruction})
+}
+
+func continuationMaxTokens(currentMaxTokens *int, model textModelDefinition, latestText string) *int {
+	if !utils.IsBlank(latestText) || !model.hasOutputTokenLimit {
+		return currentMaxTokens
+	}
+	nextMaxTokens := model.outputTokenLimit
+	if currentMaxTokens != nil && *currentMaxTokens < model.outputTokenLimit && *currentMaxTokens <= model.outputTokenLimit/2 {
+		nextMaxTokens = *currentMaxTokens * 2
+	}
+	return &nextMaxTokens
 }
 
 func (router *providerRouter) transcribeAudio(requestContext context.Context, request dictationRequestParameters, structuredLogger *zap.SugaredLogger) (string, error) {

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -101,7 +101,9 @@ func TestProviderRoutingUsesConfiguredOpenAIURLsForTextAndDictation(t *testing.T
 
 func TestProviderRoutingSupportsDeepSeekChatCompletions(t *testing.T) {
 	var capturedPayload map[string]any
+	requestCount := 0
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		requestCount++
 		if request.Method != http.MethodPost {
 			t.Fatalf("method=%s want=%s", request.Method, http.MethodPost)
 		}
@@ -119,6 +121,10 @@ func TestProviderRoutingSupportsDeepSeekChatCompletions(t *testing.T) {
 			t.Fatalf("unmarshal body: %v", unmarshalError)
 		}
 		responseWriter.Header().Set("Content-Type", "application/json")
+		if requestCount == 1 {
+			_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"deepseek partial "},"finish_reason":"length"}]}`))
+			return
+		}
 		_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"deepseek ok"},"finish_reason":"stop"}]}`))
 	}))
 	defer upstreamServer.Close()
@@ -151,14 +157,18 @@ func TestProviderRoutingSupportsDeepSeekChatCompletions(t *testing.T) {
 	if responseRecorder.Code != http.StatusOK {
 		t.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusOK, responseRecorder.Body.String())
 	}
-	if strings.TrimSpace(responseRecorder.Body.String()) != "deepseek ok" {
-		t.Fatalf("body=%q want=%q", responseRecorder.Body.String(), "deepseek ok")
+	if strings.TrimSpace(responseRecorder.Body.String()) != "deepseek partial deepseek ok" {
+		t.Fatalf("body=%q want=%q", responseRecorder.Body.String(), "deepseek partial deepseek ok")
 	}
 	if capturedPayload["model"] != proxy.ModelNameDeepSeekV4Flash {
 		t.Fatalf("model=%v want=%s", capturedPayload["model"], proxy.ModelNameDeepSeekV4Flash)
 	}
 	if _, exists := capturedPayload["max_tokens"]; exists {
 		t.Fatalf("max_tokens must be omitted by default: %v", capturedPayload)
+	}
+	messages, messagesOK := capturedPayload["messages"].([]any)
+	if !messagesOK || len(messages) != 3 {
+		t.Fatalf("continuation messages=%v", capturedPayload["messages"])
 	}
 }
 
@@ -185,7 +195,9 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(subTest *testing.T) {
 			var capturedPayload map[string]any
+			requestCount := 0
 			upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+				requestCount++
 				if request.Method != http.MethodPost {
 					subTest.Fatalf("method=%s want=%s", request.Method, http.MethodPost)
 				}
@@ -203,6 +215,10 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 					subTest.Fatalf("unmarshal body: %v", unmarshalError)
 				}
 				responseWriter.Header().Set("Content-Type", "application/json")
+				if requestCount == 1 {
+					_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"catalog partial "},"finish_reason":"length"}]}`))
+					return
+				}
 				_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"current compatible model ok"},"finish_reason":"stop"}]}`))
 			}))
 			subTest.Cleanup(upstreamServer.Close)
@@ -246,6 +262,12 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 			if responseRecorder.Code != http.StatusOK {
 				subTest.Fatalf("status=%d want=%d body=%s", responseRecorder.Code, http.StatusOK, responseRecorder.Body.String())
 			}
+			if responseRecorder.Body.String() != "catalog partial current compatible model ok" {
+				subTest.Fatalf("body=%q", responseRecorder.Body.String())
+			}
+			if requestCount != 2 {
+				subTest.Fatalf("upstream requests=%d want=2", requestCount)
+			}
 			if capturedPayload["model"] != testCase.model {
 				subTest.Fatalf("model=%v want=%s", capturedPayload["model"], testCase.model)
 			}
@@ -256,6 +278,10 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 				if _, present := capturedPayload[forbiddenField]; present {
 					subTest.Fatalf("payload unexpectedly contained %s: %v", forbiddenField, capturedPayload)
 				}
+			}
+			messages, messagesOK := capturedPayload["messages"].([]any)
+			if !messagesOK || len(messages) != 3 {
+				subTest.Fatalf("continuation messages=%v", capturedPayload["messages"])
 			}
 		})
 	}
@@ -366,6 +392,10 @@ func TestProviderRoutingSupportsMetaMuseSparkAcrossPublicTextEndpoints(t *testin
 		}
 		capturedRequests = append(capturedRequests, capturedMetaRequest{payload: payload})
 		responseWriter.Header().Set("Content-Type", "application/json")
+		if len(capturedRequests)%2 == 1 {
+			_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"meta partial "},"finish_reason":"length"}]}`))
+			return
+		}
 		_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"meta ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}`))
 	}))
 	defer upstreamServer.Close()
@@ -446,7 +476,7 @@ func TestProviderRoutingSupportsMetaMuseSparkAcrossPublicTextEndpoints(t *testin
 			if decodeError := json.Unmarshal(responseRecorder.Body.Bytes(), &response); decodeError != nil {
 				subTest.Fatalf("decode response: %v", decodeError)
 			}
-			if response.Model != proxy.ModelNameMuseSpark11 || response.Response != "meta ok" {
+			if response.Model != proxy.ModelNameMuseSpark11 || response.Response != "meta partial meta ok" {
 				subTest.Fatalf("response=%+v", response)
 			}
 			if response.Usage.RequestTokens != 11 || response.Usage.ResponseTokens != 7 || response.Usage.TotalTokens != 18 {
@@ -455,26 +485,41 @@ func TestProviderRoutingSupportsMetaMuseSparkAcrossPublicTextEndpoints(t *testin
 		})
 	}
 
-	if len(capturedRequests) != len(testCases) {
-		t.Fatalf("captured requests=%d want=%d", len(capturedRequests), len(testCases))
+	if len(capturedRequests) != len(testCases)*2 {
+		t.Fatalf("captured requests=%d want=%d", len(capturedRequests), len(testCases)*2)
 	}
-	for requestIndex, capturedRequest := range capturedRequests {
-		if capturedRequest.payload["model"] != proxy.ModelNameMuseSpark11 {
-			t.Fatalf("request %d model=%v want=%s", requestIndex, capturedRequest.payload["model"], proxy.ModelNameMuseSpark11)
+	for testCaseIndex, testCase := range testCases {
+		initialRequest := capturedRequests[testCaseIndex*2]
+		continuationRequest := capturedRequests[testCaseIndex*2+1]
+		for requestIndex, capturedRequest := range []capturedMetaRequest{initialRequest, continuationRequest} {
+			if capturedRequest.payload["model"] != proxy.ModelNameMuseSpark11 {
+				t.Fatalf("request %d.%d model=%v want=%s", testCaseIndex, requestIndex, capturedRequest.payload["model"], proxy.ModelNameMuseSpark11)
+			}
+			if capturedRequest.payload["max_completion_tokens"] != float64(321) {
+				t.Fatalf("request %d.%d max_completion_tokens=%v", testCaseIndex, requestIndex, capturedRequest.payload["max_completion_tokens"])
+			}
+			if _, deprecatedFieldPresent := capturedRequest.payload["max_tokens"]; deprecatedFieldPresent {
+				t.Fatalf("request %d.%d must not use deprecated Meta max_tokens: %v", testCaseIndex, requestIndex, capturedRequest.payload)
+			}
 		}
-		if capturedRequest.payload["max_completion_tokens"] != float64(321) {
-			t.Fatalf("request %d max_completion_tokens=%v", requestIndex, capturedRequest.payload["max_completion_tokens"])
+		initialMessages, initialMessagesOK := initialRequest.payload["messages"].([]any)
+		if !initialMessagesOK || len(initialMessages) != 1 {
+			t.Fatalf("request %d initial messages=%v", testCaseIndex, initialRequest.payload["messages"])
 		}
-		if _, deprecatedFieldPresent := capturedRequest.payload["max_tokens"]; deprecatedFieldPresent {
-			t.Fatalf("request %d must not use deprecated Meta max_tokens: %v", requestIndex, capturedRequest.payload)
+		initialMessage, initialMessageOK := initialMessages[0].(map[string]any)
+		if !initialMessageOK || initialMessage["role"] != "user" || initialMessage["content"] != testCase.expectedPrompt {
+			t.Fatalf("request %d initial message=%v", testCaseIndex, initialMessages[0])
 		}
-		messages, messagesOK := capturedRequest.payload["messages"].([]any)
-		if !messagesOK || len(messages) != 1 {
-			t.Fatalf("request %d messages=%v", requestIndex, capturedRequest.payload["messages"])
+		continuationMessages, continuationMessagesOK := continuationRequest.payload["messages"].([]any)
+		if !continuationMessagesOK || len(continuationMessages) != 3 {
+			t.Fatalf("request %d continuation messages=%v", testCaseIndex, continuationRequest.payload["messages"])
 		}
-		message, messageOK := messages[0].(map[string]any)
-		if !messageOK || message["role"] != "user" || message["content"] != testCases[requestIndex].expectedPrompt {
-			t.Fatalf("request %d message=%v", requestIndex, messages[0])
+		assistantMessage, assistantMessageOK := continuationMessages[1].(map[string]any)
+		instructionMessage, instructionMessageOK := continuationMessages[2].(map[string]any)
+		instructionContent, instructionContentOK := instructionMessage["content"].(string)
+		if !assistantMessageOK || assistantMessage["role"] != "assistant" || assistantMessage["content"] != "meta partial " ||
+			!instructionMessageOK || instructionMessage["role"] != "user" || !instructionContentOK || !strings.Contains(instructionContent, "missing suffix") {
+			t.Fatalf("request %d continuation transcript=%v", testCaseIndex, continuationMessages)
 		}
 	}
 }
@@ -1015,6 +1060,59 @@ func TestProviderRoutingSupportsGeminiGenerateContent(t *testing.T) {
 	}
 	assertGeminiContentsOmitThought(t, capturedPayload["contents"])
 	assertGeminiContentOmitsThought(t, capturedPayload["systemInstruction"], "systemInstruction")
+}
+
+func TestProviderRoutingIncreasesKnownGeminiBudgetAfterEmptyMaxTokensResponse(t *testing.T) {
+	var capturedPayloads []map[string]any
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		requestBytes, _ := io.ReadAll(request.Body)
+		var payload map[string]any
+		_ = json.Unmarshal(requestBytes, &payload)
+		capturedPayloads = append(capturedPayloads, payload)
+		responseWriter.Header().Set("Content-Type", "application/json")
+		if len(capturedPayloads) == 1 {
+			_, _ = responseWriter.Write([]byte(`{"candidates":[{"finishReason":"MAX_TOKENS","content":{"parts":[]}}]}`))
+			return
+		}
+		_, _ = responseWriter.Write([]byte(`{"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"gemini recovered"}]}}]}`))
+	}))
+	defer upstreamServer.Close()
+
+	router, buildError := buildRouterWithCatalogs(t, proxy.Configuration{
+		Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+		OpenAIKey:             TestAPIKey,
+		GeminiKey:             testGeminiKey,
+		GeminiBaseURL:         upstreamServer.URL,
+		LogLevel:              proxy.LogLevelInfo,
+		WorkerCount:           1,
+		QueueSize:             1,
+		RequestTimeoutSeconds: TestTimeout,
+	}, zap.NewNop().Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/?key="+TestSecret+"&prompt=hello&provider="+proxy.ProviderNameGemini+"&model="+proxy.ModelNameGemini25Flash+"&max_tokens=1000",
+		nil,
+	)
+	responseRecorder := httptest.NewRecorder()
+	router.ServeHTTP(responseRecorder, request)
+	if responseRecorder.Code != http.StatusOK || responseRecorder.Body.String() != "gemini recovered" {
+		t.Fatalf("status=%d body=%q", responseRecorder.Code, responseRecorder.Body.String())
+	}
+	if len(capturedPayloads) != 2 {
+		t.Fatalf("payloads=%d want=2", len(capturedPayloads))
+	}
+	generationConfig, generationConfigOK := capturedPayloads[1]["generationConfig"].(map[string]any)
+	if !generationConfigOK || generationConfig["maxOutputTokens"] != float64(2000) {
+		t.Fatalf("continuation generationConfig=%v", capturedPayloads[1]["generationConfig"])
+	}
+	contents, contentsOK := capturedPayloads[1]["contents"].([]any)
+	if !contentsOK || len(contents) != 2 {
+		t.Fatalf("continuation contents=%v", capturedPayloads[1]["contents"])
+	}
 }
 
 func TestProviderRoutingUsesGeminiDefaultModelForJSONPosts(t *testing.T) {
@@ -2015,7 +2113,7 @@ func TestProviderRoutingMapsGeminiProviderErrors(t *testing.T) {
 		{name: "malformed json", statusCode: http.StatusOK, body: `{`, wantStatus: http.StatusBadGateway},
 		{name: "negative usage", statusCode: http.StatusOK, body: `{"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"bad usage"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":-1}}`, wantStatus: http.StatusBadGateway},
 		{name: "missing finish reason", statusCode: http.StatusOK, body: `{"candidates":[{"content":{"parts":[{"text":"unfinished text"}]}}]}`, wantStatus: http.StatusBadGateway},
-		{name: "max tokens finish reason", statusCode: http.StatusOK, body: `{"candidates":[{"finishReason":"MAX_TOKENS","content":{"parts":[{"text":"partial text"}]}}]}`, wantStatus: http.StatusBadGateway},
+		{name: "safety finish reason", statusCode: http.StatusOK, body: `{"candidates":[{"finishReason":"SAFETY","content":{"parts":[{"text":"filtered text"}]}}]}`, wantStatus: http.StatusBadGateway},
 		{name: "missing text", statusCode: http.StatusOK, body: `{"candidates":[{"finishReason":"STOP","content":{"parts":[{}]}}]}`, wantStatus: http.StatusBadGateway},
 	}
 	for _, testCase := range testCases {
@@ -2124,7 +2222,7 @@ func TestProviderRoutingMapsAnthropicProviderErrors(t *testing.T) {
 		{name: "malformed json", statusCode: http.StatusOK, body: `{`, wantStatus: http.StatusBadGateway},
 		{name: "negative usage", statusCode: http.StatusOK, body: `{"content":[{"type":"text","text":"bad usage"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":-1}}`, wantStatus: http.StatusBadGateway},
 		{name: "missing stop reason", statusCode: http.StatusOK, body: `{"content":[{"type":"text","text":"unfinished text"}]}`, wantStatus: http.StatusBadGateway},
-		{name: "max tokens stop reason", statusCode: http.StatusOK, body: `{"content":[{"type":"text","text":"partial text"}],"stop_reason":"max_tokens"}`, wantStatus: http.StatusBadGateway},
+		{name: "refusal stop reason", statusCode: http.StatusOK, body: `{"content":[{"type":"text","text":"refused text"}],"stop_reason":"refusal"}`, wantStatus: http.StatusBadGateway},
 		{name: "paused turn stop reason", statusCode: http.StatusOK, body: `{"content":[{"type":"text","text":"intermediate text"}],"stop_reason":"pause_turn"}`, wantStatus: http.StatusBadGateway},
 		{name: "missing text", statusCode: http.StatusOK, body: `{"content":[{"type":"tool_use","text":"not visible"}],"stop_reason":"end_turn"}`, wantStatus: http.StatusBadGateway},
 	}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -500,7 +500,7 @@ func submitChatRequest(ginContext *gin.Context, upstreamProviders *providerRoute
 	generation, requestError := upstreamProviders.generateText(ginContext.Request.Context(), chatRequest, structuredLogger)
 	if requestError != nil {
 		if requestContextEnded(ginContext) {
-			recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
+			recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), generation.usage, requestStart)
 			return
 		}
 		markRequestOutcome(ginContext, requestFailureOutcome(requestError), managedRequestFailureOutcome(requestError))
@@ -510,7 +510,7 @@ func submitChatRequest(ginContext *gin.Context, upstreamProviders *providerRoute
 		return
 	}
 	if requestContextEnded(ginContext) {
-		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
+		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), generation.usage, requestStart)
 		return
 	}
 	completeChatRequest(ginContext, chatRequest, generation, requestTenant, usageEndpoint, managedTenants, structuredLogger, requestStart)
@@ -520,7 +520,7 @@ func completeChatRequest(ginContext *gin.Context, chatRequest chatRequestParamet
 	mime := preferredMime(ginContext)
 	formattedBody, contentType := formatResponse(generation.text, mime, chatRequest, generation.usage)
 	if requestContextEnded(ginContext) {
-		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), nil, requestStart)
+		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpoint, chatRequest.provider.identifier.string(), chatRequest.model.string(), ginContext.Writer.Status(), generation.usage, requestStart)
 		return
 	}
 	markRequestOutcome(ginContext, requestOutcomeSuccess, managedUsageOutcomeSuccess)

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -363,7 +363,7 @@ func TestChatHandlerAcceptsMessagesJSONBodyForOpenAIResponses(testingInstance *t
 	}
 }
 
-func TestChatHandlerRejectsIncompleteGPT55JSONBody(testingInstance *testing.T) {
+func TestChatHandlerCompletesIncompleteGPT55JSONBody(testingInstance *testing.T) {
 	const incompleteResponseID = "resp_incomplete_gpt55"
 
 	var capturedPayloads []map[string]any
@@ -379,7 +379,11 @@ func TestChatHandlerRejectsIncompleteGPT55JSONBody(testingInstance *testing.T) {
 				testingInstance.Fatalf("unmarshal request body: %v", unmarshalError)
 			}
 			capturedPayloads = append(capturedPayloads, capturedPayload)
-			_, _ = responseWriter.Write([]byte(`{"id":"` + incompleteResponseID + `","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial answer"}]}]}`))
+			if len(capturedPayloads) == 1 {
+				_, _ = responseWriter.Write([]byte(`{"id":"` + incompleteResponseID + `","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial answer"}]}]}`))
+				return
+			}
+			_, _ = responseWriter.Write([]byte(`{"id":"resp_complete_gpt55","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":" recovered suffix"}]}]}`))
 			return
 		}
 		http.NotFound(responseWriter, httpRequest)
@@ -410,17 +414,20 @@ func TestChatHandlerRejectsIncompleteGPT55JSONBody(testingInstance *testing.T) {
 
 	router.ServeHTTP(responseRecorder, request)
 
-	if responseRecorder.Code != http.StatusBadGateway || responseRecorder.Body.String() != proxy.ErrUpstreamIncomplete.Error() {
+	if responseRecorder.Code != http.StatusOK || responseRecorder.Body.String() != "partial answer recovered suffix" {
 		testingInstance.Fatalf("status=%d body=%q", responseRecorder.Code, responseRecorder.Body.String())
 	}
-	if len(capturedPayloads) != 1 {
-		testingInstance.Fatalf("payloads=%d want=1", len(capturedPayloads))
+	if len(capturedPayloads) != 2 {
+		testingInstance.Fatalf("payloads=%d want=2", len(capturedPayloads))
 	}
 	if capturedPayloads[0]["model"] != proxy.ModelNameGPT55 {
 		testingInstance.Fatalf("initial model=%v want=%s", capturedPayloads[0]["model"], proxy.ModelNameGPT55)
 	}
-	if strings.Contains(responseRecorder.Body.String(), "partial answer") {
-		testingInstance.Fatalf("partial response leaked: %q", responseRecorder.Body.String())
+	continuationInput, continuationInputOK := capturedPayloads[1]["input"].(string)
+	if !continuationInputOK ||
+		!strings.Contains(continuationInput, "assistant:\npartial answer") ||
+		!strings.Contains(continuationInput, "Return only the missing suffix") {
+		testingInstance.Fatalf("continuation input=%v", capturedPayloads[1]["input"])
 	}
 }
 

--- a/scripts/live_test.sh
+++ b/scripts/live_test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly PRODUCTION_API_ORIGIN="https://llm-proxy-api.mprlab.com"
+readonly ECHO_REQUEST_TIMEOUT_SECONDS=90
+readonly ECHO_CURL_TIMEOUT_SECONDS=120
+readonly LONG_COMPLETION_REQUEST_TIMEOUT_SECONDS=900
+readonly LONG_COMPLETION_CURL_TIMEOUT_SECONDS=930
+readonly CURL_CONNECT_TIMEOUT_SECONDS=15
+readonly ECHO_RESPONSE_MARKER="LLM_PROXY_LIVE_ECHO_OK"
+readonly LONG_COMPLETION_RESPONSE_MARKER="LLM_PROXY_LIVE_COMPLEX_OK"
+readonly LONG_COMPLETION_MAX_TOKENS=512
+readonly LONG_COMPLETION_MINIMUM_REQUEST_BYTES=16384
+
+LIVE_TEST_PROVIDERS=(openai anthropic meta gemini moonshot)
+LONG_COMPLETION_PROVIDERS=(openai anthropic meta)
+TEMPORARY_DIRECTORY=""
+ENCODED_TENANT_SECRET=""
+
+usage() {
+  builtin printf '%s\n' \
+    'Usage: make live-test' \
+    '' \
+    'Runs paid production requests against the Default tenant at https://llm-proxy-api.mprlab.com.' \
+    'Requires only LLM_PROXY_SECRET, the Default-tenant client secret.' \
+    'It never loads dotenv files or local upstream-provider credentials.' \
+    '' \
+    'The command sends one echo-marker request to OpenAI, Anthropic, Meta, Gemini, and Moonshot,' \
+    'then sends matching large-completion requests through OpenAI, Anthropic, and Meta.' \
+    'OpenAI waits for server-owned background polling; Anthropic and Meta exercise long synchronous completion.'
+}
+
+fail() {
+  builtin printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+cleanup() {
+  local exit_status=$?
+  trap - EXIT HUP INT TERM
+  if [[ -n "${TEMPORARY_DIRECTORY}" && -d "${TEMPORARY_DIRECTORY}" ]]; then
+    rm -rf "${TEMPORARY_DIRECTORY}"
+  fi
+  exit "${exit_status}"
+}
+
+encode_tenant_secret() {
+  printf '%s' "${LLM_PROXY_SECRET}" | python3 -c 'import sys; from urllib.parse import quote; print(quote(sys.stdin.read(), safe=""), end="")'
+}
+
+build_echo_request() {
+  builtin printf '%s' '{"messages":[{"role":"user","content":"Reply with exactly LLM_PROXY_LIVE_ECHO_OK and no other text."}]}'
+}
+
+build_long_completion_request() {
+  python3 -c '
+import json
+import sys
+
+marker = "LLM_PROXY_LIVE_COMPLEX_OK"
+regions = ("north", "south", "east", "west")
+channels = ("direct", "partner", "self-serve", "enterprise")
+records = []
+for record_index in range(1, 121):
+    records.append(
+        "Portfolio {index:03d}: region={region}; channel={channel}; baseline={baseline}; "
+        "forecast={forecast}; risk={risk}; dependency={dependency}; required_control={control}.".format(
+            index=record_index,
+            region=regions[record_index % len(regions)],
+            channel=channels[record_index % len(channels)],
+            baseline=120 + ((record_index * 37) % 880),
+            forecast=140 + ((record_index * 53) % 1040),
+            risk=("low", "medium", "high")[record_index % 3],
+            dependency=("legal", "security", "data", "operations")[record_index % 4],
+            control=("two-person review", "rollback plan", "access review", "budget cap")[record_index % 4],
+        )
+    )
+prompt = "\n".join(
+    (
+        "Inspect every record in the complete fictional portfolio below.",
+        "For every record, emit one normalized line containing its portfolio number, region, channel, baseline,",
+        "forecast, risk, dependency, and required control. Do not omit, combine, or summarize any record.",
+        "After all 120 normalized lines, calculate the total forecast uplift for records where region is north and",
+        "risk is high, then count records where dependency is security and forecast is below 600. End with exactly " +
+        marker + " followed by the two integer results separated by a single comma. Do not include any other summary.",
+        "",
+        "\n".join(records),
+    )
+)
+payload = {
+    "messages": [
+        {
+            "role": "system",
+            "content": "You are a meticulous program analyst. Follow the user response-format instruction exactly.",
+        },
+        {"role": "user", "content": prompt},
+    ],
+    "max_tokens": int(sys.argv[1]),
+}
+print(json.dumps(payload, separators=(",", ":")))
+' "${LONG_COMPLETION_MAX_TOKENS}"
+}
+
+write_curl_config() {
+  local provider_identifier="$1"
+  local curl_config_path="$2"
+  builtin printf 'url = "%s/v2?provider=%s&format=text%%2Fplain&key=%s"\n' \
+    "${PRODUCTION_API_ORIGIN}" \
+    "${provider_identifier}" \
+    "${ENCODED_TENANT_SECRET}" >"${curl_config_path}"
+}
+
+response_size() {
+  local response_path="$1"
+  if [[ ! -f "${response_path}" ]]; then
+    builtin printf '%s' '0'
+    return
+  fi
+  wc -c <"${response_path}" | tr -d '[:space:]'
+}
+
+has_expected_timeout_header() {
+  local headers_path="$1"
+  local request_timeout_seconds="$2"
+  [[ -f "${headers_path}" ]] || return 1
+  tr -d '\r' <"${headers_path}" | grep -Eiq "^X-LLM-Proxy-Request-Timeout-Seconds:[[:space:]]*${request_timeout_seconds}[[:space:]]*$"
+}
+
+run_live_case() {
+  local case_identifier="$1"
+  local provider_identifier="$2"
+  local request_body="$3"
+  local expected_marker="$4"
+  local request_timeout_seconds="$5"
+  local curl_timeout_seconds="$6"
+  local curl_config_path="${TEMPORARY_DIRECTORY}/${case_identifier}.curl"
+  local headers_path="${TEMPORARY_DIRECTORY}/${case_identifier}.headers"
+  local response_path="${TEMPORARY_DIRECTORY}/${case_identifier}.response"
+  local http_status=""
+  local response_bytes
+
+  write_curl_config "${provider_identifier}" "${curl_config_path}"
+  if ! http_status="$(
+    printf '%s' "${request_body}" | curl \
+      --silent \
+      --show-error \
+      --config "${curl_config_path}" \
+      --request POST \
+      --header 'Content-Type: application/json' \
+      --header "X-LLM-Proxy-Request-Timeout-Seconds: ${request_timeout_seconds}" \
+      --connect-timeout "${CURL_CONNECT_TIMEOUT_SECONDS}" \
+      --max-time "${curl_timeout_seconds}" \
+      --dump-header "${headers_path}" \
+      --output "${response_path}" \
+      --write-out '%{http_code}' \
+      --data-binary @-
+  )"; then
+    response_bytes="$(response_size "${response_path}")"
+    builtin printf 'live test failed: case=%s provider=%s transport_error response_bytes=%s\n' \
+      "${case_identifier}" "${provider_identifier}" "${response_bytes}" >&2
+    return 1
+  fi
+
+  response_bytes="$(response_size "${response_path}")"
+  if [[ "${http_status}" != '200' ]]; then
+    builtin printf 'live test failed: case=%s provider=%s status=%s response_bytes=%s\n' \
+      "${case_identifier}" "${provider_identifier}" "${http_status}" "${response_bytes}" >&2
+    return 1
+  fi
+  if ! has_expected_timeout_header "${headers_path}" "${request_timeout_seconds}"; then
+    builtin printf 'live test failed: case=%s provider=%s status=%s response_bytes=%s missing_timeout_header\n' \
+      "${case_identifier}" "${provider_identifier}" "${http_status}" "${response_bytes}" >&2
+    return 1
+  fi
+  if [[ ! -f "${response_path}" ]] || ! grep -Fq "${expected_marker}" "${response_path}"; then
+    builtin printf 'live test failed: case=%s provider=%s status=%s response_bytes=%s missing_response_marker\n' \
+      "${case_identifier}" "${provider_identifier}" "${http_status}" "${response_bytes}" >&2
+    return 1
+  fi
+
+  builtin printf 'live test passed: case=%s provider=%s status=%s response_bytes=%s\n' \
+    "${case_identifier}" "${provider_identifier}" "${http_status}" "${response_bytes}"
+}
+
+if [[ "${1:-}" == '--help' || "${1:-}" == '-h' ]]; then
+  usage
+  exit 0
+fi
+if [[ $# -ne 0 ]]; then
+  usage >&2
+  fail 'make live-test accepts no arguments'
+fi
+if [[ -z "${LLM_PROXY_SECRET:-}" ]]; then
+  fail 'LLM_PROXY_SECRET must contain the Default-tenant client secret'
+fi
+command -v curl >/dev/null 2>&1 || fail 'curl is required for make live-test'
+command -v python3 >/dev/null 2>&1 || fail 'python3 is required for make live-test'
+
+umask 077
+TEMPORARY_DIRECTORY="$(mktemp -d)"
+trap cleanup EXIT HUP INT TERM
+ENCODED_TENANT_SECRET="$(encode_tenant_secret)"
+
+echo_request_body="$(build_echo_request)"
+long_completion_request_body="$(build_long_completion_request)"
+if [[ "$(printf '%s' "${long_completion_request_body}" | wc -c | tr -d '[:space:]')" -lt "${LONG_COMPLETION_MINIMUM_REQUEST_BYTES}" ]]; then
+  fail 'large completion request did not meet the minimum request size'
+fi
+
+failed_case_count=0
+for provider_identifier in "${LIVE_TEST_PROVIDERS[@]}"; do
+  if ! run_live_case \
+    "${provider_identifier}-echo" \
+    "${provider_identifier}" \
+    "${echo_request_body}" \
+    "${ECHO_RESPONSE_MARKER}" \
+    "${ECHO_REQUEST_TIMEOUT_SECONDS}" \
+    "${ECHO_CURL_TIMEOUT_SECONDS}"; then
+    failed_case_count=$((failed_case_count + 1))
+  fi
+done
+for provider_identifier in "${LONG_COMPLETION_PROVIDERS[@]}"; do
+  case_identifier="${provider_identifier}-long-completion"
+  if [[ "${provider_identifier}" == 'openai' ]]; then
+    case_identifier='openai-background-polling'
+  fi
+  if ! run_live_case \
+    "${case_identifier}" \
+    "${provider_identifier}" \
+    "${long_completion_request_body}" \
+    "${LONG_COMPLETION_RESPONSE_MARKER}" \
+    "${LONG_COMPLETION_REQUEST_TIMEOUT_SECONDS}" \
+    "${LONG_COMPLETION_CURL_TIMEOUT_SECONDS}"; then
+    failed_case_count=$((failed_case_count + 1))
+  fi
+done
+
+if [[ "${failed_case_count}" -ne 0 ]]; then
+  builtin printf 'live test failed: failed_cases=%s total_cases=%s\n' \
+    "${failed_case_count}" \
+    "$(( ${#LIVE_TEST_PROVIDERS[@]} + ${#LONG_COMPLETION_PROVIDERS[@]} ))" >&2
+  exit 1
+fi
+builtin printf 'live test passed: total_cases=%s\n' \
+  "$(( ${#LIVE_TEST_PROVIDERS[@]} + ${#LONG_COMPLETION_PROVIDERS[@]} ))"

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,12 +6,12 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="796cff4216584bde8fb94cdadee195a0e715d3590a43f407c0f7ba60708b5c78">
+    <meta name="openapi-source-sha256" content="1bee45874dabc4db17f29ebd269419a55e4c2208c923b2773d1cd330055b55cf">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="796cff4216584bde8fb94cdadee195a0e715d3590a43f407c0f7ba60708b5c78">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="1bee45874dabc4db17f29ebd269419a55e4c2208c923b2773d1cd330055b55cf">
     <header class="resource-shell resource-topbar">
       <a class="resource-brand" href="/">LLM Proxy</a>
       <nav aria-label="API reference navigation">
@@ -29,7 +29,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>796cff4216584bde8fb94cdadee195a0e715d3590a43f407c0f7ba60708b5c78</code></span>
+          <span>Source SHA-256 <code>1bee45874dabc4db17f29ebd269419a55e4c2208c923b2773d1cd330055b55cf</code></span>
         </div>
         <div class="resource-actions">
           <a class="resource-button" href="/openapi.yaml">Download exact schema</a>
@@ -81,7 +81,7 @@
 <tr><td><code>model</code></td><td>query</td><td>No</td><td>string</td><td>Model identifier. Omission uses the resolved provider default.</td></tr>
 <tr><td><code>web_search</code></td><td>query</td><td>No</td><td>string</td><td>Boolean-like query value accepted by the legacy query operation.</td></tr>
 <tr><td><code>system_prompt</code></td><td>query</td><td>No</td><td>string</td><td></td></tr>
-<tr><td><code>max_tokens</code></td><td>query</td><td>No</td><td>integer</td><td></td></tr>
+<tr><td><code>max_tokens</code></td><td>query</td><td>No</td><td>integer</td><td>Initial per-attempt output budget. The same budget is reused when the proxy requests a missing suffix; after a zero-text output-budget stop, a configured model output limit bounds any generic increase.</td></tr>
 <tr><td><code>reasoning_effort</code></td><td>query</td><td>No</td><td>string</td><td>Non-blank effort supported by the resolved route. Omission selects the tenant or route default.</td></tr>
 <tr><td><code>format</code></td><td>query</td><td>No</td><td>string</td><td>Preferred response media type. Unknown values select text/plain.</td></tr>
 <tr><td><code>Accept</code></td><td>header</td><td>No</td><td>string</td><td>Response media preference used when format is omitted.</td></tr>
@@ -97,12 +97,12 @@
             <table>
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
-                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. HTTP 200 requires the selected transport&#39;s canonical completion signal: OpenAI Responses status=completed, OpenAI-compatible Chat Completions finish_reason=stop, Gemini finishReason=STOP, or Anthropic stop_reason=end_turn|stop_sequence. Incomplete, intermediate, missing, or unknown provider states never return text as success.</td></tr>
+                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
 <tr><td><code>429</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider is rate limited.</td></tr>
 <tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
-<tr><td><code>502</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider failed or returned an incomplete, intermediate, missing, or unknown completion signal. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.</td></tr>
+<tr><td><code>502</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider failed or returned a nonrecoverable completion signal. Output-budget stops are continued internally and do not create this response. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.</td></tr>
 <tr><td><code>503</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected provider is not configured or the bounded request queue is full.</td></tr>
 <tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>
               </tbody>
@@ -145,7 +145,7 @@
 <tr><td><code>model</code></td><td>No</td><td>string</td><td></td></tr>
 <tr><td><code>web_search</code></td><td>No</td><td>boolean</td><td></td></tr>
 <tr><td><code>system_prompt</code></td><td>No</td><td>string</td><td></td></tr>
-<tr><td><code>max_tokens</code></td><td>No</td><td>integer</td><td></td></tr>
+<tr><td><code>max_tokens</code></td><td>No</td><td>integer</td><td>Initial per-attempt output budget. Reused for missing-suffix attempts, with any zero-progress increase bounded by the configured model output limit.</td></tr>
 <tr><td><code>reasoning_effort</code></td><td>No</td><td>string</td><td></td></tr>
               </tbody>
             </table>
@@ -157,13 +157,13 @@
             <table>
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
-                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. HTTP 200 requires the selected transport&#39;s canonical completion signal: OpenAI Responses status=completed, OpenAI-compatible Chat Completions finish_reason=stop, Gemini finishReason=STOP, or Anthropic stop_reason=end_turn|stop_sequence. Incomplete, intermediate, missing, or unknown provider states never return text as success.</td></tr>
+                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
 <tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured prompt or audio payload limit was exceeded.</td></tr>
 <tr><td><code>429</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider is rate limited.</td></tr>
 <tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
-<tr><td><code>502</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider failed or returned an incomplete, intermediate, missing, or unknown completion signal. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.</td></tr>
+<tr><td><code>502</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider failed or returned a nonrecoverable completion signal. Output-budget stops are continued internally and do not create this response. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.</td></tr>
 <tr><td><code>503</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected provider is not configured or the bounded request queue is full.</td></tr>
 <tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>
               </tbody>
@@ -878,7 +878,7 @@
 <tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured prompt or audio payload limit was exceeded.</td></tr>
 <tr><td><code>429</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider is rate limited.</td></tr>
 <tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
-<tr><td><code>502</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider failed or returned an incomplete, intermediate, missing, or unknown completion signal. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.</td></tr>
+<tr><td><code>502</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider failed or returned a nonrecoverable completion signal. Output-budget stops are continued internally and do not create this response. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.</td></tr>
 <tr><td><code>503</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected provider is not configured or the bounded request queue is full.</td></tr>
 <tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>
               </tbody>
@@ -919,7 +919,7 @@
                 <tr><td><code>messages</code></td><td>Yes</td><td>array&lt;ChatMessage&gt;</td><td>All messages must have an allowed role and non-blank content, include at least one user message, and either all omit order or all provide unique non-negative order values.</td></tr>
 <tr><td><code>model</code></td><td>No</td><td>string</td><td>Omission selects the resolved provider default.</td></tr>
 <tr><td><code>web_search</code></td><td>No</td><td>boolean</td><td>The resolved route must declare web-search capability when true.</td></tr>
-<tr><td><code>max_tokens</code></td><td>No</td><td>integer</td><td></td></tr>
+<tr><td><code>max_tokens</code></td><td>No</td><td>integer</td><td>Initial per-attempt output budget. Reused for missing-suffix attempts, with any zero-progress increase bounded by the configured model output limit.</td></tr>
 <tr><td><code>reasoning_effort</code></td><td>No</td><td>string</td><td>Omission selects the tenant or route default. An explicit value must be non-blank and supported by the resolved provider/model route.</td></tr>
               </tbody>
             </table>
@@ -931,13 +931,13 @@
             <table>
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
-                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. HTTP 200 requires the selected transport&#39;s canonical completion signal: OpenAI Responses status=completed, OpenAI-compatible Chat Completions finish_reason=stop, Gemini finishReason=STOP, or Anthropic stop_reason=end_turn|stop_sequence. Incomplete, intermediate, missing, or unknown provider states never return text as success.</td></tr>
+                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
 <tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured prompt or audio payload limit was exceeded.</td></tr>
 <tr><td><code>429</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider is rate limited.</td></tr>
 <tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
-<tr><td><code>502</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider failed or returned an incomplete, intermediate, missing, or unknown completion signal. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.</td></tr>
+<tr><td><code>502</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected upstream provider failed or returned a nonrecoverable completion signal. Output-budget stops are continued internally and do not create this response. The response never exposes partial generated text, token-count headers, or the raw provider body; provider-reported usage can still be retained in managed failure accounting.</td></tr>
 <tr><td><code>503</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected provider is not configured or the bounded request queue is full.</td></tr>
 <tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>
               </tbody>

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -57,6 +58,7 @@ func TestOperationalHelpCommandsUseBuiltinOutput(testingInstance *testing.T) {
 	}{
 		{name: "deploy", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "deploy.sh"), expectedFragment: "scripts/deploy.sh [options]"},
 		{name: "live-providers", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), expectedFragment: "scripts/test_live_providers.sh [--preflight | --write-config <path>]"},
+		{name: "production-live-test", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "live_test.sh"), expectedFragment: "Usage: make live-test"},
 		{name: "deploy-pages", path: filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "deploy_pages_artifact.sh"), expectedFragment: "deploy_pages_artifact.sh --url <public-url> [options]"},
 		{name: "prepare-container", path: filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "prepare_container_artifact.sh"), expectedFragment: "prepare_container_artifact.sh --name <name> --image <registry/repository> [options]"},
 		{name: "prepare-pages", path: filepath.Join(repositoryRoot, operationalReleaseToolsRelative, "scripts", "prepare_pages_artifact.sh"), expectedFragment: "prepare_pages_artifact.sh --source <directory> [options]"},
@@ -1074,6 +1076,212 @@ func TestOperationalDeployForwardsSelectedRemoteToPages(testingInstance *testing
 	}
 	if !strings.Contains(string(captureBytes), "deploy-llm-proxy-backend\t") {
 		testingInstance.Fatalf("gateway deployment was not invoked: %s", captureBytes)
+	}
+}
+
+func TestOperationalProductionLiveTestUsesDefaultTenantSecretOnly(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	for _, relativePath := range []string{
+		"Makefile",
+		filepath.Join(operationalScriptsDirectory, "live_test.sh"),
+	} {
+		copyOperationalFile(testingInstance, filepath.Join(repositoryRoot, relativePath), filepath.Join(fixtureRoot, relativePath))
+	}
+
+	liveTestScript, readScriptError := os.ReadFile(filepath.Join(fixtureRoot, operationalScriptsDirectory, "live_test.sh"))
+	if readScriptError != nil {
+		testingInstance.Fatalf("read production live-test script: %v", readScriptError)
+	}
+	for _, forbiddenFragment := range []string{"LIVE_ENV_FILE", "API_KEY", "SERVICE_SECRET", "configs/.env"} {
+		if strings.Contains(string(liveTestScript), forbiddenFragment) {
+			testingInstance.Fatalf("production live-test script reads forbidden local credential source %q", forbiddenFragment)
+		}
+	}
+
+	toolDirectory := filepath.Join(fixtureRoot, "tools")
+	captureDirectory := filepath.Join(fixtureRoot, "curl-capture")
+	if createCaptureDirectoryError := os.MkdirAll(captureDirectory, 0o755); createCaptureDirectoryError != nil {
+		testingInstance.Fatalf("create curl capture directory: %v", createCaptureDirectoryError)
+	}
+	writeOperationalFile(testingInstance, filepath.Join(toolDirectory, "curl"), `#!/usr/bin/env bash
+set -euo pipefail
+
+curl_config_path=""
+headers_path=""
+response_path=""
+request_timeout_seconds=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --config)
+      curl_config_path="$2"
+      shift 2
+      ;;
+    --dump-header)
+      headers_path="$2"
+      shift 2
+      ;;
+    --output)
+      response_path="$2"
+      shift 2
+      ;;
+    --header)
+      case "$2" in
+        X-LLM-Proxy-Request-Timeout-Seconds:*)
+          request_timeout_seconds="${2#X-LLM-Proxy-Request-Timeout-Seconds: }"
+          ;;
+      esac
+      shift 2
+      ;;
+    --request|--connect-timeout|--max-time|--write-out|--data-binary)
+      shift 2
+      ;;
+    --silent|--show-error)
+      shift
+      ;;
+    *)
+      exit 2
+      ;;
+  esac
+done
+[[ -n "${curl_config_path}" ]]
+[[ -n "${headers_path}" ]]
+[[ -n "${response_path}" ]]
+[[ -n "${request_timeout_seconds}" ]]
+
+request_url=""
+while IFS= read -r config_line; do
+  if [[ "${config_line}" == url\ =\ \"* ]]; then
+    request_url="${config_line#url = \"}"
+    request_url="${request_url%\"}"
+  fi
+done <"${curl_config_path}"
+[[ -n "${request_url}" ]]
+request_body="$(< /dev/stdin)"
+
+call_count_path="${CURL_CAPTURE_DIRECTORY:?}/call-count"
+call_index=0
+if [[ -f "${call_count_path}" ]]; then
+  call_index="$(<"${call_count_path}")"
+fi
+call_index=$((call_index + 1))
+builtin printf '%s' "${call_index}" >"${call_count_path}"
+builtin printf '%s' "${request_url}" >"${CURL_CAPTURE_DIRECTORY}/url-${call_index}"
+builtin printf '%s' "${request_body}" >"${CURL_CAPTURE_DIRECTORY}/body-${call_index}"
+builtin printf '%s' "${request_timeout_seconds}" >"${CURL_CAPTURE_DIRECTORY}/timeout-${call_index}"
+
+response_marker="LLM_PROXY_LIVE_ECHO_OK"
+if [[ "${request_body}" == *LLM_PROXY_LIVE_COMPLEX_OK* ]]; then
+  response_marker="LLM_PROXY_LIVE_COMPLEX_OK"
+fi
+builtin printf 'HTTP/1.1 200 OK\r\nX-LLM-Proxy-Request-Timeout-Seconds: %s\r\n\r\n' "${request_timeout_seconds}" >"${headers_path}"
+builtin printf '%s' "${response_marker}" >"${response_path}"
+builtin printf '%s' '200'
+`, 0o755)
+	defaultTenantSecret := "default-tenant-client-secret"
+	environment := append(
+		os.Environ(),
+		"PATH="+toolDirectory+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"CURL_CAPTURE_DIRECTORY="+captureDirectory,
+		"LLM_PROXY_SECRET="+defaultTenantSecret,
+	)
+	output := runOperationalCommand(testingInstance, fixtureRoot, environment, "make", "live-test")
+	if strings.Contains(output, defaultTenantSecret) {
+		testingInstance.Fatalf("production live-test output exposed the tenant secret: %s", output)
+	}
+	if !strings.Contains(output, "live test passed: total_cases=8") {
+		testingInstance.Fatalf("production live-test did not report all cases: %s", output)
+	}
+	for _, expectedCase := range []string{
+		"case=openai-background-polling provider=openai status=200",
+		"case=anthropic-long-completion provider=anthropic status=200",
+		"case=meta-long-completion provider=meta status=200",
+	} {
+		if !strings.Contains(output, expectedCase) {
+			testingInstance.Fatalf("production live-test omitted long-completion result %q: %s", expectedCase, output)
+		}
+	}
+
+	type liveTestMessage struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type liveTestPayload struct {
+		Messages  []liveTestMessage `json:"messages"`
+		MaxTokens *int              `json:"max_tokens"`
+	}
+	expectedProviders := []string{"openai", "anthropic", "meta", "gemini", "moonshot", "openai", "anthropic", "meta"}
+	for callIndex, expectedProvider := range expectedProviders {
+		captureIndex := callIndex + 1
+		requestURLBytes, readURLError := os.ReadFile(filepath.Join(captureDirectory, "url-"+strconv.Itoa(captureIndex)))
+		if readURLError != nil {
+			testingInstance.Fatalf("read production live-test URL for call %d: %v", captureIndex, readURLError)
+		}
+		requestURL, parseURLError := url.Parse(string(requestURLBytes))
+		if parseURLError != nil {
+			testingInstance.Fatalf("parse production live-test URL for call %d: %v", captureIndex, parseURLError)
+		}
+		if requestURL.Scheme != "https" || requestURL.Host != "llm-proxy-api.mprlab.com" || requestURL.Path != "/v2" {
+			testingInstance.Fatalf("production live-test call %d used non-production endpoint: %s", captureIndex, requestURL)
+		}
+		query := requestURL.Query()
+		if query.Get("key") != defaultTenantSecret || query.Get("provider") != expectedProvider || query.Get("format") != "text/plain" {
+			testingInstance.Fatalf("production live-test call %d used unexpected tenant or route query: %s", captureIndex, requestURL)
+		}
+		if query.Has("model") {
+			testingInstance.Fatalf("production live-test call %d bypassed the saved provider default model: %s", captureIndex, requestURL)
+		}
+
+		requestBody, readBodyError := os.ReadFile(filepath.Join(captureDirectory, "body-"+strconv.Itoa(captureIndex)))
+		if readBodyError != nil {
+			testingInstance.Fatalf("read production live-test body for call %d: %v", captureIndex, readBodyError)
+		}
+		var payload liveTestPayload
+		if decodeError := json.Unmarshal(requestBody, &payload); decodeError != nil {
+			testingInstance.Fatalf("decode production live-test body for call %d: %v", captureIndex, decodeError)
+		}
+
+		timeoutBytes, readTimeoutError := os.ReadFile(filepath.Join(captureDirectory, "timeout-"+strconv.Itoa(captureIndex)))
+		if readTimeoutError != nil {
+			testingInstance.Fatalf("read production live-test timeout for call %d: %v", captureIndex, readTimeoutError)
+		}
+		if callIndex < 5 {
+			if len(payload.Messages) != 1 || payload.MaxTokens != nil || !strings.Contains(payload.Messages[0].Content, "LLM_PROXY_LIVE_ECHO_OK") {
+				testingInstance.Fatalf("echo call %d did not preserve the simple marker request: %s", captureIndex, requestBody)
+			}
+			if string(timeoutBytes) != "90" {
+				testingInstance.Fatalf("echo call %d used unexpected request budget: %s", captureIndex, timeoutBytes)
+			}
+			continue
+		}
+		if len(requestBody) < 16384 || len(payload.Messages) != 2 || payload.MaxTokens == nil || *payload.MaxTokens != 512 || !strings.Contains(payload.Messages[1].Content, "LLM_PROXY_LIVE_COMPLEX_OK") || !strings.Contains(payload.Messages[1].Content, "all 120 normalized lines") {
+			testingInstance.Fatalf("long completion call %d did not preserve the large complex request contract: bytes=%d payload=%s", captureIndex, len(requestBody), requestBody)
+		}
+		if string(timeoutBytes) != "900" {
+			testingInstance.Fatalf("long completion call %d used unexpected request budget: %s", captureIndex, timeoutBytes)
+		}
+	}
+}
+
+func TestOperationalProductionLiveTestRequiresDefaultTenantSecret(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	for _, relativePath := range []string{
+		"Makefile",
+		filepath.Join(operationalScriptsDirectory, "live_test.sh"),
+	} {
+		copyOperationalFile(testingInstance, filepath.Join(repositoryRoot, relativePath), filepath.Join(fixtureRoot, relativePath))
+	}
+
+	command := exec.Command("make", "live-test")
+	command.Dir = fixtureRoot
+	command.Env = []string{"PATH=" + os.Getenv("PATH")}
+	output, commandError := command.CombinedOutput()
+	if commandError == nil {
+		testingInstance.Fatalf("make live-test accepted a missing Default-tenant secret: %s", output)
+	}
+	if !strings.Contains(string(output), "LLM_PROXY_SECRET must contain the Default-tenant client secret") {
+		testingInstance.Fatalf("missing-secret error omitted the Default-tenant contract: %s", output)
 	}
 }
 


### PR DESCRIPTION
This update introduces a comprehensive, production-safe live test suite that validates the Default tenant's ability to route text generation requests through all main supported providers (OpenAI, Anthropic, Meta, Gemini, Moonshot) using only the canonical client secret—never local provider API keys. Eight canonical `POST /v2` tests are run: short echo-marker checks and large deterministic completions for each provider, with OpenAI receiving explicit background polling and Anthropic/Meta receiving canonical synchronous completions.

Key improvements include:

- A new `make live-test` target (excluded from CI) and a corresponding script under `scripts/live_test.sh`.
- Black-box operational coverage to verify that production calls use the correct APIs, authentication, and models.
- Test output and failures redact credentials and response data for security.
- README, API reference, and provider-routing docs updated to clarify the new output-budget continuation contract and error handling for incomplete LLM responses. Instead of returning an error for output truncation, the system continues via a provider-neutral lifecycle coordinator—attempting completion until full output is returned or the request times out.
- Provider adapters are adjusted to cooperate with the continuation contract, avoiding terminal errors on recoverable, budget-exhaustion states.
- Coverage improvements ensure all four transport families (