### PR TITLE
Fix B093 OCI platform publication

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -37,6 +37,60 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
 
+- [x] [B093] (P0) Publish prepared OCI platform indexes without rejecting attestations.
+  Goal:
+  Make `make publish` converge when current Docker Buildx publishes each
+  prepared platform image as an OCI index containing the runnable image
+  manifest and its provenance attestation.
+
+  Evidence:
+  - The real `make release` completed for `v0.2.50`, including all CI gates,
+    both platform archives, the Pages archive, the changelog-only release
+    commit, annotated tag, and sealed manifest.
+  - The first `make publish` pushed `master`, `v0.2.50`, the GitHub Release,
+    `manifest.json`, `pages.tar.gz`, and the prepared amd64 platform tag before
+    failing with `published platform tag is not a single immutable image
+    manifest`.
+  - Standard `docker buildx imagetools inspect --raw` proves the platform tag
+    is an OCI index whose digest exactly equals the prepared local image ID. It
+    contains one `linux/amd64` image manifest and one `unknown/unknown` SLSA
+    attestation manifest that references the runnable manifest.
+  - The publisher assumes a bare image manifest and compares its config digest
+    with the local image ID. With the current Docker containerd image store,
+    that local ID identifies the complete platform index instead.
+
+  Requirements:
+  - Treat one OCI index with exactly one declared Linux platform image and its
+    matching provenance attestation as the canonical platform artifact.
+  - Require the remote platform-index digest to equal the prepared local image
+    ID before reusing it.
+  - Validate a version index as the exact union of the descriptors from every
+    prepared platform index, including their attestations.
+  - Preserve partial publication and reuse exact remote state; do not rebuild,
+    replace, delete, or retag an immutable published object.
+  - Continue using only standard Docker CLI publication and inspection
+    boundaries.
+
+  Validation:
+  - Cover fresh publication, exact retry, missing version/latest recovery,
+    uncertain inspection, and immutable conflict through the black-box release
+    suite.
+  - Run the required final
+    `timeout -k 350s -s SIGKILL 350s make ci` after the last code edit.
+  - Merge through a ready PR with hosted CI, then verify the forward release
+    with exact `make release && make publish` retries on clean `master`.
+
+  Resolution:
+  - Platform publication now accepts only the canonical OCI index containing
+    exactly one runnable Linux image descriptor and its matching provenance
+    attestation, and requires the remote index digest to equal the prepared
+    image ID.
+  - Version publication now validates the exact descriptor union from every
+    prepared platform index, preserving immutable partial state across retries.
+  - The 54-scenario black-box release suite, direct standard-Docker inspection
+    of the published platform index and composed version index, and the final
+    repository `make ci` all pass.
+
 - [x] [B092] (P0) Make the container inspection-bound test deterministic.
   Goal:
   Verify that every registry inspection is independently bounded without

--- a/README.md
+++ b/README.md
@@ -1412,6 +1412,12 @@ uses `PAGES_VERIFY_ATTEMPTS` and `PAGES_VERIFY_DELAY_SECONDS` (defaults `12`
 and `5`). Each wait reports its observed external readiness boundary rather
 than treating a completed push as immediate public availability.
 
+GHCR platform tags are immutable OCI indexes containing one runnable Linux
+image manifest and its matching provenance attestation. Publication requires
+each remote platform-index digest to equal the prepared local image ID, and the
+version and `latest` indexes to contain the exact union of the prepared
+platform descriptors.
+
 The three release phases are retry-safe. A canonical release commit and its
 annotated tag identify the same sealed `.git/mprlab-release` manifest on every
 `make release` retry. New payloads are prepared under

--- a/tools/gitrelease/README.md
+++ b/tools/gitrelease/README.md
@@ -23,6 +23,12 @@ published, registry inspection ambiguity fails closed, and an existing
 conflict is never overwritten. The mutable `latest` tag changes only when its
 digest does not identify the prepared final release.
 
+Each prepared platform tag is one immutable OCI index containing exactly one
+runnable Linux image manifest and its matching provenance attestation. Its
+remote index digest must equal the prepared local image ID. Version and
+`latest` indexes contain the exact union of those platform-index descriptors,
+including the attestations.
+
 Pages artifacts always contain an empty `.nojekyll` file and a schema-versioned
 `.mprlab-release.json` marker. Deployment validates the archive contract and
 matches the release tag to `release_commit` while matching artifact and public

--- a/tools/gitrelease/scripts/container_artifact_helper.py
+++ b/tools/gitrelease/scripts/container_artifact_helper.py
@@ -10,6 +10,10 @@ import re
 
 
 CONTAINER_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+CONTAINER_PLATFORM_PATTERN = re.compile(r"^linux/(amd64|arm64)$")
+ATTESTATION_REFERENCE_DIGEST = "vnd.docker.reference.digest"
+ATTESTATION_REFERENCE_TYPE = "vnd.docker.reference.type"
+ATTESTATION_MANIFEST_TYPE = "attestation-manifest"
 IMAGE_MANIFEST_MEDIA_TYPES = frozenset(
     {
         "application/vnd.docker.distribution.manifest.v2+json",
@@ -39,72 +43,177 @@ def validated_digest(value: object, label: str) -> str:
     return value
 
 
-def command_validate_platform_manifest(args: argparse.Namespace) -> int:
-    """Require a published platform tag to identify the prepared image config."""
-    manifest = read_json_object(args.raw)
-    media_type = manifest.get("mediaType")
+def validated_size(value: object, label: str) -> int:
+    """Return one positive OCI descriptor size."""
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise SystemExit(f"{label} must be a positive integer")
+    return value
+
+
+def normalized_platform(value: object, label: str) -> dict[str, str]:
+    """Return one exact OCI operating-system and architecture pair."""
+    if not isinstance(value, dict) or set(value) != {"os", "architecture"}:
+        raise SystemExit(f"{label} must contain exactly os and architecture")
+    operating_system = value.get("os")
+    architecture = value.get("architecture")
+    if not isinstance(operating_system, str) or not isinstance(architecture, str):
+        raise SystemExit(f"{label} must contain text os and architecture values")
+    return {"os": operating_system, "architecture": architecture}
+
+
+def normalized_image_descriptor(value: object, label: str) -> dict[str, object]:
+    """Return one exact runnable image descriptor from a platform index."""
+    if not isinstance(value, dict):
+        raise SystemExit(f"{label} must be an object")
+    if set(value) != {"mediaType", "digest", "size", "platform"}:
+        raise SystemExit(f"{label} has an invalid descriptor shape")
+    media_type = value.get("mediaType")
     if media_type not in IMAGE_MANIFEST_MEDIA_TYPES:
-        raise SystemExit("published platform tag is not a single immutable image manifest")
-    config = manifest.get("config")
-    if not isinstance(config, dict):
-        raise SystemExit("published platform manifest has no image config")
-    actual_image_id = validated_digest(config.get("digest"), "published platform image config")
+        raise SystemExit(f"{label} has an invalid image manifest media type")
+    return {
+        "mediaType": media_type,
+        "digest": validated_digest(value.get("digest"), f"{label} digest"),
+        "size": validated_size(value.get("size"), f"{label} size"),
+        "platform": normalized_platform(value.get("platform"), f"{label} platform"),
+    }
+
+
+def normalized_attestation_descriptor(
+    value: object,
+    image_digest: str,
+    label: str,
+) -> dict[str, object]:
+    """Return one exact provenance attestation descriptor."""
+    if not isinstance(value, dict):
+        raise SystemExit(f"{label} must be an object")
+    if set(value) != {"mediaType", "digest", "size", "annotations", "platform"}:
+        raise SystemExit(f"{label} has an invalid descriptor shape")
+    media_type = value.get("mediaType")
+    if media_type not in IMAGE_MANIFEST_MEDIA_TYPES:
+        raise SystemExit(f"{label} has an invalid image manifest media type")
+    annotations = value.get("annotations")
+    expected_annotations = {
+        ATTESTATION_REFERENCE_DIGEST: image_digest,
+        ATTESTATION_REFERENCE_TYPE: ATTESTATION_MANIFEST_TYPE,
+    }
+    if annotations != expected_annotations:
+        raise SystemExit(f"{label} does not reference the runnable image manifest")
+    platform = normalized_platform(value.get("platform"), f"{label} platform")
+    if platform != {"os": "unknown", "architecture": "unknown"}:
+        raise SystemExit(f"{label} must use the unknown/unknown platform")
+    return {
+        "mediaType": media_type,
+        "digest": validated_digest(value.get("digest"), f"{label} digest"),
+        "size": validated_size(value.get("size"), f"{label} size"),
+        "annotations": expected_annotations,
+        "platform": platform,
+    }
+
+
+def normalized_platform_index_descriptors(
+    manifest: dict[str, object],
+    expected_platform: str | None,
+    label: str,
+) -> list[dict[str, object]]:
+    """Return the runnable image and provenance descriptors from one platform index."""
+    if manifest.get("schemaVersion") != 2 or manifest.get("mediaType") not in IMAGE_INDEX_MEDIA_TYPES:
+        raise SystemExit(f"{label} is not an immutable OCI image index")
+    raw_manifests = manifest.get("manifests")
+    if not isinstance(raw_manifests, list) or len(raw_manifests) != 2:
+        raise SystemExit(f"{label} must contain exactly one image and one attestation manifest")
+    image_candidates = [
+        item
+        for item in raw_manifests
+        if isinstance(item, dict)
+        and isinstance(item.get("platform"), dict)
+        and item["platform"].get("os") == "linux"
+    ]
+    attestation_candidates = [
+        item
+        for item in raw_manifests
+        if isinstance(item, dict)
+        and isinstance(item.get("platform"), dict)
+        and item["platform"].get("os") == "unknown"
+        and item["platform"].get("architecture") == "unknown"
+    ]
+    if len(image_candidates) != 1 or len(attestation_candidates) != 1:
+        raise SystemExit(f"{label} must contain one Linux image and one attestation manifest")
+    image_descriptor = normalized_image_descriptor(image_candidates[0], f"{label} image")
+    image_platform = image_descriptor["platform"]
+    if not isinstance(image_platform, dict):
+        raise AssertionError("normalized image platform must be an object")
+    platform_text = f"{image_platform['os']}/{image_platform['architecture']}"
+    if CONTAINER_PLATFORM_PATTERN.fullmatch(platform_text) is None:
+        raise SystemExit(f"{label} image has an unsupported platform")
+    if expected_platform is not None and platform_text != expected_platform:
+        raise SystemExit(
+            f"{label} has the wrong platform (expected {expected_platform}, found {platform_text})"
+        )
+    image_digest = str(image_descriptor["digest"])
+    attestation_descriptor = normalized_attestation_descriptor(
+        attestation_candidates[0],
+        image_digest,
+        f"{label} attestation",
+    )
+    return [image_descriptor, attestation_descriptor]
+
+
+def command_validate_platform_manifest(args: argparse.Namespace) -> int:
+    """Require a published platform tag to identify the prepared OCI index."""
+    manifest = read_json_object(args.raw)
+    if CONTAINER_PLATFORM_PATTERN.fullmatch(args.platform) is None:
+        raise SystemExit("prepared platform must be linux/amd64 or linux/arm64")
+    normalized_platform_index_descriptors(manifest, args.platform, "published platform tag")
+    actual_image_id = validated_digest(args.manifest_digest, "published platform index")
     expected_image_id = validated_digest(args.image_id, "prepared image id")
     if actual_image_id != expected_image_id:
         raise SystemExit(
-            "published platform tag conflicts with the prepared image "
+            "published platform index conflicts with the prepared image "
             f"(expected {expected_image_id}, found {actual_image_id})"
         )
     return 0
 
 
-def expected_index_entries(path: str) -> dict[tuple[str, str], str]:
-    """Read the exact platform-to-manifest mapping expected in a version index."""
-    payload = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
-    if not isinstance(payload, list) or not payload:
-        raise SystemExit("expected container index entries must be a nonempty list")
-    entries: dict[tuple[str, str], str] = {}
-    for item in payload:
-        if not isinstance(item, dict):
-            raise SystemExit("expected container index entry must be an object")
-        operating_system = item.get("os")
-        architecture = item.get("architecture")
-        if operating_system != "linux" or architecture not in {"amd64", "arm64"}:
-            raise SystemExit("expected container index entry has an unsupported platform")
-        key = (str(operating_system), str(architecture))
-        if key in entries:
-            raise SystemExit("expected container index contains a duplicate platform")
-        entries[key] = validated_digest(item.get("digest"), "expected platform manifest")
-    return entries
-
-
 def command_validate_index_manifest(args: argparse.Namespace) -> int:
     """Require a published version tag to contain exactly the prepared platforms."""
     manifest = read_json_object(args.raw)
-    if manifest.get("mediaType") not in IMAGE_INDEX_MEDIA_TYPES:
+    if manifest.get("schemaVersion") != 2 or manifest.get("mediaType") not in IMAGE_INDEX_MEDIA_TYPES:
         raise SystemExit("published version tag is not an immutable multi-platform image index")
     raw_manifests = manifest.get("manifests")
     if not isinstance(raw_manifests, list) or not raw_manifests:
         raise SystemExit("published version index has no platform manifests")
-    actual_entries: dict[tuple[str, str], str] = {}
+    actual_entries: dict[str, dict[str, object]] = {}
     for item in raw_manifests:
         if not isinstance(item, dict):
             raise SystemExit("published version index contains an invalid manifest entry")
-        platform = item.get("platform")
+        digest = validated_digest(item.get("digest"), "published version index manifest")
+        if digest in actual_entries:
+            raise SystemExit("published version index contains a duplicate manifest")
+        actual_entries[digest] = item
+    expected_entries: dict[str, dict[str, object]] = {}
+    expected_platforms: set[str] = set()
+    for platform_raw in args.platform_raw:
+        platform_manifest = read_json_object(platform_raw)
+        descriptors = normalized_platform_index_descriptors(
+            platform_manifest,
+            None,
+            f"prepared platform index {platform_raw}",
+        )
+        platform = descriptors[0]["platform"]
         if not isinstance(platform, dict):
-            raise SystemExit("published version index entry has no platform")
-        operating_system = platform.get("os")
-        architecture = platform.get("architecture")
-        if not isinstance(operating_system, str) or not isinstance(architecture, str):
-            raise SystemExit("published version index entry has an invalid platform")
-        key = (operating_system, architecture)
-        if key in actual_entries:
-            raise SystemExit("published version index contains a duplicate platform")
-        actual_entries[key] = validated_digest(item.get("digest"), "published platform manifest")
-    expected_entries = expected_index_entries(args.expected)
+            raise AssertionError("normalized image platform must be an object")
+        platform_text = f"{platform['os']}/{platform['architecture']}"
+        if platform_text in expected_platforms:
+            raise SystemExit("prepared platform indexes contain a duplicate platform")
+        expected_platforms.add(platform_text)
+        for descriptor in descriptors:
+            digest = str(descriptor["digest"])
+            if digest in expected_entries:
+                raise SystemExit("prepared platform indexes contain a duplicate manifest")
+            expected_entries[digest] = descriptor
     if actual_entries != expected_entries:
         raise SystemExit(
-            "published version tag conflicts with the prepared platform manifests "
+            "published version tag conflicts with the prepared platform indexes "
             f"(expected {expected_entries}, found {actual_entries})"
         )
     return 0
@@ -115,14 +224,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    platform_manifest = subparsers.add_parser("validate-platform-manifest")
+    platform_manifest = subparsers.add_parser("validate-platform-index")
     platform_manifest.add_argument("--raw", required=True)
+    platform_manifest.add_argument("--manifest-digest", required=True)
     platform_manifest.add_argument("--image-id", required=True)
+    platform_manifest.add_argument("--platform", required=True)
     platform_manifest.set_defaults(func=command_validate_platform_manifest)
 
-    index_manifest = subparsers.add_parser("validate-index-manifest")
+    index_manifest = subparsers.add_parser("validate-version-index")
     index_manifest.add_argument("--raw", required=True)
-    index_manifest.add_argument("--expected", required=True)
+    index_manifest.add_argument("--platform-raw", action="append", required=True)
     index_manifest.set_defaults(func=command_validate_index_manifest)
     return parser
 

--- a/tools/gitrelease/scripts/publish_container_artifacts.sh
+++ b/tools/gitrelease/scripts/publish_container_artifacts.sh
@@ -105,8 +105,7 @@ for platform in data["platforms"]:
     exit 1
   fi
   sources=()
-  expected_index_rows="${temporary_directory}/${name}-expected-index.tsv"
-  : >"${expected_index_rows}"
+  platform_raws=()
 
   while IFS=$'\t' read -r platform token local_ref expected_image_id archive_relative expected_sha256; do
     [[ -n "${platform}" ]] || continue
@@ -116,9 +115,12 @@ for platform in data["platforms"]:
     platform_ref="${image}:${version}-${token}"
     platform_raw="${temporary_directory}/${name}-${token}.json"
     if inspect_raw_manifest "${platform_ref}" "${platform_raw}"; then
-      if ! python3 "${container_helper}" validate-platform-manifest \
+      platform_digest="$(bash "${container_manifest_digest_helper}" "${platform_ref}")"
+      if ! python3 "${container_helper}" validate-platform-index \
         --raw "${platform_raw}" \
-        --image-id "${expected_image_id}"
+        --manifest-digest "${platform_digest}" \
+        --image-id "${expected_image_id}" \
+        --platform "${platform}"
       then
         echo "error: immutable container platform conflict for ${platform_ref}" >&2
         exit 1
@@ -136,41 +138,37 @@ for platform in data["platforms"]:
       [[ "${actual_image_id}" == "${expected_image_id}" ]] || { echo "error: loaded image does not match prepared ${name} ${platform}" >&2; exit 1; }
       docker tag "${local_ref}" "${platform_ref}"
       timeout -k "${publish_timeout}s" -s SIGKILL "${publish_timeout}s" docker push "${platform_ref}"
-      bash "${container_manifest_digest_helper}" "${platform_ref}" >/dev/null
+      platform_digest="$(bash "${container_manifest_digest_helper}" "${platform_ref}")"
       inspect_raw_manifest "${platform_ref}" "${platform_raw}" || {
         echo "error: published platform manifest is unreadable for ${platform_ref}" >&2
         exit 1
       }
-      python3 "${container_helper}" validate-platform-manifest \
+      if ! python3 "${container_helper}" validate-platform-index \
         --raw "${platform_raw}" \
-        --image-id "${expected_image_id}"
+        --manifest-digest "${platform_digest}" \
+        --image-id "${expected_image_id}" \
+        --platform "${platform}"
+      then
+        echo "error: immutable container platform conflict for ${platform_ref}" >&2
+        exit 1
+      fi
     fi
-    platform_digest="$(bash "${container_manifest_digest_helper}" "${platform_ref}")"
-    printf '%s\t%s\n' "${platform}" "${platform_digest}" >>"${expected_index_rows}"
     sources+=("${platform_ref}")
+    platform_raws+=("${platform_raw}")
   done < <(tail -n +4 <<<"${metadata}")
 
   [[ "${#sources[@]}" -gt 0 ]] || { echo "error: ${name} has no prepared platforms" >&2; exit 1; }
-  expected_index="${temporary_directory}/${name}-expected-index.json"
-  python3 -c '
-import json
-import pathlib
-import sys
-
-entries = []
-for row in pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
-    platform, digest = row.split("\t")
-    operating_system, architecture = platform.split("/")
-    entries.append({"os": operating_system, "architecture": architecture, "digest": digest})
-pathlib.Path(sys.argv[2]).write_text(json.dumps(entries, sort_keys=True) + "\n", encoding="utf-8")
-' "${expected_index_rows}" "${expected_index}"
+  version_validation_arguments=()
+  for platform_raw in "${platform_raws[@]}"; do
+    version_validation_arguments+=(--platform-raw "${platform_raw}")
+  done
 
   version_ref="${image}:${version}"
   version_raw="${temporary_directory}/${name}-version.json"
   if inspect_raw_manifest "${version_ref}" "${version_raw}"; then
-    if ! python3 "${container_helper}" validate-index-manifest \
+    if ! python3 "${container_helper}" validate-version-index \
       --raw "${version_raw}" \
-      --expected "${expected_index}"
+      "${version_validation_arguments[@]}"
     then
       echo "error: immutable container version conflict for ${version_ref}" >&2
       exit 1
@@ -189,9 +187,9 @@ pathlib.Path(sys.argv[2]).write_text(json.dumps(entries, sort_keys=True) + "\n",
       echo "error: published version manifest is unreadable for ${version_ref}" >&2
       exit 1
     }
-    python3 "${container_helper}" validate-index-manifest \
+    python3 "${container_helper}" validate-version-index \
       --raw "${version_raw}" \
-      --expected "${expected_index}"
+      "${version_validation_arguments[@]}"
   fi
 
   version_digest="$(bash "${container_manifest_digest_helper}" "${image}:${version}")"

--- a/tools/gitrelease/tests/test_release_pipeline.py
+++ b/tools/gitrelease/tests/test_release_pipeline.py
@@ -476,14 +476,21 @@ def read_manifest(reference):
         raise SystemExit(1)
     return manifest_path.read_text(encoding="utf-8"), digest_path.read_text(encoding="utf-8").strip()
 
-def write_manifest(reference, document):
+def write_manifest(reference, document, digest=None):
     manifest_path, digest_path = state_paths(reference)
     raw = json.dumps(document, separators=(",", ":"), sort_keys=True) + "\n"
     manifest_path.write_text(raw, encoding="utf-8")
-    digest_path.write_text(f"sha256:{hashlib.sha256(raw.encode()).hexdigest()}\n", encoding="utf-8")
+    manifest_digest = digest or f"sha256:{hashlib.sha256(raw.encode()).hexdigest()}"
+    digest_path.write_text(f"{manifest_digest}\n", encoding="utf-8")
 
 def image_id(reference):
     return "sha256:" + ("a" if reference.endswith("linux-amd64") else "b") * 64
+
+def image_manifest_digest(reference):
+    return "sha256:" + ("c" if reference.endswith("linux-amd64") else "d") * 64
+
+def attestation_manifest_digest(reference):
+    return "sha256:" + ("e" if reference.endswith("linux-amd64") else "f") * 64
 
 if arguments[:2] == ["buildx", "version"]:
     raise SystemExit(0)
@@ -504,14 +511,34 @@ if arguments[:1] == ["tag"]:
 if arguments[:1] == ["push"]:
     tag_map = json.loads((state_directory / "tags.json").read_text(encoding="utf-8"))
     reference = arguments[1]
+    local_reference = tag_map[reference]
+    architecture = "amd64" if local_reference.endswith("linux-amd64") else "arm64"
+    runnable_digest = image_manifest_digest(local_reference)
     write_manifest(
         reference,
         {
             "schemaVersion": 2,
-            "mediaType": "application/vnd.oci.image.manifest.v1+json",
-            "config": {"digest": image_id(tag_map[reference])},
-            "layers": [],
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "digest": runnable_digest,
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "platform": {"os": "linux", "architecture": architecture},
+                    "size": 1000,
+                },
+                {
+                    "annotations": {
+                        "vnd.docker.reference.digest": runnable_digest,
+                        "vnd.docker.reference.type": "attestation-manifest",
+                    },
+                    "digest": attestation_manifest_digest(local_reference),
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "platform": {"os": "unknown", "architecture": "unknown"},
+                    "size": 500,
+                },
+            ],
         },
+        image_id(local_reference),
     )
     print(f"pushed {reference}")
     raise SystemExit(0)
@@ -529,15 +556,8 @@ if arguments[:3] == ["buildx", "imagetools", "create"]:
     sources = arguments[arguments.index("--tag") + 2 :]
     manifests = []
     for source in sources:
-        _, digest = read_manifest(source)
-        architecture = "amd64" if source.endswith("linux-amd64") else "arm64"
-        manifests.append(
-            {
-                "digest": digest,
-                "mediaType": "application/vnd.oci.image.manifest.v1+json",
-                "platform": {"os": "linux", "architecture": architecture},
-            }
-        )
+        raw, _ = read_manifest(source)
+        manifests.extend(json.loads(raw)["manifests"])
     write_manifest(
         target,
         {


### PR DESCRIPTION
## Root cause

Current Docker Buildx publishes each prepared platform image as an OCI index containing one runnable Linux image manifest and one provenance attestation. The publisher incorrectly required a bare image manifest, so the real `v0.2.50` publication stopped after safely publishing the amd64 platform tag.

## Changes

- validate each immutable platform tag as exactly one runnable Linux descriptor plus its matching attestation
- require the remote platform-index digest to equal the prepared local image ID
- validate the version index as the exact descriptor union from all prepared platform indexes
- preserve and reuse exact partial publication state without rebuilding, replacing, deleting, or retagging it
- update release documentation and black-box fakes for the canonical OCI shape

## Impact

`make publish` can now resume current Docker Buildx publications and converge idempotently while still rejecting any immutable digest, platform, descriptor, or attestation conflict.

## Validation

- `make release-test` — 54 passed
- direct standard-Docker validation of the published `v0.2.50-linux-amd64` OCI index
- direct standard-Docker dry-run validation of the composed multi-platform descriptor union
- `timeout -k 350s -s SIGKILL 350s make ci` — passed