### PR TITLE
Fix B092 container inspection test determinism

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -37,6 +37,44 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
 
+- [x] [B092] (P0) Make the container inspection-bound test deterministic.
+  Goal:
+  Verify that every registry inspection is independently bounded without
+  coupling the release gate to nested wall-clock timers.
+
+  Evidence:
+  - B091's final `make ci` proved the repaired operational test under a
+    22.777-second Go package run, then failed in
+    `test_container_manifest_digest_bounds_each_inspection_attempt`.
+  - The container test expected two fake Docker attempts but observed one
+    during a 151.503-second release-suite run.
+  - The fixture wraps two real one-second `timeout` calls and a real one-second
+    delay inside an outer five-second timeout. Host scheduling can consume the
+    outer budget before the second process starts, so the assertion measures
+    scheduler timing rather than the script's per-attempt command contract.
+
+  Requirements:
+  - Replace real nested timers with fake `timeout` and `sleep` process
+    boundaries that capture and validate the exact arguments.
+  - Require two independently bounded Docker inspection commands and one
+    configured inter-attempt delay.
+  - Do not increase a timeout or change the production registry-readiness
+    script.
+
+  Validation:
+  - Run the focused release suite and the required final
+    `timeout -k 350s -s SIGKILL 350s make ci`.
+  - Do not run `make release`, `make publish`, or `make deploy`.
+
+  Resolution:
+  - Replaced the nested real timers with fake `timeout` and `sleep`
+    executables that capture the public command boundary.
+  - The test now requires two exact one-second Docker inspection bounds, one
+    configured inter-attempt delay, Docker exit `124` reporting, and the final
+    unreadable-manifest error without depending on scheduler timing.
+  - All 54 repository-owned release tests passed in 87.971 seconds under the
+    same contended host conditions.
+
 - [x] [B091] (P0) Remove synthetic local-orchestration latency from the release gate.
   Goal:
   Keep the black-box `make up` contract deterministic when `make release` runs

--- a/tools/gitrelease/tests/test_release_pipeline.py
+++ b/tools/gitrelease/tests/test_release_pipeline.py
@@ -712,36 +712,39 @@ printf '%s\\n' 'Name: ghcr.io/example/image:latest' 'Digest:    sha256:aaaaaaaaa
         fake_binary_directory = self.root / "manifest-timeout-bin"
         fake_binary_directory.mkdir()
         fake_docker = fake_binary_directory / "docker"
-        fake_docker.write_text(
+        fake_docker.write_text("#!/usr/bin/env bash\nexit 97\n", encoding="utf-8")
+        fake_docker.chmod(0o755)
+        fake_timeout = fake_binary_directory / "timeout"
+        fake_timeout.write_text(
             """#!/usr/bin/env bash
 set -euo pipefail
-[[ \"$1 $2 $3\" == \"buildx imagetools inspect\" ]] || exit 2
-attempt=0
-if [[ -f \"${FAKE_DOCKER_STATE}\" ]]; then attempt=\"$(cat \"${FAKE_DOCKER_STATE}\")\"; fi
-attempt=$((attempt + 1))
-printf '%s\\n' \"${attempt}\" >\"${FAKE_DOCKER_STATE}\"
-exec sleep \"${FAKE_DOCKER_HANG_SECONDS}\"
+printf '%s\\n' \"$*\" >>\"${FAKE_TIMEOUT_CAPTURE:?}\"
+exit 124
 """,
             encoding="utf-8",
         )
-        fake_docker.chmod(0o755)
-        state_path = self.root / "docker-timeout-attempts"
+        fake_timeout.chmod(0o755)
+        fake_sleep = fake_binary_directory / "sleep"
+        fake_sleep.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' \"$*\" >>\"${FAKE_SLEEP_CAPTURE:?}\"
+""",
+            encoding="utf-8",
+        )
+        fake_sleep.chmod(0o755)
+        timeout_capture_path = self.root / "timeout-arguments"
+        sleep_capture_path = self.root / "sleep-arguments"
         environment = os.environ.copy() | {
             "PATH": f"{fake_binary_directory}{os.pathsep}{os.environ['PATH']}",
-            "FAKE_DOCKER_STATE": str(state_path),
-            "FAKE_DOCKER_HANG_SECONDS": "30",
+            "FAKE_TIMEOUT_CAPTURE": str(timeout_capture_path),
+            "FAKE_SLEEP_CAPTURE": str(sleep_capture_path),
             "CONTAINER_REGISTRY_VERIFY_ATTEMPTS": "2",
             "CONTAINER_REGISTRY_VERIFY_DELAY_SECONDS": "1",
             "CONTAINER_REGISTRY_VERIFY_ATTEMPT_TIMEOUT_SECONDS": "1",
         }
 
         result = self.command(
-            "timeout",
-            "-k",
-            "5s",
-            "-s",
-            "SIGKILL",
-            "5s",
             "bash",
             str(CONTAINER_MANIFEST_DIGEST),
             "ghcr.io/example/image:latest",
@@ -751,8 +754,16 @@ exec sleep \"${FAKE_DOCKER_HANG_SECONDS}\"
         )
 
         self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-        self.assertEqual(state_path.read_text(encoding="utf-8").strip(), "2")
-        self.assertIn("Docker exit", result.stderr)
+        expected_timeout_arguments = (
+            "-k 1s -s SIGKILL 1s docker buildx imagetools inspect "
+            "ghcr.io/example/image:latest"
+        )
+        self.assertEqual(
+            timeout_capture_path.read_text(encoding="utf-8").splitlines(),
+            [expected_timeout_arguments, expected_timeout_arguments],
+        )
+        self.assertEqual(sleep_capture_path.read_text(encoding="utf-8").splitlines(), ["1"])
+        self.assertIn("Docker exit 124", result.stderr)
         self.assertIn("container manifest did not become readable for ghcr.io/example/image:latest", result.stderr)
 
     def test_container_manifest_digest_rejects_invalid_attempt_timeout(self) -> None:


### PR DESCRIPTION
## What changed

- replaced nested real `timeout` and `sleep` fixture timing with fake process boundaries
- assert two exact one-second Docker inspection commands and one configured inter-attempt delay
- retain the production registry-readiness script unchanged
- document B092 and its validation evidence

## Root cause

The test placed two real one-second inspection timeouts and a real one-second delay inside an outer five-second timeout. Under host scheduling contention, the outer process could expire before the second Docker attempt, so the assertion measured scheduler timing rather than the per-attempt command contract.

## Impact

The release suite now verifies bounded registry inspection deterministically without weakening or increasing production timeouts.

## Validation

- all 54 release tests passed under the same contended host conditions
- complete `make ci` passed after the final code edit