### PR TITLE
File Gemini 3.6 Flash thinking issue

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -2173,16 +2173,17 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
     an id.
   - One `gemini_interactions` adapter now uses the exact model-owned lifecycle:
     3.x creates stored background interactions, polls only `queued` and
-    `in_progress`, cancels active resources, and deletes every resource; 2.5
-    sends `background: false` and `store: false` and requires an immediate
-    terminal result. Both use `Api-Revision: 2026-05-20`, normalized complete
-    usage, safe terminal errors, and distinct output-limit continuation calls.
+    `in_progress`, cancels active resources, and deletes every resource through
+    independent bounded cancel and delete contexts. Gemini 2.5 sends
+    `background: false` and `store: false` and requires an immediate terminal
+    result. Both use `Api-Revision: 2026-05-20`, normalized complete usage, safe
+    terminal errors, and distinct output-limit continuation calls.
   - Public black-box fixtures cover synchronous id-less completion, delayed and
     immediate background completion, usage including thought tokens, every
-    terminal status, cancellation, cancel/delete ordering, cleanup failures,
-    media shape, continuation, and credential verification. The production
-    live suite pins its complex Gemini case to `gemini-3.5-flash` while the echo
-    retains the saved Default-tenant model.
+    terminal status, cancellation, cancel/delete ordering, independent cleanup
+    contexts, cleanup failures, media shape, continuation, and credential
+    verification. The production live suite pins its complex Gemini case to
+    `gemini-3.5-flash` while the echo retains the saved Default-tenant model.
   - Paid branch acceptance passed for both `gemini-2.5-flash` and
     `gemini-3.5-flash`. The final `make ci` passed all 11 gates with 100.0% Go
     statement coverage; deployment and the post-deploy production invocation
@@ -2206,6 +2207,10 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
     https://ai.google.dev/gemini-api/docs/thinking
   - The Interactions schema defines the same four-value `thinking_level` enum:
     https://ai.google.dev/api/interactions-api
+  - Google's Gemini 3.6 migration contract rejects a request whose final
+    nonempty turn is a model turn with HTTP 400 and directs multi-turn
+    Interactions callers away from manually prefilled model turns:
+    https://ai.google.dev/gemini-api/docs/latest-model
   Requirements:
   - Add only the exact stable model id `gemini-3.6-flash`. Do not add or alias
     the requested but unpublished `gemini-2.6-flash` name, use a moving
@@ -2216,6 +2221,11 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
     create, active status, retrieval, cancellation, and deletion. Register the
     model as `gemini_interactions` plus `pollable_resource` only after that
     proof succeeds.
+  - At the resolved Gemini 3.6 route edge, reject with the canonical HTTP 400
+    invalid-messages response any request whose final non-system message is an
+    assistant turn. Do not send that turn as a terminal `model_output`, rewrite
+    it into another role, or change assistant-prefill behavior for other model
+    routes as an incidental part of this issue.
   - Add the exact `gemini_interactions` reasoning-effort adapter, valid only for
     the Gemini Interactions text route. Declare the model's ordered capability
     as `minimal`, `low`, `medium`, and `high`; serialize an explicitly resolved
@@ -2239,8 +2249,9 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
   - Startup and public-boundary fixtures prove the Gemini-only adapter mapping,
     all four explicit effort payloads, omitted-effort omission, continuation
     preservation, early rejection of unsupported efforts, 65,536-token cap,
-    media declarations, management profile exposure, and saved tenant-default
-    routing.
+    media declarations, management profile exposure, saved tenant-default
+    routing, and pre-upstream rejection of a terminal assistant turn only on
+    the Gemini 3.6 route.
   - Authenticated branch acceptance runs one small request for each explicit
     thinking level and one omitted-level request, then proves one background
     create/poll/delete flow for `gemini-3.6-flash`. The final `make ci` passes

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -2187,6 +2187,65 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
     `gemini-3.5-flash`. The final `make ci` passed all 11 gates with 100.0% Go
     statement coverage; deployment and the post-deploy production invocation
     remain operator-owned.
+- [ ] [I207] (P1) {I040} Add Gemini 3.6 Flash with route-bound Interactions thinking levels.
+  Goal:
+  Add Google's current stable Flash model to the Gemini Interactions catalog
+  and carry the existing provider-neutral `reasoning_effort` contract onto its
+  documented thinking controls.
+  Evidence:
+  - Google identifies Gemini 3.6 Flash as GA and production-ready under the
+    exact stable model id `gemini-3.6-flash`, with a 65,536-token output limit
+    and `medium` as its default thinking level:
+    https://ai.google.dev/gemini-api/docs/latest-model
+  - The model page confirms that `gemini-3.6-flash` supports text, image, video,
+    audio, and PDF input, text output, and thinking:
+    https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash
+  - Google's Interactions thinking guide documents
+    `generation_config.thinking_level`; Gemini 3.6 Flash supports exactly
+    `minimal`, `low`, `medium`, and `high`, with `medium` as the default:
+    https://ai.google.dev/gemini-api/docs/thinking
+  - The Interactions schema defines the same four-value `thinking_level` enum:
+    https://ai.google.dev/api/interactions-api
+  Requirements:
+  - Add only the exact stable model id `gemini-3.6-flash`. Do not add or alias
+    the requested but unpublished `gemini-2.6-flash` name, use a moving
+    `gemini-flash-latest` alias, or change the Gemini provider default as an
+    incidental part of this issue.
+  - Before registering the route lifecycle, verify at the paid Google boundary
+    that this exact model supports stored background Interactions through
+    create, active status, retrieval, cancellation, and deletion. Register the
+    model as `gemini_interactions` plus `pollable_resource` only after that
+    proof succeeds.
+  - Add the exact `gemini_interactions` reasoning-effort adapter, valid only for
+    the Gemini Interactions text route. Declare the model's ordered capability
+    as `minimal`, `low`, `medium`, and `high`; serialize an explicitly resolved
+    public effort unchanged as `generation_config.thinking_level` on the
+    initial request and every output-limit continuation.
+  - When neither the request nor tenant default selects an effort, omit
+    `thinking_level` so Google's documented `medium` default remains
+    authoritative. Reject blank, `none`, `xhigh`, `max`, and every other
+    unsupported value before an upstream call. Do not translate values, send a
+    2.5-era `thinking_budget`, or add a second Gemini request adapter.
+  - Keep the current 65,536 proxy output limit. Declare only the image and audio
+    inputs already implemented by the public messages contract; do not imply
+    public video, PDF, tools, thought-summary, streaming, or computer-use
+    support from the broader upstream model capability list.
+  - Expose the exact route capability through the management profile and
+    Settings autosave contract, and update configuration, constants, README,
+    OpenAPI, provider-routing documentation, generated resources, and the model
+    capability table together. No persisted-routing migration or default-model
+    change is part of this issue.
+  Validation:
+  - Startup and public-boundary fixtures prove the Gemini-only adapter mapping,
+    all four explicit effort payloads, omitted-effort omission, continuation
+    preservation, early rejection of unsupported efforts, 65,536-token cap,
+    media declarations, management profile exposure, and saved tenant-default
+    routing.
+  - Authenticated branch acceptance runs one small request for each explicit
+    thinking level and one omitted-level request, then proves one background
+    create/poll/delete flow for `gemini-3.6-flash`. The final `make ci` passes
+    after the last implementation edit; deployment and production acceptance
+    remain operator-owned.
 - [ ] [I041] (P2) {I037} Migrate Grok to xAI Responses without OpenAI background assumptions.
   Goal:
   Move Grok off xAI's deprecated Chat Completions surface while preserving

--- a/README.md
+++ b/README.md
@@ -784,13 +784,14 @@ Gemini 3.x Interactions requires `store: true` for background execution. The
 proxy sends `Api-Revision: 2026-05-20`, polls only `queued` and `in_progress`,
 and never exposes or persists an interaction id. On every exit it cancels an
 interaction that is still active and then deletes the resource; a terminal
-interaction is deleted directly. A failed cancel does not skip deletion, and a
-failed deletion prevents a successful or output-limit result from escaping as
-success. Gemini 2.5 uses the same Interactions adapter synchronously with
-`background: false` and `store: false`, so it accepts an immediate terminal
-response without requiring or cleaning up an id. Output-limit continuation
-always starts a distinct inference request and never treats an arbitrary
-upstream identifier as pollable state.
+interaction is deleted directly. Cancel and delete each receive an independent
+bounded cleanup context, so a stalled or failed cancel cannot consume the
+delete attempt. A failed deletion prevents a successful or output-limit result
+from escaping as success. Gemini 2.5 uses the same Interactions adapter
+synchronously with `background: false` and `store: false`, so it accepts an
+immediate terminal response without requiring or cleaning up an id.
+Output-limit continuation always starts a distinct inference request and never
+treats an arbitrary upstream identifier as pollable state.
 
 Provider-specific details:
 

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -272,7 +272,9 @@ provider-neutral output-limit signal, and `failed`, `cancelled`,
 fail closed. The newest nonempty usage snapshot replaces earlier observations
 for one interaction; input, output, and total counts are taken from
 `total_input_tokens`, `total_output_tokens`, and `total_tokens`, so
-provider-counted thought tokens remain represented.
+provider-counted thought tokens remain represented. Active-resource cancel and
+delete operations use independent bounded contexts, so cancel exhaustion cannot
+prevent the delete request from starting.
 
 OpenAI background Responses are stored upstream. llm-proxy keeps their ids only
 in memory for the active request and never returns or persists them, but the

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -195,32 +195,35 @@ func (client *geminiInteractionsClient) getInteraction(parentContext context.Con
 }
 
 func (client *geminiInteractionsClient) releaseInteraction(parentContext context.Context, apiKey string, baseURL string, interactionIdentifier string, cleanupMode geminiInteractionCleanupMode, structuredLogger *zap.SugaredLogger) error {
-	cleanupContext, cancelCleanup := context.WithTimeout(context.WithoutCancel(parentContext), geminiInteractionCleanupTimeout)
-	defer cancelCleanup()
-
+	detachedContext := context.WithoutCancel(parentContext)
 	var cancelError error
 	if cleanupMode == geminiInteractionCancelAndDelete {
-		_, cancelError = client.performInteractionRequest(
-			cleanupContext,
+		cancelError = client.performInteractionCleanupRequest(
+			detachedContext,
 			http.MethodPost,
 			geminiInteractionResourceURL(baseURL, interactionIdentifier)+"/cancel",
 			apiKey,
-			nil,
 			structuredLogger,
 		)
 	}
-	_, deleteError := client.performInteractionRequest(
-		cleanupContext,
+	deleteError := client.performInteractionCleanupRequest(
+		detachedContext,
 		http.MethodDelete,
 		geminiInteractionResourceURL(baseURL, interactionIdentifier),
 		apiKey,
-		nil,
 		structuredLogger,
 	)
 	if cancelError != nil {
 		return cancelError
 	}
 	return deleteError
+}
+
+func (client *geminiInteractionsClient) performInteractionCleanupRequest(parentContext context.Context, method string, requestURL string, apiKey string, structuredLogger *zap.SugaredLogger) error {
+	cleanupContext, cancelCleanup := context.WithTimeout(parentContext, geminiInteractionCleanupTimeout)
+	defer cancelCleanup()
+	_, requestError := client.performInteractionRequest(cleanupContext, method, requestURL, apiKey, nil, structuredLogger)
+	return requestError
 }
 
 func (client *geminiInteractionsClient) performInteractionRequest(parentContext context.Context, method string, requestURL string, apiKey string, payload any, structuredLogger *zap.SugaredLogger) ([]byte, error) {

--- a/internal/proxy/gemini_interactions_lifecycle_test.go
+++ b/internal/proxy/gemini_interactions_lifecycle_test.go
@@ -240,6 +240,9 @@ func TestGeminiInteractionsPollFailureStillDeletesWhenCancellationFails(testingI
 	const privatePollBody = "private poll failure"
 	const privateCancelBody = "private cancel failure"
 	var observedRequests []string
+	var cancelRequestContext context.Context
+	var deleteRequestContext context.Context
+	deleteRequestStartedWithLiveContext := false
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		observedRequests = append(observedRequests, request.Method+" "+request.URL.Path)
 		assertGeminiInteractionHeaders(testingInstance, request, testGeminiKey)
@@ -257,8 +260,22 @@ func TestGeminiInteractionsPollFailureStillDeletesWhenCancellationFails(testingI
 		}
 	}))
 	testingInstance.Cleanup(upstreamServer.Close)
+	previousHTTPClient := proxy.HTTPClient
+	testingInstance.Cleanup(func() { proxy.HTTPClient = previousHTTPClient })
+	proxy.HTTPClient = coverageHTTPDoer(func(request *http.Request) (*http.Response, error) {
+		switch {
+		case request.Method == http.MethodPost && strings.HasSuffix(request.URL.Path, "/cancel"):
+			cancelRequestContext = request.Context()
+		case request.Method == http.MethodDelete:
+			deleteRequestContext = request.Context()
+			deleteRequestStartedWithLiveContext = deleteRequestContext.Err() == nil
+		}
+		return upstreamServer.Client().Do(request)
+	})
+	router := geminiInteractionsTestRouter(testingInstance, upstreamServer.URL)
+	proxy.HTTPClient = previousHTTPClient
 
-	response := performGeminiInteractionsRequest(testingInstance, geminiInteractionsTestRouter(testingInstance, upstreamServer.URL), context.Background())
+	response := performGeminiInteractionsRequest(testingInstance, router, context.Background())
 	upstreamStatus := http.StatusInternalServerError
 	assertProviderErrorResponse(testingInstance, response, providerErrorExpectation{
 		statusCode:     http.StatusBadGateway,
@@ -279,6 +296,15 @@ func TestGeminiInteractionsPollFailureStillDeletesWhenCancellationFails(testingI
 	}
 	if strings.Join(observedRequests, "|") != strings.Join(expectedRequests, "|") {
 		testingInstance.Fatalf("poll failure requests=%v want=%v", observedRequests, expectedRequests)
+	}
+	if cancelRequestContext == nil || deleteRequestContext == nil {
+		testingInstance.Fatalf("missing cleanup contexts cancel=%v delete=%v", cancelRequestContext, deleteRequestContext)
+	}
+	if cancelRequestContext == deleteRequestContext {
+		testingInstance.Fatal("cancel and delete reused one cleanup context")
+	}
+	if !deleteRequestStartedWithLiveContext {
+		testingInstance.Fatal("delete cleanup started with an exhausted context")
 	}
 }
 


### PR DESCRIPTION
## Summary
- file I207 for the current stable Gemini Flash model, gemini-3.6-flash
- define the exact Gemini Interactions reasoning-effort contract: minimal, low, medium, and high; omitted effort preserves the provider medium default
- require paid background-lifecycle and thinking-level acceptance while excluding aliases, default changes, and unsupported public capabilities

## Research
- https://ai.google.dev/gemini-api/docs/latest-model
- https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash
- https://ai.google.dev/gemini-api/docs/thinking
- https://ai.google.dev/api/interactions-api

## Validation
- git diff --check
- unique I207 tracker identifier
- documentation-only tracker change; no runtime code changed