### PR TITLE
[B388] Adopt the selected service-value contract

### DIFF
--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -1,13 +1,18 @@
 ---
 mprlab_resources:
-  schema_version: 2
+  schema_version: 3
   owner: llm-proxy
-  dependencies: []
   resources:
+    - kind: private_values
+      id: private
+      bindings:
+        admin-emails: LLM_PROXY_MANAGEMENT_ADMIN_EMAILS
+        google-web-client-id: LLM_PROXY_MANAGEMENT_GOOGLE_CLIENT_ID
+        jwt-signing-key: LLM_PROXY_MANAGEMENT_JWT_SIGNING_KEY
+        provider-key-encryption-key: LLM_PROXY_MANAGEMENT_PROVIDER_KEY_ENCRYPTION_KEY
     - kind: compose_project
       id: runtime
       placement: gateway
-      profiles: []
       retired_services:
         - project: mprlab-nginx-gateway
           service: llm-proxy
@@ -24,8 +29,57 @@ mprlab_resources:
       services:
         - id: llm-proxy
           image: llm-proxy-image
-          environment_files:
-            - secret: llm-proxy.runtime-environment
+          environment:
+            LLM_PROXY_MANAGEMENT_ADMIN_EMAILS:
+              resource: private
+              output: admin-emails
+            LLM_PROXY_MANAGEMENT_API_ORIGIN:
+              resource: public-api
+              output: origin
+            LLM_PROXY_MANAGEMENT_DATABASE_PATH:
+              value: /app/data/llm-proxy-management.sqlite
+            LLM_PROXY_MANAGEMENT_ENABLED:
+              value: "true"
+            LLM_PROXY_MANAGEMENT_GOOGLE_CLIENT_ID:
+              resource: authentication
+              output: google-web-client-id
+            LLM_PROXY_MANAGEMENT_JWT_ISSUER:
+              value: tauth
+            LLM_PROXY_MANAGEMENT_JWT_SIGNING_KEY:
+              resource: authentication
+              output: jwt-signing-key
+            LLM_PROXY_MANAGEMENT_LOCALHOST_ORIGIN:
+              value: http://localhost:4179
+            LLM_PROXY_MANAGEMENT_LOOPBACK_ORIGIN:
+              value: http://127.0.0.1:4179
+            LLM_PROXY_MANAGEMENT_PROVIDER_KEY_ENCRYPTION_KEY:
+              resource: private
+              output: provider-key-encryption-key
+            LLM_PROXY_MANAGEMENT_PROXY_ORIGIN:
+              resource: public-api
+              output: origin
+            LLM_PROXY_MANAGEMENT_PUBLIC_ORIGIN:
+              resource: website
+              output: origin
+            LLM_PROXY_MANAGEMENT_SESSION_COOKIE_NAME:
+              resource: authentication
+              output: session-cookie-name
+            LLM_PROXY_MANAGEMENT_TAUTH_LOGIN_PATH:
+              value: /auth/google
+            LLM_PROXY_MANAGEMENT_TAUTH_LOGOUT_PATH:
+              value: /auth/logout
+            LLM_PROXY_MANAGEMENT_TAUTH_NONCE_PATH:
+              value: /auth/nonce
+            LLM_PROXY_MANAGEMENT_TAUTH_SESSION_PATH:
+              value: /auth/session
+            LLM_PROXY_MANAGEMENT_TAUTH_TENANT_ID:
+              resource: authentication
+              output: tenant-id
+            LLM_PROXY_MANAGEMENT_TAUTH_URL:
+              capability: tauth.http
+              component: url
+            LLM_PROXY_MANAGEMENT_UI_DESCRIPTION:
+              value: LLM Proxy
           assets:
             - source: configs/config.yml
               target: /app/config.yml
@@ -116,9 +170,11 @@ mprlab_resources:
         origins:
           - https://llm-proxy.mprlab.com
         google_web_client_id:
-          secret: llm-proxy.google-web-client-id
+          resource: private
+          output: google-web-client-id
         jwt_signing_key:
-          secret: llm-proxy.jwt-signing-key
+          resource: private
+          output: jwt-signing-key
         cookie:
           domain: .mprlab.com
           session_name: app_session_llm_proxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ All notable changes to this project will be documented in this file.
 - Remove Moonshot's unavailable former default model and promote the verified `kimi-k2.6` model as the sole canonical default without an alias or fallback.
 - Verify every nonempty managed provider key against its exact provider and selected text model before atomic persistence, with automatic paste verification, safe stable failures, stale-attempt cancellation, and live-harness coverage.
 - Persist managed usage after response flush through one bounded FIFO writer, with explicit drop-newest overflow, at-most-once process-local durability, and safe failure logging.
-- Declare the llm-proxy TAuth tenant requirements in the app-owned deployment manifest for gateway assembly.
+- Migrate the app-owned lifecycle manifest to schema v3, remove the parallel
+  dependency list and unused Compose profiles, and let the gateway derive
+  TAuth requirements from the typed tenant resource.
+- Bind deployment-private values to exact keys in `.mprlab/deploy/.env`, use
+  closed TAuth, Caddy, and Pages outputs, and remove the whole-file service
+  environment contract.
 - Add the bounded `X-LLM-Proxy-Request-Timeout-Seconds` contract across text and dictation routes, including effective response headers and canonical `400 invalid_request_timeout` and `504 request_timeout` JSON errors.
 - Move Go and Python timeout selection from client configuration onto each messages request, replace the CLI `--timeout` flag with `--request-timeout-seconds`, and remove the arbitrary 390-second bundled-client deadline.
 - Add `server.max_request_timeout_seconds`, one ingress-owned deadline shared by body parsing, queue admission, provider calls, and OpenAI polling, plus safe terminal-outcome logging.
 - Keep response construction and managed-usage persistence under request cancellation, classify queue saturation as `proxy_overload`, reject explicit null timeout configuration, and synchronize Python client distribution metadata at `0.2.0`.
-- Replace app-owned production lifecycle machinery with one schema-v2 resource declaration and thin `make release`, `make publish`, and `make deploy` entrypoints into the exact sibling `mprlab-gateway`; render Pages with Go and declare no production Node dependency.
+- Replace app-owned production lifecycle machinery with one schema-v3 resource declaration and thin `make release`, `make publish`, and `make deploy` entrypoints into the exact sibling `mprlab-gateway`; render Pages with Go and declare no production Node dependency.
 - Give the asynchronous local orchestration contract its own bounded startup/shutdown timeout so `make release` does not fail under ordinary CI load.
 - Remove tracked generated Python `*.egg-info` metadata so a clean CI/release gate remains clean.
 

--- a/README.md
+++ b/README.md
@@ -1400,7 +1400,7 @@ This repository exposes the standard local targets used by MPR app repos:
 | `make test-live-providers` | Start a disposable managed tenant, verify every available provider key through the canonical management operation, and run that provider's live text smoke only after verification succeeds; use `LIVE_ENV_FILE=/path/to/env` to load key values. |
 | `make test-live-gemini` | Compatibility wrapper for `make test-live-providers` with `LLM_PROXY_LIVE_PROVIDERS=gemini`. |
 | `make live-test` | Send paid production `POST /v2` requests through the Default tenant using only `LLM_PROXY_SECRET`: echo checks for OpenAI, Anthropic, Meta, Gemini, and Moonshot, plus one large OpenAI background-polling request. |
-| `make release` | Delegate this clean checkout and its schema-v2 resource declaration to the exact sibling `../mprlab-gateway` release transaction. |
+| `make release` | Delegate this clean checkout and its schema-v3 resource declaration to the exact sibling `../mprlab-gateway` release transaction. |
 | `make publish` | Delegate publication of the exact sealed release to `../mprlab-gateway`; it does not rebuild or deploy. |
 | `make deploy` | Delegate convergence of only this app's declared runtime, route, health, Pages, and TAuth resources to `../mprlab-gateway`. |
 
@@ -1517,14 +1517,21 @@ The selected app transaction reads no unrelated app repository.
 This repository owns one production declaration:
 `.mprlab/deploy/resources.yml`. It declares the container image and service,
 retained data volume, `llm-proxy.http` capability, Caddy route, public health
-checks, GitHub Pages artifact, and TAuth tenant. The gateway owns schema
-validation, dependency resolution, artifact sealing and publication, Ansible
-reconciliation, inventory, and production verification. There is no
-application-owned production Ansible, Compose, Caddy, release, publish, or
-deploy implementation.
+checks, GitHub Pages artifact, TAuth tenant, and private-value bindings. The
+ignored `.mprlab/deploy/.env` file is the canonical private deployment input.
+The gateway reads it only during deployment and generates one mode-`0600`
+service environment. TAuth, Pages, Caddy, and capability resources supply
+their owned outputs without duplicate values in the private file or service
+declaration.
+
+The gateway owns schema validation, resource-output resolution, artifact
+sealing and publication, Ansible reconciliation, inventory, and production
+verification. Application private values do not use gateway inventory secret
+maps. There is no application-owned production Ansible, Compose, Caddy,
+release, publish, or deploy implementation.
 
 The runtime declaration identifies the exact legacy
-`mprlab-nginx-gateway/llm-proxy` Compose service. During the first schema-v2
+`mprlab-nginx-gateway/llm-proxy` Compose service. During the first schema-v3
 deployment, the gateway verifies that service belongs to llm-proxy before
 removing only its old container. The retained
 `mprlab-nginx-gateway_llm-proxy-data` volume is not removed.

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -448,15 +448,21 @@ a tenant secret or response body.
 
 Startup validates configured tenants, rejects duplicate tenant ids and duplicate secrets, requires API keys for each configured static tenant's default text and dictation providers when management mode is disabled, allows non-default provider API keys to be blank so those providers are disabled until configured, requires every configured provider base URL, requires transcription URLs for dictation-capable providers, requires text model catalogs for every provider, requires dictation model catalogs for dictation-capable providers, rejects blank or duplicate model ids, rejects defaults not listed in their model catalog, rejects `web_search` outside OpenAI text model entries, validates OpenAI request profiles, validates exact model-owned reasoning-effort lists, validates each configured static tenant's default text provider/model and effort, and validates endpoint/credential support for each configured static tenant's default dictation provider/model. When `management.enabled` is false, at least one static tenant is required. When `management.enabled` is true, static tenants and nonblank config-level provider API keys are rejected because managed tokens and provider credentials are user-owned database state.
 
-The repository owns the schema-v2 production declaration at
+The repository owns the schema-v3 production declaration at
 `.mprlab/deploy/resources.yml` and the standard `make release`, `make publish`,
 and `make deploy` entrypoints. Those targets resolve the exact sibling
 `../mprlab-gateway`, which owns the canonical SemVer lifecycle, schema
 validation, artifact sealing and publication, Ansible inventory and
 reconciliation, and production verification. The selected transaction reads
-only this app checkout and its declared capability dependencies; it does not
-inspect unrelated repositories. Publish and deploy consume the exact sealed
+only this app checkout and the references nested in its typed resources; it
+does not inspect unrelated repositories. Publish and deploy consume the exact sealed
 release without rerunning CI or rebuilding.
+
+The ignored `.mprlab/deploy/.env` file is the selected application's private
+deployment input. The manifest binds exact dotenv keys to closed private
+outputs. Deployment generates one service environment from private, TAuth,
+Caddy, Pages, and capability outputs. Release and publication do not read the
+private input.
 
 The management UI is served as a static GitHub Pages app from `site/` on `https://llm-proxy.mprlab.com`; the Go backend does not serve management HTML or assets. The declared `docker/pages/Dockerfile` builds the Go CLI and uses it to render and validate the Pages archive without a production Node dependency. The gateway publishes that immutable archive without changing the live site and deploy activates it on `gh-pages` after the backend rollout. The backend serves one public browser config file at `/config-ui.yaml` from the already-loaded management config, with credentialed CORS restricted to `management.public_origin`.
 

--- a/tests/lifecycle_contract_test.go
+++ b/tests/lifecycle_contract_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -29,7 +30,7 @@ var expectedSiblingGatewayWrapper = strings.Join([]string{
 	"\t\tMPRLAB_APP_ROOT=\"$${application_root}\"",
 }, "\n")
 
-func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) {
+func TestOperationalRepositoryOwnsSchemaV3Lifecycle(testingInstance *testing.T) {
 	repositoryRoot := operationalRepositoryRoot(testingInstance)
 	manifestPath := filepath.Join(repositoryRoot, filepath.FromSlash(lifecycleManifestRelativePath))
 	manifestBytes, readError := os.ReadFile(manifestPath)
@@ -48,15 +49,17 @@ func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) 
 	if !available {
 		testingInstance.Fatalf("lifecycle manifest has no mprlab_resources mapping: %#v", document)
 	}
-	if schemaVersion, schemaAvailable := resourcesDocument["schema_version"].(int); !schemaAvailable || schemaVersion != 2 {
+	if schemaVersion, schemaAvailable := resourcesDocument["schema_version"].(int); !schemaAvailable || schemaVersion != 3 {
 		testingInstance.Fatalf("unexpected lifecycle schema version: %#v", resourcesDocument["schema_version"])
 	}
 	if owner, ownerAvailable := resourcesDocument["owner"].(string); !ownerAvailable || owner != "llm-proxy" {
 		testingInstance.Fatalf("unexpected lifecycle owner: %#v", resourcesDocument["owner"])
 	}
-	dependencies, dependenciesAvailable := resourcesDocument["dependencies"].([]any)
-	if !dependenciesAvailable || len(dependencies) != 0 {
-		testingInstance.Fatalf("llm-proxy must declare no runtime dependencies: %#v", resourcesDocument["dependencies"])
+	if _, dependenciesAvailable := resourcesDocument["dependencies"]; dependenciesAvailable {
+		testingInstance.Fatalf("lifecycle manifest must not declare top-level dependencies: %#v", resourcesDocument["dependencies"])
+	}
+	if len(resourcesDocument) != 3 {
+		testingInstance.Fatalf("lifecycle manifest must contain only schema_version, owner, and resources: %#v", resourcesDocument)
 	}
 
 	resources, resourcesAvailable := resourcesDocument["resources"].([]any)
@@ -64,6 +67,7 @@ func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) 
 		testingInstance.Fatalf("lifecycle manifest has no resources list: %#v", resourcesDocument["resources"])
 	}
 	resourceIdentities := make([]string, 0, len(resources))
+	resourcesByIdentity := make(map[string]map[string]any, len(resources))
 	composeProjectFound := false
 	for _, resourceValue := range resources {
 		resource, resourceAvailable := resourceValue.(map[string]any)
@@ -72,10 +76,9 @@ func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) 
 		}
 		resourceKind := lifecycleStringField(testingInstance, resource, "kind")
 		resourceID := lifecycleStringField(testingInstance, resource, "id")
-		resourceIdentities = append(
-			resourceIdentities,
-			resourceKind+"/"+resourceID,
-		)
+		resourceIdentity := resourceKind + "/" + resourceID
+		resourceIdentities = append(resourceIdentities, resourceIdentity)
+		resourcesByIdentity[resourceIdentity] = resource
 		if resourceKind != "compose_project" || resourceID != "runtime" {
 			continue
 		}
@@ -105,6 +108,7 @@ func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) 
 		"github_pages/website",
 		"health_check/api-auth-boundary",
 		"health_check/management-config",
+		"private_values/private",
 		"runtime_capability/http",
 		"tauth_tenant/authentication",
 	}
@@ -112,9 +116,82 @@ func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) 
 		testingInstance.Fatalf("unexpected llm-proxy lifecycle resources: %#v", resourceIdentities)
 	}
 
+	privateBindings := resourcesByIdentity["private_values/private"]["bindings"]
+	expectedPrivateBindings := map[string]any{
+		"admin-emails":                "LLM_PROXY_MANAGEMENT_ADMIN_EMAILS",
+		"google-web-client-id":        "LLM_PROXY_MANAGEMENT_GOOGLE_CLIENT_ID",
+		"jwt-signing-key":             "LLM_PROXY_MANAGEMENT_JWT_SIGNING_KEY",
+		"provider-key-encryption-key": "LLM_PROXY_MANAGEMENT_PROVIDER_KEY_ENCRYPTION_KEY",
+	}
+	if !reflect.DeepEqual(privateBindings, expectedPrivateBindings) {
+		testingInstance.Fatalf("unexpected private-value bindings: %#v", privateBindings)
+	}
+
+	runtimeServices, servicesAvailable := resourcesByIdentity["compose_project/runtime"]["services"].([]any)
+	if !servicesAvailable || len(runtimeServices) != 1 {
+		testingInstance.Fatalf("unexpected runtime services: %#v", resourcesByIdentity["compose_project/runtime"]["services"])
+	}
+	runtimeService, runtimeServiceAvailable := runtimeServices[0].(map[string]any)
+	if !runtimeServiceAvailable {
+		testingInstance.Fatalf("runtime service is not a mapping: %#v", runtimeServices[0])
+	}
+	if _, environmentFilesAvailable := runtimeService["environment_files"]; environmentFilesAvailable {
+		testingInstance.Fatalf("runtime service retains environment_files: %#v", runtimeService["environment_files"])
+	}
+	runtimeEnvironment, environmentAvailable := runtimeService["environment"].(map[string]any)
+	if !environmentAvailable {
+		testingInstance.Fatalf("runtime service has no typed environment: %#v", runtimeService["environment"])
+	}
+	runtimeEnvironmentNames := make([]string, 0, len(runtimeEnvironment))
+	for environmentName := range runtimeEnvironment {
+		runtimeEnvironmentNames = append(runtimeEnvironmentNames, environmentName)
+	}
+	slices.Sort(runtimeEnvironmentNames)
+	expectedRuntimeEnvironmentNames := []string{
+		"LLM_PROXY_MANAGEMENT_ADMIN_EMAILS",
+		"LLM_PROXY_MANAGEMENT_API_ORIGIN",
+		"LLM_PROXY_MANAGEMENT_DATABASE_PATH",
+		"LLM_PROXY_MANAGEMENT_ENABLED",
+		"LLM_PROXY_MANAGEMENT_GOOGLE_CLIENT_ID",
+		"LLM_PROXY_MANAGEMENT_JWT_ISSUER",
+		"LLM_PROXY_MANAGEMENT_JWT_SIGNING_KEY",
+		"LLM_PROXY_MANAGEMENT_LOCALHOST_ORIGIN",
+		"LLM_PROXY_MANAGEMENT_LOOPBACK_ORIGIN",
+		"LLM_PROXY_MANAGEMENT_PROVIDER_KEY_ENCRYPTION_KEY",
+		"LLM_PROXY_MANAGEMENT_PROXY_ORIGIN",
+		"LLM_PROXY_MANAGEMENT_PUBLIC_ORIGIN",
+		"LLM_PROXY_MANAGEMENT_SESSION_COOKIE_NAME",
+		"LLM_PROXY_MANAGEMENT_TAUTH_LOGIN_PATH",
+		"LLM_PROXY_MANAGEMENT_TAUTH_LOGOUT_PATH",
+		"LLM_PROXY_MANAGEMENT_TAUTH_NONCE_PATH",
+		"LLM_PROXY_MANAGEMENT_TAUTH_SESSION_PATH",
+		"LLM_PROXY_MANAGEMENT_TAUTH_TENANT_ID",
+		"LLM_PROXY_MANAGEMENT_TAUTH_URL",
+		"LLM_PROXY_MANAGEMENT_UI_DESCRIPTION",
+	}
+	if !slices.Equal(runtimeEnvironmentNames, expectedRuntimeEnvironmentNames) {
+		testingInstance.Fatalf("unexpected runtime environment keys: %#v", runtimeEnvironmentNames)
+	}
+	for environmentName, expectedBinding := range map[string]map[string]any{
+		"LLM_PROXY_MANAGEMENT_ADMIN_EMAILS":                {"resource": "private", "output": "admin-emails"},
+		"LLM_PROXY_MANAGEMENT_API_ORIGIN":                  {"resource": "public-api", "output": "origin"},
+		"LLM_PROXY_MANAGEMENT_GOOGLE_CLIENT_ID":            {"resource": "authentication", "output": "google-web-client-id"},
+		"LLM_PROXY_MANAGEMENT_JWT_SIGNING_KEY":             {"resource": "authentication", "output": "jwt-signing-key"},
+		"LLM_PROXY_MANAGEMENT_PROVIDER_KEY_ENCRYPTION_KEY": {"resource": "private", "output": "provider-key-encryption-key"},
+		"LLM_PROXY_MANAGEMENT_PROXY_ORIGIN":                {"resource": "public-api", "output": "origin"},
+		"LLM_PROXY_MANAGEMENT_PUBLIC_ORIGIN":               {"resource": "website", "output": "origin"},
+		"LLM_PROXY_MANAGEMENT_SESSION_COOKIE_NAME":         {"resource": "authentication", "output": "session-cookie-name"},
+		"LLM_PROXY_MANAGEMENT_TAUTH_TENANT_ID":             {"resource": "authentication", "output": "tenant-id"},
+		"LLM_PROXY_MANAGEMENT_TAUTH_URL":                   {"capability": "tauth.http", "component": "url"},
+	} {
+		if !reflect.DeepEqual(runtimeEnvironment[environmentName], expectedBinding) {
+			testingInstance.Errorf("unexpected %s binding: %#v", environmentName, runtimeEnvironment[environmentName])
+		}
+	}
+
 	manifestText := string(manifestBytes)
 	for _, requiredContract := range []string{
-		"secret: llm-proxy.runtime-environment",
+		"kind: private_values",
 		"source: configs/config.yml",
 		"target: /app/config.yml",
 		"name: mprlab-nginx-gateway_llm-proxy-data",
@@ -132,6 +209,9 @@ func TestOperationalRepositoryOwnsSchemaV2Lifecycle(testingInstance *testing.T) 
 	}
 	for _, forbiddenContract := range []string{
 		"schema_version: 1",
+		"environment_files:",
+		"profiles:",
+		"secret:",
 		"make_workflow",
 		"ansible_task_bundle",
 		"container_name:",


### PR DESCRIPTION
Summary
- Bind application-private outputs to canonical dotenv keys.
- Project TAuth, route, Pages, and capability-owned values into the service.
- Remove overlapping whole-file environment input.
- Strengthen the schema-v3 lifecycle contract test and deployment documentation.

Validation
- make ci: all 11 gates passed, including 100 percent Go statement coverage and 75 browser cases.
- Exact two-repository deploy-plan isolation passed with gateway B388 commit 4e4d95dbe6e31eff8071b255c28a30f692c824b2.
- No release, publication, or production deployment ran.