### PR TITLE
I205: declare singleton service placement

### DIFF
--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -12,7 +12,6 @@ mprlab_resources:
         provider-key-encryption-key: LLM_PROXY_MANAGEMENT_PROVIDER_KEY_ENCRYPTION_KEY
     - kind: compose_project
       id: runtime
-      placement: gateway
       retired_services:
         - project: mprlab-nginx-gateway
           service: llm-proxy
@@ -29,6 +28,9 @@ mprlab_resources:
       services:
         - id: llm-proxy
           image: llm-proxy-image
+          placement:
+            group: gateway
+            cardinality: one
           environment:
             LLM_PROXY_MANAGEMENT_ADMIN_EMAILS:
               resource: private


### PR DESCRIPTION
## Summary

- declare the llm-proxy service placement as gateway with cardinality one
- adopt the canonical I205 per-service placement contract

## Validation

- make ci
- selected-manifest isolation proof against gateway commit 1973a6b01632f713463de3265ed697725a1d7349
- sealed plan digest sha256:bcbdb3afbe4a6eb12da5fd459329425f23c202a088c79a8def40914f3afc8eaa
- no release, publish, deploy, or production mutation was executed

## Stack

Base: B388 service value contract, PR #245.
Companion to the gateway I205 pull request.