### PR TITLE
Fix B091 release gate orchestration determinism

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -37,6 +37,50 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
 
+- [x] [B091] (P0) Remove synthetic local-orchestration latency from the release gate.
+  Goal:
+  Keep the black-box `make up` contract deterministic when `make release` runs
+  the complete CI suite under host contention.
+
+  Evidence:
+  - The user-run release gate failed after five seconds waiting for the fake
+    management-boundary `curl-ready` file even though the proxy tests around
+    it continued to pass.
+  - Ten isolated runs of
+    `TestOperationalMakeUpStartsLocalWebOrchestration` passed in
+    1.95–2.08 seconds, while the same Go package took 25.444 seconds in the
+    failing release gate.
+  - The fixture deliberately sleeps 150 ms in every fake `awk` invocation,
+    even though it already reads the invocation capture and rejects more than
+    seven processes. The sleep adds no contract evidence and turns unrelated
+    host scheduling into readiness behavior.
+  - The required pre-change `make ci` passed, but showed the same host
+    contention: the Go `tests` package took 16.562 seconds and the release
+    suite took 106.887 seconds.
+
+  Requirements:
+  - Remove the fake `awk` sleep and its environment control. Do not increase
+    the five-second diagnostic guard.
+  - Retain the real `make up` entrypoint, fake Docker/HTTP boundaries, exact
+    readiness assertions, and the process-count guard that detects
+    per-variable environment projection.
+  - Do not change production `scripts/up.sh`; its batched environment
+    projection and readiness sequence are not the failing contract.
+
+  Validation:
+  - Run the focused black-box operational test repeatedly.
+  - Run the required final
+    `timeout -k 350s -s SIGKILL 350s make ci` after the last code edit.
+  - Do not run `make release`, `make publish`, or `make deploy`.
+
+  Resolution:
+  - Removed the fake `awk` delay and its environment control without changing
+    the five-second diagnostic guard or production `scripts/up.sh`.
+  - The test still exercises the real `make up` entrypoint and asserts the
+    exact Compose, HTTP readiness, scoped-environment, cleanup, and maximum
+    process-count contracts.
+  - Thirty consecutive focused black-box runs passed in 36.283 seconds.
+
 - [x] [B090] (P0) Make release, publication, and deployment retries converge on one sealed release.
   Goal:
   Make the canonical `make release && make publish && make deploy` lifecycle

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -23,7 +23,6 @@ const (
 	operationalReleaseToolsRelative                 = "tools/gitrelease"
 	operationalHelpTimeout                          = 5 * time.Second
 	operationalHelpWaitDelay                        = time.Second
-	operationalScopedEnvironmentAWKDelaySeconds     = "0.15"
 	operationalScopedEnvironmentMaximumAWKProcesses = 7
 	constrainedPipeHelpCommand                      = `ulimit -p 1 2>/dev/null || true
 exec "$@"`
@@ -264,7 +263,6 @@ builtin printf '%s' generated-local-value
 set -euo pipefail
 
 builtin printf '%s\n' invoked >>"${AWK_INVOCATION_CAPTURE:?}"
-sleep "${AWK_DELAY_SECONDS:?}"
 exec "${REAL_AWK_PATH:?}" "$@"
 `, 0o755)
 
@@ -274,7 +272,6 @@ exec "${REAL_AWK_PATH:?}" "$@"
 	command.Env = append(
 		os.Environ(),
 		"PATH="+toolDirectory+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"AWK_DELAY_SECONDS="+operationalScopedEnvironmentAWKDelaySeconds,
 		"AWK_INVOCATION_CAPTURE="+awkInvocationsPath,
 		"REAL_AWK_PATH="+realAWKPath,
 		"DOCKER_ARGUMENT_CAPTURE="+composeArgumentsPath,


### PR DESCRIPTION
## What changed

- removed the synthetic 150 ms delay from every fake `awk` process in the black-box `make up` contract
- retained the real Makefile entrypoint, readiness assertions, cleanup checks, and seven-process ceiling
- documented B091 and its validation evidence

## Root cause

The fixture deliberately added latency that did not prove any production contract. Under host contention, that synthetic work exhausted the five-second diagnostic guard even though `scripts/up.sh` already used bounded environment projection.

## Impact

`make release` no longer fails because test-only `awk` latency turns scheduler contention into a false local-orchestration readiness failure.

## Validation

- 30 consecutive focused operational-contract runs passed
- complete `make ci` passed after the final code edit