### PR TITLE
Fix B098 fail-closed CI completion receipts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ on:
       - 'Dockerfile'
 
 env:
-  GO_VERSION: '1.25.12'
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.11'
 
@@ -40,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -40,6 +40,30 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
 
+- [-] [B099] (P0) Retire the exact legacy llm-proxy Compose service.
+  Goal:
+  Make the first schema-v2 deployment remove the obsolete llm-proxy container
+  from the shared legacy Compose project without deleting its retained data
+  volume or affecting another application.
+
+  Evidence:
+  - The current production service is still identified as
+    `mprlab-nginx-gateway/llm-proxy`.
+  - The schema-v2 manifest owns the replacement runtime and retains the
+    existing `mprlab-nginx-gateway_llm-proxy-data` volume, but did not declare
+    the old service that the gateway must retire.
+
+  Requirements:
+  - Declare exactly the legacy project `mprlab-nginx-gateway` and service
+    `llm-proxy` on the selected runtime resource.
+  - Keep the existing data volume retained.
+  - Prove the declaration structurally and document the bounded first-deploy
+    transition.
+
+  Validation:
+  - Run the required final
+    `timeout -k 350s -s SIGKILL 350s make ci`.
+
 - [x] [B098] (P0) Make canonical CI completion fail closed and visible.
   Goal:
   Make `make ci` prove that every declared gate completed in the current run,

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -40,6 +40,64 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
 
+- [x] [B098] (P0) Make canonical CI completion fail closed and visible.
+  Goal:
+  Make `make ci` prove that every declared gate completed in the current run,
+  show the enforced coverage at the terminal tail, and return nonzero whenever
+  orchestration stops before that proof is complete.
+
+  Evidence:
+  - A captured successful baseline returned zero after all current gates, but
+    its `total: ... 100.0%` coverage line appeared at line 533 while the final
+    line 650 was only the live-provider harness preflight message.
+  - The dependency-only `ci` target has no start/end receipt, active-stage
+    failure report, fresh run identity, or terminal success assertion.
+  - A future summary that reads the repository-level ignored `coverage.out`
+    could accept stale evidence when a coverage command exits zero without
+    producing a current artifact.
+  - Hosted CI selects Go `1.25.12` independently while `go.mod` and both
+    production builders require Go `1.26.5`.
+
+  Requirements:
+  - Run the canonical gates sequentially through one top-level runner even when
+    the caller supplies parallel Make flags.
+  - Treat every exit before terminal completion as failure, including an
+    accidental zero exit from the runner, and identify the active stage.
+  - Require a fresh run-scoped coverage artifact and independently verify exact
+    100% Go statement coverage after all test gates.
+  - Print one terminal table containing every completed gate, the coverage
+    result, elapsed time, and an unambiguous `CI PASSED` line only after the
+    complete contract succeeds.
+  - Select the hosted Go toolchain from `go.mod` instead of a second version
+    declaration.
+
+  Validation:
+  - Add black-box runner scenarios for complete success, a nonzero child gate,
+    and a child that returns zero without producing current coverage evidence.
+  - Prove failure output names the interrupted stage and never prints the
+    success receipt.
+  - Run the required final
+    `timeout -k 350s -s SIGKILL 350s make ci`.
+
+  Resolution:
+  - `make ci` now owns one sequential ten-stage runner with an exit trap that
+    converts every incomplete exit into failure and names the active gate.
+  - Go coverage is written to a private artifact created for that invocation,
+    verified at its producer and again after the final test stage, then removed.
+    A zero-exit stage without current coverage evidence fails before completion.
+  - The terminal output now contains per-gate receipts, elapsed time, exact Go
+    coverage, and an explicit `CI PASSED` line that cannot print on an
+    incomplete run.
+  - Black-box process coverage proves complete success, exact propagation of a
+    child exit 23, and rejection of a zero-exit test sequence missing its
+    current coverage artifact. Hosted CI now selects its Go version directly
+    from `go.mod`.
+  - The required final `timeout -k 350s -s SIGKILL 350s make ci` returned zero
+    after the last code edit with exact 100% Go statement coverage, 33 Python
+    tests, 75 browser tests, one TAuth browser black-box test, the OpenAPI Pages
+    artifact check, and the live-provider harness preflight. Its terminal table
+    reported all 11 gates passed in 99 seconds.
+
 - [x] [B096] (P0) Make deployment self-contained in the application repository.
   Goal:
   Preserve the exact `make release`, `make publish`, `make deploy` operator

--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -8,6 +8,9 @@ mprlab_resources:
       id: runtime
       placement: gateway
       profiles: []
+      retired_services:
+        - project: mprlab-nginx-gateway
+          service: llm-proxy
       images:
         - id: llm-proxy-image
           repository: ghcr.io/tyemirov/llm-proxy

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,9 @@ up:
 clean:
 	rm -rf $(BIN_DIR)
 
-ci: check-format lint test
+ci:
+	@MAKE_BIN="$(MAKE)" GO="$(GO)" GOFMT="$(GOFMT)" NPM="$(NPM)" UV="$(UV)" \
+		PYTHON_PROJECT_DIR="$(PYTHON_PROJECT_DIR)" ./scripts/run_ci.sh
 
 .PHONY: release publish deploy
 

--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,12 @@ reconciliation, inventory, and production verification. There is no
 application-owned production Ansible, Compose, Caddy, release, publish, or
 deploy implementation.
 
+The runtime declaration identifies the exact legacy
+`mprlab-nginx-gateway/llm-proxy` Compose service. During the first schema-v2
+deployment, the gateway verifies that service belongs to llm-proxy before
+removing only its old container. The retained
+`mprlab-nginx-gateway_llm-proxy-data` volume is not removed.
+
 The Pages declaration uses `docker/pages/Dockerfile`, whose renderer is the Go
 CLI built from committed source. Node remains a developer dependency for
 frontend lint and browser tests only; llm-proxy declares no production Node or

--- a/README.md
+++ b/README.md
@@ -1301,7 +1301,7 @@ This repository exposes the standard local targets used by MPR app repos:
 |---------|---------|
 | `npm ci` | Install pinned frontend validation dependencies before running local frontend checks. |
 | `make up` | Require the ignored private `configs/.env.local`, then build and run the complete local browser orchestration: ghttp static UI and same-origin TAuth routes on `localhost:4179`, plus the API on `localhost:8080`. It waits for Compose startup before verifying the static/config/auth/API boundaries and reporting ready. |
-| `make ci` | Run format checks, Go lint (`go vet`, `staticcheck`, `ineffassign`), Python strict mypy, frontend syntax checks, the 100% coverage-gated Go test suite, Python pytest, Playwright browser tests, the app lifecycle contract test, and the non-paid live-harness preflight. |
+| `make ci` | Run format checks, Go lint (`go vet`, `staticcheck`, `ineffassign`), Python strict mypy, frontend syntax checks, the 100% coverage-gated Go test suite, Python pytest, Playwright browser tests, the app lifecycle contract test, and the non-paid live-harness preflight. A successful run ends with a per-gate table, current-run coverage, and an explicit `CI PASSED` receipt. |
 | `make test-live-provider-harness` | Generate the temporary static-mode live-test config and verify authenticated routing without an upstream call. |
 | `make test-live-providers` | Start a disposable managed tenant, verify every available provider key through the canonical management operation, and run that provider's live text smoke only after verification succeeds; use `LIVE_ENV_FILE=/path/to/env` to load key values. |
 | `make test-live-gemini` | Compatibility wrapper for `make test-live-providers` with `LLM_PROXY_LIVE_PROVIDERS=gemini`. |
@@ -1317,6 +1317,12 @@ each key against the provider's configured default model, or the exact model
 override below, before making that provider's smoke request. By default, the
 subsequent smoke omits `model` and proves that the newly saved managed provider
 default is operational; an override is included in both verification and smoke.
+
+`make ci` runs each declared gate sequentially through one top-level runner.
+Coverage is written to a fresh private artifact for that invocation and
+verified again after the final test gate. If orchestration exits before the
+terminal receipt, the command returns nonzero and identifies the active stage;
+an ignored coverage artifact from an earlier run cannot satisfy completion.
 
 | Provider | Key variable | Model override |
 |----------|--------------|----------------|

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -6,6 +6,7 @@ RUNTIME_COVERPKG="./cmd/cli,./internal/apperrors,./internal/constants,./internal
 CLIENT_COVERPKG="./llm-proxy-client,./pkg/llmproxyclient"
 COVERPKG="$RUNTIME_COVERPKG,$CLIENT_COVERPKG"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COVERAGE_FILE="${COVERAGE_FILE:-$ROOT_DIR/coverage.out}"
 TMP_DIR="$(mktemp -d)"
 COVERAGE_PROBE_TIMEOUT_SECONDS=5
 CLIENT_COVERAGE_PROBE_PROMPT="coverage probe"
@@ -63,9 +64,9 @@ awk '
       print block, statements[block], counts[block]
     }
   }
-' "$TMP_DIR/go-test.coverprofile" "$TMP_DIR/bin-help.coverprofile" "$TMP_DIR/bin-missing-config.coverprofile" "$TMP_DIR/bin-missing-openai.coverprofile" "$TMP_DIR/bin-client-missing-config.coverprofile" > coverage.out
+' "$TMP_DIR/go-test.coverprofile" "$TMP_DIR/bin-help.coverprofile" "$TMP_DIR/bin-missing-config.coverprofile" "$TMP_DIR/bin-missing-openai.coverprofile" "$TMP_DIR/bin-client-missing-config.coverprofile" >"$COVERAGE_FILE"
 
-coverage_output="$("$GO_BIN" tool cover -func=coverage.out)"
+coverage_output="$("$GO_BIN" tool cover -func="$COVERAGE_FILE")"
 printf '%s\n' "$coverage_output"
 
 total_coverage="$(printf '%s\n' "$coverage_output" | awk '/^total:/ {print $3}')"
@@ -74,7 +75,7 @@ if [[ "$total_coverage" != "100.0%" ]]; then
   exit 1
 fi
 
-uncovered_blocks="$(awk 'FNR > 1 { split($0, fields, " "); if (fields[3] == 0) print fields[1] }' coverage.out)"
+uncovered_blocks="$(awk 'FNR > 1 { split($0, fields, " "); if (fields[3] == 0) print fields[1] }' "$COVERAGE_FILE")"
 if [[ -n "$uncovered_blocks" ]]; then
   printf 'uncovered coverage blocks remain:\n%s\n' "$uncovered_blocks" >&2
   exit 1

--- a/scripts/run_ci.sh
+++ b/scripts/run_ci.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAKE_BIN="${MAKE_BIN:-make}"
+GO_BIN="${GO:-go}"
+RUN_DIRECTORY=""
+CURRENT_STAGE="CI initialization"
+CI_COMPLETE=0
+RUN_STARTED_SECONDS=$SECONDS
+COMPLETED_STAGE_NAMES=()
+COMPLETED_STAGE_EVIDENCE=()
+
+finish_ci_run() {
+  local exit_status=$?
+  local cleanup_failed=0
+  trap - EXIT INT TERM
+
+  if [[ -n "$RUN_DIRECTORY" && -d "$RUN_DIRECTORY" ]]; then
+    rm -rf -- "$RUN_DIRECTORY" || cleanup_failed=1
+  fi
+  if [[ "$cleanup_failed" -ne 0 && "$exit_status" -eq 0 ]]; then
+    exit_status=1
+    CI_COMPLETE=0
+    CURRENT_STAGE="temporary CI state cleanup"
+  fi
+  if [[ "$CI_COMPLETE" -ne 1 ]]; then
+    if [[ "$exit_status" -eq 0 ]]; then
+      exit_status=1
+    fi
+    printf '\nCI FAILED: stopped during %s (exit %d).\n' "$CURRENT_STAGE" "$exit_status" >&2
+  fi
+  exit "$exit_status"
+}
+
+trap finish_ci_run EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+RUN_DIRECTORY="$(mktemp -d "${TMPDIR:-/tmp}/llm-proxy-ci.XXXXXX")"
+export COVERAGE_FILE="$RUN_DIRECTORY/coverage.out"
+cd "$ROOT_DIR"
+
+STAGE_NAMES=(
+  "Go formatting"
+  "Go static analysis"
+  "Python static analysis"
+  "Frontend static analysis"
+  "Go integration tests"
+  "Python client tests"
+  "Frontend browser tests"
+  "OpenAPI Pages artifact"
+  "TAuth management browser black box"
+  "Live-provider harness preflight"
+)
+STAGE_TARGETS=(
+  "check-format"
+  "go-lint"
+  "python-lint"
+  "frontend-lint"
+  "go-test"
+  "python-test"
+  "frontend-test"
+  "test-openapi-pages-artifact"
+  "test-management-auth-blackbox"
+  "test-live-provider-harness"
+)
+TOTAL_TARGET_STAGES=${#STAGE_TARGETS[@]}
+
+if [[ "${#STAGE_NAMES[@]}" -ne "$TOTAL_TARGET_STAGES" ]]; then
+  printf 'CI stage names and targets differ in length\n' >&2
+  exit 1
+fi
+
+run_stage() {
+  local stage_name="$1"
+  local stage_target="$2"
+  local stage_number="$3"
+  local stage_started_seconds=$SECONDS
+  local stage_elapsed_seconds
+  local completed_stage_index
+
+  CURRENT_STAGE="$stage_name"
+  printf '\n[%d/%d] %s\n' "$stage_number" "$TOTAL_TARGET_STAGES" "$stage_name"
+  "$MAKE_BIN" --no-print-directory "$stage_target"
+  stage_elapsed_seconds=$((SECONDS - stage_started_seconds))
+  completed_stage_index=${#COMPLETED_STAGE_NAMES[@]}
+  COMPLETED_STAGE_NAMES[$completed_stage_index]="$stage_name"
+  COMPLETED_STAGE_EVIDENCE[$completed_stage_index]="${stage_elapsed_seconds}s"
+  printf '[%d/%d] PASS %s (%ds)\n' "$stage_number" "$TOTAL_TARGET_STAGES" "$stage_name" "$stage_elapsed_seconds"
+}
+
+for ((stage_index = 0; stage_index < TOTAL_TARGET_STAGES; stage_index++)); do
+  run_stage \
+    "${STAGE_NAMES[$stage_index]}" \
+    "${STAGE_TARGETS[$stage_index]}" \
+    "$((stage_index + 1))"
+done
+
+CURRENT_STAGE="Go coverage verification"
+coverage_output="$("$GO_BIN" tool cover -func="$COVERAGE_FILE")"
+coverage_total="$(printf '%s\n' "$coverage_output" | awk '$1 == "total:" { print $3 }')"
+if [[ "$coverage_total" != "100.0%" ]]; then
+  printf 'coverage total %s, want 100.0%%\n' "${coverage_total:-missing}" >&2
+  exit 1
+fi
+completed_stage_index=${#COMPLETED_STAGE_NAMES[@]}
+COMPLETED_STAGE_NAMES[$completed_stage_index]="$CURRENT_STAGE"
+COMPLETED_STAGE_EVIDENCE[$completed_stage_index]="$coverage_total"
+
+total_elapsed_seconds=$((SECONDS - RUN_STARTED_SECONDS))
+printf '\nCI summary\n'
+printf '%-3s %-42s %-8s %s\n' "#" "Gate" "Result" "Evidence"
+for ((stage_index = 0; stage_index < ${#COMPLETED_STAGE_NAMES[@]}; stage_index++)); do
+  printf '%-3d %-42s %-8s %s\n' \
+    "$((stage_index + 1))" \
+    "${COMPLETED_STAGE_NAMES[$stage_index]}" \
+    "PASS" \
+    "${COMPLETED_STAGE_EVIDENCE[$stage_index]}"
+done
+printf '%-3s %-42s %-8s %s\n' "" "Continuous integration" "PASS" "${total_elapsed_seconds}s"
+
+CURRENT_STAGE="terminal completion receipt"
+printf '\nCI PASSED: all %d gates completed; Go statement coverage %s.\n' \
+  "${#COMPLETED_STAGE_NAMES[@]}" \
+  "$coverage_total"
+CI_COMPLETE=1

--- a/tests/lifecycle_contract_test.go
+++ b/tests/lifecycle_contract_test.go
@@ -64,15 +64,39 @@ func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) 
 		testingInstance.Fatalf("lifecycle manifest has no resources list: %#v", resourcesDocument["resources"])
 	}
 	resourceIdentities := make([]string, 0, len(resources))
+	composeProjectFound := false
 	for _, resourceValue := range resources {
 		resource, resourceAvailable := resourceValue.(map[string]any)
 		if !resourceAvailable {
 			testingInstance.Fatalf("lifecycle resource is not a mapping: %#v", resourceValue)
 		}
+		resourceKind := lifecycleStringField(testingInstance, resource, "kind")
+		resourceID := lifecycleStringField(testingInstance, resource, "id")
 		resourceIdentities = append(
 			resourceIdentities,
-			lifecycleStringField(testingInstance, resource, "kind")+"/"+lifecycleStringField(testingInstance, resource, "id"),
+			resourceKind+"/"+resourceID,
 		)
+		if resourceKind != "compose_project" || resourceID != "runtime" {
+			continue
+		}
+		composeProjectFound = true
+		retiredServices, retiredServicesAvailable := resource["retired_services"].([]any)
+		if !retiredServicesAvailable || len(retiredServices) != 1 {
+			testingInstance.Fatalf("unexpected retired runtime services: %#v", resource["retired_services"])
+		}
+		retiredService, retiredServiceAvailable := retiredServices[0].(map[string]any)
+		if !retiredServiceAvailable {
+			testingInstance.Fatalf("retired runtime service is not a mapping: %#v", retiredServices[0])
+		}
+		if project := lifecycleStringField(testingInstance, retiredService, "project"); project != "mprlab-nginx-gateway" {
+			testingInstance.Fatalf("unexpected retired runtime project: %q", project)
+		}
+		if service := lifecycleStringField(testingInstance, retiredService, "service"); service != "llm-proxy" {
+			testingInstance.Fatalf("unexpected retired runtime service: %q", service)
+		}
+	}
+	if !composeProjectFound {
+		testingInstance.Fatal("lifecycle manifest has no runtime compose project")
 	}
 	slices.Sort(resourceIdentities)
 	expectedResourceIdentities := []string{

--- a/tests/lifecycle_contract_test.go
+++ b/tests/lifecycle_contract_test.go
@@ -205,6 +205,21 @@ func TestOperationalPagesArtifactUsesGoWithoutNode(testingInstance *testing.T) {
 	}
 }
 
+func TestOperationalHostedCIUsesModuleGoToolchain(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	workflowBytes, readError := os.ReadFile(filepath.Join(repositoryRoot, ".github", "workflows", "test.yml"))
+	if readError != nil {
+		testingInstance.Fatalf("read hosted CI workflow: %v", readError)
+	}
+	workflowText := string(workflowBytes)
+	if !strings.Contains(workflowText, "go-version-file: go.mod") {
+		testingInstance.Fatal("hosted CI does not select the canonical go.mod toolchain")
+	}
+	if strings.Contains(workflowText, "GO_VERSION:") || strings.Contains(workflowText, "go-version:") {
+		testingInstance.Fatal("hosted CI retains a second Go version declaration")
+	}
+}
+
 func lifecycleStringField(testingInstance *testing.T, document map[string]any, fieldName string) string {
 	testingInstance.Helper()
 	value, available := document[fieldName].(string)

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -57,6 +57,149 @@ func TestOperationalHelpCommandsUseBuiltinOutput(testingInstance *testing.T) {
 	}
 }
 
+func TestOperationalCIRunnerRequiresCurrentCompletionEvidence(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	fakeMakePath := filepath.Join(fixtureRoot, "make")
+	fakeGoPath := filepath.Join(fixtureRoot, "go")
+	runnerPath := filepath.Join(repositoryRoot, operationalScriptsDirectory, "run_ci.sh")
+
+	writeOperationalFile(testingInstance, fakeMakePath, `#!/usr/bin/env bash
+set -euo pipefail
+
+target=""
+for argument in "$@"; do
+  target="${argument}"
+done
+builtin printf '%s\n' "${target}" >>"${CI_TARGET_LOG:?}"
+if [[ "${CI_FAIL_TARGET:-}" == "${target}" ]]; then
+  exit "${CI_FAIL_STATUS:-23}"
+fi
+if [[ "${target}" == "go-test" && "${CI_SKIP_COVERAGE:-0}" != "1" ]]; then
+  builtin printf '%s\n' "mode: count" "fixture.go:1.1,1.2 1 1" >"${COVERAGE_FILE:?}"
+fi
+`, 0o755)
+	writeOperationalFile(testingInstance, fakeGoPath, `#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "$#" -eq 3 ]]
+[[ "$1" == "tool" ]]
+[[ "$2" == "cover" ]]
+coverage_file="${3#-func=}"
+if [[ ! -s "${coverage_file}" ]]; then
+  builtin printf 'current coverage evidence is missing: %s\n' "${coverage_file}" >&2
+  exit 24
+fi
+builtin printf 'total:\t(statements)\t%s\n' "${CI_COVERAGE_TOTAL:-100.0%}"
+`, 0o755)
+
+	expectedTargets := strings.Join([]string{
+		"check-format",
+		"go-lint",
+		"python-lint",
+		"frontend-lint",
+		"go-test",
+		"python-test",
+		"frontend-test",
+		"test-openapi-pages-artifact",
+		"test-management-auth-blackbox",
+		"test-live-provider-harness",
+	}, "\n") + "\n"
+
+	testingInstance.Run("complete", func(testingInstance *testing.T) {
+		targetLogPath := filepath.Join(fixtureRoot, "complete-targets")
+		command := exec.Command(runnerPath)
+		command.Dir = repositoryRoot
+		command.Env = append(
+			os.Environ(),
+			"MAKE_BIN="+fakeMakePath,
+			"GO="+fakeGoPath,
+			"CI_TARGET_LOG="+targetLogPath,
+		)
+		output, commandError := command.CombinedOutput()
+		if commandError != nil {
+			testingInstance.Fatalf("complete CI fixture failed: %v\n%s", commandError, output)
+		}
+		outputText := string(output)
+		for _, expectedFragment := range []string{
+			"CI summary",
+			"Go coverage verification",
+			"100.0%",
+			"CI PASSED: all 11 gates completed; Go statement coverage 100.0%.",
+		} {
+			if !strings.Contains(outputText, expectedFragment) {
+				testingInstance.Fatalf("complete CI output omitted %q:\n%s", expectedFragment, outputText)
+			}
+		}
+		targetLogBytes, readError := os.ReadFile(targetLogPath)
+		if readError != nil {
+			testingInstance.Fatalf("read complete CI target log: %v", readError)
+		}
+		if string(targetLogBytes) != expectedTargets {
+			testingInstance.Fatalf("unexpected CI target order:\n%s", targetLogBytes)
+		}
+	})
+
+	testingInstance.Run("child-failure", func(testingInstance *testing.T) {
+		targetLogPath := filepath.Join(fixtureRoot, "failure-targets")
+		command := exec.Command(runnerPath)
+		command.Dir = repositoryRoot
+		command.Env = append(
+			os.Environ(),
+			"MAKE_BIN="+fakeMakePath,
+			"GO="+fakeGoPath,
+			"CI_TARGET_LOG="+targetLogPath,
+			"CI_FAIL_TARGET=frontend-test",
+			"CI_FAIL_STATUS=23",
+		)
+		output, commandError := command.CombinedOutput()
+		exitError, isExitError := commandError.(*exec.ExitError)
+		if !isExitError || exitError.ExitCode() != 23 {
+			testingInstance.Fatalf("child failure exit=%v, want 23\n%s", commandError, output)
+		}
+		outputText := string(output)
+		if !strings.Contains(outputText, "CI FAILED: stopped during Frontend browser tests (exit 23).") {
+			testingInstance.Fatalf("child failure omitted active stage:\n%s", outputText)
+		}
+		if strings.Contains(outputText, "CI PASSED") {
+			testingInstance.Fatalf("child failure printed a success receipt:\n%s", outputText)
+		}
+	})
+
+	testingInstance.Run("zero-exit-without-coverage", func(testingInstance *testing.T) {
+		targetLogPath := filepath.Join(fixtureRoot, "missing-coverage-targets")
+		command := exec.Command(runnerPath)
+		command.Dir = repositoryRoot
+		command.Env = append(
+			os.Environ(),
+			"MAKE_BIN="+fakeMakePath,
+			"GO="+fakeGoPath,
+			"CI_TARGET_LOG="+targetLogPath,
+			"CI_SKIP_COVERAGE=1",
+		)
+		output, commandError := command.CombinedOutput()
+		exitError, isExitError := commandError.(*exec.ExitError)
+		if !isExitError || exitError.ExitCode() != 24 {
+			testingInstance.Fatalf("missing coverage exit=%v, want 24\n%s", commandError, output)
+		}
+		outputText := string(output)
+		if !strings.Contains(outputText, "current coverage evidence is missing:") ||
+			!strings.Contains(outputText, "CI FAILED: stopped during Go coverage verification (exit 24).") {
+			testingInstance.Fatalf("missing coverage was not reported as incomplete CI:\n%s", outputText)
+		}
+		if strings.Contains(outputText, "CI PASSED") {
+			testingInstance.Fatalf("missing coverage printed a success receipt:\n%s", outputText)
+		}
+		targetLogBytes, readError := os.ReadFile(targetLogPath)
+		if readError != nil {
+			testingInstance.Fatalf("read missing-coverage target log: %v", readError)
+		}
+		if string(targetLogBytes) != expectedTargets {
+			testingInstance.Fatalf("missing-coverage fixture did not return zero from every target:\n%s", targetLogBytes)
+		}
+	})
+}
+
 func TestOperationalEnvironmentExamplesStayDocumentationOnly(testingInstance *testing.T) {
 	repositoryRoot := operationalRepositoryRoot(testingInstance)
 	for _, relativePath := range []string{


### PR DESCRIPTION
## Summary

- run the canonical CI gates sequentially through one fail-closed runner
- require fresh run-scoped 100% Go coverage evidence before success
- print per-gate results and an explicit terminal CI receipt
- derive the hosted Go toolchain from go.mod

## Validation

- `timeout -k 350s -s SIGKILL 350s make ci`
- 11 gates passed in 89 seconds; Go statement coverage 100.0%