### PR TITLE
Add strict multimodal analyzer client

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1800,6 +1800,49 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## Improvements
 
+- [x] [I044] (P0) Add an evidence-grade multimodal structured analyzer client.
+  Goal:
+  Give bounded semantic analyzers one released, provider-neutral Go client
+  operation that carries exact media bytes, requires strict structured output,
+  and returns proxy request identity without exposing provider request shapes.
+
+  Requirements:
+  - Add one current `/v2/analyze` operation distinct from ordinary text
+    generation. It accepts ordered system/user messages whose content is a
+    non-empty array of typed text, image, or audio parts.
+  - Bind every binary part to an explicit MIME type and SHA-256. The official
+    Go client computes the digest from caller-supplied bytes; the proxy decodes
+    the wire bytes and independently verifies the digest before provider
+    admission.
+  - Require a named JSON Schema and translate it to strict structured output.
+    Do not add optional strictness, free-form analyzer output, string-or-array
+    dual decoding, provider fallbacks, or compatibility aliases.
+  - Support exact ordered image input through OpenAI Responses. Reject audio
+    and every unsupported provider/model capability before an upstream call
+    until a configured route supports both its input modality and strict
+    structured output.
+  - Return the completed response text together with the proxy-owned
+    `X-LLM-Proxy-Request-ID`. Treat a missing request ID on a successful
+    response as an invalid client HTTP result.
+  - Keep output-limit exhaustion and malformed structured completion as
+    operational failures. Do not splice independent continuations into one
+    schema-constrained response.
+  - Update the canonical OpenAPI document, generated reference, README,
+    provider-routing contract, and official Go client in the same patch.
+
+  Validation:
+  - Public client tests prove constructors reject blank text, unsupported MIME
+    types, empty binary content, malformed schemas, invalid names, and
+    incomplete messages before HTTP.
+  - Real-router tests prove exact ordered image bytes and strict schema reach
+    OpenAI Responses, binary digest mismatches and unsupported routes make zero
+    upstream calls, and successful client results carry proxy request identity.
+  - OpenAPI conformance covers a representative analyzer exchange and rejects
+    obsolete or malformed shapes.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair, with the final run after the
+    last tracked edit.
+
 - [x] [I042] (P1) Remove managed-request serialization from SQLite authentication.
   Goal:
   Keep SQLite as the sole managed-tenant source of truth while allowing each

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ client.
   [canonical OpenAPI contract](docs/openapi.yaml)
 - Choose the provider per request via `provider=...`; omitted provider uses the authenticated tenant default
 - Choose the model per request via `model=...`; omitted model uses the tenant default when `provider` is omitted, otherwise the selected provider's configured default
-- Set optional nonblank `reasoning_effort=...` on `GET /`, or in a JSON body for `POST /` and `POST /v2`, to select a capability-supported reasoning level for that exact resolved route. An explicit value overrides the tenant default; an omitted value retains it. Blank or unsupported values fail before an upstream call.
+- Set optional nonblank `reasoning_effort=...` on `GET /`, or in a JSON body for `POST /`, `POST /v2`, and `POST /v2/analyze`, to select a capability-supported reasoning level for that exact resolved route. An explicit value overrides the tenant default; an omitted value retains it. Blank or unsupported values fail before an upstream call.
 - Choose the dictation model per request via `model=...` on `/dictate`; omitted model uses the tenant default when `provider` is omitted, otherwise the selected provider's configured default
 - Optional per-request web search via `web_search=1|true|yes` when the selected provider/model is configured to support it
+- Evidence-grade `POST /v2/analyze` requests with typed text/image/audio
+  content, SHA-256-bound binary bytes, mandatory strict JSON Schema output,
+  and proxy request identity
 - Optional logging at `debug` or `info` levels
 - Forwards requests using server-side provider API keys, loaded from the database in management mode
 - Optional TAuth-protected self-service UI where signed-in users automatically receive an llm-proxy client key and their provider settings plus routing defaults autosave
@@ -23,9 +26,10 @@ client.
 
 ## REST Contract
 
-llm-proxy exposes a blocking REST contract for text generation. A caller sends
-one authenticated `GET /`, `POST /`, or `POST /v2` request and receives the final
-formatted answer in that same HTTP response.
+llm-proxy exposes blocking REST contracts for text generation and bounded
+analysis. A caller sends one authenticated `GET /`, `POST /`, `POST /v2`, or
+`POST /v2/analyze` request and receives the final answer in that same HTTP
+response.
 
 ### Canonical OpenAPI ownership
 
@@ -69,6 +73,12 @@ reports its complete stop signal or the overall request deadline expires.
 Safety filters, refusals, tool/intermediate states, malformed responses, and
 missing or unknown signals remain `502` failures and never trigger this loop.
 
+`POST /v2/analyze` is deliberately outside that suffix coordinator. One
+analyzer request must complete as one valid JSON value under its mandatory
+strict schema. Output-budget exhaustion, malformed JSON, and terminal
+incomplete states are upstream failures; the proxy never splices a second
+generation into a schema-constrained report.
+
 A `504 Gateway Timeout` means the overall proxy request deadline expired before
 the selected upstream provider produced a final answer. It is not a prompt for
 the client to poll llm-proxy.
@@ -85,7 +95,8 @@ X-LLM-Proxy-Request-Timeout-Seconds: N
 `N` is the positive whole-number wall-clock budget, in seconds, for that
 request. The budget begins before body parsing and covers validation, queue
 admission, every provider call, OpenAI background polling, and response
-construction for `GET /`, `POST /`, `POST /v2`, and `POST /dictate`.
+construction for `GET /`, `POST /`, `POST /v2`, `POST /v2/analyze`, and
+`POST /dictate`.
 
 If the header is omitted, `server.request_timeout_seconds` is the effective
 budget. A supplied value must be in the inclusive range
@@ -549,11 +560,11 @@ All OpenAI Responses text requests also send `background: true` and
 reaches a documented terminal state or the request's effective work budget
 expires. Only `queued` and `in_progress` are pending states; unknown states do
 not trigger polling. Only `completed` can produce a successful response.
-Plain REST callers use one `GET /`, `POST /`, or `POST /v2` request and receive
-the final formatted answer; they do not stream, poll, or follow a separate
-resume endpoint. Separately published provider-specific deferred, batch, or
-asynchronous APIs are not implicit variants of these routes and are not
-activated by an arbitrary response `id`.
+Plain REST text callers use one `GET /`, `POST /`, or `POST /v2` request and
+receive the final formatted answer; they do not stream, poll, or follow a
+separate resume endpoint. Separately published provider-specific deferred,
+batch, or asynchronous APIs are not implicit variants of these routes and are
+not activated by an arbitrary response `id`.
 
 Provider-specific details:
 
@@ -864,11 +875,11 @@ desktop row, clears an incompatible saved value on a model change, reports `Not
 supported` for routes without a declaration, and autosaves every
 routing-default change without a separate action. The browser rejects malformed
 profile data instead of repairing it. Public
-`GET /` accepts optional query `reasoning_effort`; JSON `POST /` and `POST /v2`
-accept the same optional field in their bodies. When omitted, the saved tenant
-default remains authoritative. An explicit value must be nonblank and exactly
-supported by the resolved provider/model route, otherwise the proxy returns
-`400` before an upstream call.
+`GET /` accepts optional query `reasoning_effort`; JSON `POST /`, `POST /v2`,
+and `POST /v2/analyze` accept the same optional field in their bodies. When
+omitted, the saved tenant default remains authoritative. An explicit value must
+be nonblank and exactly supported by the resolved provider/model route,
+otherwise the proxy returns `400` before an upstream call.
 
 Management startup requires every persisted routing field to be canonical and
 catalog-valid and every nonempty provider default to have the tenant's saved
@@ -1040,7 +1051,7 @@ Production is split-origin:
 | Hostname | Owner | Purpose |
 |----------|-------|---------|
 | `llm-proxy.mprlab.com` | GitHub Pages | Static self-service frontend from `site/`. |
-| `llm-proxy-api.mprlab.com` | MPR gateway/backend | llm-proxy API, management API, `/`, `/v2`, and `/dictate`. |
+| `llm-proxy-api.mprlab.com` | MPR gateway/backend | llm-proxy API, management API, `/`, `/v2`, `/v2/analyze`, and `/dictate`. |
 | `tauth-api.mprlab.com` | TAuth backend | Google login, nonce, logout, `/auth/session`, and session-cookie issuance. |
 
 Add these DNS records:
@@ -1563,6 +1574,77 @@ caller's independent cancellation authority, and the injected `HTTPDoer` may
 have its own explicitly selected transport policy. The package does not add a
 total-response timeout.
 
+For evidence-grade analysis, construct every part and the strict output schema
+before constructing the request. Binary constructors copy the supplied bytes
+and compute the SHA-256 that the proxy independently verifies:
+
+```go
+imageBytes, err := os.ReadFile(framePath)
+if err != nil {
+    return err
+}
+image, err := llmproxyclient.NewImageContent(llmproxyclient.ImageContentInput{
+    MIMEType: "image/png",
+    Data:     imageBytes,
+    Detail:   llmproxyclient.ImageDetailHigh,
+})
+if err != nil {
+    return err
+}
+instruction, err := llmproxyclient.NewTextContent(
+    "Evaluate only the supplied assertions and return the required report.",
+)
+if err != nil {
+    return err
+}
+outputSchema, err := llmproxyclient.NewStrictOutputSchema(
+    llmproxyclient.StrictOutputSchemaInput{
+        Name: "semantic_qa_report",
+        Schema: json.RawMessage(`{
+            "type":"object",
+            "additionalProperties":false,
+            "required":["outcome"],
+            "properties":{
+                "outcome":{"type":"string","enum":["pass","return"]}
+            }
+        }`),
+    },
+)
+if err != nil {
+    return err
+}
+effort := "high"
+workBudget := 900
+request, err := llmproxyclient.NewAnalyzerRequest(
+    llmproxyclient.AnalyzerRequestInput{
+        Messages: []llmproxyclient.AnalyzerMessageInput{
+            {
+                Role:    "user",
+                Content: []llmproxyclient.ContentPart{instruction, image},
+            },
+        },
+        OutputSchema:          outputSchema,
+        Model:                 "gpt-5.5",
+        ReasoningEffort:       &effort,
+        RequestTimeoutSeconds: &workBudget,
+    },
+)
+if err != nil {
+    return err
+}
+result, err := client.PostAnalyzer(ctx, request)
+if err != nil {
+    return err
+}
+reportJSON := result.Text()
+proxyRequestID := result.RequestID()
+```
+
+`PostAnalyzer` requires explicit per-request model selection and returns both
+the completed JSON text and proxy request identity. It never reads model-profile
+files, translates provider request syntax, accepts local paths as evidence, or
+adds a schema-free continuation.
+
 To upgrade the Go package and CLI:
 
 ```shell
@@ -1877,6 +1959,32 @@ the OpenAPI schema, including the omission-versus-explicit-value contract for
 `reasoning_effort`. It rejects `prompt` and body `system_prompt`; send a
 `system` role message instead. The tenant default system prompt is still
 prepended when the submitted messages do not include a system message.
+
+### Strict multimodal analyzer
+
+`POST /v2/analyze` is the closed evidence-analysis operation. The body requires
+an explicit `model`, one or more ordered `system` or `user` messages, and one
+named `output_schema`. Message `content` is an array of typed parts:
+
+- `text` carries nonblank text.
+- `image` carries canonical base64, MIME type, detail, and the lowercase
+  SHA-256 of the decoded bytes.
+- `audio` carries canonical base64, MIME type, and the lowercase SHA-256 of the
+  decoded bytes.
+
+The proxy decodes every binary part and verifies its digest before provider
+admission. Local paths and remote-provider payload fields are not content
+transports. System messages accept text only, and every request must contain a
+user message. The current OpenAI Responses route supports text plus exact
+ordered JPEG, PNG, or WebP image parts. Audio is present in the provider-neutral
+wire and official client contract but returns `400` before upstream work until
+a configured model route supports both audio input and strict structured
+output. Non-OpenAI transports are rejected at the same pre-spend boundary.
+
+Successful responses use `application/json`, satisfy the requested strict
+schema, and include the proxy-owned `X-LLM-Proxy-Request-ID` header. The
+authoritative field and response contracts are in the
+[`POST /v2/analyze` API reference](https://llm-proxy.mprlab.com/docs/#operation-postV2Analyzer).
 
 ### Choose an OpenAI model
 

--- a/README.md
+++ b/README.md
@@ -1969,8 +1969,8 @@ named `output_schema`. Message `content` is an array of typed parts:
 - `text` carries nonblank text.
 - `image` carries canonical base64, MIME type, detail, and the lowercase
   SHA-256 of the decoded bytes.
-- `audio` carries canonical base64, MIME type, and the lowercase SHA-256 of the
-  decoded bytes.
+- `audio` carries canonical base64, an `audio/mp4`, `audio/mpeg`, or
+  `audio/wav` MIME type, and the lowercase SHA-256 of the decoded bytes.
 
 The proxy decodes every binary part and verifies its digest before provider
 admission. Local paths and remote-provider payload fields are not content

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -28,8 +28,9 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
   accept prompt strings, assistant messages, web search, system-prompt
   injection, provider tools, or response-format selection.
 - Analyzer binary parts carry canonical base64, an explicit supported MIME
-  type, and lowercase SHA-256. The proxy decodes and independently verifies
-  the digest before upstream admission. System messages accept text parts only.
+  type, and lowercase SHA-256. Audio supports exact MP4, MPEG, or WAV bytes.
+  The proxy decodes and independently verifies the digest before upstream
+  admission. System messages accept text parts only.
 - OpenAI Responses is the current analyzer transport for text and ordered JPEG,
   PNG, or WebP inputs. Audio and non-OpenAI routes return unsupported capability
   before provider work until an exact route supports the requested modality

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -8,7 +8,8 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 
 ## Request Contract
 
-- `provider` is an optional query parameter on `GET /`, `POST /`, `POST /v2`, and `POST /dictate`.
+- `provider` is an optional query parameter on `GET /`, `POST /`, `POST /v2`,
+  `POST /v2/analyze`, and `POST /dictate`.
 - Omitted `provider` means the authenticated tenant's default provider.
 - `model` keeps its current meaning; omitted `model` means the authenticated tenant's default model when set, otherwise the selected provider's configured default model.
 - A provider with an API key configured must have a configured default text model so provider-selected requests can omit `model` consistently.
@@ -21,15 +22,36 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 - Compatibility JSON `POST /` accepts exactly one text input shape: `prompt` for a single user prompt or `messages[]` for an OpenRouter/OpenAI-compatible chat transcript.
 - Canonical JSON `POST /v2` accepts only `messages[]` as the text input shape; request-body `prompt` and `system_prompt` are invalid.
 - `messages[]` items contain `role` and string `content`. Supported roles are `system`, `user`, and `assistant`; at least one `user` message is required.
+- Evidence-grade `POST /v2/analyze` is a distinct closed operation. It requires
+  an explicit model, ordered system/user messages whose `content` is an array
+  of typed text/image/audio parts, and a named strict JSON Schema. It does not
+  accept prompt strings, assistant messages, web search, system-prompt
+  injection, provider tools, or response-format selection.
+- Analyzer binary parts carry canonical base64, an explicit supported MIME
+  type, and lowercase SHA-256. The proxy decodes and independently verifies
+  the digest before upstream admission. System messages accept text parts only.
+- OpenAI Responses is the current analyzer transport for text and ordered JPEG,
+  PNG, or WebP inputs. Audio and non-OpenAI routes return unsupported capability
+  before provider work until an exact route supports the requested modality
+  together with strict structured output.
+- Analyzer success is one complete `application/json` value plus the
+  proxy-owned request ID. Output-limit exhaustion and malformed JSON are
+  operational upstream failures; analyzer requests never enter the shared
+  missing-suffix continuation loop.
 - `messages[].order` is optional. When any submitted message includes `order`, every submitted message must include a unique non-negative integer `order`; the proxy sorts submitted messages by ascending `order` before adding a request or tenant system prompt and before routing upstream.
 - With `messages[]` on `POST /`, body `system_prompt` is prepended as a system message only when the transcript does not already contain a `system` message. A body containing both `system_prompt` and a system message is invalid. With `POST /v2`, callers send system instructions as `system` role messages.
 - `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies. It is the initial per-attempt output budget and is reused for missing-suffix attempts.
 - Provided `max_tokens` maps to OpenAI Responses `max_output_tokens`, Meta, Moonshot, and MiniMax Chat Completions `max_completion_tokens`, other OpenAI-compatible chat completions `max_tokens`, Anthropic Messages `max_tokens`, and Gemini `generationConfig.maxOutputTokens`.
 - Omitted `max_tokens` means the proxy omits provider max-token fields and lets the selected provider/model default apply, except Anthropic Messages where the upstream API requires `max_tokens` and the proxy sends the selected model's configured synchronous output limit. After an output-budget stop with no visible progress, a configured model output limit becomes the generic ceiling for increasing the next attempt.
 - Known provider-specific output-token ceilings are validated before upstream calls; MiniMax M2.7 rejects `max_tokens` above `2048`, Gemini text models reject values above `65536`, and Claude models reject values above their configured synchronous Messages output limits with `400 Bad Request`.
-- `reasoning_effort` is optional on `GET /` as a query parameter and on JSON `POST /` and `POST /v2` as a body field. Omission retains the resolved tenant default. A supplied value must be nonblank and supported by the exact resolved text provider/model route; blank, `null`, or unsupported values return `400 Bad Request` before a provider call.
+- `reasoning_effort` is optional on `GET /` as a query parameter and on JSON
+  `POST /`, `POST /v2`, and `POST /v2/analyze` as a body field. Omission
+  retains the resolved tenant default. A supplied value must be nonblank and
+  supported by the exact resolved text provider/model route; blank, `null`, or
+  unsupported values return `400 Bad Request` before a provider call.
 - `X-LLM-Proxy-Request-Timeout-Seconds` is an optional positive whole-number
-  header on `GET /`, `POST /`, `POST /v2`, and `POST /dictate`. Omission uses
+  header on `GET /`, `POST /`, `POST /v2`, `POST /v2/analyze`, and
+  `POST /dictate`. Omission uses
   `server.request_timeout_seconds`; a supplied value must be in the inclusive
   range `1..server.max_request_timeout_seconds`.
 - The effective request budget begins at authenticated ingress before body
@@ -226,9 +248,10 @@ Other incomplete reasons are canonical `502` upstream failures. Usage objects
 observed while polling one response id are cumulative snapshots, so the newest
 nonempty snapshot replaces earlier observations. Usage is summed across
 distinct missing-suffix attempts and completed-response synthesis requests.
-Callers use one normal `GET /`, `POST /`, or `POST /v2` request and receive a
-complete formatted answer or a non-2xx response; there is no streaming,
-client-side polling, durable provider-job queue, or later resume contract.
+Ordinary text callers use one normal `GET /`, `POST /`, or `POST /v2` request
+and receive a complete formatted answer or a non-2xx response; there is no
+streaming, client-side polling, durable provider-job queue, or later resume
+contract.
 
 One completion coordinator owns output-budget recovery for all transports.
 Adapters normalize only their exact recoverable signal: OpenAI
@@ -254,13 +277,19 @@ managed event, while successive OpenAI snapshots for one response id replace
 one another. A recovered request records one success and no failure; a request
 deadline records one `504` with all usage observed before the deadline.
 
-Bundled clients intentionally expose only the canonical `POST /v2` text
-contract. The installable Go CLI maps prompt flags or stdin into v2 `system` and
-`user` messages, while the reusable Go and Python packages expose only
-messages-request constructors and `PostMessages`/`post_messages` send methods.
-Their optional `reasoning_effort` input serializes the same canonical field;
-the clients reject only blank local input and leave exact model-capability
-validation to the proxy edge.
+Bundled text clients expose the canonical `POST /v2` contract. The installable
+Go CLI maps prompt flags or stdin into v2 `system` and `user` messages, while
+the reusable Go and Python packages expose messages-request constructors and
+`PostMessages`/`post_messages` send methods. Their optional `reasoning_effort`
+input serializes the same canonical field; the clients reject only blank local
+input and leave exact model-capability validation to the proxy edge.
+
+The reusable Go package additionally exposes the closed `POST /v2/analyze`
+contract through typed text/image/audio constructors, a mandatory named strict
+JSON Schema, `NewAnalyzerRequest`, and `PostAnalyzer`. It computes binary
+digests locally, requires explicit per-request model selection, and returns the
+proxy request id with the completed JSON text. The Go CLI and Python package do
+not expose analyzer convenience APIs.
 Their optional request-timeout input serializes
 `X-LLM-Proxy-Request-Timeout-Seconds` on each messages request. The Go CLI uses
 `--request-timeout-seconds`; the Go and Python packages expose
@@ -514,7 +543,11 @@ that response or structured provider-failure logs.
 - OpenAI-compatible chat providers receive validated and sorted `messages[]` as provider-supported `role` and `content` items.
 - OpenAI Responses payload shape comes from the selected configured model's stable `request_profile`; model-specific web-search support comes from the selected model catalog entry. OpenAI Responses text calls run in background mode with stored responses so long provider work can be polled by llm-proxy while the caller waits on one REST request.
 - Gemini receives user messages as native `contents`, assistant messages as `model` contents, and system messages as `systemInstruction`.
-- OpenAI Responses receives single-prompt requests unchanged and multi-message requests as a deterministic role-labelled transcript.
+- OpenAI Responses receives ordinary single-prompt requests unchanged and
+  ordinary multi-message requests as a deterministic role-labelled transcript.
+  Analyzer requests instead preserve their ordered message and content-part
+  arrays, translate exact image bytes to data URLs only inside the provider
+  adapter, and set `text.format` to the caller's mandatory strict JSON Schema.
 - Dictation routing reuses the multipart transcription adapter with provider-specific URLs. OpenAI, SiliconFlow, and Zhipu send a multipart `model` field; Grok/xAI uses xAI STT and omits the multipart `model` field. Only providers that support `/dictate` expose transcription URL config fields.
 - Response formatting keeps existing text/XML/CSV bodies and existing JSON `request`, `response`, and normalized `usage` fields. JSON responses also include OpenRouter-style `object`, `model`, and `choices[].message.content` metadata, plus caller-visible request `messages` with provided `order` values. Server-injected tenant default system prompts are sent upstream but not echoed in response metadata.
 
@@ -528,6 +561,11 @@ Black-box router tests cover:
   assembly, aggregated usage, and one successful managed event.
 - OpenAI polling only for documented pending states, with missing and unknown
   states rejected without another provider call.
+- Analyzer exact ordered image and strict-schema translation through the public
+  `/v2/analyze` route, including proxy request identity on success.
+- Analyzer validation, hash mismatch, audio, and unsupported-route rejection
+  before provider work, plus strict completion, polling, malformed response,
+  terminal failure, and cancellation coverage.
 - Every configured provider through its public text route, proving the same
   shared continuation transcript, completion order, suffix assembly, and usage
   aggregation for Chat Completions, Gemini, Anthropic, and OpenAI.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2016,6 +2016,7 @@
           "mime_type": {
             "type": "string",
             "enum": [
+              "audio/mp4",
               "audio/mpeg",
               "audio/wav"
             ]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -235,6 +235,66 @@
         }
       }
     },
+    "/v2/analyze": {
+      "post": {
+        "operationId": "postV2Analyzer",
+        "summary": "Analyze hash-bound evidence with strict structured output",
+        "description": "The evidence-grade analyzer operation. It accepts ordered system and user messages containing typed text, image, or audio parts, requires a named strict JSON Schema, and returns only one complete schema-constrained JSON object. Binary bytes are canonical base64 and independently verified against their lowercase SHA-256 before provider admission. The current OpenAI Responses adapter supports text and ordered image parts; audio and every unsupported provider/model capability return 400 before upstream work.",
+        "tags": [
+          "Proxy"
+        ],
+        "security": [
+          {
+            "TenantClientKey": []
+          }
+        ],
+        "x-llm-proxy-allow-undeclared-query": false,
+        "x-llm-proxy-required-request-content-type": "application/json",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TenantClientKey"
+          },
+          {
+            "$ref": "#/components/parameters/Provider"
+          },
+          {
+            "$ref": "#/components/parameters/RequestTimeout"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AnalyzerRequest"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/AnalyzerSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProxyBadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProxyForbidden"
+          },
+          "413": {
+            "$ref": "#/components/responses/ProxyPayloadTooLarge"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProxyRateLimited"
+          },
+          "499": {
+            "$ref": "#/components/responses/CallerClosed"
+          },
+          "502": {
+            "$ref": "#/components/responses/ProxyBadGateway"
+          },
+          "503": {
+            "$ref": "#/components/responses/ProxyUnavailable"
+          },
+          "504": {
+            "$ref": "#/components/responses/ProxyTimeout"
+          }
+        }
+      }
+    },
     "/dictate": {
       "post": {
         "operationId": "postDictation",
@@ -1242,6 +1302,16 @@
           }
         }
       },
+      "AnalyzerRequest": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AnalyzerRequest"
+            }
+          }
+        }
+      },
       "DictationRequest": {
         "required": true,
         "content": {
@@ -1334,6 +1404,33 @@
           "text/csv": {
             "schema": {
               "type": "string"
+            }
+          }
+        }
+      },
+      "AnalyzerSuccess": {
+        "description": "One complete JSON value produced under the request's strict output schema. Output-budget exhaustion, malformed JSON, incomplete provider states, and schema-free continuations are never returned as success.",
+        "headers": {
+          "X-LLM-Proxy-Request-ID": {
+            "$ref": "#/components/headers/ProxyRequestID"
+          },
+          "X-LLM-Proxy-Request-Timeout-Seconds": {
+            "$ref": "#/components/headers/ResolvedRequestTimeout"
+          },
+          "X-LLM-Proxy-Request-Tokens": {
+            "$ref": "#/components/headers/OptionalTokenCount"
+          },
+          "X-LLM-Proxy-Response-Tokens": {
+            "$ref": "#/components/headers/OptionalTokenCount"
+          },
+          "X-LLM-Proxy-Total-Tokens": {
+            "$ref": "#/components/headers/OptionalTokenCount"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/JSONSchemaObject"
             }
           }
         }
@@ -1839,6 +1936,201 @@
             "type": "string",
             "minLength": 1,
             "description": "Omission selects the tenant or route default. An explicit value must be non-blank and supported by the resolved provider/model route."
+          }
+        }
+      },
+      "AnalyzerTextContent": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "text"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "text"
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "AnalyzerImageContent": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "mime_type",
+          "data",
+          "sha256",
+          "detail"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "image"
+          },
+          "mime_type": {
+            "type": "string",
+            "enum": [
+              "image/jpeg",
+              "image/png",
+              "image/webp"
+            ]
+          },
+          "data": {
+            "type": "string",
+            "minLength": 1,
+            "contentEncoding": "base64"
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "detail": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "low",
+              "high"
+            ]
+          }
+        }
+      },
+      "AnalyzerAudioContent": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "mime_type",
+          "data",
+          "sha256"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "audio"
+          },
+          "mime_type": {
+            "type": "string",
+            "enum": [
+              "audio/mpeg",
+              "audio/wav"
+            ]
+          },
+          "data": {
+            "type": "string",
+            "minLength": 1,
+            "contentEncoding": "base64"
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      },
+      "AnalyzerContent": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AnalyzerTextContent"
+          },
+          {
+            "$ref": "#/components/schemas/AnalyzerImageContent"
+          },
+          {
+            "$ref": "#/components/schemas/AnalyzerAudioContent"
+          }
+        ]
+      },
+      "AnalyzerMessage": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "role",
+          "content"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "system",
+              "user"
+            ]
+          },
+          "content": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/AnalyzerContent"
+            }
+          },
+          "order": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "JSONSchemaObject": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {}
+      },
+      "StrictOutputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "schema"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9_-]+$"
+          },
+          "description": {
+            "type": "string"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/JSONSchemaObject"
+          }
+        }
+      },
+      "AnalyzerRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "messages",
+          "output_schema",
+          "model"
+        ],
+        "properties": {
+          "messages": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Messages must include at least one user message. Either every message omits order or every message supplies one unique non-negative order. System messages accept text parts only.",
+            "items": {
+              "$ref": "#/components/schemas/AnalyzerMessage"
+            }
+          },
+          "output_schema": {
+            "$ref": "#/components/schemas/StrictOutputSchema"
+          },
+          "model": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The exact configured analyzer model. Omission is invalid."
+          },
+          "max_tokens": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "reasoning_effort": {
+            "type": "string",
+            "minLength": 1
           }
         }
       },

--- a/internal/proxy/analyzer.go
+++ b/internal/proxy/analyzer.go
@@ -1,0 +1,596 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tyemirov/llm-proxy/internal/constants"
+	"github.com/tyemirov/llm-proxy/internal/utils"
+	"go.uber.org/zap"
+)
+
+const (
+	analyzerContentTypeAudio = "audio"
+	analyzerContentTypeImage = "image"
+	analyzerContentTypeText  = "text"
+	analyzerImageMIMEJPEG    = "image/jpeg"
+	analyzerImageMIMEPNG     = "image/png"
+	analyzerImageMIMEWebP    = "image/webp"
+	openAIInputImageType     = "input_image"
+	openAIInputTextType      = "input_text"
+	openAIJSONSchemaType     = "json_schema"
+)
+
+type analyzerRequestPayload struct {
+	Messages        []analyzerMessagePayload    `json:"messages"`
+	OutputSchema    analyzerOutputSchemaPayload `json:"output_schema"`
+	Model           string                      `json:"model"`
+	MaxTokens       *int                        `json:"max_tokens"`
+	ReasoningEffort requestReasoningEffortInput `json:"reasoning_effort"`
+}
+
+type analyzerMessagePayload struct {
+	Role    string                   `json:"role"`
+	Content []analyzerContentPayload `json:"content"`
+	Order   *int                     `json:"order,omitempty"`
+}
+
+type analyzerContentPayload struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	MIMEType string `json:"mime_type,omitempty"`
+	Data     string `json:"data,omitempty"`
+	SHA256   string `json:"sha256,omitempty"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+type analyzerOutputSchemaPayload struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Schema      json.RawMessage `json:"schema"`
+}
+
+type analyzerContent struct {
+	contentType string
+	text        string
+	mimeType    string
+	data        []byte
+	detail      string
+}
+
+type analyzerMessage struct {
+	role    chatRole
+	content []analyzerContent
+	order   *int
+}
+
+type analyzerMessages []analyzerMessage
+
+type analyzerOutputSchema struct {
+	name        string
+	description string
+	schema      json.RawMessage
+}
+
+type analyzerRequestParameters struct {
+	messages        analyzerMessages
+	outputSchema    analyzerOutputSchema
+	provider        providerDefinition
+	model           textModelDefinition
+	maxTokens       *int
+	reasoningEffort string
+}
+
+func analyzerJSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, maxPromptBytes int64, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+	return func(ginContext *gin.Context) {
+		requestStart := time.Now()
+		requestTenant := authenticatedTenantFromContext(ginContext)
+		recordValidationFailure := func(model string) {
+			recordManagedUsageValidationFailure(
+				managedTenants,
+				structuredLogger,
+				ginContext,
+				requestTenant,
+				usageEndpointAnalyzer,
+				usageTextProviderIdentifier(ginContext, requestTenant.defaults),
+				usageTextModelIdentifier(ginContext, model, requestTenant.defaults),
+				requestStart,
+			)
+		}
+		if rejectClientProviderCredentialsFromQuery(ginContext) {
+			recordValidationFailure(constants.EmptyString)
+			return
+		}
+		if rejectAnalyzerQueryParameters(ginContext) {
+			recordValidationFailure(constants.EmptyString)
+			return
+		}
+		if _, suppliedModelQuery := ginContext.GetQuery(queryParameterModel); suppliedModelQuery {
+			ginContext.String(http.StatusBadRequest, errorConflictingModelParameters)
+			recordValidationFailure(constants.EmptyString)
+			return
+		}
+		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxPromptBytes)
+		bodyBytes, readBodyOK := readJSONProxyBody(ginContext)
+		if !readBodyOK {
+			recordValidationFailure(constants.EmptyString)
+			return
+		}
+		if rejectClientProviderCredentialsFromJSONBody(ginContext, bodyBytes) {
+			recordValidationFailure(constants.EmptyString)
+			return
+		}
+		var payload analyzerRequestPayload
+		if decodeError := decodeAnalyzerRequestPayload(bodyBytes, &payload); decodeError != nil {
+			ginContext.String(http.StatusBadRequest, errorInvalidAnalyzerRequest)
+			recordValidationFailure(constants.EmptyString)
+			return
+		}
+		request, requestError := newAnalyzerRequestParameters(
+			ginContext,
+			payload,
+			textRequestDefaultsForProvider(ginContext.Query(queryParameterProvider), requestTenant, providers),
+			newModelValidator(providers.forTenant(requestTenant)),
+		)
+		if requestError != nil {
+			ginContext.String(statusCodeForError(requestError), responseMessageForError(requestError))
+			recordValidationFailure(payload.Model)
+			return
+		}
+		submitAnalyzerRequest(ginContext, upstreamProviders, request, requestTenant, managedTenants, structuredLogger, requestStart)
+	}
+}
+
+func rejectAnalyzerQueryParameters(ginContext *gin.Context) bool {
+	for parameterName, parameterValues := range ginContext.Request.URL.Query() {
+		switch parameterName {
+		case queryParameterKey, queryParameterProvider, queryParameterModel:
+			if len(parameterValues) == 1 {
+				continue
+			}
+		}
+		ginContext.String(http.StatusBadRequest, errorInvalidAnalyzerRequest)
+		return true
+	}
+	return false
+}
+
+func decodeAnalyzerRequestPayload(bodyBytes []byte, payload *analyzerRequestPayload) error {
+	decoder := json.NewDecoder(bytes.NewReader(bodyBytes))
+	decoder.DisallowUnknownFields()
+	if decodeError := decoder.Decode(payload); decodeError != nil {
+		return decodeError
+	}
+	var trailing any
+	if trailingError := decoder.Decode(&trailing); !errors.Is(trailingError, io.EOF) {
+		return fmt.Errorf("analyzer request must contain one JSON object")
+	}
+	return nil
+}
+
+func newAnalyzerRequestParameters(ginContext *gin.Context, payload analyzerRequestPayload, defaults textRequestDefaults, validator *modelValidator) (analyzerRequestParameters, error) {
+	if payload.Model == constants.EmptyString || payload.Model != strings.TrimSpace(payload.Model) {
+		return analyzerRequestParameters{}, fmt.Errorf("%w: missing model", ErrInvalidAnalyzerRequest)
+	}
+	if payload.MaxTokens != nil && *payload.MaxTokens <= 0 {
+		return analyzerRequestParameters{}, fmt.Errorf("%w: max_tokens must be positive", ErrInvalidAnalyzerRequest)
+	}
+	outputSchema, schemaError := newAnalyzerOutputSchema(payload.OutputSchema)
+	if schemaError != nil {
+		return analyzerRequestParameters{}, schemaError
+	}
+	messages, messageError := newAnalyzerMessages(payload.Messages)
+	if messageError != nil {
+		return analyzerRequestParameters{}, messageError
+	}
+	providerDefinition, resolvedModel, resolutionError := validator.ResolveText(
+		ginContext.Query(queryParameterProvider),
+		payload.Model,
+		defaults.provider,
+		constants.EmptyString,
+		false,
+	)
+	if resolutionError != nil {
+		return analyzerRequestParameters{}, resolutionError
+	}
+	if providerDefinition.textTransport != textTransportOpenAIResponses {
+		return analyzerRequestParameters{}, fmt.Errorf(
+			"%w: provider=%s model=%s capability=multimodal_strict_output",
+			ErrUnsupportedCapability,
+			providerDefinition.identifier.string(),
+			resolvedModel.string(),
+		)
+	}
+	if analyzerMessagesContainAudio(messages) {
+		return analyzerRequestParameters{}, fmt.Errorf(
+			"%w: provider=%s model=%s capability=audio_strict_output",
+			ErrUnsupportedCapability,
+			providerDefinition.identifier.string(),
+			resolvedModel.string(),
+		)
+	}
+	if maxTokensError := validateTextMaxTokens(providerDefinition, resolvedModel, payload.MaxTokens); maxTokensError != nil {
+		return analyzerRequestParameters{}, fmt.Errorf("%w: max_tokens exceeds model limit", ErrInvalidAnalyzerRequest)
+	}
+	reasoningEffort, reasoningError := requestReasoningEffortForResolvedTextRoute(
+		providerDefinition,
+		resolvedModel,
+		defaults.reasoningEffort,
+		payload.ReasoningEffort,
+	)
+	if reasoningError != nil {
+		return analyzerRequestParameters{}, reasoningError
+	}
+	return analyzerRequestParameters{
+		messages:        messages,
+		outputSchema:    outputSchema,
+		provider:        providerDefinition,
+		model:           resolvedModel,
+		maxTokens:       payload.MaxTokens,
+		reasoningEffort: reasoningEffort,
+	}, nil
+}
+
+func newAnalyzerOutputSchema(payload analyzerOutputSchemaPayload) (analyzerOutputSchema, error) {
+	name := payload.Name
+	if !validAnalyzerSchemaName(name) {
+		return analyzerOutputSchema{}, fmt.Errorf("%w: invalid output_schema.name", ErrInvalidAnalyzerRequest)
+	}
+	var schema map[string]json.RawMessage
+	if len(payload.Schema) == 0 || json.Unmarshal(payload.Schema, &schema) != nil || schema == nil {
+		return analyzerOutputSchema{}, fmt.Errorf("%w: output_schema.schema must be one JSON object", ErrInvalidAnalyzerRequest)
+	}
+	return analyzerOutputSchema{
+		name:        name,
+		description: strings.TrimSpace(payload.Description),
+		schema:      append(json.RawMessage(nil), payload.Schema...),
+	}, nil
+}
+
+func validAnalyzerSchemaName(name string) bool {
+	if len(name) == 0 || len(name) > 64 {
+		return false
+	}
+	for _, character := range name {
+		if character >= 'a' && character <= 'z' ||
+			character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' ||
+			character == '_' ||
+			character == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func newAnalyzerMessages(payloadMessages []analyzerMessagePayload) (analyzerMessages, error) {
+	if len(payloadMessages) == 0 {
+		return nil, fmt.Errorf("%w: missing messages", ErrInvalidAnalyzerRequest)
+	}
+	orderedMessages, orderError := sortAnalyzerMessagePayloads(payloadMessages)
+	if orderError != nil {
+		return nil, orderError
+	}
+	messages := make(analyzerMessages, 0, len(orderedMessages))
+	hasUserMessage := false
+	for messageIndex, payloadMessage := range orderedMessages {
+		role, roleError := newChatRole(payloadMessage.Role)
+		if roleError != nil || role == chatRoleAssistant || string(role) != payloadMessage.Role {
+			return nil, fmt.Errorf("%w: messages[%d].role unsupported", ErrInvalidAnalyzerRequest, messageIndex)
+		}
+		if len(payloadMessage.Content) == 0 {
+			return nil, fmt.Errorf("%w: messages[%d].content is empty", ErrInvalidAnalyzerRequest, messageIndex)
+		}
+		content := make([]analyzerContent, 0, len(payloadMessage.Content))
+		for contentIndex, payloadContent := range payloadMessage.Content {
+			validatedContent, contentError := newAnalyzerContent(payloadContent)
+			if contentError != nil {
+				return nil, fmt.Errorf("%w: messages[%d].content[%d]: %v", ErrInvalidAnalyzerRequest, messageIndex, contentIndex, contentError)
+			}
+			if role == chatRoleSystem && validatedContent.contentType != analyzerContentTypeText {
+				return nil, fmt.Errorf("%w: system messages accept text only", ErrInvalidAnalyzerRequest)
+			}
+			content = append(content, validatedContent)
+		}
+		if role == chatRoleUser {
+			hasUserMessage = true
+		}
+		messages = append(messages, analyzerMessage{
+			role:    role,
+			content: content,
+			order:   payloadMessage.Order,
+		})
+	}
+	if !hasUserMessage {
+		return nil, fmt.Errorf("%w: messages must include a user message", ErrInvalidAnalyzerRequest)
+	}
+	return messages, nil
+}
+
+func newAnalyzerContent(payload analyzerContentPayload) (analyzerContent, error) {
+	contentType := payload.Type
+	switch contentType {
+	case analyzerContentTypeText:
+		if strings.TrimSpace(payload.Text) == constants.EmptyString {
+			return analyzerContent{}, errors.New("text is blank")
+		}
+		if payload.MIMEType != constants.EmptyString ||
+			payload.Data != constants.EmptyString ||
+			payload.SHA256 != constants.EmptyString ||
+			payload.Detail != constants.EmptyString {
+			return analyzerContent{}, errors.New("text has binary fields")
+		}
+		return analyzerContent{contentType: contentType, text: payload.Text}, nil
+	case analyzerContentTypeImage:
+		if payload.Text != constants.EmptyString {
+			return analyzerContent{}, errors.New("image has text field")
+		}
+		mimeType := payload.MIMEType
+		switch mimeType {
+		case analyzerImageMIMEJPEG, analyzerImageMIMEPNG, analyzerImageMIMEWebP:
+		default:
+			return analyzerContent{}, fmt.Errorf("unsupported image MIME type=%q", payload.MIMEType)
+		}
+		detail := payload.Detail
+		if detail != "auto" && detail != "low" && detail != "high" {
+			return analyzerContent{}, fmt.Errorf("unsupported image detail=%q", payload.Detail)
+		}
+		data, digestError := decodeHashBoundAnalyzerData(payload.Data, payload.SHA256)
+		if digestError != nil {
+			return analyzerContent{}, digestError
+		}
+		return analyzerContent{contentType: contentType, mimeType: mimeType, data: data, detail: detail}, nil
+	case analyzerContentTypeAudio:
+		if payload.Text != constants.EmptyString || payload.Detail != constants.EmptyString {
+			return analyzerContent{}, errors.New("audio has unsupported fields")
+		}
+		mimeType := payload.MIMEType
+		if mimeType != "audio/mpeg" && mimeType != "audio/wav" {
+			return analyzerContent{}, fmt.Errorf("unsupported audio MIME type=%q", payload.MIMEType)
+		}
+		data, digestError := decodeHashBoundAnalyzerData(payload.Data, payload.SHA256)
+		if digestError != nil {
+			return analyzerContent{}, digestError
+		}
+		return analyzerContent{contentType: contentType, mimeType: mimeType, data: data}, nil
+	default:
+		return analyzerContent{}, fmt.Errorf("unsupported content type=%q", payload.Type)
+	}
+}
+
+func decodeHashBoundAnalyzerData(rawData string, rawDigest string) ([]byte, error) {
+	if rawData == constants.EmptyString {
+		return nil, errors.New("binary data is empty")
+	}
+	decodedData, decodeError := base64.StdEncoding.DecodeString(rawData)
+	if decodeError != nil || len(decodedData) == 0 || base64.StdEncoding.EncodeToString(decodedData) != rawData {
+		return nil, errors.New("binary data is not canonical base64")
+	}
+	digest := rawDigest
+	digestBytes, digestError := hex.DecodeString(digest)
+	if digestError != nil || len(digestBytes) != sha256.Size || strings.ToLower(digest) != digest {
+		return nil, errors.New("sha256 is not canonical lowercase hex")
+	}
+	actualDigest := sha256.Sum256(decodedData)
+	if !bytes.Equal(actualDigest[:], digestBytes) {
+		return nil, errors.New("sha256 does not match binary data")
+	}
+	return decodedData, nil
+}
+
+func sortAnalyzerMessagePayloads(payloadMessages []analyzerMessagePayload) ([]analyzerMessagePayload, error) {
+	orderedMessages := append([]analyzerMessagePayload(nil), payloadMessages...)
+	hasExplicitOrder := false
+	for _, message := range orderedMessages {
+		if message.Order != nil {
+			hasExplicitOrder = true
+			break
+		}
+	}
+	if !hasExplicitOrder {
+		return orderedMessages, nil
+	}
+	seenOrders := map[int]struct{}{}
+	for messageIndex, message := range orderedMessages {
+		if message.Order == nil {
+			return nil, fmt.Errorf("%w: messages[%d].order missing", ErrInvalidAnalyzerRequest, messageIndex)
+		}
+		if *message.Order < 0 {
+			return nil, fmt.Errorf("%w: messages[%d].order is negative", ErrInvalidAnalyzerRequest, messageIndex)
+		}
+		if _, duplicate := seenOrders[*message.Order]; duplicate {
+			return nil, fmt.Errorf("%w: duplicate messages order=%d", ErrInvalidAnalyzerRequest, *message.Order)
+		}
+		seenOrders[*message.Order] = struct{}{}
+	}
+	sort.SliceStable(orderedMessages, func(firstIndex int, secondIndex int) bool {
+		return *orderedMessages[firstIndex].Order < *orderedMessages[secondIndex].Order
+	})
+	return orderedMessages, nil
+}
+
+func analyzerMessagesContainAudio(messages analyzerMessages) bool {
+	for _, message := range messages {
+		for _, content := range message.content {
+			if content.contentType == analyzerContentTypeAudio {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (messages analyzerMessages) openAIInput() []map[string]any {
+	input := make([]map[string]any, 0, len(messages))
+	for _, message := range messages {
+		content := make([]map[string]any, 0, len(message.content))
+		for _, contentPart := range message.content {
+			if contentPart.contentType == analyzerContentTypeText {
+				content = append(content, map[string]any{
+					keyType: openAIInputTextType,
+					keyText: contentPart.text,
+				})
+				continue
+			}
+			content = append(content, map[string]any{
+				keyType:     openAIInputImageType,
+				"image_url": "data:" + contentPart.mimeType + ";base64," + base64.StdEncoding.EncodeToString(contentPart.data),
+				"detail":    contentPart.detail,
+			})
+		}
+		input = append(input, map[string]any{
+			keyType:          responseTypeMessage,
+			jsonFieldRole:    string(message.role),
+			jsonFieldContent: content,
+		})
+	}
+	return input
+}
+
+func (schema analyzerOutputSchema) openAIFormat() map[string]any {
+	format := map[string]any{
+		keyType:  openAIJSONSchemaType,
+		"name":   schema.name,
+		"schema": schema.schema,
+		"strict": true,
+	}
+	if schema.description != constants.EmptyString {
+		format["description"] = schema.description
+	}
+	return format
+}
+
+func (router *providerRouter) analyze(requestContext context.Context, request analyzerRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	return router.openAIClient.openAIAnalyzerRequest(
+		requestContext,
+		request.provider.credentialFor(endpointKindText),
+		request.model,
+		request.messages,
+		request.outputSchema,
+		request.maxTokens,
+		request.reasoningEffort,
+		structuredLogger,
+	)
+}
+
+func (client *OpenAIClient) openAIAnalyzerRequest(parentContext context.Context, openAIKey string, model textModelDefinition, messages analyzerMessages, outputSchema analyzerOutputSchema, maxTokens *int, reasoningEffort string, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	payload := map[string]any{
+		keyModel:      model.string(),
+		keyInput:      messages.openAIInput(),
+		keyBackground: true,
+		keyStore:      true,
+		keyText: map[string]any{
+			keyFormat: outputSchema.openAIFormat(),
+		},
+	}
+	if maxTokens != nil {
+		payload[keyMaxOutputTokens] = *maxTokens
+	}
+	if reasoningEffort != constants.EmptyString {
+		payload[keyReasoning] = map[string]any{keyEffort: reasoningEffort}
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	httpRequest, buildError := buildAuthorizedJSONRequest(parentContext, http.MethodPost, client.endpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
+	if buildError != nil {
+		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
+		return textGenerationResult{}, buildError
+	}
+	statusCode, responseBytes, _, latencyMillis, requestError := client.performResponsesRequest(httpRequest, structuredLogger, logEventOpenAIRequestError)
+	if requestError != nil {
+		return textGenerationResult{}, requestError
+	}
+	responseSnapshot, snapshotError := newOpenAIResponseSnapshot(responseBytes)
+	structuredLogger.Infow(
+		logEventOpenAIResponse,
+		logFieldHTTPStatus, statusCode,
+		logFieldAPIStatus, responseSnapshot.status,
+		constants.LogFieldLatencyMilliseconds, latencyMillis,
+	)
+	if snapshotError != nil {
+		return textGenerationResult{}, errors.New(errorOpenAIAPI)
+	}
+	return client.resolveOpenAIAnalyzerResponse(parentContext, openAIKey, responseSnapshot, structuredLogger)
+}
+
+func (client *OpenAIClient) resolveOpenAIAnalyzerResponse(parentContext context.Context, openAIKey string, responseSnapshot openAIResponseSnapshot, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	if responseSnapshot.status == statusCompleted {
+		return completedAnalyzerGeneration(responseSnapshot)
+	}
+	if responseSnapshot.status == statusCancelled || responseSnapshot.status == statusFailed || responseSnapshot.status == statusIncomplete {
+		return textGenerationResult{usage: responseSnapshot.usage}, fmt.Errorf("%w: analyzer response status=%s", ErrProviderAPI, responseSnapshot.status)
+	}
+	if !responseSnapshot.isPending() || utils.IsBlank(responseSnapshot.identifier) {
+		return textGenerationResult{usage: responseSnapshot.usage}, errors.New(errorOpenAIAPI)
+	}
+	return client.pollOpenAIAnalyzerResponse(parentContext, openAIKey, responseSnapshot.identifier, responseSnapshot.usage, structuredLogger)
+}
+
+func completedAnalyzerGeneration(responseSnapshot openAIResponseSnapshot) (textGenerationResult, error) {
+	if utils.IsBlank(responseSnapshot.text) || !json.Valid([]byte(responseSnapshot.text)) {
+		return textGenerationResult{usage: responseSnapshot.usage}, fmt.Errorf("%w: analyzer response is not valid JSON", ErrProviderAPI)
+	}
+	return responseSnapshot.generation(), nil
+}
+
+func (client *OpenAIClient) pollOpenAIAnalyzerResponse(parentContext context.Context, openAIKey string, responseIdentifier string, latestUsage *tokenUsage, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	for {
+		responseSnapshot, responseComplete, fetchError := client.fetchResponseByID(parentContext, openAIKey, responseIdentifier, structuredLogger)
+		if responseSnapshot.usage != nil {
+			latestUsage = responseSnapshot.usage
+		}
+		if fetchError != nil {
+			if parentContext.Err() != nil {
+				return textGenerationResult{usage: latestUsage}, parentContext.Err()
+			}
+			return textGenerationResult{usage: latestUsage}, fetchError
+		}
+		if responseComplete {
+			responseSnapshot.usage = latestUsage
+			if responseSnapshot.status == statusCompleted {
+				return completedAnalyzerGeneration(responseSnapshot)
+			}
+			return textGenerationResult{usage: latestUsage}, fmt.Errorf("%w: analyzer response status=%s", ErrProviderAPI, responseSnapshot.status)
+		}
+		select {
+		case <-time.After(responsePollInterval):
+		case <-parentContext.Done():
+			return textGenerationResult{usage: latestUsage}, parentContext.Err()
+		}
+	}
+}
+
+func submitAnalyzerRequest(ginContext *gin.Context, upstreamProviders *providerRouter, request analyzerRequestParameters, requestTenant tenant, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger, requestStart time.Time) {
+	generation, requestError := upstreamProviders.analyze(ginContext.Request.Context(), request, structuredLogger)
+	if requestError != nil {
+		if requestContextEnded(ginContext) {
+			recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointAnalyzer, request.provider.identifier.string(), request.model.string(), ginContext.Writer.Status(), generation.usage, requestStart)
+			return
+		}
+		markRequestOutcome(ginContext, requestFailureOutcome(requestError), managedRequestFailureOutcome(requestError))
+		statusCode := statusCodeForError(requestError)
+		writeProviderRequestErrorResponse(ginContext, request.provider.identifier.string(), requestError, structuredLogger)
+		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointAnalyzer, request.provider.identifier.string(), request.model.string(), statusCode, generation.usage, requestStart)
+		return
+	}
+	if requestContextEnded(ginContext) {
+		recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointAnalyzer, request.provider.identifier.string(), request.model.string(), ginContext.Writer.Status(), generation.usage, requestStart)
+		return
+	}
+	markRequestOutcome(ginContext, requestOutcomeSuccess, managedUsageOutcomeSuccess)
+	writeTokenUsageHeaders(ginContext.Writer.Header(), generation.usage)
+	ginContext.Data(http.StatusOK, mimeApplicationJSON, []byte(generation.text))
+	recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointAnalyzer, request.provider.identifier.string(), request.model.string(), http.StatusOK, generation.usage, requestStart)
+}

--- a/internal/proxy/analyzer.go
+++ b/internal/proxy/analyzer.go
@@ -358,7 +358,7 @@ func newAnalyzerContent(payload analyzerContentPayload) (analyzerContent, error)
 			return analyzerContent{}, errors.New("audio has unsupported fields")
 		}
 		mimeType := payload.MIMEType
-		if mimeType != "audio/mpeg" && mimeType != "audio/wav" {
+		if mimeType != "audio/mp4" && mimeType != "audio/mpeg" && mimeType != "audio/wav" {
 			return analyzerContent{}, fmt.Errorf("unsupported audio MIME type=%q", payload.MIMEType)
 		}
 		data, digestError := decodeHashBoundAnalyzerData(payload.Data, payload.SHA256)

--- a/internal/proxy/analyzer_routing_test.go
+++ b/internal/proxy/analyzer_routing_test.go
@@ -162,7 +162,7 @@ func TestAnalyzerRouteRejectsInvalidDigestAudioAndUnsupportedProviderBeforeUpstr
 			"role":"user",
 			"content":[
 				{"type":"text","text":"Inspect."},
-				{"type":"audio","mime_type":"audio/mpeg","data":"` + base64.StdEncoding.EncodeToString([]byte("audio")) + `","sha256":"` + hex.EncodeToString(audioDigest[:]) + `"}
+				{"type":"audio","mime_type":"audio/mp4","data":"` + base64.StdEncoding.EncodeToString([]byte("audio")) + `","sha256":"` + hex.EncodeToString(audioDigest[:]) + `"}
 			]
 		}],
 		"output_schema":{"name":"report","schema":{"type":"object","additionalProperties":false}},

--- a/internal/proxy/analyzer_routing_test.go
+++ b/internal/proxy/analyzer_routing_test.go
@@ -1,0 +1,799 @@
+package proxy_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tyemirov/llm-proxy/internal/proxy"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
+	"go.uber.org/zap"
+)
+
+func TestAnalyzerRouteSendsExactOrderedImagesAndStrictSchemaToOpenAI(t *testing.T) {
+	var capturedPayload map[string]any
+	var upstreamCalls atomic.Int32
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		upstreamCalls.Add(1)
+		if request.Method != http.MethodPost {
+			t.Fatalf("method=%q", request.Method)
+		}
+		bodyBytes, readError := io.ReadAll(request.Body)
+		if readError != nil {
+			t.Fatalf("read upstream body: %v", readError)
+		}
+		if decodeError := json.Unmarshal(bodyBytes, &capturedPayload); decodeError != nil {
+			t.Fatalf("decode upstream body: %v", decodeError)
+		}
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{
+			"id":"analyzer-response",
+			"status":"completed",
+			"output_text":"{\"outcome\":\"pass\"}",
+			"output":[{
+				"type":"message",
+				"role":"assistant",
+				"content":[{"type":"output_text","text":"{\"outcome\":\"pass\"}"}]
+			}]
+		}`))
+	}))
+	t.Cleanup(upstreamServer.Close)
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(upstreamServer.URL)
+	router, buildError := buildRouterWithCatalogs(t, proxy.Configuration{
+		Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+		OpenAIKey:             TestAPIKey,
+		LogLevel:              proxy.LogLevelInfo,
+		WorkerCount:           1,
+		QueueSize:             1,
+		RequestTimeoutSeconds: TestTimeout,
+		Endpoints:             endpoints,
+	}, zap.NewNop().Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	firstImage := []byte("first exact image")
+	secondImage := []byte("second exact image")
+	requestBody := analyzerRequestBody(t, firstImage, secondImage)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v2/analyze?key="+url.QueryEscape(TestSecret)+"&provider=openai",
+		bytes.NewReader(requestBody),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK || strings.TrimSpace(response.Body.String()) != `{"outcome":"pass"}` {
+		t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+	}
+	if response.Header().Get(llmproxycontract.HeaderRequestID) == "" {
+		t.Fatal("successful analyzer response is missing proxy request id")
+	}
+	if upstreamCalls.Load() != 1 {
+		t.Fatalf("upstream calls=%d", upstreamCalls.Load())
+	}
+	if capturedPayload["model"] != proxy.ModelNameGPT55 ||
+		capturedPayload["background"] != true ||
+		capturedPayload["store"] != true ||
+		capturedPayload["max_output_tokens"] != float64(1200) {
+		t.Fatalf("upstream payload=%v", capturedPayload)
+	}
+	reasoning, reasoningOK := capturedPayload["reasoning"].(map[string]any)
+	if !reasoningOK || reasoning["effort"] != "high" {
+		t.Fatalf("reasoning=%v", capturedPayload["reasoning"])
+	}
+	text, textOK := capturedPayload["text"].(map[string]any)
+	format, formatOK := text["format"].(map[string]any)
+	if !textOK || !formatOK ||
+		format["type"] != "json_schema" ||
+		format["name"] != "semantic_qa_report" ||
+		format["strict"] != true {
+		t.Fatalf("text format=%v", capturedPayload["text"])
+	}
+	input, inputOK := capturedPayload["input"].([]any)
+	if !inputOK || len(input) != 2 {
+		t.Fatalf("input=%v", capturedPayload["input"])
+	}
+	userMessage := input[1].(map[string]any)
+	content := userMessage["content"].([]any)
+	if len(content) != 3 {
+		t.Fatalf("content=%v", content)
+	}
+	assertOpenAIImagePart(t, content[1], "image/png", firstImage, "high")
+	assertOpenAIImagePart(t, content[2], "image/jpeg", secondImage, "low")
+}
+
+func TestAnalyzerRouteRejectsInvalidDigestAudioAndUnsupportedProviderBeforeUpstream(t *testing.T) {
+	var upstreamCalls atomic.Int32
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		responseWriter.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(upstreamServer.Close)
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(upstreamServer.URL)
+	router, buildError := buildRouterWithCatalogs(t, proxy.Configuration{
+		Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+		OpenAIKey:             TestAPIKey,
+		DeepSeekKey:           testDeepSeekKey,
+		DeepSeekBaseURL:       upstreamServer.URL,
+		LogLevel:              proxy.LogLevelInfo,
+		WorkerCount:           1,
+		QueueSize:             1,
+		RequestTimeoutSeconds: TestTimeout,
+		Endpoints:             endpoints,
+	}, zap.NewNop().Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	validBody := analyzerRequestBody(t, []byte("first"), []byte("second"))
+	var decodedBody map[string]any
+	if decodeError := json.Unmarshal(validBody, &decodedBody); decodeError != nil {
+		t.Fatalf("decode fixture: %v", decodeError)
+	}
+	messages := decodedBody["messages"].([]any)
+	userMessage := messages[1].(map[string]any)
+	content := userMessage["content"].([]any)
+	firstImage := content[1].(map[string]any)
+	firstImage["sha256"] = strings.Repeat("0", 64)
+	invalidDigestBody, marshalError := json.Marshal(decodedBody)
+	if marshalError != nil {
+		t.Fatalf("marshal invalid digest body: %v", marshalError)
+	}
+
+	audioDigest := sha256.Sum256([]byte("audio"))
+	audioBody := []byte(`{
+		"messages":[{
+			"role":"user",
+			"content":[
+				{"type":"text","text":"Inspect."},
+				{"type":"audio","mime_type":"audio/mpeg","data":"` + base64.StdEncoding.EncodeToString([]byte("audio")) + `","sha256":"` + hex.EncodeToString(audioDigest[:]) + `"}
+			]
+		}],
+		"output_schema":{"name":"report","schema":{"type":"object","additionalProperties":false}},
+		"model":"` + proxy.ModelNameGPT55 + `"
+	}`)
+	invalidAudioDigestBody := []byte(strings.Replace(string(audioBody), hex.EncodeToString(audioDigest[:]), strings.Repeat("0", 64), 1))
+	var deepSeekBodyPayload map[string]any
+	if decodeError := json.Unmarshal(validBody, &deepSeekBodyPayload); decodeError != nil {
+		t.Fatalf("decode DeepSeek body: %v", decodeError)
+	}
+	deepSeekBodyPayload["model"] = "deepseek-v4-flash"
+	deepSeekBody, marshalError := json.Marshal(deepSeekBodyPayload)
+	if marshalError != nil {
+		t.Fatalf("marshal DeepSeek body: %v", marshalError)
+	}
+
+	testCases := []struct {
+		name     string
+		provider string
+		body     []byte
+	}{
+		{name: "digest mismatch", provider: proxy.ProviderNameOpenAI, body: invalidDigestBody},
+		{name: "audio digest mismatch", provider: proxy.ProviderNameOpenAI, body: invalidAudioDigestBody},
+		{name: "audio unsupported", provider: proxy.ProviderNameOpenAI, body: audioBody},
+		{name: "provider unsupported", provider: proxy.ProviderNameDeepSeek, body: deepSeekBody},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/v2/analyze?key="+url.QueryEscape(TestSecret)+"&provider="+url.QueryEscape(testCase.provider),
+				bytes.NewReader(testCase.body),
+			)
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != http.StatusBadRequest {
+				subTest.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+		})
+	}
+	if upstreamCalls.Load() != 0 {
+		t.Fatalf("upstream calls=%d want=0", upstreamCalls.Load())
+	}
+}
+
+func TestAnalyzerRouteHandlesStrictUpstreamLifecycle(t *testing.T) {
+	initialResponseCases := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "provider HTTP error", statusCode: http.StatusBadRequest, body: `{"error":"bad request"}`},
+		{name: "malformed provider JSON", statusCode: http.StatusOK, body: `{`},
+		{name: "completed non JSON output", statusCode: http.StatusOK, body: `{"id":"invalid","status":"completed","output_text":"not-json"}`},
+		{name: "terminal provider failure", statusCode: http.StatusOK, body: `{"id":"failed","status":"failed"}`},
+		{name: "unknown provider status", statusCode: http.StatusOK, body: `{"id":"unknown","status":"mystery"}`},
+		{name: "pending response missing identity", statusCode: http.StatusOK, body: `{"status":"queued"}`},
+	}
+	for _, testCase := range initialResponseCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			router := analyzerRouterWithResponsesHandler(subTest, TestTimeout, func(responseWriter http.ResponseWriter, _ *http.Request) {
+				responseWriter.Header().Set("Content-Type", "application/json")
+				responseWriter.WriteHeader(testCase.statusCode)
+				_, _ = responseWriter.Write([]byte(testCase.body))
+			})
+			statusCode, _ := performAnalyzerRequest(subTest, router, context.Background())
+			if statusCode != http.StatusBadGateway {
+				subTest.Fatalf("status=%d want=%d", statusCode, http.StatusBadGateway)
+			}
+		})
+	}
+
+	t.Run("queued response polls through in progress to strict completion", func(subTest *testing.T) {
+		var pollCount atomic.Int32
+		router := analyzerRouterWithResponsesHandler(subTest, TestTimeout, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			switch {
+			case httpRequest.Method == http.MethodPost && httpRequest.URL.Path == "/":
+				_, _ = responseWriter.Write([]byte(`{"id":"poll-success","status":"queued","usage":{"input_tokens":1,"output_tokens":0,"total_tokens":1}}`))
+			case httpRequest.Method == http.MethodGet && httpRequest.URL.Path == "/poll-success":
+				if pollCount.Add(1) == 1 {
+					_, _ = responseWriter.Write([]byte(`{"id":"poll-success","status":"in_progress","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+					return
+				}
+				_, _ = responseWriter.Write([]byte(`{"id":"poll-success","status":"completed","output_text":"{\"outcome\":\"pass\"}","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+			default:
+				http.NotFound(responseWriter, httpRequest)
+			}
+		})
+		statusCode, body := performAnalyzerRequest(subTest, router, context.Background())
+		if statusCode != http.StatusOK || strings.TrimSpace(body) != `{"outcome":"pass"}` {
+			subTest.Fatalf("status=%d body=%q", statusCode, body)
+		}
+		if pollCount.Load() != 2 {
+			subTest.Fatalf("poll count=%d want=2", pollCount.Load())
+		}
+	})
+
+	t.Run("poll terminal failure", func(subTest *testing.T) {
+		router := analyzerRouterWithResponsesHandler(subTest, TestTimeout, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			if httpRequest.Method == http.MethodPost {
+				_, _ = responseWriter.Write([]byte(`{"id":"poll-failed","status":"queued"}`))
+				return
+			}
+			_, _ = responseWriter.Write([]byte(`{"id":"poll-failed","status":"incomplete","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+		})
+		statusCode, _ := performAnalyzerRequest(subTest, router, context.Background())
+		if statusCode != http.StatusBadGateway {
+			subTest.Fatalf("status=%d want=%d", statusCode, http.StatusBadGateway)
+		}
+	})
+
+	t.Run("poll protocol failure", func(subTest *testing.T) {
+		router := analyzerRouterWithResponsesHandler(subTest, TestTimeout, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			if httpRequest.Method == http.MethodPost {
+				_, _ = responseWriter.Write([]byte(`{"id":"poll-unknown","status":"queued"}`))
+				return
+			}
+			_, _ = responseWriter.Write([]byte(`{"id":"poll-unknown","status":"mystery"}`))
+		})
+		statusCode, _ := performAnalyzerRequest(subTest, router, context.Background())
+		if statusCode != http.StatusBadGateway {
+			subTest.Fatalf("status=%d want=%d", statusCode, http.StatusBadGateway)
+		}
+	})
+
+	t.Run("caller cancellation during poll fetch", func(subTest *testing.T) {
+		router := analyzerRouterWithResponsesHandler(subTest, TestTimeout, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			if httpRequest.Method == http.MethodPost {
+				_, _ = responseWriter.Write([]byte(`{"id":"poll-blocked","status":"queued"}`))
+				return
+			}
+			<-httpRequest.Context().Done()
+		})
+		requestContext, cancelRequest := context.WithTimeout(context.Background(), 75*time.Millisecond)
+		defer cancelRequest()
+		statusCode, _ := performAnalyzerRequest(subTest, router, requestContext)
+		if statusCode != 499 {
+			subTest.Fatalf("status=%d want=499", statusCode)
+		}
+	})
+
+	t.Run("caller cancellation during poll interval", func(subTest *testing.T) {
+		router := analyzerRouterWithResponsesHandler(subTest, TestTimeout, func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			if httpRequest.Method == http.MethodPost {
+				_, _ = responseWriter.Write([]byte(`{"id":"poll-wait","status":"queued"}`))
+				return
+			}
+			_, _ = responseWriter.Write([]byte(`{"id":"poll-wait","status":"in_progress"}`))
+		})
+		requestContext, cancelRequest := context.WithTimeout(context.Background(), 75*time.Millisecond)
+		defer cancelRequest()
+		statusCode, _ := performAnalyzerRequest(subTest, router, requestContext)
+		if statusCode != 499 {
+			subTest.Fatalf("status=%d want=499", statusCode)
+		}
+	})
+
+	t.Run("invalid provider URL fails request construction", func(subTest *testing.T) {
+		endpoints := proxy.NewEndpoints()
+		endpoints.SetResponsesURL("http://[::1")
+		router := coverageRouter(subTest, proxy.Configuration{
+			Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+			OpenAIKey:             TestAPIKey,
+			LogLevel:              proxy.LogLevelInfo,
+			WorkerCount:           1,
+			QueueSize:             1,
+			RequestTimeoutSeconds: TestTimeout,
+			Endpoints:             endpoints,
+		})
+		statusCode, _ := performAnalyzerRequest(subTest, router, context.Background())
+		if statusCode != http.StatusBadGateway {
+			subTest.Fatalf("status=%d want=%d", statusCode, http.StatusBadGateway)
+		}
+	})
+
+	t.Run("caller cancellation after completed provider response suppresses success", func(subTest *testing.T) {
+		requestContext, cancelRequest := context.WithCancel(context.Background())
+		previousClient := proxy.HTTPClient
+		proxy.HTTPClient = coverageHTTPDoer(func(*http.Request) (*http.Response, error) {
+			cancelRequest()
+			return coverageHTTPResponse(http.StatusOK, `{"id":"completed-cancelled","status":"completed","output_text":"{\"outcome\":\"pass\"}"}`), nil
+		})
+		subTest.Cleanup(func() {
+			proxy.HTTPClient = previousClient
+			cancelRequest()
+		})
+		router := coverageRouter(subTest, proxy.Configuration{
+			Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+			OpenAIKey:             TestAPIKey,
+			LogLevel:              proxy.LogLevelInfo,
+			WorkerCount:           1,
+			QueueSize:             1,
+			RequestTimeoutSeconds: TestTimeout,
+		})
+		statusCode, _ := performAnalyzerRequest(subTest, router, requestContext)
+		if statusCode != 499 {
+			subTest.Fatalf("status=%d want=499", statusCode)
+		}
+	})
+}
+
+func TestAnalyzerRouteRejectsClosedContractViolationsBeforeUpstream(t *testing.T) {
+	var upstreamCalls atomic.Int32
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		responseWriter.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(upstreamServer.Close)
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(upstreamServer.URL)
+	router, buildError := buildRouterWithCatalogs(t, proxy.Configuration{
+		Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+		OpenAIKey:             TestAPIKey,
+		DeepSeekKey:           testDeepSeekKey,
+		DeepSeekBaseURL:       upstreamServer.URL,
+		LogLevel:              proxy.LogLevelInfo,
+		WorkerCount:           1,
+		QueueSize:             1,
+		RequestTimeoutSeconds: TestTimeout,
+		Endpoints:             endpoints,
+	}, zap.NewNop().Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	type contractCase struct {
+		name       string
+		query      url.Values
+		rawBody    []byte
+		mutateBody func(map[string]any)
+	}
+	validImage := analyzerBinaryContent("image", "image/png", []byte("image"))
+	validImage["detail"] = "auto"
+	validAudio := analyzerBinaryContent("audio", "audio/mpeg", []byte("audio"))
+	testCases := []contractCase{
+		{name: "provider credential query", query: url.Values{"openai_api_key": []string{"forbidden"}}},
+		{name: "unknown query", query: url.Values{"extra": []string{"forbidden"}}},
+		{name: "repeated provider query", query: url.Values{"provider": []string{proxy.ProviderNameOpenAI, proxy.ProviderNameOpenAI}}},
+		{name: "model query", query: url.Values{"model": []string{proxy.ModelNameGPT55}}},
+		{name: "provider credential body", mutateBody: func(body map[string]any) { body["openai_api_key"] = "forbidden" }},
+		{name: "malformed JSON", rawBody: []byte(`{`)},
+		{name: "trailing JSON", rawBody: []byte(string(analyzerTextRequestBody(t)) + `{}`)},
+		{name: "unknown body field", mutateBody: func(body map[string]any) { body["extra"] = true }},
+		{name: "missing model", mutateBody: func(body map[string]any) { delete(body, "model") }},
+		{name: "noncanonical model", mutateBody: func(body map[string]any) { body["model"] = " " + proxy.ModelNameGPT55 }},
+		{name: "invalid max tokens", mutateBody: func(body map[string]any) { body["max_tokens"] = 0 }},
+		{name: "blank schema name", mutateBody: func(body map[string]any) {
+			body["output_schema"].(map[string]any)["name"] = ""
+		}},
+		{name: "invalid schema name", mutateBody: func(body map[string]any) {
+			body["output_schema"].(map[string]any)["name"] = "bad schema"
+		}},
+		{name: "noncanonical schema name", mutateBody: func(body map[string]any) {
+			body["output_schema"].(map[string]any)["name"] = " report"
+		}},
+		{name: "non object schema", mutateBody: func(body map[string]any) {
+			body["output_schema"].(map[string]any)["schema"] = []any{}
+		}},
+		{name: "missing messages", mutateBody: func(body map[string]any) { body["messages"] = []any{} }},
+		{name: "mixed message order", mutateBody: func(body map[string]any) {
+			firstMessage := analyzerFirstMessage(body)
+			firstMessage["order"] = 1
+			body["messages"] = append(body["messages"].([]any), map[string]any{
+				"role":    "user",
+				"content": []any{map[string]any{"type": "text", "text": "second"}},
+			})
+		}},
+		{name: "negative message order", mutateBody: func(body map[string]any) {
+			analyzerFirstMessage(body)["order"] = -1
+		}},
+		{name: "duplicate message order", mutateBody: func(body map[string]any) {
+			analyzerFirstMessage(body)["order"] = 1
+			body["messages"] = append(body["messages"].([]any), map[string]any{
+				"role":    "user",
+				"order":   1,
+				"content": []any{map[string]any{"type": "text", "text": "second"}},
+			})
+		}},
+		{name: "unsupported message role", mutateBody: func(body map[string]any) {
+			analyzerFirstMessage(body)["role"] = "assistant"
+		}},
+		{name: "noncanonical message role", mutateBody: func(body map[string]any) {
+			analyzerFirstMessage(body)["role"] = "User"
+		}},
+		{name: "empty message content", mutateBody: func(body map[string]any) {
+			analyzerFirstMessage(body)["content"] = []any{}
+		}},
+		{name: "missing user message", mutateBody: func(body map[string]any) {
+			analyzerFirstMessage(body)["role"] = "system"
+		}},
+		{name: "blank text", mutateBody: func(body map[string]any) {
+			analyzerFirstContent(body)["text"] = " "
+		}},
+		{name: "text binary field", mutateBody: func(body map[string]any) {
+			analyzerFirstContent(body)["data"] = "Zm9yYmlkZGVu"
+		}},
+		{name: "unknown content type", mutateBody: func(body map[string]any) {
+			analyzerFirstContent(body)["type"] = "document"
+		}},
+		{name: "noncanonical content type", mutateBody: func(body map[string]any) {
+			analyzerFirstContent(body)["type"] = "Text"
+		}},
+		{name: "system image", mutateBody: func(body map[string]any) {
+			message := analyzerFirstMessage(body)
+			message["role"] = "system"
+			message["content"] = []any{validImage}
+		}},
+		{name: "image text field", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["text"] = "forbidden"
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "unsupported image MIME", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["mime_type"] = "image/gif"
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "noncanonical image MIME", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["mime_type"] = "IMAGE/PNG"
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "unsupported image detail", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["detail"] = "ultra"
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "noncanonical image detail", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["detail"] = "High"
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "empty image data", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["data"] = ""
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "invalid image base64", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["data"] = "not-base64"
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "noncanonical image digest", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["sha256"] = strings.ToUpper(image["sha256"].(string))
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "padded image digest", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["sha256"] = " " + image["sha256"].(string)
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "mismatched image digest", mutateBody: func(body map[string]any) {
+			image := cloneAnalyzerContent(validImage)
+			image["sha256"] = strings.Repeat("0", 64)
+			analyzerFirstMessage(body)["content"] = []any{image}
+		}},
+		{name: "audio unsupported fields", mutateBody: func(body map[string]any) {
+			audio := cloneAnalyzerContent(validAudio)
+			audio["detail"] = "high"
+			analyzerFirstMessage(body)["content"] = []any{audio}
+		}},
+		{name: "unsupported audio MIME", mutateBody: func(body map[string]any) {
+			audio := cloneAnalyzerContent(validAudio)
+			audio["mime_type"] = "audio/ogg"
+			analyzerFirstMessage(body)["content"] = []any{audio}
+		}},
+		{name: "unknown provider", query: url.Values{"provider": []string{"unknown"}}},
+		{name: "unknown model", mutateBody: func(body map[string]any) { body["model"] = "unknown-model" }},
+		{name: "unsupported reasoning effort", mutateBody: func(body map[string]any) { body["reasoning_effort"] = "impossible" }},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			queryValues := url.Values{}
+			for parameterName, parameterValues := range testCase.query {
+				for _, parameterValue := range parameterValues {
+					queryValues.Add(parameterName, parameterValue)
+				}
+			}
+			queryValues.Set("key", TestSecret)
+			if !queryValues.Has("provider") {
+				queryValues.Set("provider", proxy.ProviderNameOpenAI)
+			}
+			body := testCase.rawBody
+			if body == nil {
+				decodedBody := analyzerTextRequestMap(t)
+				if testCase.mutateBody != nil {
+					testCase.mutateBody(decodedBody)
+				}
+				var marshalError error
+				body, marshalError = json.Marshal(decodedBody)
+				if marshalError != nil {
+					subTest.Fatalf("marshal body: %v", marshalError)
+				}
+			}
+			request := httptest.NewRequest(http.MethodPost, "/v2/analyze?"+queryValues.Encode(), bytes.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != http.StatusBadRequest {
+				subTest.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+		})
+	}
+	if upstreamCalls.Load() != 0 {
+		t.Fatalf("upstream calls=%d want=0", upstreamCalls.Load())
+	}
+}
+
+func TestAnalyzerRouteRejectsOversizedBodyAndModelOutputLimitBeforeUpstream(t *testing.T) {
+	t.Run("oversized body", func(subTest *testing.T) {
+		router := coverageRouter(subTest, proxy.Configuration{
+			Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+			OpenAIKey:             TestAPIKey,
+			LogLevel:              proxy.LogLevelInfo,
+			WorkerCount:           1,
+			QueueSize:             1,
+			RequestTimeoutSeconds: TestTimeout,
+			MaxPromptBytes:        8,
+		})
+		request := httptest.NewRequest(http.MethodPost, "/v2/analyze?key="+url.QueryEscape(TestSecret), bytes.NewReader(analyzerTextRequestBody(subTest)))
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code != http.StatusRequestEntityTooLarge {
+			subTest.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+		}
+	})
+
+	t.Run("model output limit", func(subTest *testing.T) {
+		configuration, configurationError := newConfigurationWithCatalogs(subTest, proxy.Configuration{
+			Tenants:   proxy.SingleTenantConfigurations("test", TestSecret),
+			OpenAIKey: TestAPIKey,
+		})
+		if configurationError != nil {
+			subTest.Fatalf("configuration: %v", configurationError)
+		}
+		openAICatalog := configuration.ProviderModels[proxy.ProviderNameOpenAI]
+		for modelIndex := range openAICatalog.Text.Models {
+			if openAICatalog.Text.Models[modelIndex].ID == proxy.ModelNameGPT55 {
+				openAICatalog.Text.Models[modelIndex].OutputTokenLimit = 1
+			}
+		}
+		configuration.ProviderModels[proxy.ProviderNameOpenAI] = openAICatalog
+		configuration.WorkerCount = 1
+		configuration.QueueSize = 1
+		configuration.RequestTimeoutSeconds = TestTimeout
+		router, buildError := proxy.BuildRouter(configuration, zap.NewNop().Sugar())
+		if buildError != nil {
+			subTest.Fatalf(messageBuildRouterError, buildError)
+		}
+		body := analyzerTextRequestMap(subTest)
+		body["max_tokens"] = 2
+		bodyBytes, marshalError := json.Marshal(body)
+		if marshalError != nil {
+			subTest.Fatalf("marshal body: %v", marshalError)
+		}
+		request := httptest.NewRequest(http.MethodPost, "/v2/analyze?key="+url.QueryEscape(TestSecret), bytes.NewReader(bodyBytes))
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code != http.StatusBadRequest {
+			subTest.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+		}
+	})
+}
+
+func analyzerRequestBody(t *testing.T, firstImage []byte, secondImage []byte) []byte {
+	t.Helper()
+	firstDigest := sha256.Sum256(firstImage)
+	secondDigest := sha256.Sum256(secondImage)
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{
+				"role":    "system",
+				"order":   0,
+				"content": []any{map[string]any{"type": "text", "text": "Return the report."}},
+			},
+			map[string]any{
+				"role":  "user",
+				"order": 1,
+				"content": []any{
+					map[string]any{"type": "text", "text": "Inspect both frames in order."},
+					map[string]any{
+						"type":      "image",
+						"mime_type": "image/png",
+						"data":      base64.StdEncoding.EncodeToString(firstImage),
+						"sha256":    hex.EncodeToString(firstDigest[:]),
+						"detail":    "high",
+					},
+					map[string]any{
+						"type":      "image",
+						"mime_type": "image/jpeg",
+						"data":      base64.StdEncoding.EncodeToString(secondImage),
+						"sha256":    hex.EncodeToString(secondDigest[:]),
+						"detail":    "low",
+					},
+				},
+			},
+		},
+		"output_schema": map[string]any{
+			"name":        "semantic_qa_report",
+			"description": "One bounded semantic QA decision.",
+			"schema": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"outcome"},
+				"properties": map[string]any{
+					"outcome": map[string]any{"type": "string", "enum": []any{"pass", "return"}},
+				},
+			},
+		},
+		"model":            proxy.ModelNameGPT55,
+		"max_tokens":       1200,
+		"reasoning_effort": "high",
+	}
+	bodyBytes, marshalError := json.Marshal(body)
+	if marshalError != nil {
+		t.Fatalf("marshal body: %v", marshalError)
+	}
+	return bodyBytes
+}
+
+func analyzerTextRequestBody(t *testing.T) []byte {
+	t.Helper()
+	bodyBytes, marshalError := json.Marshal(analyzerTextRequestMap(t))
+	if marshalError != nil {
+		t.Fatalf("marshal body: %v", marshalError)
+	}
+	return bodyBytes
+}
+
+func analyzerTextRequestMap(t *testing.T) map[string]any {
+	t.Helper()
+	body := map[string]any{
+		"messages": []any{
+			map[string]any{
+				"role":    "user",
+				"content": []any{map[string]any{"type": "text", "text": "Inspect the evidence."}},
+			},
+		},
+		"output_schema": map[string]any{
+			"name": "report",
+			"schema": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+			},
+		},
+		"model": proxy.ModelNameGPT55,
+	}
+	bodyBytes, marshalError := json.Marshal(body)
+	if marshalError != nil {
+		t.Fatalf("marshal body: %v", marshalError)
+	}
+	var copiedBody map[string]any
+	if unmarshalError := json.Unmarshal(bodyBytes, &copiedBody); unmarshalError != nil {
+		t.Fatalf("copy body: %v", unmarshalError)
+	}
+	return copiedBody
+}
+
+func analyzerFirstMessage(body map[string]any) map[string]any {
+	return body["messages"].([]any)[0].(map[string]any)
+}
+
+func analyzerFirstContent(body map[string]any) map[string]any {
+	return analyzerFirstMessage(body)["content"].([]any)[0].(map[string]any)
+}
+
+func analyzerBinaryContent(contentType string, mimeType string, data []byte) map[string]any {
+	digest := sha256.Sum256(data)
+	return map[string]any{
+		"type":      contentType,
+		"mime_type": mimeType,
+		"data":      base64.StdEncoding.EncodeToString(data),
+		"sha256":    hex.EncodeToString(digest[:]),
+	}
+}
+
+func cloneAnalyzerContent(content map[string]any) map[string]any {
+	clonedContent := make(map[string]any, len(content))
+	for fieldName, fieldValue := range content {
+		clonedContent[fieldName] = fieldValue
+	}
+	return clonedContent
+}
+
+func analyzerRouterWithResponsesHandler(t *testing.T, timeoutSeconds int, handler http.HandlerFunc) http.Handler {
+	t.Helper()
+	upstreamServer := httptest.NewServer(handler)
+	t.Cleanup(upstreamServer.Close)
+	endpoints := proxy.NewEndpoints()
+	endpoints.SetResponsesURL(upstreamServer.URL)
+	return coverageRouter(t, proxy.Configuration{
+		Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+		OpenAIKey:             TestAPIKey,
+		LogLevel:              proxy.LogLevelInfo,
+		WorkerCount:           1,
+		QueueSize:             1,
+		RequestTimeoutSeconds: timeoutSeconds,
+		Endpoints:             endpoints,
+	})
+}
+
+func performAnalyzerRequest(t *testing.T, router http.Handler, requestContext context.Context) (int, string) {
+	t.Helper()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v2/analyze?key="+url.QueryEscape(TestSecret)+"&provider="+proxy.ProviderNameOpenAI,
+		bytes.NewReader(analyzerTextRequestBody(t)),
+	).WithContext(requestContext)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	return response.Code, response.Body.String()
+}
+
+func assertOpenAIImagePart(t *testing.T, rawPart any, mimeType string, expectedBytes []byte, detail string) {
+	t.Helper()
+	part, partOK := rawPart.(map[string]any)
+	if !partOK {
+		t.Fatalf("part=%v", rawPart)
+	}
+	expectedURL := "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(expectedBytes)
+	if part["type"] != "input_image" || part["image_url"] != expectedURL || part["detail"] != detail {
+		t.Fatalf("part=%v", part)
+	}
+}

--- a/internal/proxy/constants.go
+++ b/internal/proxy/constants.go
@@ -16,8 +16,9 @@ const (
 	headerLLMProxyTotalTokens    = "X-LLM-Proxy-Total-Tokens"
 
 	// rootPath defines the HTTP path for the root endpoint.
-	rootPath = "/"
-	v2Path   = "/v2"
+	rootPath      = "/"
+	v2Path        = "/v2"
+	v2AnalyzePath = "/v2/analyze"
 	// dictatePath defines the HTTP path for audio transcription requests.
 	dictatePath = "/dictate"
 
@@ -71,6 +72,7 @@ const (
 	errorMissingMessages            = "missing messages parameter"
 	errorUnsupportedPromptParameter = "unsupported prompt parameter"
 	errorUnsupportedSystemPrompt    = "unsupported system_prompt parameter"
+	errorInvalidAnalyzerRequest     = "invalid analyzer request"
 	errorInvalidAudioForm           = "invalid audio form"
 	errorMissingAudioFile           = "missing audio file"
 	errorAudioPayloadTooLarge       = "audio payload too large"

--- a/internal/proxy/management_usage.go
+++ b/internal/proxy/management_usage.go
@@ -20,6 +20,7 @@ import (
 const (
 	usageEndpointText      = "text"
 	usageEndpointV2        = "v2"
+	usageEndpointAnalyzer  = "analyzer"
 	usageEndpointDictation = "dictation"
 	usageDateFormat        = "2006-01-02"
 	usageIntervalAll       = usageInterval("all")

--- a/internal/proxy/openapi_contract_test.go
+++ b/internal/proxy/openapi_contract_test.go
@@ -97,7 +97,7 @@ func TestOpenAPIContractDocumentsActualAuthenticationBoundaries(t *testing.T) {
 	for _, operation := range operations {
 		expectedSecurity := [][]string{{"TAuthSession"}}
 		switch operation.Path {
-		case "/", "/v2", "/dictate":
+		case "/", "/v2", "/v2/analyze", "/dictate":
 			expectedSecurity = [][]string{{"TenantClientKey"}}
 		case proxy.ManagementConfigUIPath:
 			expectedSecurity = [][]string{}
@@ -198,6 +198,33 @@ func TestOpenAPIContractValidatesRepresentativeRealHTTPExchanges(t *testing.T) {
 	v2Response := httptest.NewRecorder()
 	router.ServeHTTP(v2Response, v2Request)
 	assertOpenAPIResponse(t, contract, "/v2", http.MethodPost, v2Response)
+
+	analyzerUpstream := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{
+			"id":"openapi-analyzer",
+			"status":"completed",
+			"output_text":"{\"outcome\":\"pass\"}",
+			"output":[{
+				"type":"message",
+				"role":"assistant",
+				"content":[{"type":"output_text","text":"{\"outcome\":\"pass\"}"}]
+			}]
+		}`))
+	}))
+	t.Cleanup(analyzerUpstream.Close)
+	analyzerRouter := NewTestRouter(t, analyzerUpstream.URL)
+	analyzerBody := analyzerRequestBody(t, []byte("openapi-first-image"), []byte("openapi-second-image"))
+	analyzerRequest := httptest.NewRequest(
+		http.MethodPost,
+		"/v2/analyze?key="+url.QueryEscape(TestSecret)+"&provider=openai",
+		bytes.NewReader(analyzerBody),
+	)
+	analyzerRequest.Header.Set("Content-Type", "application/json")
+	assertOpenAPIRequest(t, contract, "/v2/analyze", analyzerRequest, analyzerBody)
+	analyzerResponse := httptest.NewRecorder()
+	analyzerRouter.ServeHTTP(analyzerResponse, analyzerRequest)
+	assertOpenAPIResponse(t, contract, "/v2/analyze", http.MethodPost, analyzerResponse)
 
 	unsupportedReasoningBody := []byte(`{"messages":[{"role":"user","content":"Validate the route error."}],"model":"deepseek-v4-flash","reasoning_effort":"high"}`)
 	unsupportedReasoningRequest := httptest.NewRequest(

--- a/internal/proxy/provider_errors.go
+++ b/internal/proxy/provider_errors.go
@@ -24,6 +24,8 @@ var (
 	ErrProviderAPI = errors.New(errorProviderAPI)
 	// ErrInvalidChatMessages is returned when a JSON request body contains invalid chat messages.
 	ErrInvalidChatMessages = errors.New(errorInvalidChatMessages)
+	// ErrInvalidAnalyzerRequest is returned when an analyzer request violates its closed input contract.
+	ErrInvalidAnalyzerRequest = errors.New(errorInvalidAnalyzerRequest)
 	// ErrInvalidModelCatalog is returned when configured provider model catalogs are incomplete or inconsistent.
 	ErrInvalidModelCatalog = errors.New("invalid_model_catalog")
 )

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -134,6 +134,7 @@ func buildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	router.GET(rootPath, rootProxyHandler)
 	router.POST(rootPath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatJSONHandler(upstreamProviders, providers, configuration.MaxPromptBytes, managedTenants, structuredLogger))))
 	router.POST(v2Path, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatV2JSONHandler(upstreamProviders, providers, configuration.MaxPromptBytes, managedTenants, structuredLogger))))
+	router.POST(v2AnalyzePath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, analyzerJSONHandler(upstreamProviders, providers, configuration.MaxPromptBytes, managedTenants, structuredLogger))))
 	router.POST(dictatePath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, dictateHandler(upstreamProviders, providers, configuration.MaxInputAudioBytes, managedTenants, structuredLogger))))
 	return router, nil
 }
@@ -751,7 +752,7 @@ func validateTextMaxTokens(providerDefinition providerDefinition, modelIdentifie
 
 func statusCodeForError(requestError error) int {
 	switch {
-	case errors.Is(requestError, ErrUnknownProvider), errors.Is(requestError, ErrUnknownModel), errors.Is(requestError, ErrUnsupportedCapability), errors.Is(requestError, ErrUnsupportedEndpoint), errors.Is(requestError, ErrConflictingModelParameters), errors.Is(requestError, ErrInvalidChatMessages):
+	case errors.Is(requestError, ErrUnknownProvider), errors.Is(requestError, ErrUnknownModel), errors.Is(requestError, ErrUnsupportedCapability), errors.Is(requestError, ErrUnsupportedEndpoint), errors.Is(requestError, ErrConflictingModelParameters), errors.Is(requestError, ErrInvalidChatMessages), errors.Is(requestError, ErrInvalidAnalyzerRequest):
 		return http.StatusBadRequest
 	case errors.Is(requestError, ErrProviderNotConfigured), errors.Is(requestError, errQueueFull):
 		return http.StatusServiceUnavailable

--- a/pkg/llmproxyclient/analyzer.go
+++ b/pkg/llmproxyclient/analyzer.go
@@ -25,6 +25,7 @@ const (
 	imageMIMEJPEG = "image/jpeg"
 	imageMIMEPNG  = "image/png"
 	imageMIMEWebP = "image/webp"
+	audioMIMEMP4  = "audio/mp4"
 	audioMIMEMPEG = "audio/mpeg"
 	audioMIMEWAV  = "audio/wav"
 )
@@ -106,7 +107,7 @@ func NewImageContent(input ImageContentInput) (ContentPart, error) {
 func NewAudioContent(input AudioContentInput) (ContentPart, error) {
 	mimeType := strings.ToLower(strings.TrimSpace(input.MIMEType))
 	switch mimeType {
-	case audioMIMEMPEG, audioMIMEWAV:
+	case audioMIMEMP4, audioMIMEMPEG, audioMIMEWAV:
 	default:
 		return nil, fmt.Errorf("%w: unsupported analyzer audio MIME type=%q", ErrInvalidClientRequest, input.MIMEType)
 	}

--- a/pkg/llmproxyclient/analyzer.go
+++ b/pkg/llmproxyclient/analyzer.go
@@ -1,0 +1,452 @@
+package llmproxyclient
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
+)
+
+const (
+	analyzerEndpointSuffix = "/analyze"
+	contentTypeAudio       = "audio"
+	contentTypeImage       = "image"
+	contentTypeText        = "text"
+)
+
+const (
+	imageMIMEJPEG = "image/jpeg"
+	imageMIMEPNG  = "image/png"
+	imageMIMEWebP = "image/webp"
+	audioMIMEMPEG = "audio/mpeg"
+	audioMIMEWAV  = "audio/wav"
+)
+
+// ImageDetail is the provider-neutral image inspection fidelity.
+type ImageDetail string
+
+const (
+	// ImageDetailAuto delegates image fidelity selection to the supported route.
+	ImageDetailAuto ImageDetail = "auto"
+	// ImageDetailLow requests low-fidelity image inspection.
+	ImageDetailLow ImageDetail = "low"
+	// ImageDetailHigh requests high-fidelity image inspection.
+	ImageDetailHigh ImageDetail = "high"
+)
+
+// ContentPart is one validated analyzer message content part. Values are
+// created only through NewTextContent, NewImageContent, or NewAudioContent.
+type ContentPart interface {
+	analyzerContentPart() analyzerContent
+}
+
+type analyzerContent struct {
+	contentType string
+	text        string
+	mimeType    string
+	data        []byte
+	sha256      string
+	detail      ImageDetail
+}
+
+func (content analyzerContent) analyzerContentPart() analyzerContent {
+	return content
+}
+
+// ImageContentInput is unvalidated image content supplied to NewImageContent.
+type ImageContentInput struct {
+	MIMEType string
+	Data     []byte
+	Detail   ImageDetail
+}
+
+// AudioContentInput is unvalidated audio content supplied to NewAudioContent.
+type AudioContentInput struct {
+	MIMEType string
+	Data     []byte
+}
+
+// NewTextContent validates one nonblank analyzer text part.
+func NewTextContent(text string) (ContentPart, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, fmt.Errorf("%w: analyzer text content is blank", ErrInvalidClientRequest)
+	}
+	return analyzerContent{contentType: contentTypeText, text: text}, nil
+}
+
+// NewImageContent validates and hash-binds exact image bytes.
+func NewImageContent(input ImageContentInput) (ContentPart, error) {
+	mimeType := strings.ToLower(strings.TrimSpace(input.MIMEType))
+	switch mimeType {
+	case imageMIMEJPEG, imageMIMEPNG, imageMIMEWebP:
+	default:
+		return nil, fmt.Errorf("%w: unsupported analyzer image MIME type=%q", ErrInvalidClientRequest, input.MIMEType)
+	}
+	if len(input.Data) == 0 {
+		return nil, fmt.Errorf("%w: analyzer image content is empty", ErrInvalidClientRequest)
+	}
+	switch input.Detail {
+	case ImageDetailAuto, ImageDetailLow, ImageDetailHigh:
+	default:
+		return nil, fmt.Errorf("%w: unsupported analyzer image detail=%q", ErrInvalidClientRequest, input.Detail)
+	}
+	return newBinaryAnalyzerContent(contentTypeImage, mimeType, input.Data, input.Detail), nil
+}
+
+// NewAudioContent validates and hash-binds exact audio bytes. The proxy rejects
+// the part before upstream work unless the resolved analyzer route supports
+// both audio input and strict structured output.
+func NewAudioContent(input AudioContentInput) (ContentPart, error) {
+	mimeType := strings.ToLower(strings.TrimSpace(input.MIMEType))
+	switch mimeType {
+	case audioMIMEMPEG, audioMIMEWAV:
+	default:
+		return nil, fmt.Errorf("%w: unsupported analyzer audio MIME type=%q", ErrInvalidClientRequest, input.MIMEType)
+	}
+	if len(input.Data) == 0 {
+		return nil, fmt.Errorf("%w: analyzer audio content is empty", ErrInvalidClientRequest)
+	}
+	return newBinaryAnalyzerContent(contentTypeAudio, mimeType, input.Data, ""), nil
+}
+
+func newBinaryAnalyzerContent(contentType string, mimeType string, data []byte, detail ImageDetail) analyzerContent {
+	copiedData := append([]byte(nil), data...)
+	digest := sha256.Sum256(copiedData)
+	return analyzerContent{
+		contentType: contentType,
+		mimeType:    mimeType,
+		data:        copiedData,
+		sha256:      hex.EncodeToString(digest[:]),
+		detail:      detail,
+	}
+}
+
+// StrictOutputSchemaInput is unvalidated JSON Schema selection.
+type StrictOutputSchemaInput struct {
+	Name        string
+	Description string
+	Schema      json.RawMessage
+}
+
+// StrictOutputSchema is a validated strict JSON Schema selection.
+type StrictOutputSchema struct {
+	name        string
+	description string
+	schema      json.RawMessage
+}
+
+// NewStrictOutputSchema validates one named JSON Schema object. Strictness is
+// mandatory and is not caller-configurable.
+func NewStrictOutputSchema(input StrictOutputSchemaInput) (StrictOutputSchema, error) {
+	name := strings.TrimSpace(input.Name)
+	if !validOutputSchemaName(name) {
+		return StrictOutputSchema{}, fmt.Errorf("%w: invalid analyzer output schema name", ErrInvalidClientRequest)
+	}
+	var decodedSchema map[string]json.RawMessage
+	if len(input.Schema) == 0 || json.Unmarshal(input.Schema, &decodedSchema) != nil || decodedSchema == nil {
+		return StrictOutputSchema{}, fmt.Errorf("%w: analyzer output schema must be one JSON object", ErrInvalidClientRequest)
+	}
+	return StrictOutputSchema{
+		name:        name,
+		description: strings.TrimSpace(input.Description),
+		schema:      append(json.RawMessage(nil), input.Schema...),
+	}, nil
+}
+
+func validOutputSchemaName(name string) bool {
+	if len(name) == 0 || len(name) > 64 {
+		return false
+	}
+	for _, character := range name {
+		if character >= 'a' && character <= 'z' ||
+			character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' ||
+			character == '_' ||
+			character == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func (schema StrictOutputSchema) valid() bool {
+	return validOutputSchemaName(schema.name) && len(schema.schema) > 0
+}
+
+// AnalyzerMessageInput is an unvalidated system or user analyzer message.
+type AnalyzerMessageInput struct {
+	Role    string
+	Content []ContentPart
+	// Order is optional; when any message sets it, every message must set a
+	// unique non-negative value.
+	Order *int
+}
+
+type analyzerMessage struct {
+	role    string
+	content []analyzerContent
+	order   *int
+}
+
+// AnalyzerRequestInput is unvalidated input for POST /v2/analyze.
+type AnalyzerRequestInput struct {
+	Messages              []AnalyzerMessageInput
+	OutputSchema          StrictOutputSchema
+	Model                 string
+	MaxTokens             *int
+	ReasoningEffort       *string
+	RequestTimeoutSeconds *int
+}
+
+// AnalyzerRequest is one validated analyzer request.
+type AnalyzerRequest struct {
+	messages              []analyzerMessage
+	outputSchema          StrictOutputSchema
+	model                 string
+	maxTokens             *int
+	reasoningEffort       *string
+	requestTimeoutSeconds *int
+}
+
+// NewAnalyzerRequest validates a hash-bound, strict-output analyzer request.
+func NewAnalyzerRequest(input AnalyzerRequestInput) (AnalyzerRequest, error) {
+	if len(input.Messages) == 0 {
+		return AnalyzerRequest{}, fmt.Errorf("%w: missing analyzer messages", ErrInvalidClientRequest)
+	}
+	if !input.OutputSchema.valid() {
+		return AnalyzerRequest{}, fmt.Errorf("%w: missing analyzer output schema", ErrInvalidClientRequest)
+	}
+	model := strings.TrimSpace(input.Model)
+	if model == "" {
+		return AnalyzerRequest{}, fmt.Errorf("%w: missing analyzer model", ErrInvalidClientRequest)
+	}
+	if input.MaxTokens != nil && *input.MaxTokens <= 0 {
+		return AnalyzerRequest{}, fmt.Errorf("%w: analyzer max_tokens must be positive", ErrInvalidClientRequest)
+	}
+	if input.ReasoningEffort != nil && strings.TrimSpace(*input.ReasoningEffort) == "" {
+		return AnalyzerRequest{}, fmt.Errorf("%w: analyzer reasoning_effort must be nonblank", ErrInvalidClientRequest)
+	}
+	if input.RequestTimeoutSeconds != nil && *input.RequestTimeoutSeconds <= 0 {
+		return AnalyzerRequest{}, fmt.Errorf("%w: analyzer request_timeout_seconds must be positive", ErrInvalidClientRequest)
+	}
+	messages, messageError := newAnalyzerMessages(input.Messages)
+	if messageError != nil {
+		return AnalyzerRequest{}, messageError
+	}
+	return AnalyzerRequest{
+		messages:              messages,
+		outputSchema:          input.OutputSchema,
+		model:                 model,
+		maxTokens:             copyOptionalInteger(input.MaxTokens),
+		reasoningEffort:       copyOptionalString(input.ReasoningEffort),
+		requestTimeoutSeconds: copyOptionalInteger(input.RequestTimeoutSeconds),
+	}, nil
+}
+
+func newAnalyzerMessages(inputMessages []AnalyzerMessageInput) ([]analyzerMessage, error) {
+	orderedMessages, orderError := sortAnalyzerMessages(inputMessages)
+	if orderError != nil {
+		return nil, orderError
+	}
+	messages := make([]analyzerMessage, 0, len(orderedMessages))
+	hasUserMessage := false
+	for messageIndex, inputMessage := range orderedMessages {
+		role := strings.ToLower(strings.TrimSpace(inputMessage.Role))
+		if role != messageRoleSystem && role != messageRoleUser {
+			return nil, fmt.Errorf("%w: analyzer messages[%d].role unsupported", ErrInvalidClientRequest, messageIndex)
+		}
+		if len(inputMessage.Content) == 0 {
+			return nil, fmt.Errorf("%w: analyzer messages[%d].content is empty", ErrInvalidClientRequest, messageIndex)
+		}
+		content := make([]analyzerContent, 0, len(inputMessage.Content))
+		for contentIndex, inputContent := range inputMessage.Content {
+			if inputContent == nil {
+				return nil, fmt.Errorf("%w: analyzer messages[%d].content[%d] is invalid", ErrInvalidClientRequest, messageIndex, contentIndex)
+			}
+			validatedContent := inputContent.analyzerContentPart()
+			if role == messageRoleSystem && validatedContent.contentType != contentTypeText {
+				return nil, fmt.Errorf("%w: analyzer system messages accept text only", ErrInvalidClientRequest)
+			}
+			content = append(content, validatedContent)
+		}
+		if role == messageRoleUser {
+			hasUserMessage = true
+		}
+		messages = append(messages, analyzerMessage{
+			role:    role,
+			content: content,
+			order:   copyOptionalInteger(inputMessage.Order),
+		})
+	}
+	if !hasUserMessage {
+		return nil, fmt.Errorf("%w: analyzer messages must include a user message", ErrInvalidClientRequest)
+	}
+	return messages, nil
+}
+
+func sortAnalyzerMessages(inputMessages []AnalyzerMessageInput) ([]AnalyzerMessageInput, error) {
+	orderedMessages := append([]AnalyzerMessageInput(nil), inputMessages...)
+	hasExplicitOrder := false
+	for _, inputMessage := range orderedMessages {
+		if inputMessage.Order != nil {
+			hasExplicitOrder = true
+			break
+		}
+	}
+	if !hasExplicitOrder {
+		return orderedMessages, nil
+	}
+	seenOrders := map[int]struct{}{}
+	for messageIndex, inputMessage := range orderedMessages {
+		if inputMessage.Order == nil {
+			return nil, fmt.Errorf("%w: analyzer messages[%d].order missing", ErrInvalidClientRequest, messageIndex)
+		}
+		if *inputMessage.Order < 0 {
+			return nil, fmt.Errorf("%w: analyzer messages[%d].order is negative", ErrInvalidClientRequest, messageIndex)
+		}
+		if _, exists := seenOrders[*inputMessage.Order]; exists {
+			return nil, fmt.Errorf("%w: duplicate analyzer messages order=%d", ErrInvalidClientRequest, *inputMessage.Order)
+		}
+		seenOrders[*inputMessage.Order] = struct{}{}
+	}
+	sort.SliceStable(orderedMessages, func(firstIndex int, secondIndex int) bool {
+		return *orderedMessages[firstIndex].Order < *orderedMessages[secondIndex].Order
+	})
+	return orderedMessages, nil
+}
+
+func copyOptionalInteger(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copiedValue := *value
+	return &copiedValue
+}
+
+func copyOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	copiedValue := strings.TrimSpace(*value)
+	return &copiedValue
+}
+
+func (request AnalyzerRequest) payloadBody() []byte {
+	payload := map[string]any{
+		"messages":      analyzerMessagePayload(request.messages),
+		"model":         request.model,
+		"output_schema": strictOutputSchemaPayload(request.outputSchema),
+	}
+	if request.maxTokens != nil {
+		payload["max_tokens"] = *request.maxTokens
+	}
+	if request.reasoningEffort != nil {
+		payload["reasoning_effort"] = *request.reasoningEffort
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	return payloadBytes
+}
+
+func analyzerMessagePayload(messages []analyzerMessage) []map[string]any {
+	payload := make([]map[string]any, 0, len(messages))
+	for _, message := range messages {
+		payloadMessage := map[string]any{
+			"role":    message.role,
+			"content": analyzerContentPayload(message.content),
+		}
+		if message.order != nil {
+			payloadMessage["order"] = *message.order
+		}
+		payload = append(payload, payloadMessage)
+	}
+	return payload
+}
+
+func analyzerContentPayload(content []analyzerContent) []map[string]any {
+	payload := make([]map[string]any, 0, len(content))
+	for _, contentPart := range content {
+		payloadPart := map[string]any{"type": contentPart.contentType}
+		if contentPart.contentType == contentTypeText {
+			payloadPart["text"] = contentPart.text
+		} else {
+			payloadPart["mime_type"] = contentPart.mimeType
+			payloadPart["data"] = base64.StdEncoding.EncodeToString(contentPart.data)
+			payloadPart["sha256"] = contentPart.sha256
+			if contentPart.contentType == contentTypeImage {
+				payloadPart["detail"] = string(contentPart.detail)
+			}
+		}
+		payload = append(payload, payloadPart)
+	}
+	return payload
+}
+
+func strictOutputSchemaPayload(outputSchema StrictOutputSchema) map[string]any {
+	payload := map[string]any{
+		"name":   outputSchema.name,
+		"schema": outputSchema.schema,
+	}
+	if outputSchema.description != "" {
+		payload["description"] = outputSchema.description
+	}
+	return payload
+}
+
+// AnalyzerResponse is one completed analyzer response and its proxy identity.
+type AnalyzerResponse struct {
+	text      string
+	requestID string
+}
+
+// Text returns the strict structured-output response text.
+func (response AnalyzerResponse) Text() string {
+	return response.text
+}
+
+// RequestID returns the proxy-owned request identifier.
+func (response AnalyzerResponse) RequestID() string {
+	return response.requestID
+}
+
+// PostAnalyzer sends a validated POST /v2/analyze request.
+func (client Client) PostAnalyzer(contextValue context.Context, request AnalyzerRequest) (AnalyzerResponse, error) {
+	if client.config.modelProfilePath != "" {
+		return AnalyzerResponse{}, fmt.Errorf("%w: analyzer requests require explicit per-request model selection", ErrInvalidModelProfile)
+	}
+	requestURL := client.config.analyzerPostURLForProvider(client.config.provider)
+	response, postError := client.postPayloadResponse(contextValue, requestURL, request.payloadBody(), request.requestTimeoutSeconds, acceptApplicationJSON)
+	if postError != nil {
+		return AnalyzerResponse{}, postError
+	}
+	requestID := strings.TrimSpace(response.header.Get(llmproxycontract.HeaderRequestID))
+	if requestID == "" {
+		return AnalyzerResponse{}, fmt.Errorf("%w: successful analyzer response missing request id", ErrClientHTTPFailure)
+	}
+	return AnalyzerResponse{text: string(response.body), requestID: requestID}, nil
+}
+
+func (config Config) analyzerPostURLForProvider(provider string) url.URL {
+	requestURL := *config.baseURL
+	requestURL.Path = analyzerEndpointPath(requestURL.Path)
+	requestURL = config.authenticatedPostURL(requestURL, provider)
+	queryValues := requestURL.Query()
+	queryValues.Del(queryFormat)
+	requestURL.RawQuery = queryValues.Encode()
+	return requestURL
+}
+
+func analyzerEndpointPath(basePath string) string {
+	trimmedPath := strings.TrimRight(strings.TrimSpace(basePath), "/")
+	if strings.HasSuffix(trimmedPath, "/v2"+analyzerEndpointSuffix) {
+		return trimmedPath
+	}
+	return v2EndpointPath(trimmedPath) + analyzerEndpointSuffix
+}

--- a/pkg/llmproxyclient/analyzer_test.go
+++ b/pkg/llmproxyclient/analyzer_test.go
@@ -1,0 +1,488 @@
+package llmproxyclient_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tyemirov/llm-proxy/pkg/llmproxyclient"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
+)
+
+func TestClientPostAnalyzerSendsHashBoundContentAndReturnsRequestIdentity(t *testing.T) {
+	contract := loadCanonicalOpenAPIContract(t)
+	imageBytes := []byte("exact-image-bytes")
+	audioBytes := []byte("exact-audio-bytes")
+	imagePart, imageError := llmproxyclient.NewImageContent(llmproxyclient.ImageContentInput{
+		MIMEType: "image/png",
+		Data:     imageBytes,
+		Detail:   llmproxyclient.ImageDetailHigh,
+	})
+	if imageError != nil {
+		t.Fatalf("image content: %v", imageError)
+	}
+	audioPart, audioError := llmproxyclient.NewAudioContent(llmproxyclient.AudioContentInput{
+		MIMEType: "audio/mpeg",
+		Data:     audioBytes,
+	})
+	if audioError != nil {
+		t.Fatalf("audio content: %v", audioError)
+	}
+	systemPart, systemError := llmproxyclient.NewTextContent("Return only the required report.")
+	if systemError != nil {
+		t.Fatalf("system content: %v", systemError)
+	}
+	userPart, userError := llmproxyclient.NewTextContent("Inspect the supplied evidence.")
+	if userError != nil {
+		t.Fatalf("user content: %v", userError)
+	}
+	outputSchema, schemaError := llmproxyclient.NewStrictOutputSchema(llmproxyclient.StrictOutputSchemaInput{
+		Name:        "semantic_qa_report",
+		Description: "One bounded semantic QA decision.",
+		Schema: json.RawMessage(`{
+			"type":"object",
+			"additionalProperties":false,
+			"required":["outcome"],
+			"properties":{"outcome":{"type":"string","enum":["pass","return"]}}
+		}`),
+	})
+	if schemaError != nil {
+		t.Fatalf("output schema: %v", schemaError)
+	}
+	reasoningEffort := "high"
+	maxTokens := 1200
+	requestTimeoutSeconds := 900
+	request, requestError := llmproxyclient.NewAnalyzerRequest(llmproxyclient.AnalyzerRequestInput{
+		Messages: []llmproxyclient.AnalyzerMessageInput{
+			{Role: "system", Content: []llmproxyclient.ContentPart{systemPart}, Order: messageOrder(0)},
+			{Role: "user", Content: []llmproxyclient.ContentPart{userPart, imagePart, audioPart}, Order: messageOrder(1)},
+		},
+		OutputSchema:          outputSchema,
+		Model:                 "gpt-5.6",
+		MaxTokens:             &maxTokens,
+		ReasoningEffort:       &reasoningEffort,
+		RequestTimeoutSeconds: &requestTimeoutSeconds,
+	})
+	if requestError != nil {
+		t.Fatalf("analyzer request: %v", requestError)
+	}
+
+	var capturedBody map[string]any
+	var capturedTimeout string
+	var capturedAccept string
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		if httpRequest.URL.Path != "/v2/analyze" {
+			t.Fatalf("path=%q", httpRequest.URL.Path)
+		}
+		capturedTimeout = httpRequest.Header.Get(llmproxycontract.HeaderRequestTimeoutSeconds)
+		capturedAccept = httpRequest.Header.Get("Accept")
+		if httpRequest.URL.Query().Has("format") {
+			t.Fatalf("analyzer URL must not select text response format: %s", httpRequest.URL.RawQuery)
+		}
+		bodyBytes, readError := io.ReadAll(httpRequest.Body)
+		if readError != nil {
+			t.Fatalf("read body: %v", readError)
+		}
+		if decodeError := json.Unmarshal(bodyBytes, &capturedBody); decodeError != nil {
+			t.Fatalf("decode body: %v", decodeError)
+		}
+		if validationError := contract.ValidateRequest("/v2/analyze", httpRequest.Method, httpRequest, bodyBytes); validationError != nil {
+			t.Fatalf("Go analyzer request violates OpenAPI: %v", validationError)
+		}
+		responseBody := []byte(`{"outcome":"pass"}`)
+		responseHeader := http.Header{}
+		responseHeader.Set("Content-Type", "application/json")
+		responseHeader.Set(llmproxycontract.HeaderRequestID, "proxy-request-123")
+		responseHeader.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "900")
+		if validationError := contract.ValidateResponse("/v2/analyze", http.MethodPost, http.StatusOK, responseHeader, responseBody); validationError != nil {
+			t.Fatalf("Go analyzer success fixture violates OpenAPI: %v", validationError)
+		}
+		for headerName, headerValues := range responseHeader {
+			responseWriter.Header()[headerName] = headerValues
+		}
+		_, _ = responseWriter.Write(responseBody)
+	}))
+	t.Cleanup(server.Close)
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+		BaseURL:  server.URL,
+		Secret:   "sekret",
+		Provider: "openai",
+	})
+	if configError != nil {
+		t.Fatalf("config: %v", configError)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		t.Fatalf("client: %v", clientError)
+	}
+
+	response, postError := client.PostAnalyzer(context.Background(), request)
+	if postError != nil {
+		t.Fatalf("post analyzer: %v", postError)
+	}
+	if response.Text() != `{"outcome":"pass"}` || response.RequestID() != "proxy-request-123" {
+		t.Fatalf("response text=%q request_id=%q", response.Text(), response.RequestID())
+	}
+	if capturedTimeout != "900" {
+		t.Fatalf("timeout=%q", capturedTimeout)
+	}
+	if capturedAccept != "application/json" {
+		t.Fatalf("accept=%q", capturedAccept)
+	}
+	if capturedBody["model"] != "gpt-5.6" ||
+		capturedBody["max_tokens"] != float64(1200) ||
+		capturedBody["reasoning_effort"] != "high" {
+		t.Fatalf("request fields=%v", capturedBody)
+	}
+	messages, messagesOK := capturedBody["messages"].([]any)
+	if !messagesOK || len(messages) != 2 {
+		t.Fatalf("messages=%v", capturedBody["messages"])
+	}
+	userMessage := messages[1].(map[string]any)
+	content := userMessage["content"].([]any)
+	if len(content) != 3 {
+		t.Fatalf("content=%v", content)
+	}
+	assertBinaryContentPart(t, content[1], "image", "image/png", imageBytes)
+	assertBinaryContentPart(t, content[2], "audio", "audio/mpeg", audioBytes)
+	imagePayload := content[1].(map[string]any)
+	if imagePayload["detail"] != string(llmproxyclient.ImageDetailHigh) {
+		t.Fatalf("image detail=%v", imagePayload["detail"])
+	}
+	outputSchemaPayload, outputSchemaOK := capturedBody["output_schema"].(map[string]any)
+	if !outputSchemaOK ||
+		outputSchemaPayload["name"] != "semantic_qa_report" ||
+		outputSchemaPayload["description"] != "One bounded semantic QA decision." {
+		t.Fatalf("output_schema=%v", capturedBody["output_schema"])
+	}
+}
+
+func TestAnalyzerConstructorsRejectInvalidInputsBeforeHTTP(t *testing.T) {
+	if _, textError := llmproxyclient.NewTextContent(" \n\t "); !errors.Is(textError, llmproxyclient.ErrInvalidClientRequest) {
+		t.Fatalf("blank text error=%v", textError)
+	}
+	invalidImageCases := []llmproxyclient.ImageContentInput{
+		{MIMEType: "image/png"},
+		{MIMEType: "text/plain", Data: []byte("not an image")},
+		{MIMEType: "image/png", Data: []byte("image"), Detail: "ultra"},
+	}
+	for _, input := range invalidImageCases {
+		if _, imageError := llmproxyclient.NewImageContent(input); !errors.Is(imageError, llmproxyclient.ErrInvalidClientRequest) {
+			t.Fatalf("image input=%+v error=%v", input, imageError)
+		}
+	}
+	invalidAudioCases := []llmproxyclient.AudioContentInput{
+		{MIMEType: "audio/mpeg"},
+		{MIMEType: "audio/ogg", Data: []byte("audio")},
+	}
+	for _, input := range invalidAudioCases {
+		if _, audioError := llmproxyclient.NewAudioContent(input); !errors.Is(audioError, llmproxyclient.ErrInvalidClientRequest) {
+			t.Fatalf("audio input=%+v error=%v", input, audioError)
+		}
+	}
+	invalidSchemaCases := []llmproxyclient.StrictOutputSchemaInput{
+		{Name: "bad schema name", Schema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "report", Schema: json.RawMessage(`{`)},
+		{Name: "report", Schema: json.RawMessage(`[]`)},
+		{Name: "report"},
+	}
+	for _, input := range invalidSchemaCases {
+		if _, schemaError := llmproxyclient.NewStrictOutputSchema(input); !errors.Is(schemaError, llmproxyclient.ErrInvalidClientRequest) {
+			t.Fatalf("schema input=%+v error=%v", input, schemaError)
+		}
+	}
+
+	validText, textError := llmproxyclient.NewTextContent("inspect")
+	if textError != nil {
+		t.Fatalf("valid text: %v", textError)
+	}
+	validImage, imageError := llmproxyclient.NewImageContent(llmproxyclient.ImageContentInput{
+		MIMEType: "image/webp",
+		Data:     []byte("image"),
+		Detail:   llmproxyclient.ImageDetailAuto,
+	})
+	if imageError != nil {
+		t.Fatalf("valid image: %v", imageError)
+	}
+	validSchema, schemaError := llmproxyclient.NewStrictOutputSchema(llmproxyclient.StrictOutputSchemaInput{
+		Name:   "report",
+		Schema: json.RawMessage(`{"type":"object","additionalProperties":false}`),
+	})
+	if schemaError != nil {
+		t.Fatalf("valid schema: %v", schemaError)
+	}
+	blankReasoning := " \t "
+	zero := 0
+	negative := -1
+	invalidRequestCases := []struct {
+		name  string
+		input llmproxyclient.AnalyzerRequestInput
+	}{
+		{name: "missing messages", input: llmproxyclient.AnalyzerRequestInput{OutputSchema: validSchema, Model: "gpt-5.6"}},
+		{name: "missing schema", input: llmproxyclient.AnalyzerRequestInput{
+			Messages: []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{validText}}},
+			Model:    "gpt-5.6",
+		}},
+		{name: "missing model", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{validText}}},
+			OutputSchema: validSchema,
+		}},
+		{name: "invalid max tokens", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{validText}}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+			MaxTokens:    &zero,
+		}},
+		{name: "blank reasoning effort", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:        []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{validText}}},
+			OutputSchema:    validSchema,
+			Model:           "gpt-5.6",
+			ReasoningEffort: &blankReasoning,
+		}},
+		{name: "invalid request timeout", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:              []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{validText}}},
+			OutputSchema:          validSchema,
+			Model:                 "gpt-5.6",
+			RequestTimeoutSeconds: &zero,
+		}},
+		{name: "empty content", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user"}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+		}},
+		{name: "nil content", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{nil}}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+		}},
+		{name: "unsupported role", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "assistant", Content: []llmproxyclient.ContentPart{validText}}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+		}},
+		{name: "system binary", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "system", Content: []llmproxyclient.ContentPart{validImage}}, {Role: "user", Content: []llmproxyclient.ContentPart{validText}}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+		}},
+		{name: "missing user", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "system", Content: []llmproxyclient.ContentPart{validText}}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+		}},
+		{name: "mixed order", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{validText}, Order: messageOrder(1)}, {Role: "user", Content: []llmproxyclient.ContentPart{validText}}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+		}},
+		{name: "negative order", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{validText}, Order: &negative}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+		}},
+		{name: "duplicate order", input: llmproxyclient.AnalyzerRequestInput{
+			Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{validText}, Order: messageOrder(1)}, {Role: "user", Content: []llmproxyclient.ContentPart{validText}, Order: messageOrder(1)}},
+			OutputSchema: validSchema,
+			Model:        "gpt-5.6",
+		}},
+	}
+	for _, testCase := range invalidRequestCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			if _, requestError := llmproxyclient.NewAnalyzerRequest(testCase.input); !errors.Is(requestError, llmproxyclient.ErrInvalidClientRequest) {
+				subTest.Fatalf("request input=%+v error=%v", testCase.input, requestError)
+			}
+		})
+	}
+}
+
+func TestClientPostAnalyzerRejectsHTTPFailureAndModelProfile(t *testing.T) {
+	request := validAnalyzerClientRequest(t)
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		calls++
+		if httpRequest.URL.Path != "/v2/analyze" {
+			t.Fatalf("path=%q", httpRequest.URL.Path)
+		}
+		responseWriter.WriteHeader(http.StatusBadGateway)
+		_, _ = responseWriter.Write([]byte(`{"error":"upstream"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{BaseURL: server.URL, Secret: "sekret"})
+	if configError != nil {
+		t.Fatalf("config: %v", configError)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		t.Fatalf("client: %v", clientError)
+	}
+	if _, postError := client.PostAnalyzer(context.Background(), request); !errors.Is(postError, llmproxyclient.ErrClientHTTPFailure) {
+		t.Fatalf("HTTP failure error=%v", postError)
+	}
+
+	profileConfig, profileConfigError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+		BaseURL:          server.URL,
+		Secret:           "sekret",
+		ModelProfilePath: "/profiles/current.json",
+		ModelProfileReader: func(string) ([]byte, error) {
+			return []byte(`{"provider":"openai","model":"gpt-5.6"}`), nil
+		},
+	})
+	if profileConfigError != nil {
+		t.Fatalf("profile config: %v", profileConfigError)
+	}
+	profileClient, profileClientError := llmproxyclient.NewClient(profileConfig, server.Client())
+	if profileClientError != nil {
+		t.Fatalf("profile client: %v", profileClientError)
+	}
+	if _, postError := profileClient.PostAnalyzer(context.Background(), request); !errors.Is(postError, llmproxyclient.ErrInvalidModelProfile) {
+		t.Fatalf("model profile error=%v", postError)
+	}
+	if calls != 1 {
+		t.Fatalf("HTTP calls=%d want=1", calls)
+	}
+}
+
+func TestClientPostAnalyzerKeepsExistingAnalyzerEndpoint(t *testing.T) {
+	request := validAnalyzerClientRequest(t)
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		if httpRequest.URL.Path != "/v2/analyze" {
+			t.Fatalf("path=%q", httpRequest.URL.Path)
+		}
+		responseWriter.Header().Set(llmproxycontract.HeaderRequestID, "existing-endpoint")
+		_, _ = responseWriter.Write([]byte(`{"outcome":"pass"}`))
+	}))
+	t.Cleanup(server.Close)
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+		BaseURL: server.URL + "/v2/analyze/",
+		Secret:  "sekret",
+	})
+	if configError != nil {
+		t.Fatalf("config: %v", configError)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		t.Fatalf("client: %v", clientError)
+	}
+	if _, postError := client.PostAnalyzer(context.Background(), request); postError != nil {
+		t.Fatalf("post analyzer: %v", postError)
+	}
+}
+
+func TestClientPostAnalyzerRejectsSuccessfulResponseWithoutRequestIdentity(t *testing.T) {
+	textPart, textError := llmproxyclient.NewTextContent("inspect")
+	if textError != nil {
+		t.Fatalf("text: %v", textError)
+	}
+	outputSchema, schemaError := llmproxyclient.NewStrictOutputSchema(llmproxyclient.StrictOutputSchemaInput{
+		Name:   "report",
+		Schema: json.RawMessage(`{"type":"object","additionalProperties":false}`),
+	})
+	if schemaError != nil {
+		t.Fatalf("schema: %v", schemaError)
+	}
+	request, requestError := llmproxyclient.NewAnalyzerRequest(llmproxyclient.AnalyzerRequestInput{
+		Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{textPart}}},
+		OutputSchema: outputSchema,
+		Model:        "gpt-5.6",
+	})
+	if requestError != nil {
+		t.Fatalf("request: %v", requestError)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		_, _ = responseWriter.Write([]byte(`{"outcome":"pass"}`))
+	}))
+	t.Cleanup(server.Close)
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{BaseURL: server.URL, Secret: "sekret"})
+	if configError != nil {
+		t.Fatalf("config: %v", configError)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		t.Fatalf("client: %v", clientError)
+	}
+
+	if _, postError := client.PostAnalyzer(context.Background(), request); !errors.Is(postError, llmproxyclient.ErrClientHTTPFailure) ||
+		!strings.Contains(postError.Error(), "missing request id") {
+		t.Fatalf("post error=%v", postError)
+	}
+}
+
+func validAnalyzerClientRequest(t *testing.T) llmproxyclient.AnalyzerRequest {
+	t.Helper()
+	textPart, textError := llmproxyclient.NewTextContent("inspect")
+	if textError != nil {
+		t.Fatalf("text: %v", textError)
+	}
+	outputSchema, schemaError := llmproxyclient.NewStrictOutputSchema(llmproxyclient.StrictOutputSchemaInput{
+		Name:   "report",
+		Schema: json.RawMessage(`{"type":"object","additionalProperties":false}`),
+	})
+	if schemaError != nil {
+		t.Fatalf("schema: %v", schemaError)
+	}
+	request, requestError := llmproxyclient.NewAnalyzerRequest(llmproxyclient.AnalyzerRequestInput{
+		Messages:     []llmproxyclient.AnalyzerMessageInput{{Role: "user", Content: []llmproxyclient.ContentPart{textPart}}},
+		OutputSchema: outputSchema,
+		Model:        "gpt-5.6",
+	})
+	if requestError != nil {
+		t.Fatalf("request: %v", requestError)
+	}
+	return request
+}
+
+func assertBinaryContentPart(t *testing.T, rawPart any, partType string, mimeType string, expectedBytes []byte) {
+	t.Helper()
+	part, partOK := rawPart.(map[string]any)
+	if !partOK {
+		t.Fatalf("part=%v", rawPart)
+	}
+	expectedDigest := sha256.Sum256(expectedBytes)
+	if part["type"] != partType ||
+		part["mime_type"] != mimeType ||
+		part["data"] != encodeBase64(expectedBytes) ||
+		part["sha256"] != hex.EncodeToString(expectedDigest[:]) {
+		t.Fatalf("part=%v", part)
+	}
+}
+
+func encodeBase64(value []byte) string {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	if len(value) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	for byteIndex := 0; byteIndex < len(value); byteIndex += 3 {
+		remaining := len(value) - byteIndex
+		first := value[byteIndex]
+		var second byte
+		var third byte
+		if remaining > 1 {
+			second = value[byteIndex+1]
+		}
+		if remaining > 2 {
+			third = value[byteIndex+2]
+		}
+		builder.WriteByte(alphabet[first>>2])
+		builder.WriteByte(alphabet[((first&0x03)<<4)|(second>>4)])
+		if remaining > 1 {
+			builder.WriteByte(alphabet[((second&0x0f)<<2)|(third>>6)])
+		} else {
+			builder.WriteByte('=')
+		}
+		if remaining > 2 {
+			builder.WriteByte(alphabet[third&0x3f])
+		} else {
+			builder.WriteByte('=')
+		}
+	}
+	return builder.String()
+}

--- a/pkg/llmproxyclient/analyzer_test.go
+++ b/pkg/llmproxyclient/analyzer_test.go
@@ -29,7 +29,7 @@ func TestClientPostAnalyzerSendsHashBoundContentAndReturnsRequestIdentity(t *tes
 		t.Fatalf("image content: %v", imageError)
 	}
 	audioPart, audioError := llmproxyclient.NewAudioContent(llmproxyclient.AudioContentInput{
-		MIMEType: "audio/mpeg",
+		MIMEType: "audio/mp4",
 		Data:     audioBytes,
 	})
 	if audioError != nil {
@@ -151,7 +151,7 @@ func TestClientPostAnalyzerSendsHashBoundContentAndReturnsRequestIdentity(t *tes
 		t.Fatalf("content=%v", content)
 	}
 	assertBinaryContentPart(t, content[1], "image", "image/png", imageBytes)
-	assertBinaryContentPart(t, content[2], "audio", "audio/mpeg", audioBytes)
+	assertBinaryContentPart(t, content[2], "audio", "audio/mp4", audioBytes)
 	imagePayload := content[1].(map[string]any)
 	if imagePayload["detail"] != string(llmproxyclient.ImageDetailHigh) {
 		t.Fatalf("image detail=%v", imagePayload["detail"])

--- a/pkg/llmproxyclient/client.go
+++ b/pkg/llmproxyclient/client.go
@@ -18,6 +18,7 @@ import (
 )
 
 const (
+	acceptApplicationJSON     = "application/json"
 	formatQueryValueTextPlain = "text/plain"
 	headerAccept              = "Accept"
 	headerContentType         = "Content-Type"
@@ -382,6 +383,19 @@ func (client Client) messagesPostRequest(request MessagesRequest) (url.URL, []by
 }
 
 func (client Client) postPayload(contextValue context.Context, requestURL url.URL, requestBody []byte, requestTimeoutSeconds *int) (string, error) {
+	response, postError := client.postPayloadResponse(contextValue, requestURL, requestBody, requestTimeoutSeconds, formatQueryValueTextPlain)
+	if postError != nil {
+		return "", postError
+	}
+	return string(response.body), nil
+}
+
+type clientHTTPResponse struct {
+	body   []byte
+	header http.Header
+}
+
+func (client Client) postPayloadResponse(contextValue context.Context, requestURL url.URL, requestBody []byte, requestTimeoutSeconds *int, accept string) (clientHTTPResponse, error) {
 	httpRequest := (&http.Request{
 		Method:        http.MethodPost,
 		URL:           &requestURL,
@@ -389,7 +403,7 @@ func (client Client) postPayload(contextValue context.Context, requestURL url.UR
 		Body:          io.NopCloser(bytes.NewReader(requestBody)),
 		ContentLength: int64(len(requestBody)),
 	}).WithContext(contextValue)
-	httpRequest.Header.Set(headerAccept, formatQueryValueTextPlain)
+	httpRequest.Header.Set(headerAccept, accept)
 	httpRequest.Header.Set(headerContentType, jsonContentType)
 	if requestTimeoutSeconds != nil {
 		httpRequest.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, strconv.Itoa(*requestTimeoutSeconds))
@@ -397,20 +411,20 @@ func (client Client) postPayload(contextValue context.Context, requestURL url.UR
 
 	httpResponse, httpError := client.httpClient.Do(httpRequest)
 	if httpError != nil {
-		return "", fmt.Errorf("%w: post request: %v", ErrClientHTTPFailure, httpError)
+		return clientHTTPResponse{}, fmt.Errorf("%w: post request: %v", ErrClientHTTPFailure, httpError)
 	}
 	responseBody, readError := io.ReadAll(httpResponse.Body)
 	_ = httpResponse.Body.Close()
 	if readError != nil {
-		return "", fmt.Errorf("%w: read response body: %v", ErrClientHTTPFailure, readError)
+		return clientHTTPResponse{}, fmt.Errorf("%w: read response body: %v", ErrClientHTTPFailure, readError)
 	}
 	if httpResponse.StatusCode < http.StatusOK || httpResponse.StatusCode >= http.StatusMultipleChoices {
-		return "", fmt.Errorf(
+		return clientHTTPResponse{}, fmt.Errorf(
 			"%w: status=%d body=%q",
 			ErrClientHTTPFailure,
 			httpResponse.StatusCode,
 			strings.TrimSpace(string(responseBody)),
 		)
 	}
-	return string(responseBody), nil
+	return clientHTTPResponse{body: responseBody, header: httpResponse.Header.Clone()}, nil
 }

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,12 +6,12 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="e8b15ba737bfbdd5a9062148cfc00a878c1792d9c31c998f21792db331b9d41d">
+    <meta name="openapi-source-sha256" content="73f7342b0d4cd2d8e1c3aa956c3d5d4ee0afaf8e112d44fb442eb447abfdab59">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="e8b15ba737bfbdd5a9062148cfc00a878c1792d9c31c998f21792db331b9d41d">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="73f7342b0d4cd2d8e1c3aa956c3d5d4ee0afaf8e112d44fb442eb447abfdab59">
     <header class="resource-shell resource-topbar">
       <a class="resource-brand" href="/">LLM Proxy</a>
       <nav aria-label="API reference navigation">
@@ -29,7 +29,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>e8b15ba737bfbdd5a9062148cfc00a878c1792d9c31c998f21792db331b9d41d</code></span>
+          <span>Source SHA-256 <code>73f7342b0d4cd2d8e1c3aa956c3d5d4ee0afaf8e112d44fb442eb447abfdab59</code></span>
         </div>
         <div class="resource-actions">
           <a class="resource-button" href="/openapi.yaml">Download exact schema</a>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,12 +6,12 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="1031046624a1706dab111360366d77b803c39b737dd9ab0acc7970b6911f1119">
+    <meta name="openapi-source-sha256" content="e8b15ba737bfbdd5a9062148cfc00a878c1792d9c31c998f21792db331b9d41d">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="1031046624a1706dab111360366d77b803c39b737dd9ab0acc7970b6911f1119">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="e8b15ba737bfbdd5a9062148cfc00a878c1792d9c31c998f21792db331b9d41d">
     <header class="resource-shell resource-topbar">
       <a class="resource-brand" href="/">LLM Proxy</a>
       <nav aria-label="API reference navigation">
@@ -29,7 +29,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>1031046624a1706dab111360366d77b803c39b737dd9ab0acc7970b6911f1119</code></span>
+          <span>Source SHA-256 <code>e8b15ba737bfbdd5a9062148cfc00a878c1792d9c31c998f21792db331b9d41d</code></span>
         </div>
         <div class="resource-actions">
           <a class="resource-button" href="/openapi.yaml">Download exact schema</a>
@@ -59,6 +59,7 @@
 <a href="#operation-getBrowserConfiguration"><span class="api-method api-method-get">GET</span><code>/config-ui.yaml</code><span>Read the browser runtime configuration</span></a>
 <a href="#operation-postDictation"><span class="api-method api-method-post">POST</span><code>/dictate</code><span>Transcribe an audio upload</span></a>
 <a href="#operation-postV2Messages"><span class="api-method api-method-post">POST</span><code>/v2</code><span>Generate text from canonical messages</span></a>
+<a href="#operation-postV2Analyzer"><span class="api-method api-method-post">POST</span><code>/v2/analyze</code><span>Analyze hash-bound evidence with strict structured output</span></a>
         </div>
       </section>
       <section class="api-operation" id="operation-getText">
@@ -937,6 +938,64 @@
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
                 <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
+<tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
+<tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
+<tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured prompt or audio payload limit was exceeded.</td></tr>
+<tr><td><code>429</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider returned HTTP 429. The proxy preserves 429 at its public boundary and returns only sanitized provider metadata; it never exposes the raw provider body or message.</td></tr>
+<tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
+<tr><td><code>502</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider failed, returned a non-429 unsuccessful HTTP status, or returned an unusable success payload. Output-budget stops are continued internally and do not create this response. The response contains only sanitized provider metadata and never exposes partial generated text, token-count headers, a raw provider body, or a provider error message; provider-reported usage can still be retained in managed failure accounting.</td></tr>
+<tr><td><code>503</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected provider is not configured or the bounded request queue is full.</td></tr>
+<tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+<section class="api-operation" id="operation-postV2Analyzer">
+        <header class="api-operation-heading">
+          <span class="api-method api-method-post">POST</span>
+          <code>/v2/analyze</code>
+          <span class="api-operation-id">postV2Analyzer</span>
+        </header>
+        <h2>Analyze hash-bound evidence with strict structured output</h2>
+        <p>The evidence-grade analyzer operation. It accepts ordered system and user messages containing typed text, image, or audio parts, requires a named strict JSON Schema, and returns only one complete schema-constrained JSON object. Binary bytes are canonical base64 and independently verified against their lowercase SHA-256 before provider admission. The current OpenAI Responses adapter supports text and ordered image parts; audio and every unsupported provider/model capability return 400 before upstream work.</p>
+        <p class="api-security"><strong>Authentication:</strong> TenantClientKey (query key)</p>
+        <p class="api-security"><strong>Required Content-Type:</strong> <code>application/json</code></p>
+        <div class="api-contract-block">
+          <h3>Parameters</h3>
+          <div class="resource-table-wrap">
+            <table>
+              <thead><tr><th>Name</th><th>Location</th><th>Required</th><th>Type</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>key</code></td><td>query</td><td>Yes</td><td>string</td><td>Tenant client secret.</td></tr>
+<tr><td><code>provider</code></td><td>query</td><td>No</td><td>string</td><td>Canonical provider identifier. Omission uses the tenant default.</td></tr>
+<tr><td><code>X-LLM-Proxy-Request-Timeout-Seconds</code></td><td>header</td><td>No</td><td>integer</td><td>A positive whole-second request budget no greater than the server maximum. Omission selects the configured default.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="api-contract-block">
+          <h3>Request fields</h3>
+          <div class="resource-table-wrap">
+            <table>
+              <thead><tr><th>Field</th><th>Required</th><th>Type</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>messages</code></td><td>Yes</td><td>array&lt;AnalyzerMessage&gt;</td><td>Messages must include at least one user message. Either every message omits order or every message supplies one unique non-negative order. System messages accept text parts only.</td></tr>
+<tr><td><code>output_schema</code></td><td>Yes</td><td>object</td><td></td></tr>
+<tr><td><code>model</code></td><td>Yes</td><td>string</td><td>The exact configured analyzer model. Omission is invalid.</td></tr>
+<tr><td><code>max_tokens</code></td><td>No</td><td>integer</td><td></td></tr>
+<tr><td><code>reasoning_effort</code></td><td>No</td><td>string</td><td></td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="api-contract-block">
+          <h3>Responses</h3>
+          <div class="resource-table-wrap">
+            <table>
+              <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>200</code></td><td>application/json</td><td>X-LLM-Proxy-Request-ID, X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>One complete JSON value produced under the request&#39;s strict output schema. Output-budget exhaustion, malformed JSON, incomplete provider states, and schema-free continuations are never returned as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
 <tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured prompt or audio payload limit was exceeded.</td></tr>

--- a/tests/e2e/management-ui.spec.js
+++ b/tests/e2e/management-ui.spec.js
@@ -316,10 +316,12 @@ test("site publishes the exact canonical OpenAPI artifact and its derived refere
   expect(documentationHTML).toContain(`data-openapi-source-sha256="${sourceDigest}"`);
   expect(documentationHTML).toContain("https://llm-proxy-api.mprlab.com");
   expect(documentationHTML).toContain('id="operation-postV2Messages"');
+  expect(documentationHTML).toContain('id="operation-postV2Analyzer"');
+  expect(canonicalSource).toContain('"/v2/analyze"');
   expect(documentationHTML).not.toContain('id="operation-deleteManagementTenantSecret"');
   expect(documentationHTML).toContain("<code>reasoning_effort</code>");
   expect(documentationHTML).toContain(`href="${openAPIPath}"`);
-  expect(documentationHTML.match(/<section class="api-operation"/g) || []).toHaveLength(20);
+  expect(documentationHTML.match(/<section class="api-operation"/g) || []).toHaveLength(21);
 });
 
 test("SEO resource pages are crawlable from the public site", async ({ request }) => {


### PR DESCRIPTION
## Summary

- add the closed `POST /v2/analyze` operation for ordered text, image, and audio content with mandatory named strict JSON Schema output
- hash-bind binary evidence in the official Go client and independently verify canonical base64 plus lowercase SHA-256 at the proxy edge
- translate supported text/image requests to OpenAI Responses, reject audio and unsupported provider transports before upstream work, and return proxy request identity
- publish the OpenAPI operation, generated reference, routing contract, and client documentation together

This is the released-client prerequisite for Smith I001 and its autonomous semantic QA return loop.

## Validation

- `timeout -k 350s -s SIGKILL 350s make ci`
- 100% Go statement coverage
- 33 Python tests and package install test
- 75 Playwright UI/reference tests plus black-box auth
- 57 release lifecycle tests
- live provider harness preflight

## Review

Reviewed the complete diff against `origin/master`, including runtime/OpenAPI parity, exact byte and digest handling, provider pre-spend boundaries, async completion and cancellation behavior, generated documentation equality, and forward-only query/path semantics. No unresolved findings remain.