### PR TITLE
Fix B097 typed sanitized client failures

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -47,6 +47,41 @@ explicit caller completion-budget exhaustion, not missing B077 activation.
 
 ## BugFixes
 
+- [x] [B097] (P1) Return typed sanitized failures from the official Go client.
+  Goal:
+  Let server-side callers classify authentication, rate-limit, proxy
+  work-budget, and upstream-availability failures without parsing formatted
+  error strings or retaining raw response bodies.
+  Evidence:
+  - `pkg/llmproxyclient` returns only `ErrClientHTTPFailure` plus a formatted
+    `status=<n> body=<raw>` string for every non-2xx response.
+  - The public proxy publishes four stable JSON error codes for invalid request
+    timeouts, provider failures, provider rate limits, and proxy work-budget
+    expiry.
+  Requirements:
+  - Return one typed official-client failure for every completed non-2xx HTTP
+    response, with read-only HTTP status and recognized stable proxy error-code
+    accessors.
+  - Preserve `errors.Is(error, ErrClientHTTPFailure)` while supporting
+    `errors.As` for the typed failure.
+  - Exclude raw response bodies from the returned error.
+  - Keep transport and read failures distinct from completed HTTP responses.
+  Validation:
+  - Exercise the public Go client through a fake HTTP server for structured and
+    unstructured non-2xx responses.
+  - Prove typed status and code values, sentinel identity, sanitized error text,
+    and rejection of unknown or malformed error codes.
+  - Run final `timeout -k 350s -s SIGKILL 350s make ci`.
+  Resolution:
+  - Completed non-2xx responses now return a sanitized `HTTPFailure` with
+    read-only status and recognized proxy error-code accessors while preserving
+    `ErrClientHTTPFailure` identity. Raw bodies remain outside the returned
+    error, and transport and response-read failures retain their distinct path.
+  - Fake-server coverage passes for all four published codes and for
+    unstructured, malformed, and unknown bodies. The focused Go gate passed at
+    100.0% statement coverage, and final `make ci` passed all 11 gates in 102
+    seconds with 100.0% Go statement coverage.
+
 - [x] [B125] (P1) {I219} Isolate and stop public-capability test servers.
   Goal:
   Keep frontend and Pages artifact validation deterministic and free of

--- a/README.md
+++ b/README.md
@@ -1947,6 +1947,14 @@ caller's independent cancellation authority, and the injected `HTTPDoer` may
 have its own explicitly selected transport policy. The package does not add a
 total-response timeout.
 
+Every completed non-2xx response returns an `*llmproxyclient.HTTPFailure`.
+Use `errors.As` to read its `StatusCode()` and recognized stable
+`ProxyErrorCode()` values; `errors.Is(err,
+llmproxyclient.ErrClientHTTPFailure)` also remains true. Raw response bodies
+are never included in or exposed by the returned error. Transport and response
+read failures preserve `ErrClientHTTPFailure` without fabricating a completed
+HTTP status.
+
 To upgrade the Go package and CLI:
 
 ```shell

--- a/pkg/llmproxyclient/client.go
+++ b/pkg/llmproxyclient/client.go
@@ -442,12 +442,7 @@ func (client Client) postPayload(contextValue context.Context, requestURL url.UR
 		return "", fmt.Errorf("%w: read response body: %v", ErrClientHTTPFailure, readError)
 	}
 	if httpResponse.StatusCode < http.StatusOK || httpResponse.StatusCode >= http.StatusMultipleChoices {
-		return "", fmt.Errorf(
-			"%w: status=%d body=%q",
-			ErrClientHTTPFailure,
-			httpResponse.StatusCode,
-			strings.TrimSpace(string(responseBody)),
-		)
+		return "", newHTTPFailure(httpResponse.StatusCode, responseBody)
 	}
 	return string(responseBody), nil
 }

--- a/pkg/llmproxyclient/client_test.go
+++ b/pkg/llmproxyclient/client_test.go
@@ -188,6 +188,107 @@ func TestClientPostMessagesSendsV2MessagesBody(testingInstance *testing.T) {
 	}
 }
 
+func TestClientReturnsTypedSanitizedHTTPFailures(testingInstance *testing.T) {
+	testCases := []struct {
+		name                   string
+		statusCode             int
+		responseBody           string
+		expectedProxyErrorCode string
+	}{
+		{
+			name:                   "recognized request timeout",
+			statusCode:             http.StatusGatewayTimeout,
+			responseBody:           `{"error":{"code":"request_timeout","request_timeout_seconds":360,"private_detail":"never expose this"}}`,
+			expectedProxyErrorCode: llmproxycontract.ErrorCodeRequestTimeout,
+		},
+		{
+			name:                   "recognized provider rate limit",
+			statusCode:             http.StatusTooManyRequests,
+			responseBody:           `{"error":{"code":"provider_rate_limited","provider":"openai","private_detail":"never expose this"}}`,
+			expectedProxyErrorCode: llmproxycontract.ErrorCodeProviderRateLimited,
+		},
+		{
+			name:                   "recognized invalid request timeout",
+			statusCode:             http.StatusBadRequest,
+			responseBody:           `{"error":{"code":"invalid_request_timeout","private_detail":"never expose this"}}`,
+			expectedProxyErrorCode: llmproxycontract.ErrorCodeInvalidRequestTimeout,
+		},
+		{
+			name:                   "recognized provider failure",
+			statusCode:             http.StatusBadGateway,
+			responseBody:           `{"error":{"code":"provider_error","private_detail":"never expose this"}}`,
+			expectedProxyErrorCode: llmproxycontract.ErrorCodeProviderError,
+		},
+		{
+			name:         "unstructured authentication failure",
+			statusCode:   http.StatusForbidden,
+			responseBody: "forbidden raw body never expose this",
+		},
+		{
+			name:         "malformed structured failure",
+			statusCode:   http.StatusBadGateway,
+			responseBody: `{"error":{"code":`,
+		},
+		{
+			name:         "unknown error code",
+			statusCode:   http.StatusBadRequest,
+			responseBody: `{"error":{"code":"unknown_private_code","private_detail":"never expose this"}}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+				responseWriter.WriteHeader(testCase.statusCode)
+				_, _ = responseWriter.Write([]byte(testCase.responseBody))
+			}))
+			defer server.Close()
+
+			config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{
+				BaseURL: server.URL,
+				Secret:  "sekret",
+			})
+			if configError != nil {
+				subTest.Fatalf("config error: %v", configError)
+			}
+			client, clientError := llmproxyclient.NewClient(config, server.Client())
+			if clientError != nil {
+				subTest.Fatalf("client error: %v", clientError)
+			}
+			request, requestError := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+				Messages: []llmproxyclient.MessageInput{{Role: "user", Content: "Classify safely"}},
+			})
+			if requestError != nil {
+				subTest.Fatalf("request error: %v", requestError)
+			}
+
+			_, postError := client.PostMessages(context.Background(), request)
+			if !errors.Is(postError, llmproxyclient.ErrClientHTTPFailure) {
+				subTest.Fatalf("post error=%v does not preserve HTTP failure sentinel", postError)
+			}
+			var httpFailure *llmproxyclient.HTTPFailure
+			if !errors.As(postError, &httpFailure) {
+				subTest.Fatalf("post error=%T %v is not a typed HTTP failure", postError, postError)
+			}
+			if httpFailure.StatusCode() != testCase.statusCode {
+				subTest.Fatalf("status=%d want=%d", httpFailure.StatusCode(), testCase.statusCode)
+			}
+			if httpFailure.ProxyErrorCode() != testCase.expectedProxyErrorCode {
+				subTest.Fatalf(
+					"proxy error code=%q want=%q",
+					httpFailure.ProxyErrorCode(),
+					testCase.expectedProxyErrorCode,
+				)
+			}
+			if strings.Contains(postError.Error(), "never expose this") ||
+				strings.Contains(postError.Error(), "unknown_private_code") ||
+				strings.Contains(postError.Error(), `{"error"`) {
+				subTest.Fatalf("typed HTTP failure exposed raw response body: %v", postError)
+			}
+		})
+	}
+}
+
 func loadCanonicalOpenAPIContract(testingInstance *testing.T) *openapitest.Contract {
 	testingInstance.Helper()
 	contract, loadError := openapitest.Load(filepath.Join("..", "..", openapitest.CanonicalDocumentPath))

--- a/pkg/llmproxyclient/http_failure.go
+++ b/pkg/llmproxyclient/http_failure.go
@@ -1,0 +1,72 @@
+package llmproxyclient
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
+)
+
+// HTTPFailure is a completed non-2xx llm-proxy response. It exposes only the
+// safe status and recognized stable proxy error code; the raw response body is
+// deliberately unavailable.
+type HTTPFailure struct {
+	statusCode     int
+	proxyErrorCode string
+}
+
+// Error reports the sanitized completed-response failure.
+func (failure *HTTPFailure) Error() string {
+	if failure.proxyErrorCode == "" {
+		return fmt.Sprintf("%s: status=%d", ErrClientHTTPFailure, failure.statusCode)
+	}
+	return fmt.Sprintf(
+		"%s: status=%d code=%s",
+		ErrClientHTTPFailure,
+		failure.statusCode,
+		failure.proxyErrorCode,
+	)
+}
+
+// Unwrap preserves errors.Is(error, ErrClientHTTPFailure).
+func (failure *HTTPFailure) Unwrap() error {
+	return ErrClientHTTPFailure
+}
+
+// StatusCode returns the proxy HTTP response status.
+func (failure *HTTPFailure) StatusCode() int {
+	return failure.statusCode
+}
+
+// ProxyErrorCode returns the recognized stable proxy error code, or an empty
+// string when the response has no recognized structured error code.
+func (failure *HTTPFailure) ProxyErrorCode() string {
+	return failure.proxyErrorCode
+}
+
+func newHTTPFailure(statusCode int, responseBody []byte) *HTTPFailure {
+	return &HTTPFailure{
+		statusCode:     statusCode,
+		proxyErrorCode: recognizedProxyErrorCode(responseBody),
+	}
+}
+
+func recognizedProxyErrorCode(responseBody []byte) string {
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if decodeError := json.Unmarshal(responseBody, &envelope); decodeError != nil {
+		return ""
+	}
+	switch envelope.Error.Code {
+	case llmproxycontract.ErrorCodeInvalidRequestTimeout,
+		llmproxycontract.ErrorCodeProviderError,
+		llmproxycontract.ErrorCodeProviderRateLimited,
+		llmproxycontract.ErrorCodeRequestTimeout:
+		return envelope.Error.Code
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary
- return a typed `HTTPFailure` for every completed non-2xx official Go client response
- expose only the HTTP status and recognized stable proxy error code while preserving `errors.Is(..., ErrClientHTTPFailure)`
- keep raw response bodies out of returned errors and retain distinct transport/read failure paths
- document the client contract and resolve B097 in the repository tracker

## Validation
- `timeout -k 350s -s SIGKILL 350s make go-test` — passed with 100.0% Go statement coverage
- `timeout -k 350s -s SIGKILL 350s make ci` — passed all 11 gates in 102 seconds with 100.0% Go statement coverage

## Plan
- preserve the current official Go client contract while replacing raw-body HTTP errors with a typed sanitized failure
- cover every published stable proxy error code plus unstructured, malformed, and unknown response bodies through the public client and a fake HTTP server
- align README and B097 tracker documentation
- validate, commit, push, and open this ready pull request against `master`
