### PR TITLE
I037: Model provider wire contracts and lifecycles

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1973,7 +1973,7 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair for the implementation, with
     the final run after the last code edit.
-- [ ] [I037] (P1) Model provider wire contracts separately from execution lifecycles.
+- [x] [I037] (P1) Model provider wire contracts separately from execution lifecycles.
   Goal:
   Let each configured text model use its provider's exact current request shape
   and execution lifecycle without inferring OpenAI Responses semantics from an
@@ -2052,6 +2052,24 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
   - Public-boundary fixtures prove synchronous, pollable, continuation,
     cancellation, timeout, and provider-terminal-error behavior without
     exposing upstream IDs or provider bodies.
+  Resolution:
+  - Every configured text model now declares one closed `wire_contract` and one
+    closed `execution_lifecycle`. Startup rejects absent, unknown,
+    provider-incompatible, contradictory, or dictation-scoped declarations;
+    no route capability is inferred from a provider, URL, request profile, or
+    upstream identifier.
+  - Model-owned route adapters now select OpenAI Responses polling,
+    OpenAI-compatible Chat Completions, Gemini generateContent, or Anthropic
+    Messages. Provider-key verification uses the selected model's wire
+    contract, and the obsolete provider-level combined transport enum is gone.
+  - The checked-in catalog records OpenAI as `pollable_resource` and every
+    audited no-migration provider as `synchronous_completion`. Public routing
+    coverage enumerates every configured provider/model, while existing public
+    lifecycle fixtures continue to prove continuation, cancellation, timeout,
+    terminal errors, safe responses, and blocking callers.
+  - README, the canonical provider-routing guide, and OpenAPI now publish the
+    capability matrix, continuation separation, and exact upstream storage,
+    cancellation, deletion, and retention consequences.
 - [ ] [I038] (P2) {I037} Adopt DashScope's synchronous Responses API without background mode.
   Goal:
   Move eligible DashScope Qwen models from Chat Completions to Alibaba's newer

--- a/README.md
+++ b/README.md
@@ -223,14 +223,22 @@ providers:
       default_model: "gpt-4.1"
       models:
         - id: "gpt-4o-mini"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature"
         - id: "gpt-4o"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature_tools"
           web_search: true
         - id: "gpt-4.1"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature_tools"
           web_search: true
         - id: "gpt-5-mini"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           reasoning_effort:
             adapter: "openai_responses"
@@ -240,6 +248,8 @@ providers:
               - medium
               - high
         - id: "gpt-5"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -250,6 +260,8 @@ providers:
               - medium
               - high
         - id: "gpt-5.5"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -261,6 +273,8 @@ providers:
               - high
               - xhigh
         - id: "gpt-5.5-pro"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -270,6 +284,8 @@ providers:
               - high
               - xhigh
         - id: "gpt-5.6"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -282,6 +298,8 @@ providers:
               - xhigh
               - max
         - id: "gpt-5.6-sol"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -294,6 +312,8 @@ providers:
               - xhigh
               - max
         - id: "gpt-5.6-terra"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -306,6 +326,8 @@ providers:
               - xhigh
               - max
         - id: "gpt-5.6-luna"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -328,42 +350,66 @@ providers:
       default_model: "muse-spark-1.1"
       models:
         - id: "muse-spark-1.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   deepseek:
     base_url: "https://api.deepseek.com"
     text:
       default_model: "deepseek-v4-flash"
       models:
         - id: "deepseek-v4-flash"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-v4-pro"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-chat"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-reasoner"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   dashscope:
     base_url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
     text:
       default_model: "qwen-plus"
       models:
         - id: "qwen-plus"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   qwencloud:
     base_url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
     text:
       default_model: "qwen3.8-max-preview"
       models:
         - id: "qwen3.8-max-preview"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   moonshot:
     base_url: "https://api.moonshot.ai/v1"
     text:
       default_model: "kimi-k2.6"
       models:
         - id: "kimi-k2.6"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "kimi-k3"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "kimi-k2.7-code"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "kimi-k2.7-code-highspeed"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   minimax:
     base_url: "https://api.minimax.io/v1"
     text:
       default_model: "MiniMax-M2.7"
       models:
         - id: "MiniMax-M2.7"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 2048
   siliconflow:
     base_url: "https://api.siliconflow.com/v1"
@@ -372,6 +418,8 @@ providers:
       default_model: "deepseek-ai/DeepSeek-R1"
       models:
         - id: "deepseek-ai/DeepSeek-R1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
     dictation:
       default_model: "FunAudioLLM/SenseVoiceSmall"
       models:
@@ -383,7 +431,11 @@ providers:
       default_model: "glm-5.1"
       models:
         - id: "glm-5.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "glm-5.2"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 131072
     dictation:
       default_model: "glm-asr-2512"
@@ -395,18 +447,32 @@ providers:
       default_model: "gemini-2.5-flash"
       models:
         - id: "gemini-3.5-flash"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-3.1-pro-preview"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-3-flash-preview"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-3.1-flash-lite"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-2.5-flash"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-2.5-flash-lite"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-2.5-pro"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
   anthropic:
     base_url: "https://api.anthropic.com"
@@ -414,24 +480,44 @@ providers:
       default_model: "claude-sonnet-4-6"
       models:
         - id: "claude-fable-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 128000
         - id: "claude-sonnet-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 128000
         - id: "claude-opus-4-8"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 128000
         - id: "claude-sonnet-4-6"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-haiku-4-5-20251001"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-haiku-4-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-sonnet-4-5-20250929"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-sonnet-4-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-opus-4-1-20250805"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 32000
         - id: "claude-opus-4-1"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 32000
   grok:
     base_url: "https://api.x.ai/v1"
@@ -440,15 +526,35 @@ providers:
       default_model: "grok-4.3"
       models:
         - id: "grok-4.3"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.3-latest"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.5"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.20-0309-reasoning"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.20-0309-non-reasoning"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-latest"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-build-0.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast-1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast-1-0825"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
     dictation:
       default_model: "xai-stt"
       models:
@@ -497,20 +603,20 @@ default text model. This table describes capabilities currently wired through
 Upstream providers may expose additional speech APIs that need separate proxy
 adapters before they are available through `/dictate`.
 
-| Provider selector | Aliases | Text API | Configured default text model | Credential field | Default base URL | Dictation | Web search |
-|-------------------|---------|----------|-------------------------------|------------------|------------------|-----------|------------|
-| `openai` | none | OpenAI Responses | `gpt-4.1` | `providers.openai.api_key` | `https://api.openai.com/v1` | Yes: `gpt-4o-mini-transcribe`, `gpt-4o-transcribe` | Yes, on marked OpenAI models |
-| `meta` | none | Meta Model API OpenAI-compatible chat completions | `muse-spark-1.1` | `providers.meta.api_key` | `https://api.meta.ai/v1` | No | No |
-| `deepseek` | none | OpenAI-compatible chat completions | `deepseek-v4-flash` | `providers.deepseek.api_key` | `https://api.deepseek.com` | No | No |
-| `dashscope` | `qwen` | OpenAI-compatible chat completions | `qwen-plus` | `providers.dashscope.api_key` | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` | No | No |
-| `qwencloud` | none | Qwen Cloud Token Plan OpenAI-compatible chat completions | `qwen3.8-max-preview` | `providers.qwencloud.api_key` | `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` | No | No |
-| `moonshot` | `kimi` | OpenAI-compatible chat completions | `kimi-k2.6` | `providers.moonshot.api_key` | `https://api.moonshot.ai/v1` | No | No |
-| `minimax` | none | MiniMax OpenAI-compatible chat completions | `MiniMax-M2.7` | `providers.minimax.api_key` | `https://api.minimax.io/v1` | No | No |
-| `siliconflow` | none | OpenAI-compatible chat completions | `deepseek-ai/DeepSeek-R1` | `providers.siliconflow.api_key` | `https://api.siliconflow.com/v1` | Yes: `FunAudioLLM/SenseVoiceSmall` | No |
-| `zhipu` | `glm` | OpenAI-compatible chat completions | `glm-5.1` | `providers.zhipu.api_key` | `https://open.bigmodel.cn/api/paas/v4` | Yes: `glm-asr-2512` | No |
-| `gemini` | none | Gemini native `generateContent` | `gemini-2.5-flash` | `providers.gemini.api_key` | `https://generativelanguage.googleapis.com/v1` | No | No |
-| `anthropic` | `claude` | Anthropic native Messages | `claude-sonnet-4-6` | `providers.anthropic.api_key` | `https://api.anthropic.com` | No | No |
-| `grok` | `xai` | xAI OpenAI-compatible chat completions | `grok-4.3` | `providers.grok.api_key` | `https://api.x.ai/v1` | Yes: `xai-stt` | No |
+| Provider selector | Aliases | Wire contract | Execution lifecycle | Configured default text model | Credential field | Default base URL | Dictation | Web search |
+|-------------------|---------|---------------|---------------------|-------------------------------|------------------|------------------|-----------|------------|
+| `openai` | none | `openai_responses` | `pollable_resource` | `gpt-4.1` | `providers.openai.api_key` | `https://api.openai.com/v1` | Yes: `gpt-4o-mini-transcribe`, `gpt-4o-transcribe` | Yes, on marked OpenAI models |
+| `meta` | none | `openai_chat_completions` | `synchronous_completion` | `muse-spark-1.1` | `providers.meta.api_key` | `https://api.meta.ai/v1` | No | No |
+| `deepseek` | none | `openai_chat_completions` | `synchronous_completion` | `deepseek-v4-flash` | `providers.deepseek.api_key` | `https://api.deepseek.com` | No | No |
+| `dashscope` | `qwen` | `openai_chat_completions` | `synchronous_completion` | `qwen-plus` | `providers.dashscope.api_key` | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` | No | No |
+| `qwencloud` | none | `openai_chat_completions` | `synchronous_completion` | `qwen3.8-max-preview` | `providers.qwencloud.api_key` | `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` | No | No |
+| `moonshot` | `kimi` | `openai_chat_completions` | `synchronous_completion` | `kimi-k2.6` | `providers.moonshot.api_key` | `https://api.moonshot.ai/v1` | No | No |
+| `minimax` | none | `openai_chat_completions` | `synchronous_completion` | `MiniMax-M2.7` | `providers.minimax.api_key` | `https://api.minimax.io/v1` | No | No |
+| `siliconflow` | none | `openai_chat_completions` | `synchronous_completion` | `deepseek-ai/DeepSeek-R1` | `providers.siliconflow.api_key` | `https://api.siliconflow.com/v1` | Yes: `FunAudioLLM/SenseVoiceSmall` | No |
+| `zhipu` | `glm` | `openai_chat_completions` | `synchronous_completion` | `glm-5.1` | `providers.zhipu.api_key` | `https://open.bigmodel.cn/api/paas/v4` | Yes: `glm-asr-2512` | No |
+| `gemini` | none | `gemini_generate_content` | `synchronous_completion` | `gemini-2.5-flash` | `providers.gemini.api_key` | `https://generativelanguage.googleapis.com/v1` | No | No |
+| `anthropic` | `claude` | `anthropic_messages` | `synchronous_completion` | `claude-sonnet-4-6` | `providers.anthropic.api_key` | `https://api.anthropic.com` | No | No |
+| `grok` | `xai` | `openai_chat_completions` | `synchronous_completion` | `grok-4.3` | `providers.grok.api_key` | `https://api.x.ai/v1` | Yes: `xai-stt` | No |
 
 All upstream provider credentials are server-side only. Client requests must
 never send OpenAI, Meta, Anthropic, xAI, Gemini, or other upstream API keys.
@@ -529,10 +635,13 @@ declares `image` and `audio` only for `gemini-3.5-flash` and
 
 Model ids and per-model metadata are runtime config data. To add, remove, or
 replace provider models, update the selected `config.yml` and restart the
-service; provider transports stay code-owned.
+service. Every text model explicitly owns one validated `wire_contract` and
+`execution_lifecycle`; adapter codecs and allowed provider capability pairs
+stay code-owned.
 
 The model-capability table below mirrors the checked-in catalog. Refresh that
-table and `config.yml` together; provider transports remain code-owned.
+table and `config.yml` together; no capability is inferred from the provider,
+base URL, request profile, or upstream response identifier.
 Moonshot's current Kimi route receives Chat Completions
 `max_completion_tokens` when callers set the proxy `max_tokens` value.
 The transport deliberately omits sampling controls because Kimi K3 fixes those
@@ -561,6 +670,8 @@ providers:
       default_model: "provider-default-model"
       models:
         - id: "provider-model-id"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature_tools"
           web_search: true
           output_token_limit: 65536
@@ -591,7 +702,17 @@ providers:
         - id: "provider-dictation-model-id"
 ```
 
-Catalog validation fails startup when a provider text catalog is missing, a
+`wire_contract` is required on every text model and currently accepts
+`openai_responses`, `openai_chat_completions`, `gemini_generate_content`, or
+`anthropic_messages`. `execution_lifecycle` is also required and accepts
+`synchronous_completion` or `pollable_resource`. Startup rejects missing,
+unknown, provider-incompatible, or contradictory pairs and rejects either
+field on dictation models. The only current pollable pair is OpenAI Responses;
+all other registered pairs complete synchronously. A future one-read deferred
+result requires a new exact lifecycle value rather than reusing
+`pollable_resource`.
+
+Catalog validation also fails startup when a provider text catalog is missing, a
 dictation-capable provider dictation catalog is missing, a model id is blank or
 duplicated, `default_model` is not present in the corresponding `models` list,
 or `web_search: true` appears outside an OpenAI text model entry.
@@ -613,6 +734,8 @@ providers:
       default_model: "gemini-2.5-flash"
       models:
         - id: "gemini-2.5-flash"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
           media_inputs:
             - image
@@ -647,6 +770,18 @@ the final formatted answer; they do not stream, poll, or follow a separate
 resume endpoint. Separately published provider-specific deferred, batch, or
 asynchronous APIs are not implicit variants of these routes and are not
 activated by an arbitrary response `id`.
+
+The OpenAI adapter requests provider storage because background Responses need
+`store: true`. The response identifier exists only in memory for the active
+proxy call and is never returned to the caller or persisted by llm-proxy. The
+current adapter stops observing the resource when the caller cancels or the
+proxy budget expires; it does not issue an upstream cancel or delete after
+success, failure, timeout, or cancellation, so OpenAI account retention policy
+continues to govern that stored resource. The synchronous adapters do not ask
+for a reusable provider resource and have no cancel/delete operation; their
+providers' ordinary request-retention policies still apply. Output-limit
+continuation always starts a distinct inference request and never treats an
+arbitrary upstream identifier as pollable state.
 
 Provider-specific details:
 

--- a/cmd/cli/config_file.go
+++ b/cmd/cli/config_file.go
@@ -143,12 +143,14 @@ type modelEndpointConfiguration struct {
 }
 
 type modelConfiguration struct {
-	ID               string                           `mapstructure:"id"`
-	RequestProfile   string                           `mapstructure:"request_profile"`
-	WebSearch        bool                             `mapstructure:"web_search"`
-	OutputTokenLimit int                              `mapstructure:"output_token_limit"`
-	ReasoningEffort  *reasoningEffortCapabilityConfig `mapstructure:"reasoning_effort"`
-	MediaInputs      []string                         `mapstructure:"media_inputs"`
+	ID                 string                           `mapstructure:"id"`
+	WireContract       string                           `mapstructure:"wire_contract"`
+	ExecutionLifecycle string                           `mapstructure:"execution_lifecycle"`
+	RequestProfile     string                           `mapstructure:"request_profile"`
+	WebSearch          bool                             `mapstructure:"web_search"`
+	OutputTokenLimit   int                              `mapstructure:"output_token_limit"`
+	ReasoningEffort    *reasoningEffortCapabilityConfig `mapstructure:"reasoning_effort"`
+	MediaInputs        []string                         `mapstructure:"media_inputs"`
 }
 
 type reasoningEffortCapabilityConfig struct {
@@ -447,12 +449,14 @@ func (configuration modelEndpointConfiguration) proxyCatalog() proxy.ModelEndpoi
 	models := make([]proxy.ModelConfiguration, 0, len(configuration.Models))
 	for _, currentModel := range configuration.Models {
 		models = append(models, proxy.ModelConfiguration{
-			ID:               currentModel.ID,
-			RequestProfile:   currentModel.RequestProfile,
-			WebSearch:        currentModel.WebSearch,
-			OutputTokenLimit: currentModel.OutputTokenLimit,
-			ReasoningEffort:  proxyReasoningEffortCapability(currentModel.ReasoningEffort),
-			MediaInputs:      append([]string(nil), currentModel.MediaInputs...),
+			ID:                 currentModel.ID,
+			WireContract:       currentModel.WireContract,
+			ExecutionLifecycle: currentModel.ExecutionLifecycle,
+			RequestProfile:     currentModel.RequestProfile,
+			WebSearch:          currentModel.WebSearch,
+			OutputTokenLimit:   currentModel.OutputTokenLimit,
+			ReasoningEffort:    proxyReasoningEffortCapability(currentModel.ReasoningEffort),
+			MediaInputs:        append([]string(nil), currentModel.MediaInputs...),
 		})
 	}
 	return proxy.ModelEndpointCatalog{

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -220,6 +220,13 @@ P411_MANAGEMENT_PROVIDER_KEY_ENCRYPTION_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlh
 	if len(openAIModels) < 3 || openAIModels[2].ID != "gpt-4.1" || openAIModels[2].RequestProfile != "openai_responses_temperature_tools" || !openAIModels[2].WebSearch {
 		t.Fatalf("openai model catalog=%+v", openAIModels)
 	}
+	for providerName, providerCatalog := range capturedConfiguration.ProviderModels {
+		for _, model := range providerCatalog.Text.Models {
+			if model.WireContract == "" || model.ExecutionLifecycle == "" {
+				t.Fatalf("provider=%s model=%s missing route capabilities: %+v", providerName, model.ID, model)
+			}
+		}
+	}
 }
 
 func TestRootCommandRunsProductionLoggerFromConfigFile(t *testing.T) {
@@ -1639,7 +1646,7 @@ providers:
 		},
 		{
 			name:          "missing provider text models",
-			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "models:\n        - id: \"qwen-plus\"", "models: []", 1),
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "models:\n        - id: \"qwen-plus\"\n          wire_contract: \"openai_chat_completions\"\n          execution_lifecycle: \"synchronous_completion\"", "models: []", 1),
 			expectedError: "invalid_model_catalog: provider=dashscope endpoint=text field=providers.dashscope.text.models",
 		},
 		{
@@ -1684,8 +1691,48 @@ providers:
 		},
 		{
 			name:          "anthropic output token limit required",
-			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "id: \"claude-sonnet-4-6\"\n          output_token_limit: 64000", "id: \"claude-sonnet-4-6\"\n          output_token_limit: 0", 1),
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "id: \"claude-sonnet-4-6\"\n          wire_contract: \"anthropic_messages\"\n          execution_lifecycle: \"synchronous_completion\"\n          output_token_limit: 64000", "id: \"claude-sonnet-4-6\"\n          wire_contract: \"anthropic_messages\"\n          execution_lifecycle: \"synchronous_completion\"\n          output_token_limit: 0", 1),
 			expectedError: "invalid_model_catalog: provider=anthropic endpoint=text field=providers.anthropic.text.models[1].output_token_limit",
+		},
+		{
+			name:          "missing text wire contract",
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "\n          wire_contract: \"openai_responses\"", "", 1),
+			expectedError: "invalid_model_catalog: provider=openai endpoint=text field=providers.openai.text.models[0].wire_contract",
+		},
+		{
+			name:          "missing text execution lifecycle",
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "\n          execution_lifecycle: \"pollable_resource\"", "", 1),
+			expectedError: "invalid_model_catalog: provider=openai endpoint=text field=providers.openai.text.models[0].execution_lifecycle",
+		},
+		{
+			name:          "unknown text wire contract",
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "wire_contract: \"openai_responses\"", "wire_contract: \"future_responses\"", 1),
+			expectedError: "invalid_model_catalog: provider=openai endpoint=text field=providers.openai.text.models[0].wire_contract wire_contract=future_responses",
+		},
+		{
+			name:          "unknown text execution lifecycle",
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "execution_lifecycle: \"pollable_resource\"", "execution_lifecycle: \"deferred_once\"", 1),
+			expectedError: "invalid_model_catalog: provider=openai endpoint=text field=providers.openai.text.models[0].execution_lifecycle execution_lifecycle=deferred_once",
+		},
+		{
+			name:          "contradictory openai lifecycle",
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "execution_lifecycle: \"pollable_resource\"", "execution_lifecycle: \"synchronous_completion\"", 1),
+			expectedError: "invalid_model_catalog: provider=openai endpoint=text wire_contract=openai_responses execution_lifecycle=synchronous_completion",
+		},
+		{
+			name:          "provider incompatible wire contract",
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "wire_contract: \"openai_chat_completions\"", "wire_contract: \"anthropic_messages\"", 1),
+			expectedError: "invalid_model_catalog: provider=deepseek endpoint=text wire_contract=anthropic_messages execution_lifecycle=synchronous_completion",
+		},
+		{
+			name:          "dictation wire contract",
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "id: \"gpt-4o-mini-transcribe\"", "id: \"gpt-4o-mini-transcribe\"\n          wire_contract: \"openai_responses\"", 1),
+			expectedError: "invalid_model_catalog: provider=openai endpoint=dictation field=providers.openai.dictation.models[0].wire_contract",
+		},
+		{
+			name:          "dictation execution lifecycle",
+			providersYAML: strings.Replace(completeLiteralProvidersYAML(), "id: \"gpt-4o-mini-transcribe\"", "id: \"gpt-4o-mini-transcribe\"\n          execution_lifecycle: \"synchronous_completion\"", 1),
+			expectedError: "invalid_model_catalog: provider=openai endpoint=dictation field=providers.openai.dictation.models[0].execution_lifecycle",
 		},
 		{
 			name:          "blank openai request profile",
@@ -1943,14 +1990,22 @@ providers:
       default_model: "gpt-4.1"
       models:
         - id: "gpt-4o-mini"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature"
         - id: "gpt-4o"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature_tools"
           web_search: true
         - id: "gpt-4.1"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature_tools"
           web_search: true
         - id: "gpt-5-mini"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           reasoning_effort:
             adapter: "openai_responses"
@@ -1960,12 +2015,18 @@ providers:
               - medium
               - high
         - id: "gpt-5"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
         - id: "gpt-5.5"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
         - id: "gpt-5.5-pro"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
     dictation:
@@ -1980,9 +2041,17 @@ providers:
       default_model: "deepseek-v4-flash"
       models:
         - id: "deepseek-v4-flash"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-v4-pro"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-chat"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-reasoner"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   dashscope:
     api_key: "%s"
     base_url: "%s"
@@ -1990,6 +2059,8 @@ providers:
       default_model: "qwen-plus"
       models:
         - id: "qwen-plus"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   qwencloud:
     api_key: "%s"
     base_url: "%s"
@@ -1997,6 +2068,8 @@ providers:
       default_model: "qwen3.8-max-preview"
       models:
         - id: "qwen3.8-max-preview"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   moonshot:
     api_key: "%s"
     base_url: "%s"
@@ -2004,6 +2077,8 @@ providers:
       default_model: "%s"
       models:
         - id: "%s"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   minimax:
     api_key: "%s"
     base_url: "%s"
@@ -2011,6 +2086,8 @@ providers:
       default_model: "MiniMax-M2.7"
       models:
         - id: "MiniMax-M2.7"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 2048
   siliconflow:
     api_key: "%s"
@@ -2020,6 +2097,8 @@ providers:
       default_model: "deepseek-ai/DeepSeek-R1"
       models:
         - id: "deepseek-ai/DeepSeek-R1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
     dictation:
       default_model: "FunAudioLLM/SenseVoiceSmall"
       models:
@@ -2032,6 +2111,8 @@ providers:
       default_model: "glm-5.1"
       models:
         - id: "glm-5.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
     dictation:
       default_model: "glm-asr-2512"
       models:
@@ -2043,14 +2124,24 @@ providers:
       default_model: "gemini-2.5-flash"
       models:
         - id: "gemini-3.5-flash"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-3.1-flash-lite"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-2.5-flash"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-2.5-flash-lite"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-2.5-pro"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
   anthropic:
     api_key: "%s"
@@ -2059,20 +2150,36 @@ providers:
       default_model: "claude-sonnet-4-6"
       models:
         - id: "claude-opus-4-8"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 128000
         - id: "claude-sonnet-4-6"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-haiku-4-5-20251001"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-haiku-4-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-sonnet-4-5-20250929"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-sonnet-4-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-opus-4-1-20250805"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 32000
         - id: "claude-opus-4-1"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 32000
   meta:
     api_key: "%s"
@@ -2081,6 +2188,8 @@ providers:
       default_model: "muse-spark-1.1"
       models:
         - id: "muse-spark-1.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   grok:
     api_key: "%s"
     base_url: "%s"
@@ -2089,12 +2198,26 @@ providers:
       default_model: "grok-4.3"
       models:
         - id: "grok-4.3"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.3-latest"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-latest"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-build-0.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast-1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast-1-0825"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
     dictation:
       default_model: "xai-stt"
       models:

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -40,14 +40,22 @@ providers:
       default_model: "gpt-4.1"
       models:
         - id: "gpt-4o-mini"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature"
         - id: "gpt-4o"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature_tools"
           web_search: true
         - id: "gpt-4.1"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_temperature_tools"
           web_search: true
         - id: "gpt-5-mini"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           reasoning_effort:
             adapter: "openai_responses"
@@ -57,6 +65,8 @@ providers:
               - medium
               - high
         - id: "gpt-5"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -67,6 +77,8 @@ providers:
               - medium
               - high
         - id: "gpt-5.5"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -78,6 +90,8 @@ providers:
               - high
               - xhigh
         - id: "gpt-5.5-pro"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -87,6 +101,8 @@ providers:
               - high
               - xhigh
         - id: "gpt-5.6"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -99,6 +115,8 @@ providers:
               - xhigh
               - max
         - id: "gpt-5.6-sol"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -111,6 +129,8 @@ providers:
               - xhigh
               - max
         - id: "gpt-5.6-terra"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -123,6 +143,8 @@ providers:
               - xhigh
               - max
         - id: "gpt-5.6-luna"
+          wire_contract: "openai_responses"
+          execution_lifecycle: "pollable_resource"
           request_profile: "openai_responses_reasoning_tools"
           web_search: true
           reasoning_effort:
@@ -145,36 +167,58 @@ providers:
       default_model: "deepseek-v4-flash"
       models:
         - id: "deepseek-v4-flash"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-v4-pro"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-chat"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "deepseek-reasoner"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   dashscope:
     base_url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
     text:
       default_model: "qwen-plus"
       models:
         - id: "qwen-plus"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   qwencloud:
     base_url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
     text:
       default_model: "qwen3.8-max-preview"
       models:
         - id: "qwen3.8-max-preview"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   moonshot:
     base_url: "https://api.moonshot.ai/v1"
     text:
       default_model: "kimi-k2.6"
       models:
         - id: "kimi-k2.6"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "kimi-k3"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "kimi-k2.7-code"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "kimi-k2.7-code-highspeed"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   minimax:
     base_url: "https://api.minimax.io/v1"
     text:
       default_model: "MiniMax-M2.7"
       models:
         - id: "MiniMax-M2.7"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 2048
   siliconflow:
     base_url: "https://api.siliconflow.com/v1"
@@ -183,6 +227,8 @@ providers:
       default_model: "deepseek-ai/DeepSeek-R1"
       models:
         - id: "deepseek-ai/DeepSeek-R1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
     dictation:
       default_model: "FunAudioLLM/SenseVoiceSmall"
       models:
@@ -194,7 +240,11 @@ providers:
       default_model: "glm-5.1"
       models:
         - id: "glm-5.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "glm-5.2"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 131072
     dictation:
       default_model: "glm-asr-2512"
@@ -206,24 +256,38 @@ providers:
       default_model: "gemini-2.5-flash"
       models:
         - id: "gemini-3.5-flash"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
           media_inputs:
             - image
             - audio
         - id: "gemini-3.1-pro-preview"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-3-flash-preview"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-3.1-flash-lite"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-2.5-flash"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
           media_inputs:
             - image
             - audio
         - id: "gemini-2.5-flash-lite"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
         - id: "gemini-2.5-pro"
+          wire_contract: "gemini_generate_content"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 65536
   anthropic:
     base_url: "https://api.anthropic.com"
@@ -231,24 +295,44 @@ providers:
       default_model: "claude-sonnet-4-6"
       models:
         - id: "claude-fable-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 128000
         - id: "claude-sonnet-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 128000
         - id: "claude-opus-4-8"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 128000
         - id: "claude-sonnet-4-6"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-haiku-4-5-20251001"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-haiku-4-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-sonnet-4-5-20250929"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-sonnet-4-5"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 64000
         - id: "claude-opus-4-1-20250805"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 32000
         - id: "claude-opus-4-1"
+          wire_contract: "anthropic_messages"
+          execution_lifecycle: "synchronous_completion"
           output_token_limit: 32000
   meta:
     base_url: "https://api.meta.ai/v1"
@@ -256,6 +340,8 @@ providers:
       default_model: "muse-spark-1.1"
       models:
         - id: "muse-spark-1.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
   grok:
     base_url: "https://api.x.ai/v1"
     transcriptions_url: "https://api.x.ai/v1/stt"
@@ -263,15 +349,35 @@ providers:
       default_model: "grok-4.3"
       models:
         - id: "grok-4.3"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.3-latest"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.5"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.20-0309-reasoning"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-4.20-0309-non-reasoning"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-latest"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-build-0.1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast-1"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
         - id: "grok-code-fast-1-0825"
+          wire_contract: "openai_chat_completions"
+          execution_lifecycle: "synchronous_completion"
     dictation:
       default_model: "xai-stt"
       models:

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -64,20 +64,20 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 
 ## Providers
 
-| Provider | Aliases | Text | Dictation | Web Search |
-|----------|---------|------|-----------|------------|
-| `openai` | none | OpenAI Responses API | OpenAI audio transcription | Supported by configured OpenAI model entries with `web_search: true` |
-| `meta` | none | Meta Model API OpenAI-compatible chat completions | Not supported | Not supported |
-| `deepseek` | none | OpenAI-compatible chat completions | Not supported | Not supported |
-| `dashscope` | `qwen` | OpenAI-compatible chat completions | Not supported | Not supported |
-| `qwencloud` | none | Qwen Cloud Token Plan OpenAI-compatible chat completions | Not supported | Not supported |
-| `moonshot` | `kimi` | OpenAI-compatible chat completions | Not supported | Not supported |
-| `minimax` | none | MiniMax OpenAI-compatible chat completions | Not supported | Not supported |
-| `siliconflow` | none | OpenAI-compatible chat completions | OpenAI-compatible audio transcription | Not supported |
-| `zhipu` | `glm` | OpenAI-compatible chat completions | Z.AI GLM-ASR transcription | Not supported |
-| `gemini` | none | Native Gemini generateContent | Not supported | Not supported |
-| `anthropic` | `claude` | Native Anthropic Messages | Not supported | Not supported |
-| `grok` | `xai` | xAI OpenAI-compatible chat completions | xAI STT | Not supported |
+| Provider | Aliases | Wire contract | Execution lifecycle | Dictation | Web Search |
+|----------|---------|---------------|---------------------|-----------|------------|
+| `openai` | none | `openai_responses` | `pollable_resource` | OpenAI audio transcription | Supported by configured OpenAI model entries with `web_search: true` |
+| `meta` | none | `openai_chat_completions` | `synchronous_completion` | Not supported | Not supported |
+| `deepseek` | none | `openai_chat_completions` | `synchronous_completion` | Not supported | Not supported |
+| `dashscope` | `qwen` | `openai_chat_completions` | `synchronous_completion` | Not supported | Not supported |
+| `qwencloud` | none | `openai_chat_completions` | `synchronous_completion` | Not supported | Not supported |
+| `moonshot` | `kimi` | `openai_chat_completions` | `synchronous_completion` | Not supported | Not supported |
+| `minimax` | none | `openai_chat_completions` | `synchronous_completion` | Not supported | Not supported |
+| `siliconflow` | none | `openai_chat_completions` | `synchronous_completion` | OpenAI-compatible audio transcription | Not supported |
+| `zhipu` | `glm` | `openai_chat_completions` | `synchronous_completion` | Z.AI GLM-ASR transcription | Not supported |
+| `gemini` | none | `gemini_generate_content` | `synchronous_completion` | Not supported | Not supported |
+| `anthropic` | `claude` | `anthropic_messages` | `synchronous_completion` | Not supported | Not supported |
+| `grok` | `xai` | `openai_chat_completions` | `synchronous_completion` | xAI STT | Not supported |
 
 This matrix describes capabilities wired through `llm-proxy`. Upstream products
 can expose speech APIs that are not yet proxy adapters; do not mark them
@@ -183,6 +183,8 @@ Provider model catalogs:
 
 - `providers.<provider>.text.default_model`
 - `providers.<provider>.text.models[].id`
+- `providers.<provider>.text.models[].wire_contract`
+- `providers.<provider>.text.models[].execution_lifecycle`
 - `providers.<provider>.text.models[].output_token_limit`
 - `providers.<provider>.text.models[].media_inputs`
 - `providers.<provider>.text.models[].reasoning_effort`
@@ -198,8 +200,9 @@ Provider model catalogs:
 - `providers.grok.dictation.models[].id`
 
 The model catalog is runtime config data. Code owns provider selectors,
-aliases, transports, endpoint shapes, and stable OpenAI request-profile
-implementations. `config.yml` owns provider model ids, provider default models,
+aliases, allowed wire/lifecycle pairs, endpoint shapes, adapters, and stable
+OpenAI request-profile implementations. `config.yml` owns provider model ids,
+each model's explicit wire contract and execution lifecycle, provider default models,
 dictation model ids, model-specific web-search enablement, provider/model
 reasoning-effort and media-input capability declarations, and known
 provider-side output-token limits.
@@ -230,6 +233,16 @@ OpenAI `request_profile` values select stable payload shapes:
 - `openai_responses_temperature_tools`
 - `openai_responses_reasoning_tools`
 
+Every text model must explicitly declare one current `wire_contract` and one
+`execution_lifecycle`; the loader does not infer either capability from the
+provider, base URL, request profile, or presence of an upstream identifier.
+The closed wire values are `openai_responses`, `openai_chat_completions`,
+`gemini_generate_content`, and `anthropic_messages`. The closed lifecycle
+values are `synchronous_completion` and `pollable_resource`. Startup rejects
+missing, unknown, contradictory, or provider-incompatible pairs and rejects
+these text-only fields on dictation entries. A future one-read deferred result
+must introduce a distinct lifecycle value.
+
 Every OpenAI Responses text request includes `background: true` and
 `store: true`. A nonblank response id is polled server-side only for the
 documented `queued` and `in_progress` pending states or for a proxy-initiated
@@ -245,6 +258,15 @@ distinct missing-suffix attempts and completed-response synthesis requests.
 Callers use one normal `GET /`, `POST /`, or `POST /v2` request and receive a
 complete formatted answer or a non-2xx response; there is no streaming,
 client-side polling, durable provider-job queue, or later resume contract.
+
+OpenAI background Responses are stored upstream. llm-proxy keeps their ids only
+in memory for the active request and never returns or persists them, but the
+current adapter does not cancel or delete the stored resource after completion,
+failure, timeout, or caller cancellation; OpenAI account retention policy
+therefore applies. Synchronous adapters create no reusable provider resource
+and expose no lifecycle cancel/delete operation, while each provider's normal
+request-retention policy still applies. Output-limit continuation creates a new
+inference request and is never resource observation.
 
 One completion coordinator owns output-budget recovery for all transports.
 Adapters normalize only their exact recoverable signal: OpenAI

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,7 +2,18 @@ openapi: 3.1.0
 info:
   title: LLM Proxy HTTP API
   version: 1.0.0
-  description: The sole canonical wire contract for llm-proxy-owned proxy, browser configuration, and management endpoints. Contributors must update this document in the same change as any owned handler or bundled-client wire change. TAuth-owned endpoints are outside this contract.
+  description: >-
+    The sole canonical wire contract for llm-proxy-owned proxy, browser
+    configuration, and management endpoints. Each configured text model owns
+    one explicit upstream wire contract and execution lifecycle. OpenAI
+    Responses uses a stored pollable resource; OpenAI-compatible Chat
+    Completions, Gemini generateContent, and Anthropic Messages complete
+    synchronously. Public proxy operations remain blocking and never expose an
+    upstream resource id. OpenAI resource ids remain in memory only, but the
+    current adapter does not cancel or delete stored Responses, so OpenAI
+    account retention policy applies. TAuth-owned endpoints are outside this
+    contract. Contributors must update this document in the same change as any
+    owned handler or bundled-client wire change.
 servers:
   - url: https://llm-proxy-api.mprlab.com
     description: Production API origin
@@ -782,7 +793,7 @@ components:
             $ref: '#/components/schemas/EmptyObject'
   responses:
     TextSuccess:
-      description: 'Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.'
+      description: 'Complete generated text in the selected representation. The selected model has one validated wire contract and one execution lifecycle; no lifecycle is inferred from an endpoint or upstream id. The proxy internally observes OpenAI queued and in_progress states for its pollable resource and keeps every public operation blocking. Separately, it continues exact output-budget stops through new provider calls: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the adapter reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.'
       headers:
         X-LLM-Proxy-Request-Timeout-Seconds:
           $ref: '#/components/headers/ResolvedRequestTimeout'

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -1022,9 +1022,12 @@ func TestManagementRoutingDefaultsRequireSavedProviderKeys(t *testing.T) {
 func TestManagementRoutingDefaultsDoNotRequireConfiguredStaticDefault(t *testing.T) {
 	configuration := withProviderModelCatalogs(t, managementConfigurationWithDatabasePath(proxy.Configuration{}, filepath.Join(t.TempDir(), "managed-tenants.db")))
 	openAIModels := configuration.ProviderModels[proxy.ProviderNameOpenAI]
+	configuredModel := openAIModels.Text.Models[0]
+	configuredModel.ID = "gpt-4o-mini"
+	configuredModel.RequestProfile = "openai_responses_temperature"
 	openAIModels.Text = proxy.ModelEndpointCatalog{
 		DefaultModel: "gpt-4o-mini",
-		Models:       []proxy.ModelConfiguration{{ID: "gpt-4o-mini", RequestProfile: "openai_responses_temperature"}},
+		Models:       []proxy.ModelConfiguration{configuredModel},
 	}
 	configuration.ProviderModels[proxy.ProviderNameOpenAI] = openAIModels
 	if _, buildError := buildRouterWithCatalogs(t, configuration, zap.NewNop().Sugar()); buildError != nil {

--- a/internal/proxy/management_usage_logging_internal_test.go
+++ b/internal/proxy/management_usage_logging_internal_test.go
@@ -344,8 +344,10 @@ func internalManagedUsageWriterProviderModels() ProviderModelCatalogs {
 	textModel := ModelEndpointCatalog{
 		DefaultModel: ModelNameGPT41,
 		Models: []ModelConfiguration{{
-			ID:             ModelNameGPT41,
-			RequestProfile: string(requestProfileOpenAIResponsesTemperatureTools),
+			ID:                 ModelNameGPT41,
+			WireContract:       string(textWireContractOpenAIResponses),
+			ExecutionLifecycle: string(textExecutionLifecyclePollableResource),
+			RequestProfile:     string(requestProfileOpenAIResponsesTemperatureTools),
 		}},
 	}
 	return ProviderModelCatalogs{

--- a/internal/proxy/model_catalog.go
+++ b/internal/proxy/model_catalog.go
@@ -24,12 +24,53 @@ type ModelEndpointCatalog struct {
 
 // ModelConfiguration declares runtime metadata for one configured model.
 type ModelConfiguration struct {
-	ID               string
-	RequestProfile   string
-	WebSearch        bool
-	OutputTokenLimit int
-	ReasoningEffort  *ReasoningEffortCapability
-	MediaInputs      []string
+	ID                 string
+	WireContract       string
+	ExecutionLifecycle string
+	RequestProfile     string
+	WebSearch          bool
+	OutputTokenLimit   int
+	ReasoningEffort    *ReasoningEffortCapability
+	MediaInputs        []string
+}
+
+var providerTextRouteCapabilities = map[string]map[textRouteCapabilities]struct{}{
+	ProviderNameOpenAI: {
+		openAIResponsesPollableRouteCapabilities: {},
+	},
+	ProviderNameDeepSeek: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
+	ProviderNameDashScope: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
+	ProviderNameQwenCloud: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
+	ProviderNameMoonshot: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
+	ProviderNameMiniMax: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
+	ProviderNameSiliconFlow: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
+	ProviderNameZhipu: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
+	ProviderNameGemini: {
+		geminiGenerateContentSynchronousRouteCapabilities: {},
+	},
+	ProviderNameAnthropic: {
+		anthropicMessagesSynchronousRouteCapabilities: {},
+	},
+	ProviderNameMeta: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
+	ProviderNameGrok: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+	},
 }
 
 // ReasoningEffortCapability declares the configured upstream mapping for one
@@ -104,10 +145,13 @@ func validateModelEndpointCatalog(providerName string, endpoint endpointKind, ca
 		if providerName == ProviderNameAnthropic && endpoint == endpointKindText && modelConfiguration.OutputTokenLimit <= 0 {
 			return fmt.Errorf("%w: provider=%s endpoint=%s field=%s.models[%d].output_token_limit", ErrInvalidModelCatalog, providerName, endpointName, fieldPrefix, modelIndex)
 		}
+		modelFieldPrefix := fmt.Sprintf("%s.models[%d]", fieldPrefix, modelIndex)
+		if _, capabilityError := validatedTextRouteCapabilities(providerName, endpoint, modelConfiguration, modelFieldPrefix); capabilityError != nil {
+			return capabilityError
+		}
 		if profileError := validateModelRequestProfile(providerName, endpoint, modelConfiguration); profileError != nil {
 			return fmt.Errorf("%w: field=%s.models[%d].request_profile", profileError, fieldPrefix, modelIndex)
 		}
-		modelFieldPrefix := fmt.Sprintf("%s.models[%d]", fieldPrefix, modelIndex)
 		modelReasoningEffort, modelCapabilityError := validatedReasoningEffortCapability(modelConfiguration.ReasoningEffort, modelFieldPrefix+".reasoning_effort")
 		if modelCapabilityError != nil {
 			return fmt.Errorf("%w: provider=%s endpoint=%s", modelCapabilityError, providerName, endpointName)
@@ -125,6 +169,69 @@ func validateModelEndpointCatalog(providerName string, endpoint endpointKind, ca
 		return fmt.Errorf("%w: provider=%s endpoint=%s default_model=%s", ErrInvalidModelCatalog, providerName, endpointName, defaultModel)
 	}
 	return nil
+}
+
+func validatedTextRouteCapabilities(providerName string, endpoint endpointKind, modelConfiguration ModelConfiguration, fieldPrefix string) (textRouteCapabilities, error) {
+	rawWireContract := modelConfiguration.WireContract
+	rawExecutionLifecycle := modelConfiguration.ExecutionLifecycle
+	if endpoint != endpointKindText {
+		if rawWireContract != constants.EmptyString {
+			return textRouteCapabilities{}, fmt.Errorf("%w: provider=%s endpoint=%s field=%s.wire_contract", ErrInvalidModelCatalog, providerName, endpoint, fieldPrefix)
+		}
+		if rawExecutionLifecycle != constants.EmptyString {
+			return textRouteCapabilities{}, fmt.Errorf("%w: provider=%s endpoint=%s field=%s.execution_lifecycle", ErrInvalidModelCatalog, providerName, endpoint, fieldPrefix)
+		}
+		return textRouteCapabilities{}, nil
+	}
+	if rawWireContract == constants.EmptyString || rawWireContract != strings.TrimSpace(rawWireContract) {
+		return textRouteCapabilities{}, fmt.Errorf("%w: provider=%s endpoint=%s field=%s.wire_contract", ErrInvalidModelCatalog, providerName, endpoint, fieldPrefix)
+	}
+	if rawExecutionLifecycle == constants.EmptyString || rawExecutionLifecycle != strings.TrimSpace(rawExecutionLifecycle) {
+		return textRouteCapabilities{}, fmt.Errorf("%w: provider=%s endpoint=%s field=%s.execution_lifecycle", ErrInvalidModelCatalog, providerName, endpoint, fieldPrefix)
+	}
+	capabilities := textRouteCapabilities{
+		wireContract:       textWireContract(rawWireContract),
+		executionLifecycle: textExecutionLifecycle(rawExecutionLifecycle),
+	}
+	if !knownTextWireContract(capabilities.wireContract) {
+		return textRouteCapabilities{}, fmt.Errorf("%w: provider=%s endpoint=%s field=%s.wire_contract wire_contract=%s", ErrInvalidModelCatalog, providerName, endpoint, fieldPrefix, rawWireContract)
+	}
+	if !knownTextExecutionLifecycle(capabilities.executionLifecycle) {
+		return textRouteCapabilities{}, fmt.Errorf("%w: provider=%s endpoint=%s field=%s.execution_lifecycle execution_lifecycle=%s", ErrInvalidModelCatalog, providerName, endpoint, fieldPrefix, rawExecutionLifecycle)
+	}
+	if _, allowed := providerTextRouteCapabilities[providerName][capabilities]; !allowed {
+		return textRouteCapabilities{}, fmt.Errorf(
+			"%w: provider=%s endpoint=%s wire_contract=%s execution_lifecycle=%s",
+			ErrInvalidModelCatalog,
+			providerName,
+			endpoint,
+			rawWireContract,
+			rawExecutionLifecycle,
+		)
+	}
+	return capabilities, nil
+}
+
+func knownTextWireContract(wireContract textWireContract) bool {
+	switch wireContract {
+	case textWireContractOpenAIResponses,
+		textWireContractOpenAIChatCompletions,
+		textWireContractGeminiGenerateContent,
+		textWireContractAnthropicMessages:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownTextExecutionLifecycle(executionLifecycle textExecutionLifecycle) bool {
+	switch executionLifecycle {
+	case textExecutionLifecycleSynchronousCompletion,
+		textExecutionLifecyclePollableResource:
+		return true
+	default:
+		return false
+	}
 }
 
 func validatedReasoningEffortCapability(rawCapability *ReasoningEffortCapability, fieldPrefix string) (*reasoningEffortCapability, error) {
@@ -199,8 +306,15 @@ func textModelSet(catalog ModelEndpointCatalog) map[string]textModelDefinition {
 	for _, modelConfiguration := range catalog.Models {
 		trimmedModelIdentifier := strings.TrimSpace(modelConfiguration.ID)
 		if trimmedModelIdentifier != constants.EmptyString {
+			routeCapabilities := textRouteCapabilities{
+				wireContract:       textWireContract(strings.TrimSpace(modelConfiguration.WireContract)),
+				executionLifecycle: textExecutionLifecycle(strings.TrimSpace(modelConfiguration.ExecutionLifecycle)),
+			}
 			models[strings.ToLower(trimmedModelIdentifier)] = textModelDefinition{
 				identifier:          modelID(trimmedModelIdentifier),
+				wireContract:        routeCapabilities.wireContract,
+				executionLifecycle:  routeCapabilities.executionLifecycle,
+				routeAdapter:        textRouteAdapters[routeCapabilities],
 				requestProfile:      modelRequestProfile(strings.TrimSpace(modelConfiguration.RequestProfile)),
 				supportsWebSearch:   modelConfiguration.WebSearch,
 				outputTokenLimit:    modelConfiguration.OutputTokenLimit,

--- a/internal/proxy/provider_key_verifier.go
+++ b/internal/proxy/provider_key_verifier.go
@@ -34,17 +34,17 @@ var (
 		statusCompleted:  {},
 		statusIncomplete: {},
 	}
-	providerKeyVerificationRequestBuilders = map[providerTextTransport]providerKeyVerificationRequestBuilder{
-		textTransportOpenAIResponses:      buildOpenAIProviderKeyVerificationRequest,
-		textTransportOpenAICompatibleChat: buildChatProviderKeyVerificationRequest,
-		textTransportGeminiGenerate:       buildGeminiProviderKeyVerificationRequest,
-		textTransportAnthropicMessages:    buildAnthropicProviderKeyVerificationRequest,
+	providerKeyVerificationRequestBuilders = map[textWireContract]providerKeyVerificationRequestBuilder{
+		textWireContractOpenAIResponses:       buildOpenAIProviderKeyVerificationRequest,
+		textWireContractOpenAIChatCompletions: buildChatProviderKeyVerificationRequest,
+		textWireContractGeminiGenerateContent: buildGeminiProviderKeyVerificationRequest,
+		textWireContractAnthropicMessages:     buildAnthropicProviderKeyVerificationRequest,
 	}
-	providerKeyVerificationResponseValidators = map[providerTextTransport]providerKeyVerificationResponseValidator{
-		textTransportOpenAIResponses:      validOpenAIProviderKeyVerificationResponse,
-		textTransportOpenAICompatibleChat: validChatProviderKeyVerificationResponse,
-		textTransportGeminiGenerate:       validGeminiProviderKeyVerificationResponse,
-		textTransportAnthropicMessages:    validAnthropicProviderKeyVerificationResponse,
+	providerKeyVerificationResponseValidators = map[textWireContract]providerKeyVerificationResponseValidator{
+		textWireContractOpenAIResponses:       validOpenAIProviderKeyVerificationResponse,
+		textWireContractOpenAIChatCompletions: validChatProviderKeyVerificationResponse,
+		textWireContractGeminiGenerateContent: validGeminiProviderKeyVerificationResponse,
+		textWireContractAnthropicMessages:     validAnthropicProviderKeyVerificationResponse,
 	}
 )
 
@@ -92,7 +92,7 @@ func (verifier *operationalProviderKeyVerifier) verify(parentContext context.Con
 	verificationContext, cancelVerification := context.WithTimeout(parentContext, verifier.timeout)
 	defer cancelVerification()
 
-	requestBuilder := providerKeyVerificationRequestBuilders[provider.textTransport]
+	requestBuilder := providerKeyVerificationRequestBuilders[model.wireContract]
 	httpRequest, buildError := requestBuilder(verificationContext, verifier.endpoints, provider, model, strings.TrimSpace(apiKey))
 	if buildError != nil {
 		return errProviderKeyVerificationUnavailable
@@ -110,7 +110,7 @@ func (verifier *operationalProviderKeyVerifier) verify(parentContext context.Con
 	if readError != nil || int64(len(responseBytes)) > providerKeyVerificationResponseLimit {
 		return errProviderKeyVerificationUnavailable
 	}
-	responseValidator := providerKeyVerificationResponseValidators[provider.textTransport]
+	responseValidator := providerKeyVerificationResponseValidators[model.wireContract]
 	if !responseValidator(responseBytes) {
 		return errProviderKeyVerificationUnavailable
 	}

--- a/internal/proxy/provider_registry.go
+++ b/internal/proxy/provider_registry.go
@@ -67,7 +67,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			textModels:                textModelSet(openAIModels.Text),
 			transcriptionModels:       dictationModelSet(openAIModels.Dictation),
 			supportsDictation:         true,
-			textTransport:             textTransportOpenAIResponses,
 		},
 		deepSeekProviderID: {
 			identifier:              deepSeekProviderID,
@@ -76,7 +75,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:        modelID(deepSeekModels.Text.DefaultModel),
 			textModels:              textModelSet(deepSeekModels.Text),
 			transcriptionModels:     map[string]modelID{},
-			textTransport:           textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter: chatCompletionTokenLimitMaxTokens,
 		},
 		dashScopeProviderID: {
@@ -87,7 +85,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:        modelID(dashScopeModels.Text.DefaultModel),
 			textModels:              textModelSet(dashScopeModels.Text),
 			transcriptionModels:     map[string]modelID{},
-			textTransport:           textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter: chatCompletionTokenLimitMaxTokens,
 		},
 		qwenCloudProviderID: {
@@ -97,7 +94,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:        modelID(qwenCloudModels.Text.DefaultModel),
 			textModels:              textModelSet(qwenCloudModels.Text),
 			transcriptionModels:     map[string]modelID{},
-			textTransport:           textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter: chatCompletionTokenLimitMaxTokens,
 		},
 		moonshotProviderID: {
@@ -108,7 +104,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:        modelID(moonshotModels.Text.DefaultModel),
 			textModels:              textModelSet(moonshotModels.Text),
 			transcriptionModels:     map[string]modelID{},
-			textTransport:           textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter: chatCompletionTokenLimitMaxCompletionTokens,
 		},
 		miniMaxProviderID: {
@@ -118,7 +113,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:        modelID(miniMaxModels.Text.DefaultModel),
 			textModels:              textModelSet(miniMaxModels.Text),
 			transcriptionModels:     map[string]modelID{},
-			textTransport:           textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter: chatCompletionTokenLimitMaxCompletionTokens,
 		},
 		siliconFlowProviderID: {
@@ -133,7 +127,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			textModels:                textModelSet(siliconFlowModels.Text),
 			transcriptionModels:       dictationModelSet(siliconFlowModels.Dictation),
 			supportsDictation:         true,
-			textTransport:             textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter:   chatCompletionTokenLimitMaxTokens,
 		},
 		zhipuProviderID: {
@@ -149,7 +142,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			textModels:                textModelSet(zhipuModels.Text),
 			transcriptionModels:       dictationModelSet(zhipuModels.Dictation),
 			supportsDictation:         true,
-			textTransport:             textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter:   chatCompletionTokenLimitMaxTokens,
 		},
 		geminiProviderID: {
@@ -159,7 +151,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:    modelID(geminiModels.Text.DefaultModel),
 			textModels:          textModelSet(geminiModels.Text),
 			transcriptionModels: map[string]modelID{},
-			textTransport:       textTransportGeminiGenerate,
 		},
 		anthropicProviderID: {
 			identifier:          anthropicProviderID,
@@ -169,7 +160,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:    modelID(anthropicModels.Text.DefaultModel),
 			textModels:          textModelSet(anthropicModels.Text),
 			transcriptionModels: map[string]modelID{},
-			textTransport:       textTransportAnthropicMessages,
 		},
 		metaProviderID: {
 			identifier:              metaProviderID,
@@ -178,7 +168,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			defaultTextModel:        modelID(metaModels.Text.DefaultModel),
 			textModels:              textModelSet(metaModels.Text),
 			transcriptionModels:     map[string]modelID{},
-			textTransport:           textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter: chatCompletionTokenLimitMaxCompletionTokens,
 		},
 		grokProviderID: {
@@ -194,7 +183,6 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 			textModels:                textModelSet(grokModels.Text),
 			transcriptionModels:       dictationModelSet(grokModels.Dictation),
 			supportsDictation:         true,
-			textTransport:             textTransportOpenAICompatibleChat,
 			chatTokenLimitParameter:   chatCompletionTokenLimitMaxTokens,
 		},
 	}

--- a/internal/proxy/provider_router.go
+++ b/internal/proxy/provider_router.go
@@ -19,6 +19,22 @@ type providerRouter struct {
 	anthropicClient *anthropicMessagesClient
 }
 
+type textRouteAdapter interface {
+	generateText(context.Context, *providerRouter, chatRequestParameters, *zap.SugaredLogger) (textGenerationResult, error)
+}
+
+type openAIResponsesTextRouteAdapter struct{}
+type openAIChatCompletionsTextRouteAdapter struct{}
+type geminiGenerateContentTextRouteAdapter struct{}
+type anthropicMessagesTextRouteAdapter struct{}
+
+var textRouteAdapters = map[textRouteCapabilities]textRouteAdapter{
+	openAIResponsesPollableRouteCapabilities:          openAIResponsesTextRouteAdapter{},
+	openAIChatCompletionsSynchronousRouteCapabilities: openAIChatCompletionsTextRouteAdapter{},
+	geminiGenerateContentSynchronousRouteCapabilities: geminiGenerateContentTextRouteAdapter{},
+	anthropicMessagesSynchronousRouteCapabilities:     anthropicMessagesTextRouteAdapter{},
+}
+
 func newProviderRouter(openAIClient *OpenAIClient, chatClient *openAICompatibleChatClient, geminiClient *geminiGenerateContentClient, anthropicClient *anthropicMessagesClient) *providerRouter {
 	return &providerRouter{
 		openAIClient:    openAIClient,
@@ -57,40 +73,23 @@ func (router *providerRouter) generateText(requestContext context.Context, reque
 }
 
 func (router *providerRouter) generateTextAttempt(requestContext context.Context, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
-	if request.provider.textTransport == textTransportOpenAIResponses {
-		return router.openAIClient.openAIRequest(
-			requestContext,
-			request.provider.credentialFor(endpointKindText),
-			request.model,
-			request.messages,
-			request.webSearchEnabled,
-			request.maxTokens,
-			request.reasoningEffort,
-			structuredLogger,
-		)
-	}
-	if request.provider.textTransport == textTransportGeminiGenerate {
-		return router.geminiClient.generateText(
-			requestContext,
-			request.provider.credentialFor(endpointKindText),
-			request.provider.textBaseURL,
-			request.model,
-			request.messages,
-			request.maxTokens,
-			structuredLogger,
-		)
-	}
-	if request.provider.textTransport == textTransportAnthropicMessages {
-		return router.anthropicClient.generateText(
-			requestContext,
-			request.provider.credentialFor(endpointKindText),
-			request.provider.textBaseURL,
-			request.model,
-			request.messages,
-			request.maxTokens,
-			structuredLogger,
-		)
-	}
+	return request.model.routeAdapter.generateText(requestContext, router, request, structuredLogger)
+}
+
+func (openAIResponsesTextRouteAdapter) generateText(requestContext context.Context, router *providerRouter, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	return router.openAIClient.openAIRequest(
+		requestContext,
+		request.provider.credentialFor(endpointKindText),
+		request.model,
+		request.messages,
+		request.webSearchEnabled,
+		request.maxTokens,
+		request.reasoningEffort,
+		structuredLogger,
+	)
+}
+
+func (openAIChatCompletionsTextRouteAdapter) generateText(requestContext context.Context, router *providerRouter, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
 	return router.chatClient.generateText(
 		requestContext,
 		request.provider.credentialFor(endpointKindText),
@@ -99,6 +98,30 @@ func (router *providerRouter) generateTextAttempt(requestContext context.Context
 		request.messages,
 		request.maxTokens,
 		request.provider.chatTokenLimitParameter,
+		structuredLogger,
+	)
+}
+
+func (geminiGenerateContentTextRouteAdapter) generateText(requestContext context.Context, router *providerRouter, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	return router.geminiClient.generateText(
+		requestContext,
+		request.provider.credentialFor(endpointKindText),
+		request.provider.textBaseURL,
+		request.model,
+		request.messages,
+		request.maxTokens,
+		structuredLogger,
+	)
+}
+
+func (anthropicMessagesTextRouteAdapter) generateText(requestContext context.Context, router *providerRouter, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	return router.anthropicClient.generateText(
+		requestContext,
+		request.provider.credentialFor(endpointKindText),
+		request.provider.textBaseURL,
+		request.model,
+		request.messages,
+		request.maxTokens,
 		structuredLogger,
 	)
 }

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -99,6 +99,163 @@ func TestProviderRoutingUsesConfiguredOpenAIURLsForTextAndDictation(t *testing.T
 	}
 }
 
+func TestProviderRoutingEnumeratesConfiguredTextRouteCapabilities(t *testing.T) {
+	providerOrder := []string{
+		proxy.ProviderNameOpenAI,
+		proxy.ProviderNameDeepSeek,
+		proxy.ProviderNameDashScope,
+		proxy.ProviderNameQwenCloud,
+		proxy.ProviderNameMoonshot,
+		proxy.ProviderNameMiniMax,
+		proxy.ProviderNameSiliconFlow,
+		proxy.ProviderNameZhipu,
+		proxy.ProviderNameGemini,
+		proxy.ProviderNameAnthropic,
+		proxy.ProviderNameMeta,
+		proxy.ProviderNameGrok,
+	}
+	expectedCapabilities := map[string]struct {
+		wireContract       string
+		executionLifecycle string
+	}{
+		proxy.ProviderNameOpenAI:      {wireContract: "openai_responses", executionLifecycle: "pollable_resource"},
+		proxy.ProviderNameDeepSeek:    {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameDashScope:   {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameQwenCloud:   {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameMoonshot:    {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameMiniMax:     {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameSiliconFlow: {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameZhipu:       {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameGemini:      {wireContract: "gemini_generate_content", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameAnthropic:   {wireContract: "anthropic_messages", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameMeta:        {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameGrok:        {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+	}
+	catalogs := testfixtures.ProviderModelCatalogs(t)
+	providerByModel := map[string]string{}
+	for _, providerName := range providerOrder {
+		for _, model := range catalogs[providerName].Text.Models {
+			if existingProvider, duplicate := providerByModel[model.ID]; duplicate {
+				t.Fatalf("model=%s is shared by providers=%s,%s", model.ID, existingProvider, providerName)
+			}
+			providerByModel[model.ID] = providerName
+		}
+	}
+
+	pollModel := catalogs[proxy.ProviderNameOpenAI].Text.Models[0].ID
+	observedPaths := map[string][]string{}
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		if request.URL.Path == "/responses/capability-poll" {
+			routeKey := proxy.ProviderNameOpenAI + "/" + pollModel
+			observedPaths[routeKey] = append(observedPaths[routeKey], request.Method+" "+request.URL.Path)
+			_, _ = responseWriter.Write([]byte(`{"id":"capability-poll","status":"completed","output_text":"route ok"}`))
+			return
+		}
+
+		var payload struct {
+			Model string `json:"model"`
+		}
+		_ = json.NewDecoder(request.Body).Decode(&payload)
+		modelIdentifier := payload.Model
+		if strings.HasPrefix(request.URL.Path, "/models/") && strings.HasSuffix(request.URL.Path, ":generateContent") {
+			modelIdentifier = strings.TrimSuffix(strings.TrimPrefix(request.URL.Path, "/models/"), ":generateContent")
+		}
+		providerName, configured := providerByModel[modelIdentifier]
+		if !configured {
+			t.Fatalf("unrecognized upstream model=%q path=%s", modelIdentifier, request.URL.Path)
+		}
+		routeKey := providerName + "/" + modelIdentifier
+		observedPaths[routeKey] = append(observedPaths[routeKey], request.Method+" "+request.URL.Path)
+
+		switch request.URL.Path {
+		case "/responses":
+			if modelIdentifier == pollModel {
+				_, _ = responseWriter.Write([]byte(`{"id":"capability-poll","status":"queued"}`))
+				return
+			}
+			_, _ = responseWriter.Write([]byte(`{"id":"capability-complete","status":"completed","output_text":"route ok"}`))
+		case "/chat/completions":
+			_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"route ok"},"finish_reason":"stop"}]}`))
+		case "/v1/messages":
+			_, _ = responseWriter.Write([]byte(`{"id":"capability-message","type":"message","role":"assistant","content":[{"type":"text","text":"route ok"}],"stop_reason":"end_turn"}`))
+		default:
+			if !strings.HasPrefix(request.URL.Path, "/models/") || !strings.HasSuffix(request.URL.Path, ":generateContent") {
+				t.Fatalf("unexpected upstream path=%s", request.URL.Path)
+			}
+			_, _ = responseWriter.Write([]byte(`{"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"route ok"}]}}]}`))
+		}
+	}))
+	t.Cleanup(upstreamServer.Close)
+
+	router, buildError := buildRouterWithCatalogs(t, proxy.Configuration{
+		Tenants:                      proxy.SingleTenantConfigurations("test", TestSecret),
+		OpenAIKey:                    TestAPIKey,
+		DeepSeekKey:                  testDeepSeekKey,
+		DashScopeKey:                 "sk-dashscope",
+		QwenCloudKey:                 "sk-qwencloud",
+		MoonshotKey:                  "sk-moonshot",
+		MiniMaxKey:                   "sk-minimax",
+		SiliconFlowKey:               testSiliconFlowKey,
+		ZhipuKey:                     testZhipuKey,
+		GeminiKey:                    testGeminiKey,
+		AnthropicKey:                 testAnthropicKey,
+		MetaKey:                      testMetaKey,
+		GrokKey:                      testGrokKey,
+		OpenAIBaseURL:                upstreamServer.URL,
+		OpenAITranscriptionsURL:      upstreamServer.URL + "/audio/transcriptions",
+		DeepSeekBaseURL:              upstreamServer.URL,
+		DashScopeBaseURL:             upstreamServer.URL,
+		QwenCloudBaseURL:             upstreamServer.URL,
+		MoonshotBaseURL:              upstreamServer.URL,
+		MiniMaxBaseURL:               upstreamServer.URL,
+		SiliconFlowBaseURL:           upstreamServer.URL,
+		SiliconFlowTranscriptionsURL: upstreamServer.URL + "/audio/transcriptions",
+		ZhipuBaseURL:                 upstreamServer.URL,
+		ZhipuTranscriptionsURL:       upstreamServer.URL + "/audio/transcriptions",
+		GeminiBaseURL:                upstreamServer.URL,
+		AnthropicBaseURL:             upstreamServer.URL,
+		MetaBaseURL:                  upstreamServer.URL,
+		GrokBaseURL:                  upstreamServer.URL,
+		GrokTranscriptionsURL:        upstreamServer.URL + "/audio/transcriptions",
+		LogLevel:                     proxy.LogLevelInfo,
+		WorkerCount:                  1,
+		QueueSize:                    1,
+		RequestTimeoutSeconds:        TestTimeout,
+		ProviderModels:               catalogs,
+	}, zap.NewNop().Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	for _, providerName := range providerOrder {
+		expected := expectedCapabilities[providerName]
+		for _, model := range catalogs[providerName].Text.Models {
+			if model.WireContract != expected.wireContract || model.ExecutionLifecycle != expected.executionLifecycle {
+				t.Fatalf("provider=%s model=%s capabilities=%s/%s want=%s/%s", providerName, model.ID, model.WireContract, model.ExecutionLifecycle, expected.wireContract, expected.executionLifecycle)
+			}
+			queryParameters := url.Values{}
+			queryParameters.Set("key", TestSecret)
+			queryParameters.Set("prompt", "enumerate route capabilities")
+			queryParameters.Set("provider", providerName)
+			queryParameters.Set("model", model.ID)
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/?"+queryParameters.Encode(), nil))
+			if response.Code != http.StatusOK || strings.TrimSpace(response.Body.String()) != "route ok" {
+				t.Fatalf("provider=%s model=%s status=%d body=%q", providerName, model.ID, response.Code, response.Body.String())
+			}
+			routeKey := providerName + "/" + model.ID
+			expectedRequestCount := 1
+			if model.ID == pollModel {
+				expectedRequestCount = 2
+			}
+			if len(observedPaths[routeKey]) != expectedRequestCount {
+				t.Fatalf("provider=%s model=%s upstream=%v want requests=%d", providerName, model.ID, observedPaths[routeKey], expectedRequestCount)
+			}
+		}
+	}
+}
+
 func TestProviderRoutingSupportsDeepSeekChatCompletions(t *testing.T) {
 	var capturedPayload map[string]any
 	requestCount := 0
@@ -536,7 +693,9 @@ func TestProviderRoutingUsesConfiguredTextModelCatalog(t *testing.T) {
 	}
 	configuredCatalogs := baseConfiguration.ProviderModels
 	deepSeekCatalog := configuredCatalogs[proxy.ProviderNameDeepSeek]
-	deepSeekCatalog.Text.Models = append(deepSeekCatalog.Text.Models, proxy.ModelConfiguration{ID: configuredDeepSeekModel})
+	configuredModel := deepSeekCatalog.Text.Models[0]
+	configuredModel.ID = configuredDeepSeekModel
+	deepSeekCatalog.Text.Models = append(deepSeekCatalog.Text.Models, configuredModel)
 	configuredCatalogs[proxy.ProviderNameDeepSeek] = deepSeekCatalog
 
 	var capturedPayload map[string]any

--- a/internal/proxy/provider_types.go
+++ b/internal/proxy/provider_types.go
@@ -133,13 +133,44 @@ const (
 	endpointKindDictation endpointKind = "dictation"
 )
 
-type providerTextTransport string
+type textWireContract string
 
 const (
-	textTransportOpenAIResponses      providerTextTransport = "openai_responses"
-	textTransportOpenAICompatibleChat providerTextTransport = "openai_compatible_chat"
-	textTransportGeminiGenerate       providerTextTransport = "gemini_generate"
-	textTransportAnthropicMessages    providerTextTransport = "anthropic_messages"
+	textWireContractOpenAIResponses       textWireContract = "openai_responses"
+	textWireContractOpenAIChatCompletions textWireContract = "openai_chat_completions"
+	textWireContractGeminiGenerateContent textWireContract = "gemini_generate_content"
+	textWireContractAnthropicMessages     textWireContract = "anthropic_messages"
+)
+
+type textExecutionLifecycle string
+
+const (
+	textExecutionLifecycleSynchronousCompletion textExecutionLifecycle = "synchronous_completion"
+	textExecutionLifecyclePollableResource      textExecutionLifecycle = "pollable_resource"
+)
+
+type textRouteCapabilities struct {
+	wireContract       textWireContract
+	executionLifecycle textExecutionLifecycle
+}
+
+var (
+	openAIResponsesPollableRouteCapabilities = textRouteCapabilities{
+		wireContract:       textWireContractOpenAIResponses,
+		executionLifecycle: textExecutionLifecyclePollableResource,
+	}
+	openAIChatCompletionsSynchronousRouteCapabilities = textRouteCapabilities{
+		wireContract:       textWireContractOpenAIChatCompletions,
+		executionLifecycle: textExecutionLifecycleSynchronousCompletion,
+	}
+	geminiGenerateContentSynchronousRouteCapabilities = textRouteCapabilities{
+		wireContract:       textWireContractGeminiGenerateContent,
+		executionLifecycle: textExecutionLifecycleSynchronousCompletion,
+	}
+	anthropicMessagesSynchronousRouteCapabilities = textRouteCapabilities{
+		wireContract:       textWireContractAnthropicMessages,
+		executionLifecycle: textExecutionLifecycleSynchronousCompletion,
+	}
 )
 
 type chatCompletionTokenLimitParameter string
@@ -229,6 +260,9 @@ func (capability *reasoningEffortCapability) supports(effort string) bool {
 
 type textModelDefinition struct {
 	identifier          modelID
+	wireContract        textWireContract
+	executionLifecycle  textExecutionLifecycle
+	routeAdapter        textRouteAdapter
 	requestProfile      modelRequestProfile
 	supportsWebSearch   bool
 	outputTokenLimit    int
@@ -259,7 +293,6 @@ type providerDefinition struct {
 	textModels                map[string]textModelDefinition
 	transcriptionModels       map[string]modelID
 	supportsDictation         bool
-	textTransport             providerTextTransport
 	chatTokenLimitParameter   chatCompletionTokenLimitParameter
 }
 

--- a/internal/testfixtures/provider_models.go
+++ b/internal/testfixtures/provider_models.go
@@ -24,12 +24,14 @@ type providerModelsEndpointConfiguration struct {
 }
 
 type providerModelsModelConfiguration struct {
-	ID               string                               `mapstructure:"id"`
-	RequestProfile   string                               `mapstructure:"request_profile"`
-	WebSearch        bool                                 `mapstructure:"web_search"`
-	OutputTokenLimit int                                  `mapstructure:"output_token_limit"`
-	ReasoningEffort  *providerModelsReasoningEffortConfig `mapstructure:"reasoning_effort"`
-	MediaInputs      []string                             `mapstructure:"media_inputs"`
+	ID                 string                               `mapstructure:"id"`
+	WireContract       string                               `mapstructure:"wire_contract"`
+	ExecutionLifecycle string                               `mapstructure:"execution_lifecycle"`
+	RequestProfile     string                               `mapstructure:"request_profile"`
+	WebSearch          bool                                 `mapstructure:"web_search"`
+	OutputTokenLimit   int                                  `mapstructure:"output_token_limit"`
+	ReasoningEffort    *providerModelsReasoningEffortConfig `mapstructure:"reasoning_effort"`
+	MediaInputs        []string                             `mapstructure:"media_inputs"`
 }
 
 type providerModelsReasoningEffortConfig struct {
@@ -76,12 +78,14 @@ func (configuration providerModelsEndpointConfiguration) proxyCatalog() proxy.Mo
 	models := make([]proxy.ModelConfiguration, 0, len(configuration.Models))
 	for _, modelConfiguration := range configuration.Models {
 		models = append(models, proxy.ModelConfiguration{
-			ID:               modelConfiguration.ID,
-			RequestProfile:   modelConfiguration.RequestProfile,
-			WebSearch:        modelConfiguration.WebSearch,
-			OutputTokenLimit: modelConfiguration.OutputTokenLimit,
-			ReasoningEffort:  providerModelsReasoningEffortCapability(modelConfiguration.ReasoningEffort),
-			MediaInputs:      append([]string(nil), modelConfiguration.MediaInputs...),
+			ID:                 modelConfiguration.ID,
+			WireContract:       modelConfiguration.WireContract,
+			ExecutionLifecycle: modelConfiguration.ExecutionLifecycle,
+			RequestProfile:     modelConfiguration.RequestProfile,
+			WebSearch:          modelConfiguration.WebSearch,
+			OutputTokenLimit:   modelConfiguration.OutputTokenLimit,
+			ReasoningEffort:    providerModelsReasoningEffortCapability(modelConfiguration.ReasoningEffort),
+			MediaInputs:        append([]string(nil), modelConfiguration.MediaInputs...),
 		})
 	}
 	return proxy.ModelEndpointCatalog{

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,12 +6,12 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="9bedcfe24bef1de14e903a692491521391bcbdb24699cf8fe20c83f21a242531">
+    <meta name="openapi-source-sha256" content="b9867e70e4d6e77fe325bae6676767f283916a9e4f04e8424dfa04f6a6909688">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="9bedcfe24bef1de14e903a692491521391bcbdb24699cf8fe20c83f21a242531">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="b9867e70e4d6e77fe325bae6676767f283916a9e4f04e8424dfa04f6a6909688">
     <header class="resource-shell resource-topbar">
       <a class="resource-brand" href="/">LLM Proxy</a>
       <nav aria-label="API reference navigation">
@@ -25,11 +25,11 @@
       <section class="resource-hero">
         <p class="eyebrow">Canonical API contract</p>
         <h1>LLM Proxy HTTP API</h1>
-        <p class="resource-deck">The sole canonical wire contract for llm-proxy-owned proxy, browser configuration, and management endpoints. Contributors must update this document in the same change as any owned handler or bundled-client wire change. TAuth-owned endpoints are outside this contract.</p>
+        <p class="resource-deck">The sole canonical wire contract for llm-proxy-owned proxy, browser configuration, and management endpoints. Each configured text model owns one explicit upstream wire contract and execution lifecycle. OpenAI Responses uses a stored pollable resource; OpenAI-compatible Chat Completions, Gemini generateContent, and Anthropic Messages complete synchronously. Public proxy operations remain blocking and never expose an upstream resource id. OpenAI resource ids remain in memory only, but the current adapter does not cancel or delete stored Responses, so OpenAI account retention policy applies. TAuth-owned endpoints are outside this contract. Contributors must update this document in the same change as any owned handler or bundled-client wire change.</p>
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>9bedcfe24bef1de14e903a692491521391bcbdb24699cf8fe20c83f21a242531</code></span>
+          <span>Source SHA-256 <code>b9867e70e4d6e77fe325bae6676767f283916a9e4f04e8424dfa04f6a6909688</code></span>
         </div>
         <div class="resource-actions">
           <a class="resource-button" href="/openapi.yaml">Download exact schema</a>
@@ -97,7 +97,7 @@
             <table>
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
-                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
+                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The selected model has one validated wire contract and one execution lifecycle; no lifecycle is inferred from an endpoint or upstream id. The proxy internally observes OpenAI queued and in_progress states for its pollable resource and keeps every public operation blocking. Separately, it continues exact output-budget stops through new provider calls: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the adapter reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
 <tr><td><code>429</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider returned HTTP 429. The proxy preserves 429 at its public boundary and returns only sanitized provider metadata; it never exposes the raw provider body or message.</td></tr>
@@ -157,7 +157,7 @@
             <table>
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
-                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
+                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The selected model has one validated wire contract and one execution lifecycle; no lifecycle is inferred from an endpoint or upstream id. The proxy internally observes OpenAI queued and in_progress states for its pollable resource and keeps every public operation blocking. Separately, it continues exact output-budget stops through new provider calls: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the adapter reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
 <tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured JSON request or dictation audio payload limit was exceeded.</td></tr>
@@ -936,7 +936,7 @@
             <table>
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
-                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The proxy internally continues exact output-budget stops through one provider-neutral lifecycle: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the selected transport reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
+                <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The selected model has one validated wire contract and one execution lifecycle; no lifecycle is inferred from an endpoint or upstream id. The proxy internally observes OpenAI queued and in_progress states for its pollable resource and keeps every public operation blocking. Separately, it continues exact output-budget stops through new provider calls: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini MAX_TOKENS, and Anthropic max_tokens. HTTP 200 is returned only after the adapter reports its complete signal: OpenAI completed, Chat stop, Gemini STOP, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
 <tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured JSON request or dictation audio payload limit was exceeded.</td></tr>


### PR DESCRIPTION
## Summary

- replace the provider-level combined transport enum with explicit per-model wire-contract and execution-lifecycle capabilities
- route text requests and provider-key verification through model-owned adapters, with OpenAI polling isolated behind its pollable capability
- publish the exact configured capability matrix, retention behavior, and public-boundary lifecycle coverage

## Validation

- `timeout -k 350s -s SIGKILL 350s make ci`
- all 11 gates passed, including 75 browser tests and the TAuth black-box test
- Go statement coverage: 100.0%

## Stack

- depends on #250 (`B087`)
- resolves `I037`
