### PR TITLE
bugfix/B100-self-contained-frontend-validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install frontend dependencies
-        run: npm ci
-      - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
       - name: Install uv
         run: python -m pip install uv
       - name: Install Go lint tools

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -39,6 +39,47 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
 
+- [x] [B100] (P0) Make declared frontend validation self-contained in a clean checkout.
+  Goal:
+  Make the public `make test` and `make ci` contracts install their exact pinned
+  frontend dependencies and Chromium before invoking Playwright.
+  Evidence:
+  - Agentic execution of recurring issue M001R at exact remote revision
+    `95457e317a93e85b6b225babd9064284089dab1d` passed Go and Python baseline
+    validation, then failed with `playwright: not found` and zero provider
+    requests.
+  - The GitHub workflow installs npm dependencies and Chromium before calling
+    `make ci`, while the repository Make targets assume that untracked state
+    already exists.
+  Requirements:
+  - Give Make one canonical dependency-preparation target using the pinned npm
+    lock and the declared Chromium browser.
+  - Make clean `make test`, `make lint`, focused frontend targets, and `make ci`
+    cross that preparation boundary before frontend validation.
+  - Remove workflow-only duplicate setup so hosted and Agentic execution use
+    the same public contract.
+  - Keep dependency state untracked and do not add an alternate validation
+    path or fallback browser.
+  Validation:
+  - Add a black-box Make regression that invokes the public targets with an
+    empty dependency state and records exact npm preparation/test ordering.
+  - Run the focused regression and the required final
+    `timeout -k 350s -s SIGKILL 350s make ci`.
+  Resolution:
+  - Make now installs the exact lockfile graph and invokes its pinned Playwright
+    binary to install Chromium into ignored project-local state before any
+    frontend validation target runs.
+  - The preparation stamp makes recursive `make ci` stages reuse that exact
+    state, while a changed package manifest or lockfile requires preparation
+    again.
+  - Black-box Make fixtures prove clean focused frontend, `make test`, and
+    `make ci` executions prepare dependencies exactly once and in the required
+    order. Hosted CI now delegates the same setup to `make ci` instead of
+    maintaining a second workflow-only path.
+  - The focused dependency-contract target, real pinned dependency and browser
+    preparation, 75 frontend browser tests, and one TAuth browser black-box
+    test passed. The required final `make ci` returned zero with all 11 gates
+    complete and exact 100% Go statement coverage.
 - [-] [B099] (P0) Retire the exact legacy llm-proxy Compose service.
   Goal:
   Make the first schema-v2 deployment remove the obsolete llm-proxy container
@@ -3982,5 +4023,3 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
     are not tied to an approved source.
   - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci`
     pair for the implementation, with the final run after the last code edit.
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Make every public frontend validation path install the pinned npm graph and project-local Chromium before use, including clean `make test` and `make ci` executions.
 - **Breaking:** `GET /` now accepts `web_search` only as exact `true` or `false`; former aliases and malformed supplied values return HTTP 400. The bundled Go package, Go CLI, and Python package remain on `POST /v2` and serialize `web_search` as a native JSON boolean.
 - Remove Moonshot's unavailable former default model and promote the verified `kimi-k2.6` model as the sole canonical default without an alias or fallback.
 - Verify every nonempty managed provider key against its exact provider and selected text model before atomic persistence, with automatic paste verification, safe stable failures, stale-attempt cancellation, and live-harness coverage.

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,14 @@ UV ?= uv
 BIN_DIR ?= bin
 BINARY_NAME ?= llm-proxy
 PYTHON_PROJECT_DIR ?= python
+PLAYWRIGHT_BROWSERS_PATH := $(CURDIR)/node_modules/.cache/ms-playwright
+FRONTEND_DEPENDENCY_STAMP := $(PLAYWRIGHT_BROWSERS_PATH)/.llm-proxy-frontend-dependencies
+
+export PLAYWRIGHT_BROWSERS_PATH
 
 GO_SOURCES := $(shell find . -name '*.go' -not -path './vendor/*')
 
-.PHONY: fmt check-format lint go-lint python-lint frontend-lint test go-test python-test python-package-install-test frontend-test test-openapi-pages-artifact test-management-auth-blackbox test-live-provider-harness test-live-providers test-live-gemini live-test build clean ci up
+.PHONY: fmt check-format lint go-lint python-lint frontend-dependencies frontend-lint test go-test python-test python-package-install-test frontend-test test-frontend-dependency-contract test-openapi-pages-artifact test-management-auth-blackbox test-live-provider-harness test-live-providers test-live-gemini live-test build clean ci up
 
 fmt:
 	$(GOFMT) -w $(GO_SOURCES)
@@ -33,7 +37,14 @@ go-lint:
 python-lint:
 	cd $(PYTHON_PROJECT_DIR) && $(UV) run --group dev mypy --strict llm_proxy_client
 
-frontend-lint:
+frontend-dependencies: $(FRONTEND_DEPENDENCY_STAMP)
+
+$(FRONTEND_DEPENDENCY_STAMP): package.json package-lock.json
+	$(NPM) ci
+	./node_modules/.bin/playwright install --with-deps chromium
+	@touch "$@"
+
+frontend-lint: frontend-dependencies
 	$(NPM) run frontend:lint
 
 test: go-test python-test frontend-test test-openapi-pages-artifact test-management-auth-blackbox test-live-provider-harness
@@ -48,13 +59,16 @@ python-test:
 python-package-install-test:
 	@set -eu; temporary_package_directory="$$(mktemp -d)"; trap 'rm -rf "$$temporary_package_directory"' 0; cp "$(PYTHON_PROJECT_DIR)/pyproject.toml" "$$temporary_package_directory/pyproject.toml"; cp -R "$(PYTHON_PROJECT_DIR)/llm_proxy_client" "$$temporary_package_directory/llm_proxy_client"; LLM_PROXY_CLIENT_PROJECT_PATH="$$temporary_package_directory/pyproject.toml" $(UV) run --no-project --with "$$temporary_package_directory" python -c 'from importlib.metadata import version; from pathlib import Path; import os, tomllib; from llm_proxy_client import Client, ClientConfig, ClientMessage, ClientMessagesRequest, LLMProxyModelProfileError; assert version("llm-proxy-client") == tomllib.loads(Path(os.environ["LLM_PROXY_CLIENT_PROJECT_PATH"]).read_text(encoding="utf-8"))["project"]["version"]; assert Client and ClientConfig and ClientMessage and ClientMessagesRequest and LLMProxyModelProfileError'
 
-frontend-test:
+frontend-test: frontend-dependencies
 	$(NPM) run frontend:test
+
+test-frontend-dependency-contract:
+	$(GO) test ./tests -run '^TestOperationalFrontendValidationPreparesPinnedDependencies$$' -count=1
 
 test-openapi-pages-artifact:
 	@./scripts/test-openapi-pages-artifact.sh
 
-test-management-auth-blackbox:
+test-management-auth-blackbox: frontend-dependencies
 	$(NPM) run frontend:test:blackbox
 
 test-live-provider-harness:

--- a/README.md
+++ b/README.md
@@ -1550,9 +1550,9 @@ This repository exposes the standard local targets used by MPR app repos:
 
 | Command | Purpose |
 |---------|---------|
-| `npm ci` | Install pinned frontend validation dependencies before running local frontend checks. |
+| `make frontend-dependencies` | Install the pinned npm graph and Chromium into ignored project-local state. Focused frontend validation, `make lint`, `make test`, and `make ci` invoke this target automatically. |
 | `make up` | Require the ignored private `configs/.env.local`, then build and run the complete local browser orchestration: ghttp static UI and same-origin TAuth routes on `localhost:4179`, plus the API on `localhost:8080`. It waits for Compose startup before verifying the static/config/auth/API boundaries and reporting ready. |
-| `make ci` | Run format checks, Go lint (`go vet`, `staticcheck`, `ineffassign`), Python strict mypy, frontend syntax checks, the 100% coverage-gated Go test suite, Python pytest, Playwright browser tests, the app lifecycle contract test, and the non-paid live-harness preflight. A successful run ends with a per-gate table, current-run coverage, and an explicit `CI PASSED` receipt. |
+| `make ci` | Prepare pinned frontend dependencies, then run format checks, Go lint (`go vet`, `staticcheck`, `ineffassign`), Python strict mypy, frontend syntax checks, the 100% coverage-gated Go test suite, Python pytest, Playwright browser tests, the app lifecycle contract test, and the non-paid live-harness preflight. A successful run ends with a per-gate table, current-run coverage, and an explicit `CI PASSED` receipt. |
 | `make test-live-provider-harness` | Generate the temporary static-mode live-test config and verify authenticated routing without an upstream call. |
 | `make test-live-providers` | Start a disposable managed tenant, verify every available provider key through the canonical management operation, and run that provider's live text smoke only after verification succeeds; use `LIVE_ENV_FILE=/path/to/env` to load key values. |
 | `make test-live-gemini` | Compatibility wrapper for `make test-live-providers` with `LLM_PROXY_LIVE_PROVIDERS=gemini`. |

--- a/tests/frontend_dependency_contract_test.go
+++ b/tests/frontend_dependency_contract_test.go
@@ -1,0 +1,209 @@
+package tests_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const frontendDependencyContractTimeout = 10 * time.Second
+
+func TestOperationalFrontendValidationPreparesPinnedDependencies(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	makePath, lookupError := exec.LookPath("make")
+	if lookupError != nil {
+		testingInstance.Fatalf("resolve Make executable: %v", lookupError)
+	}
+
+	scenarios := []struct {
+		name             string
+		target           string
+		expectedCommands []string
+	}{
+		{
+			name:   "frontend-lint",
+			target: "frontend-lint",
+			expectedCommands: []string{
+				"ci",
+				"playwright install --with-deps chromium",
+				"run frontend:lint",
+			},
+		},
+		{
+			name:   "frontend-test",
+			target: "frontend-test",
+			expectedCommands: []string{
+				"ci",
+				"playwright install --with-deps chromium",
+				"run frontend:test",
+			},
+		},
+		{
+			name:   "management-black-box",
+			target: "test-management-auth-blackbox",
+			expectedCommands: []string{
+				"ci",
+				"playwright install --with-deps chromium",
+				"run frontend:test:blackbox",
+			},
+		},
+		{
+			name:   "test",
+			target: "test",
+			expectedCommands: []string{
+				"ci",
+				"playwright install --with-deps chromium",
+				"run frontend:test",
+				"run frontend:test:blackbox",
+			},
+		},
+		{
+			name:   "ci",
+			target: "ci",
+			expectedCommands: []string{
+				"ci",
+				"playwright install --with-deps chromium",
+				"run frontend:lint",
+				"run frontend:test",
+				"run frontend:test:blackbox",
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		testingInstance.Run(scenario.name, func(testingInstance *testing.T) {
+			fixtureRoot := testingInstance.TempDir()
+			prepareFrontendDependencyFixture(testingInstance, repositoryRoot, fixtureRoot)
+			npmLogPath := filepath.Join(fixtureRoot, "npm.log")
+			canonicalFixtureRoot, evaluateError := filepath.EvalSymlinks(fixtureRoot)
+			if evaluateError != nil {
+				testingInstance.Fatalf("resolve fixture path: %v", evaluateError)
+			}
+			browserPath := filepath.Join(canonicalFixtureRoot, "node_modules", ".cache", "ms-playwright")
+
+			commandContext, cancelCommand := context.WithTimeout(context.Background(), frontendDependencyContractTimeout)
+			defer cancelCommand()
+			command := exec.CommandContext(
+				commandContext,
+				makePath,
+				"--no-print-directory",
+				scenario.target,
+				"NPM="+filepath.Join(fixtureRoot, "npm"),
+				"GO="+filepath.Join(fixtureRoot, "go"),
+				"GOFMT=true",
+				"UV=true",
+			)
+			command.Dir = fixtureRoot
+			command.Env = append(
+				os.Environ(),
+				"FRONTEND_NPM_LOG="+npmLogPath,
+				"FRONTEND_PLAYWRIGHT_FIXTURE="+filepath.Join(fixtureRoot, "playwright"),
+			)
+			output, commandError := command.CombinedOutput()
+			if commandContext.Err() != nil {
+				testingInstance.Fatalf("make %s timed out: %v\n%s", scenario.target, commandContext.Err(), output)
+			}
+			if commandError != nil {
+				testingInstance.Fatalf("make %s failed: %v\n%s", scenario.target, commandError, output)
+			}
+
+			npmLogBytes, readError := os.ReadFile(npmLogPath)
+			if readError != nil {
+				testingInstance.Fatalf("read npm command log: %v", readError)
+			}
+			expectedLines := make([]string, 0, len(scenario.expectedCommands))
+			for _, expectedCommand := range scenario.expectedCommands {
+				expectedLines = append(expectedLines, expectedCommand+"|"+browserPath)
+			}
+			expectedLog := strings.Join(expectedLines, "\n") + "\n"
+			if string(npmLogBytes) != expectedLog {
+				testingInstance.Fatalf("unexpected npm command order for make %s:\n%s", scenario.target, npmLogBytes)
+			}
+		})
+	}
+
+	workflowBytes, readError := os.ReadFile(filepath.Join(repositoryRoot, ".github", "workflows", "test.yml"))
+	if readError != nil {
+		testingInstance.Fatalf("read hosted CI workflow: %v", readError)
+	}
+	workflow := string(workflowBytes)
+	for _, duplicateSetup := range []string{"run: npm ci", "run: npx playwright install"} {
+		if strings.Contains(workflow, duplicateSetup) {
+			testingInstance.Fatalf("hosted CI duplicates Make-owned frontend setup %q", duplicateSetup)
+		}
+	}
+	if !strings.Contains(workflow, "run: timeout -k 350s -s SIGKILL 350s make ci") {
+		testingInstance.Fatal("hosted CI does not invoke the canonical make ci contract")
+	}
+}
+
+func prepareFrontendDependencyFixture(testingInstance *testing.T, repositoryRoot string, fixtureRoot string) {
+	testingInstance.Helper()
+	makefileBytes, readError := os.ReadFile(filepath.Join(repositoryRoot, "Makefile"))
+	if readError != nil {
+		testingInstance.Fatalf("read Makefile: %v", readError)
+	}
+	writeOperationalFile(
+		testingInstance,
+		filepath.Join(fixtureRoot, "Makefile"),
+		string(makefileBytes)+`\ncheck-format go-lint python-lint python-test test-openapi-pages-artifact test-live-provider-harness:
+	@:
+
+go-test:
+	@if [ -n "$${COVERAGE_FILE:-}" ]; then \
+		printf '%s\n' 'mode: count' 'fixture.go:1.1,1.2 1 1' >"$$COVERAGE_FILE"; \
+	fi
+`,
+		0o644,
+	)
+	for _, relativePath := range []string{
+		"package.json",
+		"package-lock.json",
+		filepath.Join("scripts", "run_ci.sh"),
+	} {
+		copyOperationalFile(
+			testingInstance,
+			filepath.Join(repositoryRoot, relativePath),
+			filepath.Join(fixtureRoot, relativePath),
+		)
+	}
+	writeOperationalFile(testingInstance, filepath.Join(fixtureRoot, "npm"), `#!/usr/bin/env bash
+set -euo pipefail
+
+builtin printf '%s|%s\n' "$*" "${PLAYWRIGHT_BROWSERS_PATH:?}" >>"${FRONTEND_NPM_LOG:?}"
+case "${1:?}" in
+  ci)
+    [[ "$#" -eq 1 ]]
+    mkdir -p node_modules/.bin
+    cp "${FRONTEND_PLAYWRIGHT_FIXTURE:?}" node_modules/.bin/playwright
+    chmod 755 node_modules/.bin/playwright
+    ;;
+  run)
+    [[ -f "${PLAYWRIGHT_BROWSERS_PATH}/.llm-proxy-frontend-dependencies" ]]
+    ;;
+  *)
+    exit 31
+    ;;
+esac
+`, 0o755)
+	writeOperationalFile(testingInstance, filepath.Join(fixtureRoot, "playwright"), `#!/usr/bin/env bash
+set -euo pipefail
+
+builtin printf 'playwright %s|%s\n' "$*" "${PLAYWRIGHT_BROWSERS_PATH:?}" >>"${FRONTEND_NPM_LOG:?}"
+[[ "$*" == "install --with-deps chromium" ]]
+mkdir -p "${PLAYWRIGHT_BROWSERS_PATH}"
+`, 0o755)
+	writeOperationalFile(testingInstance, filepath.Join(fixtureRoot, "go"), `#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "$#" -eq 3 ]]
+[[ "$1" == "tool" ]]
+[[ "$2" == "cover" ]]
+[[ -s "${3#-func=}" ]]
+builtin printf 'total:\t(statements)\t100.0%%\n'
+`, 0o755)
+}


### PR DESCRIPTION
## Summary

This change ensures that all frontend validation targets (`make test`, `make ci`, and focused `make` targets) are now truly self-contained: they automatically prepare the exact pinned npm dependencies and a project-local Playwright Chromium install before running any frontend validation.

## Why

- Previously, CI workflows installed frontend dependencies and Playwright’s Chromium browser separately, while the Makefile assumed those dependencies were present. This led to discrepancies, particularly when running on a clean checkout or agentic execution, where frontend tests could fail due to missing dependencies or browser binaries.
- The solution centralizes responsibility for frontend setup to the Makefile, making operational guarantees consistent across local and hosted environments.

## Highlights

- **Makefile Enhancements**: 
  - Introduces a `frontend-dependencies` target that installs the locked npm graph and the Playwright Chromium binary.
  - Frontend-related targets (`frontend-test`, `frontend-lint`, `test-management-auth-blackbox`, etc.) now depend on this setup.
  - Adds a dependency stamp file so set-up only re-runs if relevant files change.
- **CI Workflow Simplification**: 
  - Removes duplicate setup steps (`npm ci`, Playwright install) from the workflow.
  - Ensures all frontend validation