### PR TITLE
B099: retire legacy llm-proxy Compose service

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -40,6 +40,30 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
 
+- [-] [B099] (P0) Retire the exact legacy llm-proxy Compose service.
+  Goal:
+  Make the first schema-v2 deployment remove the obsolete llm-proxy container
+  from the shared legacy Compose project without deleting its retained data
+  volume or affecting another application.
+
+  Evidence:
+  - The current production service is still identified as
+    `mprlab-nginx-gateway/llm-proxy`.
+  - The schema-v2 manifest owns the replacement runtime and retains the
+    existing `mprlab-nginx-gateway_llm-proxy-data` volume, but did not declare
+    the old service that the gateway must retire.
+
+  Requirements:
+  - Declare exactly the legacy project `mprlab-nginx-gateway` and service
+    `llm-proxy` on the selected runtime resource.
+  - Keep the existing data volume retained.
+  - Prove the declaration structurally and document the bounded first-deploy
+    transition.
+
+  Validation:
+  - Run the required final
+    `timeout -k 350s -s SIGKILL 350s make ci`.
+
 - [x] [B098] (P0) Make canonical CI completion fail closed and visible.
   Goal:
   Make `make ci` prove that every declared gate completed in the current run,

--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -8,6 +8,9 @@ mprlab_resources:
       id: runtime
       placement: gateway
       profiles: []
+      retired_services:
+        - project: mprlab-nginx-gateway
+          service: llm-proxy
       images:
         - id: llm-proxy-image
           repository: ghcr.io/tyemirov/llm-proxy

--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,12 @@ reconciliation, inventory, and production verification. There is no
 application-owned production Ansible, Compose, Caddy, release, publish, or
 deploy implementation.
 
+The runtime declaration identifies the exact legacy
+`mprlab-nginx-gateway/llm-proxy` Compose service. During the first schema-v2
+deployment, the gateway verifies that service belongs to llm-proxy before
+removing only its old container. The retained
+`mprlab-nginx-gateway_llm-proxy-data` volume is not removed.
+
 The Pages declaration uses `docker/pages/Dockerfile`, whose renderer is the Go
 CLI built from committed source. Node remains a developer dependency for
 frontend lint and browser tests only; llm-proxy declares no production Node or

--- a/tests/lifecycle_contract_test.go
+++ b/tests/lifecycle_contract_test.go
@@ -64,15 +64,39 @@ func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) 
 		testingInstance.Fatalf("lifecycle manifest has no resources list: %#v", resourcesDocument["resources"])
 	}
 	resourceIdentities := make([]string, 0, len(resources))
+	composeProjectFound := false
 	for _, resourceValue := range resources {
 		resource, resourceAvailable := resourceValue.(map[string]any)
 		if !resourceAvailable {
 			testingInstance.Fatalf("lifecycle resource is not a mapping: %#v", resourceValue)
 		}
+		resourceKind := lifecycleStringField(testingInstance, resource, "kind")
+		resourceID := lifecycleStringField(testingInstance, resource, "id")
 		resourceIdentities = append(
 			resourceIdentities,
-			lifecycleStringField(testingInstance, resource, "kind")+"/"+lifecycleStringField(testingInstance, resource, "id"),
+			resourceKind+"/"+resourceID,
 		)
+		if resourceKind != "compose_project" || resourceID != "runtime" {
+			continue
+		}
+		composeProjectFound = true
+		retiredServices, retiredServicesAvailable := resource["retired_services"].([]any)
+		if !retiredServicesAvailable || len(retiredServices) != 1 {
+			testingInstance.Fatalf("unexpected retired runtime services: %#v", resource["retired_services"])
+		}
+		retiredService, retiredServiceAvailable := retiredServices[0].(map[string]any)
+		if !retiredServiceAvailable {
+			testingInstance.Fatalf("retired runtime service is not a mapping: %#v", retiredServices[0])
+		}
+		if project := lifecycleStringField(testingInstance, retiredService, "project"); project != "mprlab-nginx-gateway" {
+			testingInstance.Fatalf("unexpected retired runtime project: %q", project)
+		}
+		if service := lifecycleStringField(testingInstance, retiredService, "service"); service != "llm-proxy" {
+			testingInstance.Fatalf("unexpected retired runtime service: %q", service)
+		}
+	}
+	if !composeProjectFound {
+		testingInstance.Fatal("lifecycle manifest has no runtime compose project")
 	}
 	slices.Sort(resourceIdentities)
 	expectedResourceIdentities := []string{


### PR DESCRIPTION
## Summary

- declare the exact legacy `mprlab-nginx-gateway/llm-proxy` service for bounded retirement
- retain `mprlab-nginx-gateway_llm-proxy-data`
- prove and document the first schema-v2 transition

## Validation

- `timeout -k 350s -s SIGKILL 350s make ci` (11 gates, 100% Go coverage)
- sealed gateway `plan-app-release` at gateway `816cb74071bf8154821ec4c9f298457b7aadcf33`

Stacked on #242.