### PR TITLE
feat(catalog): centralize model operation capabilities and pricing

### DIFF
--- a/.mprlab/ISSUES-ARCHIVE.md
+++ b/.mprlab/ISSUES-ARCHIVE.md
@@ -17,6 +17,8 @@ Archive passes:
   managed data to schema version 4.
 - 2026-08-10: Archived I221 after normalizing model identity and provider
   offerings.
+- 2026-08-10: Archived I216 after publishing the authoritative model-operation
+  capability and pricing catalog.
 
 `CHANGELOG.md` remains the release-level history. This index keeps completed
 issue titles discoverable without making the active tracker noisy.
@@ -2891,6 +2893,64 @@ issue titles discoverable without making the active tracker noisy.
 
 
 ### Complete entries archived 2026-08-10
+
+- [x] [I216] (P0) Make one model-operation capability and pricing catalog authoritative.
+  Goal:
+  Publish one tenant-safe catalog for every provider-backed model operation.
+  Use it for planning, routing, validation, pricing, public discovery, and
+  official clients.
+  Cross-repository source:
+  - Completed MediaOps I068 supplies exact condition matching and reviewed
+    pricing records for the bounded import into LLM Proxy.
+  Requirements:
+  - Extend the normalized I221 catalog with credential kinds, operation kinds,
+    pricing, controls, enums, bounds, account-dependent limits, and artifact
+    types.
+  - Add typed prices with components, currency, units, exact conditions,
+    minimum charges, official source, verification date, and an explicit
+    unavailable reason.
+  - Require exact price-condition matches. Missing, incomplete, or conflicting
+    conditions must return a typed unavailable result.
+  - Keep observed provider usage as execution evidence separate from published
+    pricing and management usage telemetry.
+  - Use organization-level canonical provider identifiers at shared credential
+    boundaries. Keep `gemini` and `vertex` distinct because they use different
+    APIs and credentials. Make `xai` canonical for xAI text and video, migrate
+    persisted managed `grok` routes once, and remove the dual selector.
+  - Expose one catalog service consumed by the later
+    `GET /model/v1/capabilities` handler, planning validation, the public
+    catalog, and provider-management choices.
+  - Import the stabilized MediaOps pricing data in one bounded migration and
+    remove each migrated MediaOps provider record during its family cutover.
+  Deliverables:
+  - Add the catalog types, strict loader, deterministic public projection,
+    exact price selector, one-off xAI route migration, and generated docs.
+  - Add catalog revision identifiers that bind plans to the exact capability
+    and pricing snapshot used to create them.
+  Validation:
+  - Prove all accepted operation routes and prices are catalog-backed and that
+    unknown fields, duplicate identifiers, unsupported credential/lifecycle
+    pairs, and ambiguous prices fail startup.
+  - Prove the public projection excludes credentials, private account state,
+    provider handles, and tenant defaults.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+  Resolved 2026-08-10:
+  - Catalog revision `2026-08-10.i216.1` now defines operation artifacts,
+    provider credential kinds, exact offerings, controls, limits, and one typed
+    price descriptor for every offering operation.
+  - Exact condition selection imports the reviewed xAI video rates from
+    MediaOps I068 and returns typed unavailable results for every missing or
+    incomplete match. Historical managed usage remains separate telemetry.
+  - `xai` is the sole current provider identifier. Schema version 6 re-encrypts
+    stored `grok` credentials for `xai`, rewrites current text and dictation
+    defaults once, and preserves historical `grok` usage unchanged.
+  - Public REST data, OpenAPI, generated site content, runtime configuration,
+    management choices, and the catalog service share the same validated
+    snapshot without provider-native models, credentials, tenant defaults, or
+    private account state.
+  - The final `make ci` passed all 11 reported gates with 100.0% Go statement
+    coverage and 90 browser scenarios.
 
 - [x] [I221] (P0) Make model identity independent from provider offerings.
   Goal:

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1026,11 +1026,11 @@ retain satisfied historical dependencies.
 
 ## Features
 
-- [ ] [F033] (P0) {F022} Support large media in canonical message requests.
+- [ ] [F033] (P0) {F022} Pass canonical message media to selected providers.
   Goal:
-  Let `/v2` callers reference tenant assets when inline media would exceed
-  `max_prompt_bytes`. Keep the JSON request limit. Preserve exact media bytes,
-  order, MIME type, and SHA-256.
+  Let `/v2` accept provider-neutral media without a smaller LLM Proxy media
+  limit. Translate each attachment into the selected provider's supported
+  transport. Preserve exact media bytes, order, MIME type, and SHA-256.
 
   Observed failure:
   - Creative Director sends `master-character-sheet.png` through
@@ -1040,74 +1040,105 @@ retain satisfied historical dependencies.
   - The deployed capability resource reports `max_prompt_bytes: 4194304`.
   - LLM Proxy returns HTTP 413 `prompt payload too large` before Gemini
     receives the image.
+  - Gemini permits this request under its documented inline request limit.
   - Creative Director receives no QA result. It cannot produce the next
     MediaOps operation.
-  - The current Go client accepts the PNG. It cannot compare the serialized
-    request with the deployed request limit.
+
+  Provider limit evidence:
+  - The following provider limits were verified on 2026-08-10.
+  - Gemini Interactions permits 20 MB for a request with inline image data.
+    This total includes text, system instructions, and inline bytes. Gemini
+    permits 3,600 image files per request. Gemini directs larger requests to
+    its Files API:
+    https://ai.google.dev/gemini-api/docs/image-understanding
+  - OpenAI vision permits a 512 MB total request payload. It permits 1,500
+    image inputs per request:
+    https://developers.openai.com/api/docs/guides/images-vision
+  - Anthropic Messages permits a 32 MB request. The direct Claude API permits
+    10 MB for each base64 image:
+    https://platform.claude.com/docs/en/api/errors
+    https://platform.claude.com/docs/en/build-with-claude/vision
+  - Anthropic permits 100 images for models with a 200,000-token context.
+    Anthropic permits 600 images for other models.
+  - xAI permits 20 MiB for each image. xAI publishes no image-count limit:
+    https://docs.x.ai/developers/model-capabilities/images/understanding
+  - These values are provider facts. They do not define one proxy limit.
+  - LLM Proxy currently routes message media only to Gemini. Other values
+    define contracts for future provider adapters.
 
   Contract gap:
-  - The current `/v2` contract supports only inline base64 media.
-  - F022 defines streaming asset upload. It does not connect uploaded assets
-    to blocking message attachments.
-  - A configured model can support an image that the public request transport
-    cannot carry.
+  - The current `/v2` contract applies one 4 MiB limit before provider
+    dispatch.
+  - The selected Gemini provider permits the rejected request.
+  - One proxy limit cannot represent different provider limits or transports.
+  - F022 defines asset upload. It does not connect assets to `/v2` attachments.
 
   Requirements:
-  - Use the F022 tenant asset store as the large-media input boundary.
+  - Use the F022 tenant asset store for asset-backed attachments.
   - Add an asset-reference variant to the canonical user-message attachment
     union.
   - Require `type`, `asset_id`, `mime_type`, and `sha256` in each asset
     reference.
   - Reject an attachment that contains both `data` and `asset_id`.
-  - Keep inline base64 attachments for requests that satisfy
-    `max_prompt_bytes`.
-  - Apply `max_prompt_bytes` only to the JSON body. Apply separate limits to
-    resolved asset bytes.
-  - Publish the attachment count, per-asset byte limit, and aggregate media
-    byte limit in public capabilities.
+  - Remove `server.max_prompt_bytes` as a provider-independent `/v2` media
+    admission rule.
+  - Do not define a smaller proxy-owned media limit.
+  - Apply the selected provider offering limits before provider dispatch.
+  - Count bytes with the selected provider's documented unit and scope.
+  - Include base64 expansion only when the provider counts encoded request
+    bytes.
+  - Send inline media when the selected provider accepts that transport and
+    size.
+  - Use provider file upload when the selected provider requires that
+    transport for the media size.
+  - Return a stable provider-limit error when no provider transport accepts
+    the media.
+  - Send the request when the provider publishes no applicable limit.
+  - Map a provider limit response into the stable LLM Proxy error contract.
+  - Keep provider limits in provider offering data, not one server setting.
+  - Add media limits only to provider offerings that declare the media input.
+  - Publish each limit's value, unit, scope, source, and verification date.
+  - Represent an explicit provider no-limit value as `unbounded`.
+  - Represent an unpublished provider limit as `unknown`.
+  - Reverify provider limits during implementation.
   - Validate tenant ownership, asset state, expiry, MIME type, size, and
     SHA-256 before provider dispatch.
   - Preserve message order and attachment order after asset resolution.
-  - Translate each resolved asset into the selected provider's exact media
-    input shape.
   - Preserve caller bytes without resize, compression, or format conversion.
   - Keep caller filesystem paths outside the HTTP contract.
-  - Return stable errors for missing, foreign, expired, oversized, mismatched,
-    and unsupported assets.
   - Exclude asset bytes and authenticated asset URLs from logs, responses, and
     usage records.
   - Add official-client constructors for asset-backed image and audio
     attachments.
-  - Expose the serialized JSON byte count before an official client submits a
-    request.
 
   Deliverables:
-  - Add the OpenAPI asset-reference schemas and canonical message request
-    union.
-  - Add tenant asset resolution and provider adapter integration.
-  - Add public capability limits and official-client support.
+  - Add the OpenAPI asset-reference schema and provider limit schema.
+  - Add tenant asset resolution and provider transport selection.
+  - Add provider offering limits to the public capability resource.
+  - Add official-client support for asset-backed attachments and provider
+    limits.
   - Update the root README, API reference, provider routing guide, and release
     notes.
 
   Validation:
-  - Use a 3,326,724-byte image fixture with a 4,194,304-byte JSON limit.
-  - Upload the fixture through F022. Send one `/v2` asset reference.
-  - Prove the JSON stays below the limit. Prove the fake Gemini adapter
-    receives the exact original bytes, MIME type, SHA-256, and order.
-  - Send the same bytes as inline base64. Require HTTP 413 before provider
-    dispatch.
-  - Send a JSON-only request above the limit. Require the same bounded HTTP
-    413 result.
-  - Cover missing, foreign, expired, deleted, oversized, wrong-MIME, and
-    wrong-digest assets.
-  - Cover one image, ordered images, audio, mixed media, count limits, and
-    aggregate byte limits.
+  - Send the 3,326,724-byte image inline through `/v2` to fake Gemini.
+  - Require provider dispatch without a proxy 413 response.
+  - Upload the same fixture through F022. Send one `/v2` asset reference.
+  - Require fake Gemini to receive the exact bytes, MIME type, SHA-256, and
+    order.
+  - Do a test of each provider boundary at the limit and one unit above it.
+  - Do a test of Gemini inline and Files API transport selection.
+  - Do a test of each documented provider limit record.
+  - Prove no provider-valid request fails because of a smaller proxy limit.
+  - Cover missing, foreign, expired, deleted, wrong-MIME, and wrong-digest
+    assets.
+  - Cover one image, ordered images, audio, and mixed media.
   - Prove asset cleanup cannot change an admitted request or expose another
     tenant's asset.
   - Prove logs, errors, responses, and usage records contain no asset bytes or
     authenticated asset URLs.
-  - Exercise the public router and every released official client against a
-    fake provider.
+  - Exercise the public router and every released official client against fake
+    providers.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair.
 

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -173,47 +173,38 @@ retain satisfied historical dependencies.
     `timeout -k 350s -s SIGKILL 350s make ci` pair.
 ## Improvements
 
-- [ ] [I216] (P0) Make one model-operation capability and pricing catalog authoritative.
+- [ ] [I041] (P1) Migrate xAI text routes to Responses without OpenAI background assumptions.
   Goal:
-  Publish one tenant-safe catalog for every provider-backed model operation.
-  Use it for planning, routing, validation, pricing, public discovery, and
-  official clients.
-  Cross-repository source:
-  - Completed MediaOps I068 supplies exact condition matching and reviewed
-    pricing records for the bounded import into LLM Proxy.
+  Move Grok models off xAI's deprecated Chat Completions surface while
+  preserving xAI's actual synchronous Responses behavior.
+  Evidence:
+  - xAI calls Responses its preferred API and Chat Completions deprecated:
+    https://docs.x.ai/developers/model-capabilities/text/comparison
+  - xAI Responses supports typed output and optional stored conversation state,
+    but its `background` field is currently compatibility-only and unused:
+    https://docs.x.ai/developers/rest-api-reference/inference/chat
+  - xAI separately exposes Deferred Chat Completions with `202` polling and a
+    final result retrievable exactly once, but that operation belongs to the
+    deprecated Chat family:
+    https://docs.x.ai/developers/advanced-api-usage/deferred-chat-completions
   Requirements:
-  - Extend the normalized I221 catalog with credential kinds, operation kinds,
-    pricing, controls, enums, bounds, account-dependent limits, and artifact
-    types.
-  - Add typed prices with components, currency, units, exact conditions,
-    minimum charges, official source, verification date, and an explicit
-    unavailable reason.
-  - Require exact price-condition matches. Missing, incomplete, or conflicting
-    conditions must return a typed unavailable result.
-  - Keep observed provider usage as execution evidence separate from published
-    pricing and management usage telemetry.
-  - Use organization-level canonical provider identifiers at shared credential
-    boundaries. Keep `gemini` and `vertex` distinct because they use different
-    APIs and credentials. Make `xai` canonical for xAI text and video, migrate
-    persisted managed `grok` routes once, and remove the dual selector.
-  - Expose one catalog service consumed by the later
-    `GET /model/v1/capabilities` handler, planning validation, the public
-    catalog, and provider-management choices.
-  - Import the stabilized MediaOps pricing data in one bounded migration and
-    remove each migrated MediaOps provider record during its family cutover.
-  Deliverables:
-  - Add the catalog types, strict loader, deterministic public projection,
-    exact price selector, one-off xAI route migration, and generated docs.
-  - Add catalog revision identifiers that bind plans to the exact capability
-    and pricing snapshot used to create them.
+  - Verify Responses support for every configured Grok model and migrate each
+    eligible model to an xAI-owned Responses codec. Do not reuse OpenAI's
+    request builder or terminal-state parser merely because the endpoint path
+    and typed output resemble OpenAI.
+  - Omit `background` and register the lifecycle as synchronous. Parse xAI
+    output, reasoning, usage, errors, storage controls, and output limits from
+    xAI's schema.
+  - Keep proxy requests stateless by default and document any approved use of
+    xAI's 30-day stored response state. Do not retrieve a completed stored
+    response as if it were an in-progress job.
+  - Do not adopt Deferred Chat merely to manufacture polling. If xAI later
+    offers deferred execution on its current Responses contract, audit that
+    lifecycle in a separate issue.
   Validation:
-  - Prove all accepted operation routes and prices are catalog-backed and that
-    unknown fields, duplicate identifiers, unsupported credential/lifecycle
-    pairs, and ambiguous prices fail startup.
-  - Prove the public projection excludes credentials, private account state,
-    provider handles, and tenant defaults.
-  - Run the required baseline and final
-    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+  - Public fixtures prove xAI Responses request/response mapping, synchronous
+    continuation, storage policy, usage, safe errors, and absence of
+    `background` polling. Existing xAI speech routing remains independent.
 
 - [ ] [I218] (P1) Expand the product node into integration routes.
   Goal:
@@ -378,34 +369,6 @@ retain satisfied historical dependencies.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair for the implementation, with
     the final run after the last code edit.
-- [ ] [I038] (P2) Adopt DashScope's synchronous Responses API without background mode.
-  Goal:
-  Move eligible DashScope Qwen models from Chat Completions to Alibaba's newer
-  Responses wire format while retaining its explicitly synchronous lifecycle.
-  Evidence:
-  - Alibaba documents an OpenAI-compatible Responses endpoint with typed output,
-    tools, `previous_response_id`, and storage controls:
-    https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-responses
-  - The same reference states that `background` is unsupported and that only
-    synchronous calls are processed. Unlisted OpenAI fields may be ignored.
-  Requirements:
-  - Verify the Responses support matrix for every configured DashScope model.
-    Migrate supported models to a dedicated DashScope Responses wire adapter;
-    leave any unsupported model on one explicitly registered current contract
-    rather than trying Responses and falling back at runtime.
-  - Send only Alibaba-documented fields and omit `background`. Parse typed
-    output items, incomplete status, Qwen reasoning usage, and provider errors
-    from the Alibaba schema rather than the OpenAI schema by assumption.
-  - Keep public proxy calls stateless unless a separately approved retention
-    contract requires stored provider state. Do not adopt
-    `previous_response_id`, conversations, built-in tools, or default storage
-    merely because the fields exist.
-  - Use output-limit continuation only after a terminal incomplete result.
-    Never issue `GET /responses/{id}` as a progress poll.
-  Validation:
-  - Public black-box tests prove the eligible-model request shape, typed text
-    extraction, synchronous incomplete continuation, usage, safe errors, and
-    rejection of accidental `background` or unsupported OpenAI-only fields.
 - [ ] [I207] (P1) Add Gemini 3.6 Flash with route-bound Interactions thinking levels.
   Goal:
   Add Google's current stable Flash model to the Gemini Interactions catalog
@@ -475,38 +438,128 @@ retain satisfied historical dependencies.
     create/poll/delete flow for `gemini-3.6-flash`. The final `make ci` passes
     after the last implementation edit; deployment and production acceptance
     remain operator-owned.
-- [ ] [I041] (P2) {I216} Migrate Grok to xAI Responses without OpenAI background assumptions.
+- [ ] [I027] (P1) Redesign the user dashboard around connected-provider widgets.
   Goal:
-  Move Grok off xAI's deprecated Chat Completions surface while preserving
-  xAI's actual synchronous Responses behavior.
-  Evidence:
-  - xAI calls Responses its preferred API and Chat Completions deprecated:
-    https://docs.x.ai/developers/model-capabilities/text/comparison
-  - xAI Responses supports typed output and optional stored conversation state,
-    but its `background` field is currently compatibility-only and unused:
-    https://docs.x.ai/developers/rest-api-reference/inference/chat
-  - xAI separately exposes Deferred Chat Completions with `202` polling and a
-    final result retrievable exactly once, but that operation belongs to the
-    deprecated Chat family:
-    https://docs.x.ai/developers/advanced-api-usage/deferred-chat-completions
+  Make the authenticated dashboard answer, at a glance, which upstream
+  providers the selected Usage scope has connected. Preserve usage reporting as
+  a separate measure of activity so an unused connected provider remains
+  visible and historical traffic never implies that a provider is still
+  connected.
+  Current scope:
+  - Usage is account-wide by default and has an independent tenant filter. One
+    selected Usage tenant shows that tenant's connections. `All tenants` shows
+    tenant-labelled connections across all owned tenants. The Settings tenant
+    does not control the dashboard projection.
   Requirements:
-  - Verify Responses support for every configured Grok model and migrate each
-    eligible model to an xAI-owned Responses codec. Do not reuse OpenAI's
-    request builder or terminal-state parser merely because the endpoint path
-    and typed output resemble OpenAI.
-  - Omit `background` and register the lifecycle as synchronous. Parse xAI
-    output, reasoning, usage, errors, storage controls, and output limits from
-    xAI's schema.
-  - Keep proxy requests stateless by default and document any approved use of
-    xAI's 30-day stored response state. Do not retrieve a completed stored
-    response as if it were an in-progress job.
-  - Do not adopt Deferred Chat merely to manufacture polling. If xAI later
-    offers deferred execution on its current Responses contract, audit that
-    lifecycle in a separate issue.
+  - Define a connected provider solely from canonical authenticated profile
+    data whose `has_key` value is `true`. Do not infer connection from catalog
+    membership, aliases, routing defaults, local environment credentials, or a
+    provider's presence in historical usage.
+  - Add a prominent `Connected providers` section to the user usage dashboard
+    and render exactly one widget for each tenant/provider connection in the
+    selected Usage scope. An explicit tenant uses that profile's deterministic
+    provider order. `All tenants` groups connections by account tenant order and
+    then provider order, labels every group with tenant name and opaque ID, and
+    does not merge the same provider across two tenants. Do not hard-code
+    provider names or duplicate provider-registration state in the browser.
+  - Give each widget a concise, consistent summary: the profile label,
+    `Connected` status, saved text model, declared text/dictation capabilities,
+    and current-period request and token totals matched by exact canonical
+    provider ID. A connected provider with no usage in the period must still
+    render with zero activity. A usage-load failure must render as unavailable,
+    not as a false zero or a disconnected provider.
+  - Add a provider-specific `Manage` action that opens Settings with that exact
+    tenant and provider selected without changing the Usage tenant filter. It
+    must not reveal a key, invoke the key-reveal endpoint, or alter
+    provider/default settings merely by opening the editor.
+  - Replace the ambiguous usage-derived `Providers` summary metric with a
+    `Connected providers` count derived from the same scope-correct `has_key`
+    projection. Under `All tenants`, count tenant/provider connections rather
+    than deduplicated provider IDs.
+    Keep provider/model usage breakdowns explicitly labeled as activity for the
+    selected reporting period, including historical rows for providers that are
+    no longer connected.
+  - Render a purposeful empty state when no providers are connected, with one
+    action that opens Settings. The state must coexist with mandatory onboarding
+    and must not create a path around its persisted-key requirements.
+  - Keep the widgets synchronized with canonical profile state: a successful
+    provider-key autosave adds its widget, a successful removal removes it,
+    failed mutations leave the current projection unchanged, and dashboard
+    refresh reloads both connection state and usage for the selected Usage
+    scope. Never let an out-of-order response restore stale connection state.
+  - Treat widgets as non-secret metadata. Never render provider API keys,
+    masked-key suffixes, client keys, system prompts, or credential-bearing
+    values in widget text, attributes, accessible names, or browser storage.
+  - Use semantic headings and per-provider articles, unique accessible action
+    names such as `Manage OpenAI`, full keyboard operation, and a responsive
+    grid that remains aligned without horizontal overflow on narrow screens.
+    Keep the provider widgets confined to the current user's owned tenants. The
+    admin dashboard must not project another tenant's provider credentials or
+    connection state.
+  - Add one canonical owner-wide safe connection projection because the account
+    summary does not contain provider `has_key` facts and the browser must not
+    fan out profile requests under `All tenants`. Preserve the existing tenant
+    profile as the canonical explicitly selected-tenant projection. Do not add
+    cached shadow state, compatibility aliases, fallback matching, or expose
+    masked/raw key material in the owner-wide response.
+  - Update dashboard and self-service documentation so `connected provider` and
+    `active provider` have explicit, non-overlapping meanings.
+  Deliverables:
+  - Add the connected-provider widget grid, connected count, provider-specific
+    Settings navigation, empty/error states, and responsive styling to the user
+    dashboard.
+  - Add the owner-wide safe connection projection plus one derived presentation
+    model that joins tenant/provider connections to usage by exact canonical IDs
+    while keeping registration authoritative to `has_key`.
+  - Update first-party frontend types, copy, documentation, and rendered-browser
+    coverage for the final dashboard contract.
   Validation:
-  - Public fixtures prove xAI Responses request/response mapping, synchronous
-    continuation, storage policy, usage, safe errors, and absence of
-    `background` polling; existing xAI speech routing remains independent.
+  - Add Playwright scenarios for `All tenants` and one explicit Usage tenant.
+  - Cover zero, one, and multiple connected providers.
+  - Cover duplicate provider IDs in two tenants and deterministic group order.
+  - Cover a connected provider with zero activity.
+  - Cover an unconnected provider with historical activity.
+  - Cover exact model, capability, usage, and connected-provider count values.
+  - Prove successful key autosave/removal and dashboard refresh update the
+    widgets, while rejected or out-of-order requests do not mutate the visible
+    projection and usage failure leaves connection state intact with activity
+    marked unavailable.
+  - Prove each `Manage` action selects the intended Settings tenant and provider
+    without changing the Usage tenant or making a reveal/mutation request, no
+    secret-bearing value reaches the rendered dashboard or browser storage, and
+    admin/user dashboard switching preserves isolation.
+  - Cover keyboard navigation, accessible names, and desktop/narrow viewport
+    layout without overlap or horizontal overflow.
+  - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci`
+    pair for the implementation, with the final run after the last code edit.
+- [ ] [I038] (P2) Adopt DashScope's synchronous Responses API without background mode.
+  Goal:
+  Move eligible DashScope Qwen models from Chat Completions to Alibaba's newer
+  Responses wire format while retaining its explicitly synchronous lifecycle.
+  Evidence:
+  - Alibaba documents an OpenAI-compatible Responses endpoint with typed output,
+    tools, `previous_response_id`, and storage controls:
+    https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-responses
+  - The same reference states that `background` is unsupported and that only
+    synchronous calls are processed. Unlisted OpenAI fields may be ignored.
+  Requirements:
+  - Verify the Responses support matrix for every configured DashScope model.
+    Migrate supported models to a dedicated DashScope Responses wire adapter.
+    Leave any unsupported model on one explicitly registered current contract
+    rather than trying Responses and falling back at runtime.
+  - Send only Alibaba-documented fields and omit `background`. Parse typed
+    output items, incomplete status, Qwen reasoning usage, and provider errors
+    from the Alibaba schema rather than the OpenAI schema by assumption.
+  - Keep public proxy calls stateless unless a separately approved retention
+    contract requires stored provider state. Do not adopt
+    `previous_response_id`, conversations, built-in tools, or default storage
+    merely because the fields exist.
+  - Use output-limit continuation only after a terminal incomplete result.
+    Never issue `GET /responses/{id}` as a progress poll.
+  Validation:
+  - Public black-box tests prove the eligible-model request shape, typed text
+    extraction, synchronous incomplete continuation, usage, safe errors, and
+    rejection of accidental `background` or unsupported OpenAI-only fields.
 - [ ] [I035] (P2) Persist each user's selected Usage interval across sessions.
   Goal:
   Make the Usage Overview reopen with the last interval the authenticated user
@@ -733,105 +786,12 @@ retain satisfied historical dependencies.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair for the implementation, with
     the final run after the last code edit.
-- [ ] [I027] (P1) Redesign the user dashboard around connected-provider widgets.
-  Goal:
-  Make the authenticated dashboard answer, at a glance, which upstream
-  providers the selected Usage scope has connected. Preserve usage reporting as
-  a separate measure of activity so an unused connected provider remains
-  visible and historical traffic never implies that a provider is still
-  connected.
-  Current scope:
-  - Usage is account-wide by default and has an independent tenant filter. One
-    selected Usage tenant shows that tenant's connections. `All tenants` shows
-    tenant-labelled connections across all owned tenants. The Settings tenant
-    does not control the dashboard projection.
-  Requirements:
-  - Define a connected provider solely from canonical authenticated profile
-    data whose `has_key` value is `true`. Do not infer connection from catalog
-    membership, aliases, routing defaults, local environment credentials, or a
-    provider's presence in historical usage.
-  - Add a prominent `Connected providers` section to the user usage dashboard
-    and render exactly one widget for each tenant/provider connection in the
-    selected Usage scope. An explicit tenant uses that profile's deterministic
-    provider order. `All tenants` groups connections by account tenant order and
-    then provider order, labels every group with tenant name and opaque ID, and
-    does not merge the same provider across two tenants. Do not hard-code
-    provider names or duplicate provider-registration state in the browser.
-  - Give each widget a concise, consistent summary: the profile label,
-    `Connected` status, saved text model, declared text/dictation capabilities,
-    and current-period request and token totals matched by exact canonical
-    provider ID. A connected provider with no usage in the period must still
-    render with zero activity; a usage-load failure must render as unavailable,
-    not as a false zero or a disconnected provider.
-  - Add a provider-specific `Manage` action that opens Settings with that exact
-    tenant and provider selected without changing the Usage tenant filter. It
-    must not reveal a key, invoke the key-reveal endpoint, or alter
-    provider/default settings merely by opening the editor.
-  - Replace the ambiguous usage-derived `Providers` summary metric with a
-    `Connected providers` count derived from the same scope-correct `has_key`
-    projection. Under `All tenants`, count tenant/provider connections rather
-    than deduplicated provider IDs.
-    Keep provider/model usage breakdowns explicitly labeled as activity for the
-    selected reporting period, including historical rows for providers that are
-    no longer connected.
-  - Render a purposeful empty state when no providers are connected, with one
-    action that opens Settings. The state must coexist with mandatory onboarding
-    and must not create a path around its persisted-key requirements.
-  - Keep the widgets synchronized with canonical profile state: a successful
-    provider-key autosave adds its widget, a successful removal removes it,
-    failed mutations leave the current projection unchanged, and dashboard
-    refresh reloads both connection state and usage for the selected Usage
-    scope. Never let an out-of-order response restore stale connection state.
-  - Treat widgets as non-secret metadata. Never render provider API keys,
-    masked-key suffixes, client keys, system prompts, or credential-bearing
-    values in widget text, attributes, accessible names, or browser storage.
-  - Use semantic headings and per-provider articles, unique accessible action
-    names such as `Manage OpenAI`, full keyboard operation, and a responsive
-    grid that remains aligned without horizontal overflow on narrow screens.
-    Keep the provider widgets confined to the current user's owned tenants; the
-    admin dashboard must not project another tenant's provider credentials or
-    connection state.
-  - Add one canonical owner-wide safe connection projection because the account
-    summary does not contain provider `has_key` facts and the browser must not
-    fan out profile requests under `All tenants`. Preserve the existing tenant
-    profile as the canonical explicitly selected-tenant projection. Do not add
-    cached shadow state, compatibility aliases, fallback matching, or expose
-    masked/raw key material in the owner-wide response.
-  - Update dashboard and self-service documentation so `connected provider` and
-    `active provider` have explicit, non-overlapping meanings.
-  Deliverables:
-  - Add the connected-provider widget grid, connected count, provider-specific
-    Settings navigation, empty/error states, and responsive styling to the user
-    dashboard.
-  - Add the owner-wide safe connection projection plus one derived presentation
-    model that joins tenant/provider connections to usage by exact canonical IDs
-    while keeping registration authoritative to `has_key`.
-  - Update first-party frontend types, copy, documentation, and rendered-browser
-    coverage for the final dashboard contract.
-  Validation:
-  - Add Playwright scenarios for `All tenants` and one explicit Usage tenant;
-    zero, one, and multiple connected providers; duplicate provider IDs in two
-    tenants; deterministic grouping/order; a connected provider with zero
-    activity; an unconnected provider with historical activity; exact
-    model/capability and usage rendering; and the connected-provider count.
-  - Prove successful key autosave/removal and dashboard refresh update the
-    widgets, while rejected or out-of-order requests do not mutate the visible
-    projection and usage failure leaves connection state intact with activity
-    marked unavailable.
-  - Prove each `Manage` action selects the intended Settings tenant and provider
-    without changing the Usage tenant or making a reveal/mutation request, no
-    secret-bearing value reaches the rendered dashboard or browser storage, and
-    admin/user dashboard switching preserves isolation.
-  - Cover keyboard navigation, accessible names, and desktop/narrow viewport
-    layout without overlap or horizontal overflow.
-  - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci`
-    pair for the implementation, with the final run after the last code edit.
 ## Maintenance
 
 - [ ] [M021] (P1) {F024,F025,F026,F027} Remove the completed MediaOps operation-import bridge.
   Goal:
-  Leave only the canonical model-operation contract after every selected
-  MediaOps provider record has been migrated.
+  Leave only the canonical model-operation contract after migration of every
+  selected MediaOps provider record.
   Cross-repository prerequisite:
   - MediaOps M227 must produce the operator-held final per-tenant migration
     receipt and prove that every eligible legacy record is migrated or
@@ -852,72 +812,6 @@ retain satisfied historical dependencies.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair.
 
-- [ ] [M001R] (P2) Backlog hygiene and archive.
-  Goal:
-  Keep the issue tracker reliable, readable, and focused on active work while preserving resolved history in the appropriate archive.
-  Requirements:
-  - Cadence: run weekly during active development and before each release cut.
-  - Validate section names, identifier prefixes, recurrence suffixes, priority markers, dependencies, and duplicate IDs against the current `issues-md-format.md`.
-  - Reconcile stale statuses, duplicate issues, broken references, obsolete instructions, and entries filed under the wrong section.
-  - Move completed non-recurring history to the repository issue archive or durable documentation when the active tracker becomes noisy.
-  - Keep active, blocked, planning, and recurring entries visible in `ISSUES.md`.
-  Deliverables:
-  - Normalized `ISSUES.md` structure and statuses.
-  - Updated issue archive or docs when completed entries are removed from the active tracker.
-  - A short `Last run:` note summarizing the cleanup and any follow-up issues filed.
-  Validation:
-  - Re-read `ISSUES.md` after edits and confirm every issue is under the right section with a unique section-aware ID.
-  - Confirm recurring entries remain open and keep the `R` suffix.
-  - Confirm no active, blocked, recurring, or planning work was archived.
-  Last run: 2026-08-10. Reviewed 84 resolved or retired non-recurring issues
-  against current source and durable documentation. Archived 56 BugFixes, 22
-  Improvements, four Features, and two Planning issues. Kept all 44 current
-  open, blocked, Planning, and recurring entries active. Removed 28 satisfied
-  dependency tokens from 17 active entries during the archive pass.
-- [ ] [M002R] (P2) Polish open issues.
-  Goal:
-  Keep unresolved work executable by making each open issue concrete, ordered, and testable.
-  Requirements:
-  - Cadence: run weekly during active development and before handing a repo to automated execution.
-  - Review every unresolved non-recurring issue for missing context, dependencies, repro steps, acceptance criteria, and validation expectations.
-  - Make priorities concrete and ensure each open issue has actionable deliverables.
-  - Merge duplicate open issues or add explicit dependency links when separate entries must remain.
-  - Do not close or implement issues as part of this polish pass unless that work is separately requested.
-  Deliverables:
-  - Open issues with enough detail for a person or agent to execute without rediscovery.
-  - New or updated dependency markers where ordering matters.
-  - A short `Last run:` note listing the number of issues polished and any blockers found.
-  Validation:
-  - Sample the open entries after the pass and confirm each has clear next actions and validation expectations.
-  - Confirm no recurring runbook was marked complete.
-  - Confirm duplicates were merged or explicitly cross-referenced.
-  Last run: 2026-08-10. Audited all 46 unresolved entries from the archive
-  pass. Archived B099 because its merged contract is enforced. Archived B077
-  because its historical release contract is verified. Archived F018 because
-  I027 supersedes it. Archived I205 because it belongs to the ISSUES.md editor
-  repository. Added B126 for current release activation and P007 for the
-  Alibaba provider decision.
-  Added 11 dependency tokens, removed stale prerequisite prose, and demoted six
-  downstream or planning items to P2. The tracker now has 44 current entries:
-  42 open and two blocked. B126 and F021 each name one exact external action or
-  issue in their `Blocked:` line.
-- [ ] [M003R] (P2) Architecture and policy review.
-  Goal:
-  Catch architecture, policy, and workflow drift before it becomes hidden maintenance debt.
-  Requirements:
-  - Cadence: run monthly, before large refactors, and after major framework or runtime changes.
-  - Review the codebase, docs, and workflow against `AGENTS.md`, `POLICY.md`, stack guides, and the current architecture notes.
-  - Look for drift from forward-only contracts, edge-validation boundaries, smart-constructor usage, testing policy, and module ownership.
-  - Record findings as new Maintenance issues with concrete scope, priority, and validation.
-  - Close the pass with a no-action note only when the review finds no actionable drift.
-  Deliverables:
-  - New Maintenance issues for each actionable architecture or policy drift finding.
-  - Updated notes on areas reviewed and areas intentionally left unchanged.
-  - A short `Last run:` note with the review scope and outcome.
-  Validation:
-  - Confirm every finding is represented as an issue with owner-readable context and validation criteria.
-  - Confirm no implementation changes were mixed into the review runbook unless separately requested.
-  - Confirm all recurring runbooks remain open.
 - [ ] [M004R] (P1) Dependency and security audit.
   Goal:
   Keep third-party dependencies, runtime versions, and security-sensitive configuration within the current supported contract.
@@ -997,6 +891,72 @@ retain satisfied historical dependencies.
   The public Pages marker still reports `v0.3.0` and source commit
   `7917ce1ed824b9946d2a98a5a55b90c443db884a`. B126 owns that exact activation
   drift and the operator-held running-image receipt.
+- [ ] [M001R] (P2) Backlog hygiene and archive.
+  Goal:
+  Keep the issue tracker reliable, readable, and focused on active work while preserving resolved history in the appropriate archive.
+  Requirements:
+  - Cadence: run weekly during active development and before each release cut.
+  - Validate section names, identifier prefixes, recurrence suffixes, priority markers, dependencies, and duplicate IDs against the current `issues-md-format.md`.
+  - Reconcile stale statuses, duplicate issues, broken references, obsolete instructions, and entries filed under the wrong section.
+  - Move completed non-recurring history to the repository issue archive or durable documentation when the active tracker becomes noisy.
+  - Keep active, blocked, planning, and recurring entries visible in `ISSUES.md`.
+  Deliverables:
+  - Normalized `ISSUES.md` structure and statuses.
+  - Updated issue archive or docs when completed entries are removed from the active tracker.
+  - A short `Last run:` note summarizing the cleanup and any follow-up issues filed.
+  Validation:
+  - Re-read `ISSUES.md` after edits and confirm every issue is under the right section with a unique section-aware ID.
+  - Confirm recurring entries remain open and keep the `R` suffix.
+  - Confirm no active, blocked, recurring, or planning work was archived.
+  Last run: 2026-08-10. Reviewed 84 resolved or retired non-recurring issues
+  against current source and durable documentation. Archived 56 BugFixes, 22
+  Improvements, four Features, and two Planning issues. Kept all 44 current
+  open, blocked, Planning, and recurring entries active. Removed 28 satisfied
+  dependency tokens from 17 active entries during the archive pass.
+- [ ] [M002R] (P2) Polish open issues.
+  Goal:
+  Keep unresolved work executable by making each open issue concrete, ordered, and testable.
+  Requirements:
+  - Cadence: run weekly during active development and before handing a repo to automated execution.
+  - Review every unresolved non-recurring issue for missing context, dependencies, repro steps, acceptance criteria, and validation expectations.
+  - Make priorities concrete. Make sure each open issue has actionable deliverables.
+  - Merge duplicate open issues or add explicit dependency links when separate entries must remain.
+  - Do not close or implement issues as part of this polish pass unless that work is separately requested.
+  Deliverables:
+  - Open issues with enough detail for a person or agent to execute without rediscovery.
+  - New or updated dependency markers where ordering matters.
+  - A short `Last run:` note listing the number of issues polished and any blockers found.
+  Validation:
+  - Sample the open entries after the pass and confirm each has clear next actions and validation expectations.
+  - Confirm no recurring runbook was marked complete.
+  - Confirm duplicates were merged or explicitly cross-referenced.
+  Last run: 2026-08-10. Audited all 46 unresolved entries from the archive
+  pass. Archived B099 because its merged contract is enforced. Archived B077
+  because its historical release contract is verified. Archived F018 because
+  I027 supersedes it. Archived I205 because it belongs to the ISSUES.md editor
+  repository. Added B126 for current release activation and P007 for the
+  Alibaba provider decision.
+  Added 11 dependency tokens, removed stale prerequisite prose, and demoted six
+  downstream or planning items to P2. The tracker now has 44 current entries:
+  42 open and two blocked. B126 and F021 each name one exact external action or
+  issue in their `Blocked:` line.
+- [ ] [M003R] (P2) Architecture and policy review.
+  Goal:
+  Catch architecture, policy, and workflow drift before it becomes hidden maintenance debt.
+  Requirements:
+  - Cadence: run monthly, before large refactors, and after major framework or runtime changes.
+  - Review the codebase, docs, and workflow against `AGENTS.md`, `POLICY.md`, stack guides, and the current architecture notes.
+  - Look for drift from forward-only contracts, edge-validation boundaries, smart-constructor usage, testing policy, and module ownership.
+  - Record findings as new Maintenance issues with concrete scope, priority, and validation.
+  - Close the pass with a no-action note only when the review finds no actionable drift.
+  Deliverables:
+  - New Maintenance issues for each actionable architecture or policy drift finding.
+  - Updated notes on areas reviewed and areas intentionally left unchanged.
+  - A short `Last run:` note with the review scope and outcome.
+  Validation:
+  - Confirm every finding is represented as an issue with owner-readable context and validation criteria.
+  - Confirm no implementation changes were mixed into the review runbook unless separately requested.
+  - Confirm all recurring runbooks remain open.
 - [ ] [M008R] (P2) Documentation and runbook hygiene.
   Goal:
   Keep durable documentation and runbooks aligned with the current behavior users and operators actually rely on.
@@ -1021,19 +981,6 @@ retain satisfied historical dependencies.
   current endpoint contract. Regenerated 46 SEO resources. Their content
   already matched the current source. `PRD.md` and `ARCHITECTURE.md` remain
   absent, and M013 tracks that decision.
-- [ ] [M012] (P2) {M013} Reconcile repository governance with the MPR Lab normalizer.
-  Goal:
-  Make the governance normalizer check pass without deleting repository-owned binding contracts.
-  Requirements:
-  - Resolve M013's product-context document decision first so the normalizer
-    works from the final repository-owned root guidance.
-  - Inspect the normalizer differences reported for root `AGENTS.md` and every managed `.mprlab/` guide.
-  - Preserve the M011 pre-change and post-change CI requirement and all other current repository-owned rules.
-  - Update the appropriate managed templates, boundaries, or repository documents as one canonical forward-only contract rather than applying a destructive bulk rewrite.
-  Deliverables:
-  - A reviewed governance normalization change with no unrelated product or runtime edits.
-  Validation:
-  - Run the MPR Lab governor in `--dry-run` and `--check` modes and require no pending managed-file changes.
 - [ ] [M013] (P2) Resolve missing product-context document references.
   Goal:
   Keep the root governance entrypoint limited to product-context documents that exist and represent the current contract.
@@ -1048,6 +995,21 @@ retain satisfied historical dependencies.
   - Root governance references that resolve to current product-context files.
   Validation:
   - Verify every product-context path named by root `AGENTS.md` exists and contains current repository guidance.
+- [ ] [M012] (P2) {M013} Reconcile repository governance with the MPR Lab normalizer.
+  Goal:
+  Make the governance normalizer check pass without deleting repository-owned binding contracts.
+  Requirements:
+  - Resolve M013's product-context document decision first so the normalizer
+    works from the final repository-owned root guidance.
+  - Inspect the normalizer differences reported for root `AGENTS.md` and every managed `.mprlab/` guide.
+  - Preserve the M011 pre-change and post-change CI requirement and all other current repository-owned rules.
+  - Update the appropriate managed templates, boundaries, or repository
+    documents as one canonical forward-only contract.
+  - Do not apply a destructive bulk rewrite.
+  Deliverables:
+  - A reviewed governance normalization change with no unrelated product or runtime edits.
+  Validation:
+  - Run the MPR Lab governor in `--dry-run` and `--check` modes and require no pending managed-file changes.
 - [ ] [M019] (P2) Refresh non-security direct dependency pins.
   Goal:
   Bring direct Go, frontend, and Python development dependencies to their current supported releases after the security graph is stable.
@@ -1158,7 +1120,7 @@ retain satisfied historical dependencies.
     `timeout -k 350s -s SIGKILL 350s make ci` pair. Keep deployment and
     production acceptance operator-owned.
 
-- [ ] [F022] (P1) {I216} Add the durable model-operation, asset, and official-client foundation.
+- [ ] [F022] (P1) Add the durable model-operation, asset, and official-client foundation.
   Goal:
   Extend LLM Proxy from blocking text and dictation into a shared model-provider
   data plane while keeping MediaOps and other callers responsible for their
@@ -1298,7 +1260,7 @@ retain satisfied historical dependencies.
   - Preserve GCS/object-store staging, xAI retained-file authentication and
     cleanup evidence, observed usage, and every current recoverable artifact.
   - Make `xai` the only xAI selector supplied by the canonical catalog after
-    the I216 persisted-route migration.
+    the schema-v6 xAI persisted-route migration.
   - Register exact import validators for selected recoverable Vertex, Gemini
     Omni, Runway, FAL, Kling, and xAI video records. Imported records must enter
     the canonical operation schema without submitting new provider work.
@@ -1384,222 +1346,6 @@ retain satisfied historical dependencies.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair.
 
-- [ ] [F028] (P2) {F027} Add HeyGen Avatar V as a gateway-owned avatar engine.
-  Goal:
-  Add the current Avatar V engine to the gateway HeyGen avatar contract before
-  MediaOps exposes it through its product surfaces.
-  Cross-repository sequence:
-  - MediaOps I066 consumes this after its I073 base HeyGen/Kling cutover.
-  Requirements:
-  - Add exact engine values `avatar_iv` and `avatar_v` to the HeyGen avatar-video
-    operation and capability catalog.
-  - Resolve the selected look through `GET /v3/avatars/looks/{look_id}` and
-    require `supported_api_engines` to contain `avatar_v` before submitting an
-    Avatar V operation.
-  - Reject Avatar IV-only `motion_prompt` and `expressiveness` controls for an
-    Avatar V plan and preserve the selected engine in the immutable intent.
-  - Use the existing tenant-owned HeyGen credential profile, durable operation
-    state, gateway assets, price evidence, and artifact recovery.
-  Deliverables:
-  - Add the provider adapter fields, catalog metadata, official-client types,
-    HeyGen fixtures, docs, and an explicitly enabled paid live target.
-  Validation:
-  - Prove eligible success, ineligible pre-dispatch rejection, engine-specific
-    control rejection, terminal artifact download, and restart recovery.
-  - Run the required baseline and final
-    `timeout -k 350s -s SIGKILL 350s make ci` pair.
-
-- [ ] [F029] (P2) {F025} Add MiniMax H3 V2 video generation to model operations.
-  Goal:
-  Add the provider-qualified MiniMax H3 V2 route to the gateway before MediaOps
-  exposes the model through its video product contracts.
-  Cross-repository sequence:
-  - MediaOps I060 consumes this after its I071 base video cutover.
-  Requirements:
-  - Add canonical provider `minimax`, exact model `MiniMax-H3`, and only the
-    documented V2 create/query and `video_generation_input` upload contracts.
-  - Support text, first/last frame, and reference image/video/audio roles with
-    the documented mutual exclusions, media limits, 768P/2K resolutions,
-    4..15-second duration, and exact aspect behavior.
-  - Store provider task and upload ids in the durable operation, poll only the
-    V2 task resource, materialize the terminal MP4 as a gateway artifact, and
-    recover through the gateway operation id.
-  - Publish the H3 price as unavailable until MiniMax publishes an exact rate;
-    preserve returned duration and media counts as observed usage.
-  - Use one tenant-owned MiniMax credential profile and catalog-owned account
-    concurrency.
-  Deliverables:
-  - Add the MiniMax adapter, catalog, official-client types, provider fixtures,
-    recovery, docs, and an explicitly enabled minimal live target.
-  Validation:
-  - Prove exact payload roles, upload URI mapping, polling states, restart and
-    uncertain recovery, input limits, artifact integrity, and absence of Hailuo
-    V1 behavior through public black-box tests.
-  - Run the required baseline and final
-    `timeout -k 350s -s SIGKILL 350s make ci` pair.
-
-- [ ] [F030] (P2) {F026} Add Speechify text-to-speech and voice discovery to model operations.
-  Goal:
-  Add the current Speechify complete-response speech and voice-discovery
-  contracts to the gateway before MediaOps exposes them in narration flows.
-  Cross-repository sequence:
-  - MediaOps I058 consumes this after its I072 base audio cutover.
-  Requirements:
-  - Add canonical provider `speechify`, live `GET /v1/audio/models` and
-    `GET /v1/voices` discovery, and complete-response `POST /v1/audio/speech`.
-  - Admit only non-deprecated models that declare the speech endpoint and
-    preserve exact model, language, voice, output format, billable character,
-    request-id, and speech-mark metadata.
-  - Apply the documented input and pagination limits, account concurrency,
-    `Retry-After`, and provider error classification before returning a typed
-    result.
-  - Decode and validate returned audio into a gateway artifact and expose
-    provider-tagged speech marks as a JSON artifact. Mark provider recovery
-    unavailable when no durable retrieval handle exists.
-  - Use one tenant-owned Speechify credential profile. Publish price
-    unavailable until an exact official rate is cataloged.
-  Deliverables:
-  - Add Speechify adapters, live discovery projection, catalog entries,
-    official-client types, fixtures, docs, and an explicitly enabled live
-    discovery/minimal speech target.
-  Validation:
-  - Prove discovery, voice pagination, exact speech payload, audio decoding,
-    speech marks, rate/concurrency handling, transport uncertainty, secret
-    safety, and artifact integrity through public black-box tests.
-  - Run the required baseline and final
-    `timeout -k 350s -s SIGKILL 350s make ci` pair.
-
-- [!] [F021] (P1) Add OAuth-authenticated tenant-scoped MCP access.
-  Goal:
-  An authenticated user can connect a remote MCP client to one owned tenant.
-  The server uses that tenant's saved provider credentials, routing defaults,
-  and standard text-generation lifecycle for each MCP request.
-  Current contract:
-  - Public proxy requests use a generated tenant secret in `key=...`.
-  - TAuth browser sessions authorize management operations.
-  - Provider credentials remain on the server and belong to one tenant.
-  - TAuth provides the OAuth authorization-server contract that a remote MCP
-    client requires.
-  - The gateway cannot yet generate the root OAuth block or tenant OAuth policy.
-  Requirements:
-  - Serve MCP protocol version `2026-07-28` at the exact resource URL
-    `https://llm-proxy-api.mprlab.com/mcp/{tenant_id}`.
-  - Use the official Go MCP SDK in stateless Streamable HTTP mode. Return JSON
-    responses and reject every unsupported protocol version.
-  - Do not create an MCP session or implement an earlier MCP transport.
-  - Treat the exact MCP URL as the OAuth protected-resource identifier and
-    access-token audience.
-  - Publish path-specific OAuth Protected Resource Metadata at
-    `/.well-known/oauth-protected-resource/mcp/{tenant_id}`.
-  - Return an RFC-compliant Bearer challenge for an unauthenticated MCP
-    request. Include the protected-resource metadata URL in the challenge.
-  - Validate each JWT access token signature, issuer, subject, exact audience,
-    expiry, and required `llm-proxy:use` scope at the HTTP edge.
-  - Confirm that the token subject owns `{tenant_id}` before an MCP operation.
-    Return the same `404 Not Found` result for a missing tenant and a foreign
-    tenant after successful token validation.
-  - Keep provider credentials on the server. Never return provider credentials,
-    tenant secrets, access tokens, refresh tokens, or session data through MCP.
-  - Expose one tool named `llm_proxy.generate_text`. Require `messages` and
-    accept optional `provider`, `model`, `web_search`, `max_tokens`,
-    `reasoning_effort`, and `request_timeout_seconds` inputs.
-  - Use the canonical `/v2` message and attachment contract for the tool.
-    Preserve ordered image and audio attachments on user messages.
-  - Return generated text and structured `request_id`, `provider`, `model`,
-    `usage`, and `request_timeout_seconds` fields from a successful tool call.
-  - Mark the tool as not read-only, not destructive, not idempotent, and
-    open-world because one call can create provider charges.
-  - Return a sanitized MCP tool error with `isError: true` for an accepted tool
-    call that fails. Preserve the canonical proxy error classification without
-    exposing an upstream body, provider message, prompt, response, or secret.
-  - Expose `llm-proxy://routes` as a tenant-scoped resource. Return only the
-    tenant's configured text routes, defaults, and declared capabilities.
-  - Keep management and dictation outside this first MCP contract.
-  - Extract one transport-neutral text-generation service from the current
-    HTTP handlers. Make `/v2` and MCP use the same routing, admission, queue,
-    rate-limit, timeout, cancellation, continuation, error, and usage logic.
-  - Record MCP usage with endpoint value `mcp`. Record the logical proxy result
-    status when an MCP tool error uses a successful HTTP transport response.
-  - Add a `Copy MCP URL` action for each owned tenant. Show the action only
-    after the tenant has at least one configured text route.
-  - Document the MCP URL, OAuth flow, tool schema, resource schema, client
-    configuration, security boundary, and provider-key requirement.
-  - Add the MCP route and OAuth metadata to OpenAPI, runtime configuration, and
-    the repository deployment capability contract.
-  - Keep local acceptance separate from live deployment acceptance. Do not
-    contact or change production during implementation.
-  Deliverables:
-  - Add the stateless MCP transport and the path-specific protected-resource
-    metadata endpoint.
-  - Add strict OAuth bearer-token validation and tenant ownership checks.
-  - Add the shared text-generation service, `llm_proxy.generate_text` tool,
-    and `llm-proxy://routes` resource.
-  - Add tenant UI copy, configuration, OpenAPI, deployment, and user-guide
-    updates for the MCP connection contract.
-  - Add black-box integration and browser coverage through public entry points.
-  Validation:
-  - Run an official MCP client against the real local HTTP route, real local
-    TAuth OAuth flow, and a fake upstream provider.
-  - Verify successful authorization-code and PKCE login, token refresh, token
-    revocation, and consent behavior.
-  - Verify missing, malformed, expired, wrong-issuer, wrong-audience, and
-    wrong-scope tokens. Verify missing and foreign tenant identifiers.
-  - Verify exact tool discovery, input-schema validation, route selection,
-    defaults, media inputs, structured success output, and route-resource data.
-  - Verify queue rejection, provider rate limits, request timeouts, caller
-    cancellation, sanitized tool errors, and managed usage records.
-  - Verify that logs, MCP results, OAuth responses, and browser content contain
-    no provider credential, tenant secret, token, prompt, or generated response.
-  - Run `/v2` regression scenarios to prove one shared execution lifecycle and
-    unchanged tenant-secret authentication for the REST contract.
-  - Use MCP Inspector and one supported remote MCP client for manual local
-    acceptance. Record live-host acceptance as a separate deployment result.
-  - Run the required baseline and final
-    `timeout -k 350s -s SIGKILL 350s make ci` pair.
-  Blocked: mprlab-gateway F001 must complete the TAuth OAuth aggregate
-  deployment contract before this feature can declare its protected resources.
-
-- [ ] [F020] (P2) {I216,F016} Add route-validated sampling controls to the canonical v3 messages contract.
-  Goal:
-  Let a caller set low-level sampling controls only when the selected provider
-  offering declares exact support for them.
-  Requirements:
-  - Use I216 as the authoritative source for each provider offering's supported
-    controls, numeric bounds, defaults, and incompatible control combinations.
-  - Add one optional `sampling` object with exact fields `temperature`,
-    `top_p`, `presence_penalty`, and `frequency_penalty`. Reject unknown
-    fields, non-finite numbers, and values outside the selected route's bounds.
-  - Make `POST /v3` the canonical messages operation. Update every first-party
-    client, example, generated contract, and caller in the same forward-only
-    change, then remove the obsolete `/v2` route and schema.
-  - Resolve the provider and model route before validation. Reject a supplied
-    control that the resolved offering does not support before an upstream
-    request. Omit only controls that the caller did not supply.
-  - Define the exact interaction between `sampling` and `reasoning_effort`
-    for each offering in the capability catalog. Reject unsupported
-    combinations without translation, clamping, or silent removal.
-  - Map each accepted field through the provider-owned adapter and documented
-    provider-native field. Keep provider-specific names and defaults at that
-    adapter boundary.
-  - Update the Go, Python, Node.js, and CLI clients to expose the same typed
-    sampling object and canonical `/v3` request.
-  Deliverables:
-  - Add the strict `/v3` request schema, route-capability validation, provider
-    mappings, official-client types, CLI flags, OpenAPI contract, and current
-    documentation.
-  - Remove the obsolete `/v2` route, schemas, examples, and first-party client
-    calls after the forward migration.
-  Validation:
-  - Exercise the real public router against fake upstream providers. Prove each
-    accepted control maps to the exact provider request and every invalid or
-    unsupported control fails before upstream dispatch.
-  - Prove absent controls remain absent, accepted zero values remain explicit,
-    and supported sampling plus reasoning combinations preserve exact values.
-  - Exercise all official clients and the CLI through `/v3`. Prove they expose
-    the same typed failures and do not retain a `/v2` request path.
-  - Run the required baseline and final
-    `timeout -k 350s -s SIGKILL 350s make ci` pair.
-
 - [ ] [F017] (P1) Add shared MPR UI inactivity warning and automatic logout.
   Goal:
   Make an authenticated browser session warn and sign out explicitly after
@@ -1609,8 +1355,8 @@ retain satisfied historical dependencies.
   Evidence:
   - An unattended llm-proxy Usage view can retain MPR UI's last authenticated
     state and the last accepted workspace data after the server session has
-    expired. Returning to the tab therefore presents stale data; a full reload
-    then restores the authoritative signed-out first screen.
+    expired. As a result, returning to the tab presents stale data. A full
+    reload then restores the authoritative signed-out first screen.
   - llm-proxy currently refreshes Usage only during authenticated-workspace
     startup, scope/interval changes, or explicit Refresh. It receives MPR UI
     authentication events but has no independent authority to inspect,
@@ -1626,8 +1372,8 @@ retain satisfied historical dependencies.
     create a second browser authentication owner and violate the shared
     MPR UI/TAuth integration contract.
   - I033 proposed 60-second foreground Usage polling for the stale-snapshot
-    symptom. Product direction now selects explicit inactivity warning/logout
-    instead; active users retain the existing manual Refresh path.
+    symptom. Product direction now selects explicit inactivity warning/logout.
+    Active users retain the existing manual Refresh path.
   Requirements:
   - Implement the inactivity state machine, warning surface, and logout
     transaction in MPR UI first. Publish it through the canonical literal
@@ -1857,29 +1603,225 @@ retain satisfied historical dependencies.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair for the implementation, with
     the final run after the last code edit.
+- [!] [F021] (P1) Add OAuth-authenticated tenant-scoped MCP access.
+  Goal:
+  An authenticated user can connect a remote MCP client to one owned tenant.
+  The server uses that tenant's saved provider credentials, routing defaults,
+  and standard text-generation lifecycle for each MCP request.
+  Current contract:
+  - Public proxy requests use a generated tenant secret in `key=...`.
+  - TAuth browser sessions authorize management operations.
+  - Provider credentials remain on the server and belong to one tenant.
+  - TAuth provides the OAuth authorization-server contract that a remote MCP
+    client requires.
+  - The gateway cannot yet generate the root OAuth block or tenant OAuth policy.
+  Requirements:
+  - Serve MCP protocol version `2026-07-28` at the exact resource URL
+    `https://llm-proxy-api.mprlab.com/mcp/{tenant_id}`.
+  - Use the official Go MCP SDK in stateless Streamable HTTP mode. Return JSON
+    responses and reject every unsupported protocol version.
+  - Do not create an MCP session or implement an earlier MCP transport.
+  - Treat the exact MCP URL as the OAuth protected-resource identifier and
+    access-token audience.
+  - Publish path-specific OAuth Protected Resource Metadata at
+    `/.well-known/oauth-protected-resource/mcp/{tenant_id}`.
+  - Return an RFC-compliant Bearer challenge for an unauthenticated MCP
+    request. Include the protected-resource metadata URL in the challenge.
+  - Validate each JWT access token signature, issuer, subject, exact audience,
+    expiry, and required `llm-proxy:use` scope at the HTTP edge.
+  - Confirm that the token subject owns `{tenant_id}` before an MCP operation.
+    Return the same `404 Not Found` result for a missing tenant and a foreign
+    tenant after successful token validation.
+  - Keep provider credentials on the server. Never return provider credentials,
+    tenant secrets, access tokens, refresh tokens, or session data through MCP.
+  - Expose one tool named `llm_proxy.generate_text`. Require `messages` and
+    accept optional `provider`, `model`, `web_search`, `max_tokens`,
+    `reasoning_effort`, and `request_timeout_seconds` inputs.
+  - Use the canonical `/v2` message and attachment contract for the tool.
+    Preserve ordered image and audio attachments on user messages.
+  - Return generated text and structured `request_id`, `provider`, `model`,
+    `usage`, and `request_timeout_seconds` fields from a successful tool call.
+  - Mark the tool as not read-only, not destructive, not idempotent, and
+    open-world because one call can create provider charges.
+  - Return a sanitized MCP tool error with `isError: true` for an accepted tool
+    call that fails. Preserve the canonical proxy error classification without
+    exposing an upstream body, provider message, prompt, response, or secret.
+  - Expose `llm-proxy://routes` as a tenant-scoped resource. Return only the
+    tenant's configured text routes, defaults, and declared capabilities.
+  - Keep management and dictation outside this first MCP contract.
+  - Extract one transport-neutral text-generation service from the current
+    HTTP handlers. Make `/v2` and MCP use the same routing, admission, queue,
+    rate-limit, timeout, cancellation, continuation, error, and usage logic.
+  - Record MCP usage with endpoint value `mcp`. Record the logical proxy result
+    status when an MCP tool error uses a successful HTTP transport response.
+  - Add a `Copy MCP URL` action for each owned tenant. Show the action only
+    after the tenant has at least one configured text route.
+  - Document the MCP URL, OAuth flow, tool schema, resource schema, client
+    configuration, security boundary, and provider-key requirement.
+  - Add the MCP route and OAuth metadata to OpenAPI, runtime configuration, and
+    the repository deployment capability contract.
+  - Keep local acceptance separate from live deployment acceptance. Do not
+    contact or change production during implementation.
+  Deliverables:
+  - Add the stateless MCP transport and the path-specific protected-resource
+    metadata endpoint.
+  - Add strict OAuth bearer-token validation and tenant ownership checks.
+  - Add the shared text-generation service, `llm_proxy.generate_text` tool,
+    and `llm-proxy://routes` resource.
+  - Add tenant UI copy, configuration, OpenAPI, deployment, and user-guide
+    updates for the MCP connection contract.
+  - Add black-box integration and browser coverage through public entry points.
+  Validation:
+  - Run an official MCP client against the real local HTTP route, real local
+    TAuth OAuth flow, and a fake upstream provider.
+  - Verify successful authorization-code and PKCE login, token refresh, token
+    revocation, and consent behavior.
+  - Verify missing, malformed, expired, wrong-issuer, wrong-audience, and
+    wrong-scope tokens. Verify missing and foreign tenant identifiers.
+  - Verify exact tool discovery, input-schema validation, route selection,
+    defaults, media inputs, structured success output, and route-resource data.
+  - Verify queue rejection, provider rate limits, request timeouts, caller
+    cancellation, sanitized tool errors, and managed usage records.
+  - Verify that logs, MCP results, OAuth responses, and browser content contain
+    no provider credential, tenant secret, token, prompt, or generated response.
+  - Run `/v2` regression scenarios to prove one shared execution lifecycle and
+    unchanged tenant-secret authentication for the REST contract.
+  - Use MCP Inspector and one supported remote MCP client for manual local
+    acceptance. Record live-host acceptance as a separate deployment result.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+  Blocked: mprlab-gateway F001 must complete the TAuth OAuth aggregate
+  deployment contract before this feature can declare its protected resources.
+
+- [ ] [F028] (P2) {F027} Add HeyGen Avatar V as a gateway-owned avatar engine.
+  Goal:
+  Add the current Avatar V engine to the gateway HeyGen avatar contract before
+  MediaOps exposes it through its product surfaces.
+  Cross-repository sequence:
+  - MediaOps I066 consumes this after its I073 base HeyGen/Kling cutover.
+  Requirements:
+  - Add exact engine values `avatar_iv` and `avatar_v` to the HeyGen avatar-video
+    operation and capability catalog.
+  - Resolve the selected look through `GET /v3/avatars/looks/{look_id}` and
+    require `supported_api_engines` to contain `avatar_v` before submitting an
+    Avatar V operation.
+  - Reject Avatar IV-only `motion_prompt` and `expressiveness` controls for an
+    Avatar V plan and preserve the selected engine in the immutable intent.
+  - Use the existing tenant-owned HeyGen credential profile, durable operation
+    state, gateway assets, price evidence, and artifact recovery.
+  Deliverables:
+  - Add the provider adapter fields, catalog metadata, official-client types,
+    HeyGen fixtures, docs, and an explicitly enabled paid live target.
+  Validation:
+  - Prove eligible success, ineligible pre-dispatch rejection, engine-specific
+    control rejection, terminal artifact download, and restart recovery.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+
+- [ ] [F029] (P2) {F025} Add MiniMax H3 V2 video generation to model operations.
+  Goal:
+  Add the provider-qualified MiniMax H3 V2 route to the gateway before MediaOps
+  exposes the model through its video product contracts.
+  Cross-repository sequence:
+  - MediaOps I060 consumes this after its I071 base video cutover.
+  Requirements:
+  - Add canonical provider `minimax`, exact model `MiniMax-H3`, and only the
+    documented V2 create/query and `video_generation_input` upload contracts.
+  - Support text, first/last frame, and reference image/video/audio roles with
+    the documented mutual exclusions, media limits, 768P/2K resolutions,
+    4..15-second duration, and exact aspect behavior.
+  - Store provider task and upload ids in the durable operation, poll only the
+    V2 task resource, materialize the terminal MP4 as a gateway artifact, and
+    recover through the gateway operation id.
+  - Publish the H3 price as unavailable until MiniMax publishes an exact rate.
+    Preserve returned duration and media counts as observed usage.
+  - Use one tenant-owned MiniMax credential profile and catalog-owned account
+    concurrency.
+  Deliverables:
+  - Add the MiniMax adapter, catalog, official-client types, provider fixtures,
+    recovery, docs, and an explicitly enabled minimal live target.
+  Validation:
+  - Prove exact payload roles, upload URI mapping, polling states, restart and
+    uncertain recovery, input limits, artifact integrity, and absence of Hailuo
+    V1 behavior through public black-box tests.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+
+- [ ] [F030] (P2) {F026} Add Speechify text-to-speech and voice discovery to model operations.
+  Goal:
+  Add the current Speechify complete-response speech and voice-discovery
+  contracts to the gateway before MediaOps exposes them in narration flows.
+  Cross-repository sequence:
+  - MediaOps I058 consumes this after its I072 base audio cutover.
+  Requirements:
+  - Add canonical provider `speechify`, live `GET /v1/audio/models` and
+    `GET /v1/voices` discovery, and complete-response `POST /v1/audio/speech`.
+  - Admit only non-deprecated models that declare the speech endpoint and
+    preserve exact model, language, voice, output format, billable character,
+    request-id, and speech-mark metadata.
+  - Apply the documented input and pagination limits, account concurrency,
+    `Retry-After`, and provider error classification before returning a typed
+    result.
+  - Decode and validate returned audio into a gateway artifact and expose
+    provider-tagged speech marks as a JSON artifact. Mark provider recovery
+    unavailable when no durable retrieval handle exists.
+  - Use one tenant-owned Speechify credential profile. Publish price
+    unavailable until an exact official rate is cataloged.
+  Deliverables:
+  - Add Speechify adapters, live discovery projection, catalog entries,
+    official-client types, fixtures, docs, and an explicitly enabled live
+    discovery/minimal speech target.
+  Validation:
+  - Prove discovery, voice pagination, exact speech payload, audio decoding,
+    speech marks, rate/concurrency handling, transport uncertainty, secret
+    safety, and artifact integrity through public black-box tests.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+
+- [ ] [F020] (P2) {F016} Add route-validated sampling controls to the canonical v3 messages contract.
+  Goal:
+  Let a caller set low-level sampling controls only when the selected provider
+  offering declares exact support for them.
+  Requirements:
+  - Use the authoritative catalog as the source for each provider offering's supported
+    controls, numeric bounds, defaults, and incompatible control combinations.
+  - Add one optional `sampling` object with exact fields `temperature`,
+    `top_p`, `presence_penalty`, and `frequency_penalty`. Reject unknown
+    fields, non-finite numbers, and values outside the selected route's bounds.
+  - Make `POST /v3` the canonical messages operation. Update every first-party
+    client, example, generated contract, and caller in the same forward-only
+    change, then remove the obsolete `/v2` route and schema.
+  - Resolve the provider and model route before validation. Reject a supplied
+    control that the resolved offering does not support before an upstream
+    request. Omit only controls that the caller did not supply.
+  - Define the exact interaction between `sampling` and `reasoning_effort`
+    for each offering in the capability catalog. Reject unsupported
+    combinations without translation, clamping, or silent removal.
+  - Map each accepted field through the provider-owned adapter and documented
+    provider-native field. Keep provider-specific names and defaults at that
+    adapter boundary.
+  - Update the Go, Python, Node.js, and CLI clients to expose the same typed
+    sampling object and canonical `/v3` request.
+  Deliverables:
+  - Add the strict `/v3` request schema, route-capability validation, provider
+    mappings, official-client types, CLI flags, OpenAPI contract, and current
+    documentation.
+  - Remove the obsolete `/v2` route, schemas, examples, and first-party client
+    calls after the forward migration.
+  Validation:
+  - Exercise the real public router against fake upstream providers. Prove each
+    accepted control maps to the exact provider request and every invalid or
+    unsupported control fails before upstream dispatch.
+  - Prove absent controls remain absent, accepted zero values remain explicit,
+    and supported sampling plus reasoning combinations preserve exact values.
+  - Exercise all official clients and the CLI through `/v3`. Prove they expose
+    the same typed failures and do not retain a `/v2` request path.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+
 ## Planning
 *do not implement yet*
 
-- [ ] [P006] (P2) Define provider lifecycle, model onboarding, and hosted service SLA terms.
-  Goal:
-  Turn the proposed long-term provider support, model-addition timing, and
-  hosted availability promises into measurable service commitments before they
-  appear in public marketing copy.
-  Requirements:
-  - Define separate provider lifecycle, model-onboarding SLO, and hosted uptime
-    SLA scopes, including eligibility, measurement windows, exclusions,
-    deprecation notice, incident communication, and remedies where applicable.
-  - Decide which commitments apply to the open-source integration contract,
-    managed provider onboarding, and a hosted service; do not collapse them into
-    one ambiguous guarantee.
-  - Identify the operational evidence, ownership, monitoring, support channel,
-    and approval needed to publish each commitment.
-  Deliverables:
-  - An approved support-policy and SLA contract suitable for public-site copy,
-    with implementation issues for any missing operational controls.
-  Validation:
-  - Legal, product, and service owners approve each published metric and the
-    production evidence path can calculate it without manual interpretation.
 - [ ] [P001] (P1) Design a tenant-scoped provider, model, and key-acquisition onboarding flow.
   Goal:
   Let a signed-in managed user complete one clear text-routing setup: select a
@@ -1945,6 +1887,26 @@ retain satisfied historical dependencies.
     narrow layouts, saved-key updates, and explicit failure states.
   - Run the required baseline and final `timeout -k 350s -s SIGKILL 350s make ci`
     pair for the implementation, with the final run after the last code edit.
+- [ ] [P006] (P2) Define provider lifecycle, model onboarding, and hosted service SLA terms.
+  Goal:
+  Turn the proposed long-term provider support, model-addition timing, and
+  hosted availability promises into measurable service commitments before they
+  appear in public marketing copy.
+  Requirements:
+  - Define separate provider lifecycle, model-onboarding SLO, and hosted uptime
+    SLA scopes, including eligibility, measurement windows, exclusions,
+    deprecation notice, incident communication, and remedies where applicable.
+  - Decide which commitments apply to the open-source integration contract,
+    managed provider onboarding, and a hosted service. Do not collapse them into
+    one ambiguous guarantee.
+  - Identify the operational evidence, ownership, monitoring, support channel,
+    and approval needed to publish each commitment.
+  Deliverables:
+  - An approved support-policy and SLA contract suitable for public-site copy,
+    with implementation issues for any missing operational controls.
+  Validation:
+  - Legal, product, and service owners approve each published metric and the
+    production evidence path can calculate it without manual interpretation.
 - [ ] [P003] (P2) {I218} Re-audit and expand the SEO/use-case resource system from verified product contracts.
   Goal:
   Refresh LLM Proxy's search and resource strategy from the current repository

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1026,6 +1026,91 @@ retain satisfied historical dependencies.
 
 ## Features
 
+- [ ] [F033] (P0) {F022} Support large media in canonical message requests.
+  Goal:
+  Let `/v2` callers reference tenant assets when inline media would exceed
+  `max_prompt_bytes`. Keep the JSON request limit. Preserve exact media bytes,
+  order, MIME type, and SHA-256.
+
+  Observed failure:
+  - Creative Director sends `master-character-sheet.png` through
+    `NewImageAttachment` for Gemini semantic image QA.
+  - The PNG is 3,326,724 bytes. Canonical base64 requires 4,435,632 bytes
+    before JSON and prompt content.
+  - The deployed capability resource reports `max_prompt_bytes: 4194304`.
+  - LLM Proxy returns HTTP 413 `prompt payload too large` before Gemini
+    receives the image.
+  - Creative Director receives no QA result. It cannot produce the next
+    MediaOps operation.
+  - The current Go client accepts the PNG. It cannot compare the serialized
+    request with the deployed request limit.
+
+  Contract gap:
+  - The current `/v2` contract supports only inline base64 media.
+  - F022 defines streaming asset upload. It does not connect uploaded assets
+    to blocking message attachments.
+  - A configured model can support an image that the public request transport
+    cannot carry.
+
+  Requirements:
+  - Use the F022 tenant asset store as the large-media input boundary.
+  - Add an asset-reference variant to the canonical user-message attachment
+    union.
+  - Require `type`, `asset_id`, `mime_type`, and `sha256` in each asset
+    reference.
+  - Reject an attachment that contains both `data` and `asset_id`.
+  - Keep inline base64 attachments for requests that satisfy
+    `max_prompt_bytes`.
+  - Apply `max_prompt_bytes` only to the JSON body. Apply separate limits to
+    resolved asset bytes.
+  - Publish the attachment count, per-asset byte limit, and aggregate media
+    byte limit in public capabilities.
+  - Validate tenant ownership, asset state, expiry, MIME type, size, and
+    SHA-256 before provider dispatch.
+  - Preserve message order and attachment order after asset resolution.
+  - Translate each resolved asset into the selected provider's exact media
+    input shape.
+  - Preserve caller bytes without resize, compression, or format conversion.
+  - Keep caller filesystem paths outside the HTTP contract.
+  - Return stable errors for missing, foreign, expired, oversized, mismatched,
+    and unsupported assets.
+  - Exclude asset bytes and authenticated asset URLs from logs, responses, and
+    usage records.
+  - Add official-client constructors for asset-backed image and audio
+    attachments.
+  - Expose the serialized JSON byte count before an official client submits a
+    request.
+
+  Deliverables:
+  - Add the OpenAPI asset-reference schemas and canonical message request
+    union.
+  - Add tenant asset resolution and provider adapter integration.
+  - Add public capability limits and official-client support.
+  - Update the root README, API reference, provider routing guide, and release
+    notes.
+
+  Validation:
+  - Use a 3,326,724-byte image fixture with a 4,194,304-byte JSON limit.
+  - Upload the fixture through F022. Send one `/v2` asset reference.
+  - Prove the JSON stays below the limit. Prove the fake Gemini adapter
+    receives the exact original bytes, MIME type, SHA-256, and order.
+  - Send the same bytes as inline base64. Require HTTP 413 before provider
+    dispatch.
+  - Send a JSON-only request above the limit. Require the same bounded HTTP
+    413 result.
+  - Cover missing, foreign, expired, deleted, oversized, wrong-MIME, and
+    wrong-digest assets.
+  - Cover one image, ordered images, audio, mixed media, count limits, and
+    aggregate byte limits.
+  - Prove asset cleanup cannot change an admitted request or expose another
+    tenant's asset.
+  - Prove logs, errors, responses, and usage records contain no asset bytes or
+    authenticated asset URLs.
+  - Exercise the public router and every released official client against a
+    fake provider.
+  - Run the required baseline and final
+    `timeout -k 350s -s SIGKILL 350s make ci` pair.
+
 - [ ] [F032] (P1) Add Baidu Qianfan as a user-configurable text provider.
   Goal:
   Let a managed user paste, verify, and save a Baidu Qianfan API key through

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ adapters before they are available through `/dictate`.
 | `zhipu` | `glm` | `openai_chat_completions` | `synchronous_completion` | `glm-5.1` | `providers.zhipu.api_key` | `https://open.bigmodel.cn/api/paas/v4` | Yes: `glm-asr-2512` | No |
 | `gemini` | none | `gemini_interactions` | Model-specific: Gemini 3.x `pollable_resource`; Gemini 2.5 `synchronous_completion` | `gemini-2.5-flash` | `providers.gemini.api_key` | `https://generativelanguage.googleapis.com/v1beta` | No | No |
 | `anthropic` | `claude` | `anthropic_messages` | `synchronous_completion` | `claude-sonnet-4-6` | `providers.anthropic.api_key` | `https://api.anthropic.com` | No | No |
-| `grok` | `xai` | `openai_chat_completions` | `synchronous_completion` | `grok-4.3` | `providers.grok.api_key` | `https://api.x.ai/v1` | Yes: `xai-stt` | No |
+| `xai` | none | `openai_chat_completions` | `synchronous_completion` | `grok-4.3` | `providers.xai.api_key` | `https://api.x.ai/v1` | Yes: `xai-stt` | No |
 
 All upstream provider credentials are server-side only. Client requests must
 never send OpenAI, Meta, Anthropic, xAI, Gemini, or other upstream API keys.
@@ -343,18 +343,28 @@ declares `image` and `audio` only for `gemini-3.5-flash` and
 
 ### Model catalog schema
 
-The normalized `catalog` has five related lists:
+The normalized `catalog` has one immutable `revision` and seven related lists:
 
-- `providers` identifies each provider that can own an offering.
+- `operations` defines operation identifiers and their input and output artifact kinds.
+- `providers` identifies each provider that can own an offering and its credential kinds.
 - `publishers` identifies each organization or community that publishes models.
 - `families` groups exact models under one publisher.
 - `models` defines each provider-independent exact model.
 - `offerings` defines each provider route for one exact model.
+- `prices` defines one typed available or unavailable price descriptor for each offering operation.
 
 An exact model owns its canonical identifier, publisher, family, version,
 operations, and media inputs. A provider offering owns its provider-native
 model identifier, operations, defaults, wire contract, lifecycle, limits, and
 route-specific capabilities.
+
+Controls declare canonical boolean, integer, or enum inputs. Limits declare
+fixed bounds or account-dependent capacity. Prices declare components, USD
+rates, units, exact condition tuples, an optional minimum charge, an official
+source, and a verification date. Price selection succeeds only for an exact
+component and condition match. Missing or conflicting matches return a typed
+unavailable result. Managed usage remains execution telemetry and is not a
+pricing or billing record.
 
 A request route contains a canonical provider identifier and exact model
 identifier. The registry resolves that pair to one provider offering. The
@@ -373,11 +383,13 @@ operation. Defaults belong to provider offerings through
 `default_operations`. Managed tenant defaults remain canonical provider and
 exact model pairs.
 
-`wire_contract` is required for each text offering. Its current values are
+`wire_contract` and `execution_lifecycle` are required for every offering. Text
+wire contracts are
 `openai_responses`, `openai_chat_completions`,
-`gemini_interactions`, and `anthropic_messages`.
-`execution_lifecycle` is also required for each text offering. Its current
-values are `synchronous_completion` and `pollable_resource`.
+`gemini_interactions`, and `anthropic_messages`. Dictation uses
+`multipart_transcription`, and xAI video generation uses
+`xai_videos_generations`. Lifecycle values are `synchronous_completion` and
+`pollable_resource`.
 
 `output_token_limit`, `web_search`, `request_profile`,
 `reasoning_effort`, and offering `media_inputs` are route-specific
@@ -460,8 +472,8 @@ Provider-specific details:
 * Only dictation-capable providers expose `transcriptions_url` fields:
   OpenAI uses `providers.openai.transcriptions_url`, SiliconFlow uses
   `providers.siliconflow.transcriptions_url`, Zhipu uses
-  `providers.zhipu.transcriptions_url`, and Grok/xAI uses
-  `providers.grok.transcriptions_url`.
+  `providers.zhipu.transcriptions_url`, and xAI uses
+  `providers.xai.transcriptions_url`.
 * Gemini text requests use native `POST /interactions` against the configured
   `v1beta` base URL with `x-goog-api-key` and
   `Api-Revision: 2026-05-20`. Gemini 3.x sends `background: true` and
@@ -491,9 +503,9 @@ Provider-specific details:
 * Zhipu dictation uses Z.AI GLM-ASR through
   `providers.zhipu.transcriptions_url` with the selected configured dictation
   model.
-* Grok text requests use xAI's OpenAI-compatible `/chat/completions` API at
+* xAI text requests use xAI's OpenAI-compatible `/chat/completions` API at
   `https://api.x.ai/v1`. Grok/xAI dictation uses xAI STT through
-  `providers.grok.transcriptions_url`; the upstream STT endpoint does not
+  `providers.xai.transcriptions_url`. The upstream STT endpoint does not
   receive a `model` multipart field.
 
 When management is disabled, provider API keys are optional until a configured
@@ -1256,14 +1268,14 @@ tenants:
       model: claude-sonnet-4-6
 ```
 
-Set Grok as the default text provider:
+Set xAI as the default text provider:
 
 ```yaml
 tenants:
-  - id: grok
+  - id: xai
     secret: "${SERVICE_SECRET}"
     defaults:
-      provider: grok
+      provider: xai
       model: grok-4.3
 ```
 
@@ -1322,7 +1334,7 @@ an ignored coverage artifact from an earlier run cannot satisfy completion.
 | Zhipu/GLM | `ZHIPU_API_KEY` | `LLM_PROXY_LIVE_ZHIPU_MODEL` |
 | Gemini | `GEMINI_API_KEY` | `LLM_PROXY_LIVE_GEMINI_MODEL` |
 | Anthropic/Claude | `ANTHROPIC_API_KEY` | `LLM_PROXY_LIVE_ANTHROPIC_MODEL` |
-| Grok/xAI | `XAI_API_KEY` | `LLM_PROXY_LIVE_GROK_MODEL` |
+| xAI/Grok | `XAI_API_KEY` | `LLM_PROXY_LIVE_XAI_MODEL` |
 
 Run every provider with an available key:
 
@@ -1820,13 +1832,13 @@ curl --get \
   "http://localhost:8080/"
 ```
 
-Grok text generation:
+xAI Grok text generation:
 
 ```shell
 curl --get \
   --data-urlencode "prompt=Summarize this with Grok" \
   --data-urlencode "key=mysecret" \
-  --data-urlencode "provider=grok" \
+  --data-urlencode "provider=xai" \
   --data-urlencode "model=grok-4.3" \
   --data-urlencode "max_tokens=512" \
   "http://localhost:8080/"
@@ -2128,7 +2140,7 @@ and [latest-model guide](https://developers.openai.com/api/docs/guides/latest-mo
 | `openai` | `gpt-4o-mini-transcribe`, `gpt-4o-transcribe` | `providers.openai.api_key` | `providers.openai.transcriptions_url` | Default dictation provider and default model `gpt-4o-mini-transcribe`. |
 | `siliconflow` | `sensevoice-small` | `providers.siliconflow.api_key` | `providers.siliconflow.transcriptions_url` | OpenAI-compatible audio transcription. |
 | `zhipu` / `glm` | `glm-asr-2512` | `providers.zhipu.api_key` | `providers.zhipu.transcriptions_url` | Z.AI GLM-ASR; sends `model=glm-asr-2512`. |
-| `grok` / `xai` | `xai-stt` | `providers.grok.api_key` | `providers.grok.transcriptions_url` | xAI STT; the proxy model name selects the provider but is not sent as a multipart `model` field. |
+| `xai` | `xai-stt` | `providers.xai.api_key` | `providers.xai.transcriptions_url` | xAI STT. The proxy model name selects the provider but is not sent as a multipart `model` field. |
 
 ### Status codes
 

--- a/cmd/cli/config_file.go
+++ b/cmd/cli/config_file.go
@@ -25,7 +25,6 @@ const (
 	providerAliasKimi   = "kimi"
 	providerAliasGLM    = "glm"
 	providerAliasClaude = "claude"
-	providerAliasXAI    = "xai"
 )
 
 var (
@@ -46,11 +45,11 @@ var (
 )
 
 type fileConfiguration struct {
-	Server     serverConfiguration       `mapstructure:"server"`
-	Management managementConfiguration   `mapstructure:"management"`
-	Tenants    []tenantConfiguration     `mapstructure:"tenants"`
-	Providers  providersConfiguration    `mapstructure:"providers"`
-	Catalog    modelCatalogConfiguration `mapstructure:"catalog"`
+	Server     serverConfiguration     `mapstructure:"server"`
+	Management managementConfiguration `mapstructure:"management"`
+	Tenants    []tenantConfiguration   `mapstructure:"tenants"`
+	Providers  providersConfiguration  `mapstructure:"providers"`
+	Catalog    proxy.ModelCatalog      `mapstructure:"catalog"`
 }
 
 type serverConfiguration struct {
@@ -120,7 +119,7 @@ type providersConfiguration struct {
 	Gemini      providerConfiguration             `mapstructure:"gemini"`
 	Anthropic   providerConfiguration             `mapstructure:"anthropic"`
 	Meta        providerConfiguration             `mapstructure:"meta"`
-	Grok        transcribingProviderConfiguration `mapstructure:"grok"`
+	XAI         transcribingProviderConfiguration `mapstructure:"xai"`
 }
 
 type providerConfiguration struct {
@@ -132,59 +131,6 @@ type transcribingProviderConfiguration struct {
 	APIKey            string `mapstructure:"api_key"`
 	BaseURL           string `mapstructure:"base_url"`
 	TranscriptionsURL string `mapstructure:"transcriptions_url"`
-}
-
-type modelCatalogConfiguration struct {
-	Providers  []catalogProviderConfiguration  `mapstructure:"providers"`
-	Publishers []modelPublisherConfiguration   `mapstructure:"publishers"`
-	Families   []modelFamilyConfiguration      `mapstructure:"families"`
-	Models     []exactModelConfiguration       `mapstructure:"models"`
-	Offerings  []providerOfferingConfiguration `mapstructure:"offerings"`
-}
-
-type catalogProviderConfiguration struct {
-	ID    string `mapstructure:"id"`
-	Label string `mapstructure:"label"`
-}
-
-type modelPublisherConfiguration struct {
-	ID    string `mapstructure:"id"`
-	Label string `mapstructure:"label"`
-}
-
-type modelFamilyConfiguration struct {
-	ID        string `mapstructure:"id"`
-	Publisher string `mapstructure:"publisher"`
-	Label     string `mapstructure:"label"`
-}
-
-type exactModelConfiguration struct {
-	ID          string   `mapstructure:"id"`
-	Publisher   string   `mapstructure:"publisher"`
-	Family      string   `mapstructure:"family"`
-	Version     string   `mapstructure:"version"`
-	Operations  []string `mapstructure:"operations"`
-	MediaInputs []string `mapstructure:"media_inputs"`
-}
-
-type providerOfferingConfiguration struct {
-	Provider           string                           `mapstructure:"provider"`
-	Model              string                           `mapstructure:"model"`
-	ProviderModel      string                           `mapstructure:"provider_model"`
-	Operations         []string                         `mapstructure:"operations"`
-	DefaultOperations  []string                         `mapstructure:"default_operations"`
-	WireContract       string                           `mapstructure:"wire_contract"`
-	ExecutionLifecycle string                           `mapstructure:"execution_lifecycle"`
-	RequestProfile     string                           `mapstructure:"request_profile"`
-	WebSearch          bool                             `mapstructure:"web_search"`
-	OutputTokenLimit   int                              `mapstructure:"output_token_limit"`
-	ReasoningEffort    *reasoningEffortCapabilityConfig `mapstructure:"reasoning_effort"`
-	MediaInputs        []string                         `mapstructure:"media_inputs"`
-}
-
-type reasoningEffortCapabilityConfig struct {
-	Adapter string   `mapstructure:"adapter"`
-	Efforts []string `mapstructure:"efforts"`
 }
 
 type providerAPIKeyRequirement struct {
@@ -341,7 +287,7 @@ func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configurati
 		GeminiKey:                    configuration.Providers.Gemini.APIKey,
 		AnthropicKey:                 configuration.Providers.Anthropic.APIKey,
 		MetaKey:                      configuration.Providers.Meta.APIKey,
-		GrokKey:                      configuration.Providers.Grok.APIKey,
+		XAIKey:                       configuration.Providers.XAI.APIKey,
 		OpenAIBaseURL:                configuration.Providers.OpenAI.BaseURL,
 		OpenAITranscriptionsURL:      configuration.Providers.OpenAI.TranscriptionsURL,
 		DeepSeekBaseURL:              configuration.Providers.DeepSeek.BaseURL,
@@ -355,8 +301,8 @@ func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configurati
 		GeminiBaseURL:                configuration.Providers.Gemini.BaseURL,
 		AnthropicBaseURL:             configuration.Providers.Anthropic.BaseURL,
 		MetaBaseURL:                  configuration.Providers.Meta.BaseURL,
-		GrokBaseURL:                  configuration.Providers.Grok.BaseURL,
-		GrokTranscriptionsURL:        configuration.Providers.Grok.TranscriptionsURL,
+		XAIBaseURL:                   configuration.Providers.XAI.BaseURL,
+		XAITranscriptionsURL:         configuration.Providers.XAI.TranscriptionsURL,
 		Port:                         configuration.Server.Port,
 		LogLevel:                     configuration.Server.LogLevel,
 		WorkerCount:                  configuration.Server.Workers,
@@ -366,7 +312,7 @@ func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configurati
 		MaxPromptBytes:               configuration.Server.MaxPromptBytes,
 		MaxInputAudioBytes:           configuration.Server.MaxInputAudioBytes,
 		UpstreamRateLimits:           proxyUpstreamRateLimitConfigurations(configuration.Server.UpstreamRateLimits),
-		ModelCatalog:                 configuration.Catalog.proxyCatalog(),
+		ModelCatalog:                 configuration.Catalog,
 	})
 }
 
@@ -417,39 +363,6 @@ func managementProxyConfiguration(configuration managementConfiguration, usageQu
 	}
 }
 
-func (configuration modelCatalogConfiguration) proxyCatalog() proxy.ModelCatalog {
-	providers := make([]proxy.CatalogProvider, 0, len(configuration.Providers))
-	for _, provider := range configuration.Providers {
-		providers = append(providers, proxy.CatalogProvider{ID: provider.ID, Label: provider.Label})
-	}
-	publishers := make([]proxy.ModelPublisher, 0, len(configuration.Publishers))
-	for _, publisher := range configuration.Publishers {
-		publishers = append(publishers, proxy.ModelPublisher{ID: publisher.ID, Label: publisher.Label})
-	}
-	families := make([]proxy.ModelFamily, 0, len(configuration.Families))
-	for _, family := range configuration.Families {
-		families = append(families, proxy.ModelFamily{ID: family.ID, Publisher: family.Publisher, Label: family.Label})
-	}
-	models := make([]proxy.ExactModel, 0, len(configuration.Models))
-	for _, model := range configuration.Models {
-		models = append(models, proxy.ExactModel{
-			ID: model.ID, Publisher: model.Publisher, Family: model.Family, Version: model.Version,
-			Operations: append([]string(nil), model.Operations...), MediaInputs: append([]string(nil), model.MediaInputs...),
-		})
-	}
-	offerings := make([]proxy.ProviderOffering, 0, len(configuration.Offerings))
-	for _, offering := range configuration.Offerings {
-		offerings = append(offerings, proxy.ProviderOffering{
-			Provider: offering.Provider, Model: offering.Model, ProviderModel: offering.ProviderModel,
-			Operations: append([]string(nil), offering.Operations...), DefaultOperations: append([]string(nil), offering.DefaultOperations...),
-			WireContract: offering.WireContract, ExecutionLifecycle: offering.ExecutionLifecycle, RequestProfile: offering.RequestProfile,
-			WebSearch: offering.WebSearch, OutputTokenLimit: offering.OutputTokenLimit,
-			ReasoningEffort: proxyReasoningEffortCapability(offering.ReasoningEffort), MediaInputs: append([]string(nil), offering.MediaInputs...),
-		})
-	}
-	return proxy.ModelCatalog{Providers: providers, Publishers: publishers, Families: families, Models: models, Offerings: offerings}
-}
-
 func (configuration fileConfiguration) validateCompleteConfiguration() error {
 	if providerValidationError := configuration.Providers.validateCompleteProviderConfiguration(); providerValidationError != nil {
 		return providerValidationError
@@ -458,16 +371,6 @@ func (configuration fileConfiguration) validateCompleteConfiguration() error {
 		return nil
 	}
 	return configuration.validateTenantDefaultProviderCredentials()
-}
-
-func proxyReasoningEffortCapability(configuration *reasoningEffortCapabilityConfig) *proxy.ReasoningEffortCapability {
-	if configuration == nil {
-		return nil
-	}
-	return &proxy.ReasoningEffortCapability{
-		Adapter: configuration.Adapter,
-		Efforts: append([]string(nil), configuration.Efforts...),
-	}
 }
 
 func (configuration providersConfiguration) validateCompleteProviderConfiguration() error {
@@ -486,7 +389,7 @@ func (configuration providersConfiguration) validateCompleteProviderConfiguratio
 		{providerName: proxy.ProviderNameGemini, fieldName: "providers.gemini.base_url", baseURL: configuration.Gemini.BaseURL},
 		{providerName: proxy.ProviderNameAnthropic, fieldName: "providers.anthropic.base_url", baseURL: configuration.Anthropic.BaseURL},
 		{providerName: proxy.ProviderNameMeta, fieldName: "providers.meta.base_url", baseURL: configuration.Meta.BaseURL},
-		{providerName: proxy.ProviderNameGrok, fieldName: "providers.grok.base_url", baseURL: configuration.Grok.BaseURL},
+		{providerName: proxy.ProviderNameXAI, fieldName: "providers.xai.base_url", baseURL: configuration.XAI.BaseURL},
 	}
 	for _, requiredBaseURL := range requiredBaseURLs {
 		if strings.TrimSpace(requiredBaseURL.baseURL) == constants.EmptyString {
@@ -502,7 +405,7 @@ func (configuration providersConfiguration) validateCompleteProviderConfiguratio
 		{providerName: proxy.ProviderNameOpenAI, fieldName: "providers.openai.transcriptions_url", transcriptionsURL: configuration.OpenAI.TranscriptionsURL},
 		{providerName: proxy.ProviderNameSiliconFlow, fieldName: "providers.siliconflow.transcriptions_url", transcriptionsURL: configuration.SiliconFlow.TranscriptionsURL},
 		{providerName: proxy.ProviderNameZhipu, fieldName: "providers.zhipu.transcriptions_url", transcriptionsURL: configuration.Zhipu.TranscriptionsURL},
-		{providerName: proxy.ProviderNameGrok, fieldName: "providers.grok.transcriptions_url", transcriptionsURL: configuration.Grok.TranscriptionsURL},
+		{providerName: proxy.ProviderNameXAI, fieldName: "providers.xai.transcriptions_url", transcriptionsURL: configuration.XAI.TranscriptionsURL},
 	}
 	for _, requiredTranscriptionsURL := range requiredTranscriptionsURLs {
 		if strings.TrimSpace(requiredTranscriptionsURL.transcriptionsURL) == constants.EmptyString {
@@ -538,7 +441,7 @@ func (configuration providersConfiguration) dictationAPIKeyRequirement(rawProvid
 		normalizedProvider = proxy.ProviderNameOpenAI
 	}
 	switch normalizedProvider {
-	case proxy.ProviderNameOpenAI, proxy.ProviderNameSiliconFlow, proxy.ProviderNameZhipu, providerAliasGLM, proxy.ProviderNameGrok, providerAliasXAI:
+	case proxy.ProviderNameOpenAI, proxy.ProviderNameSiliconFlow, proxy.ProviderNameZhipu, providerAliasGLM, proxy.ProviderNameXAI:
 		return configuration.apiKeyRequirement(normalizedProvider)
 	default:
 		return providerAPIKeyRequirement{}, false
@@ -567,8 +470,8 @@ func (configuration providersConfiguration) apiKeyRequirement(normalizedProvider
 		return providerAPIKeyRequirement{providerName: proxy.ProviderNameAnthropic, fieldName: "providers.anthropic.api_key", apiKey: configuration.Anthropic.APIKey}, true
 	case proxy.ProviderNameMeta:
 		return providerAPIKeyRequirement{providerName: proxy.ProviderNameMeta, fieldName: "providers.meta.api_key", apiKey: configuration.Meta.APIKey}, true
-	case proxy.ProviderNameGrok, providerAliasXAI:
-		return providerAPIKeyRequirement{providerName: proxy.ProviderNameGrok, fieldName: "providers.grok.api_key", apiKey: configuration.Grok.APIKey}, true
+	case proxy.ProviderNameXAI:
+		return providerAPIKeyRequirement{providerName: proxy.ProviderNameXAI, fieldName: "providers.xai.api_key", apiKey: configuration.XAI.APIKey}, true
 	default:
 		return providerAPIKeyRequirement{}, false
 	}

--- a/cmd/cli/public_capabilities.go
+++ b/cmd/cli/public_capabilities.go
@@ -51,7 +51,7 @@ func loadPublicCapabilityAPIConfiguration(rawConfigPath string) (publicCapabilit
 	if unmarshalError := providersReader.UnmarshalExact(&providersConfig); unmarshalError != nil {
 		return publicCapabilityAPIConfiguration{}, fmt.Errorf("%w: path=%s field=providers: %v", errPublicCapabilityConfig, configPath, unmarshalError)
 	}
-	var catalogConfig modelCatalogConfiguration
+	var catalogConfig proxy.ModelCatalog
 	if unmarshalError := catalogReader.UnmarshalExact(&catalogConfig); unmarshalError != nil {
 		return publicCapabilityAPIConfiguration{}, fmt.Errorf("%w: path=%s field=catalog: %v", errPublicCapabilityConfig, configPath, unmarshalError)
 	}
@@ -60,7 +60,7 @@ func loadPublicCapabilityAPIConfiguration(rawConfigPath string) (publicCapabilit
 		return publicCapabilityAPIConfiguration{}, fmt.Errorf("%w: path=%s: %v", errPublicCapabilityConfig, configPath, timeoutError)
 	}
 	capabilityCatalog, catalogError := proxy.NewPublicCapabilityCatalog(proxy.Configuration{
-		ModelCatalog:             catalogConfig.proxyCatalog(),
+		ModelCatalog:             catalogConfig,
 		MaxPromptBytes:           serverConfig.MaxPromptBytes,
 		MaxInputAudioBytes:       serverConfig.MaxInputAudioBytes,
 		MaxRequestTimeoutSeconds: maxRequestTimeoutSeconds,

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -45,9 +45,9 @@ func TestRootCommandRunsConfiguredProxyFromConfigFile(t *testing.T) {
 	providerValues.AnthropicBaseURL = "https://anthropic.example"
 	providerValues.MetaAPIKey = ""
 	providerValues.MetaBaseURL = "https://meta.example/v1"
-	providerValues.GrokAPIKey = ""
-	providerValues.GrokBaseURL = "https://grok.example"
-	providerValues.GrokTranscriptionsURL = "https://grok.example/stt"
+	providerValues.XAIAPIKey = ""
+	providerValues.XAIBaseURL = "https://xai.example"
+	providerValues.XAITranscriptionsURL = "https://xai.example/stt"
 	configPath := writeTestConfig(t, tempDir, `
 server:
   port: 18080
@@ -192,14 +192,14 @@ P411_MANAGEMENT_PROVIDER_KEY_ENCRYPTION_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlh
 	if capturedConfiguration.ZhipuTranscriptionsURL != "https://zhipu.example/audio/transcriptions" {
 		t.Fatalf("zhipuTranscriptionsURL=%q", capturedConfiguration.ZhipuTranscriptionsURL)
 	}
-	if capturedConfiguration.GrokKey != "" {
-		t.Fatalf("grokKey=%q", capturedConfiguration.GrokKey)
+	if capturedConfiguration.XAIKey != "" {
+		t.Fatalf("grokKey=%q", capturedConfiguration.XAIKey)
 	}
-	if capturedConfiguration.GrokBaseURL != "https://grok.example" {
-		t.Fatalf("grokBaseURL=%q", capturedConfiguration.GrokBaseURL)
+	if capturedConfiguration.XAIBaseURL != "https://xai.example" {
+		t.Fatalf("grokBaseURL=%q", capturedConfiguration.XAIBaseURL)
 	}
-	if capturedConfiguration.GrokTranscriptionsURL != "https://grok.example/stt" {
-		t.Fatalf("grokTranscriptionsURL=%q", capturedConfiguration.GrokTranscriptionsURL)
+	if capturedConfiguration.XAITranscriptionsURL != "https://xai.example/stt" {
+		t.Fatalf("grokTranscriptionsURL=%q", capturedConfiguration.XAITranscriptionsURL)
 	}
 	deepSeekDefault, deepSeekDefaultFound := configuredDefaultOffering(capturedConfiguration.ModelCatalog, proxy.ProviderNameDeepSeek, proxy.ModelOperationText)
 	if !deepSeekDefaultFound || deepSeekDefault.Model != "deepseek-v4-flash" {
@@ -868,13 +868,13 @@ func TestRootCommandRejectsMissingDefaultTextProviderKeys(t *testing.T) {
 			expectedError: "provider_api_key_required: provider=meta field=providers.meta.api_key",
 		},
 		{
-			name:     "grok alias",
-			provider: providerAliasXAI,
+			name:     "xai canonical",
+			provider: proxy.ProviderNameXAI,
 			model:    proxy.ModelNameGrok43,
 			missingKey: func(values *providerYAMLValues) {
-				values.GrokAPIKey = "${P411_MISSING_XAI_KEY}"
+				values.XAIAPIKey = "${P411_MISSING_XAI_KEY}"
 			},
-			expectedError: "provider_api_key_required: provider=grok field=providers.grok.api_key",
+			expectedError: "provider_api_key_required: provider=xai field=providers.xai.api_key",
 		},
 	}
 	for _, testCase := range testCases {
@@ -1187,7 +1187,7 @@ providers:
   meta:
     api_key: "sk-meta"
     base_url: "https://api.meta.ai/v1"
-  grok:
+  xai:
     api_key: "sk-grok"
     base_url: "https://api.x.ai/v1"
     transcriptions_url: "https://api.x.ai/v1/stt"
@@ -1227,12 +1227,12 @@ providers:
   meta:
     api_key: "sk-meta"
     base_url: "https://api.meta.ai/v1"
-  grok:
+  xai:
     api_key: "sk-grok"
     base_url: ""
     transcriptions_url: "https://api.x.ai/v1/stt"
 `,
-			expectedError: "provider_base_url_required: provider=grok field=providers.grok.base_url",
+			expectedError: "provider_base_url_required: provider=xai field=providers.xai.base_url",
 		},
 		{
 			name: "missing openai transcriptions url",
@@ -1268,7 +1268,7 @@ providers:
   meta:
     api_key: "sk-meta"
     base_url: "https://api.meta.ai/v1"
-  grok:
+  xai:
     api_key: "sk-grok"
     base_url: "https://api.x.ai/v1"
     transcriptions_url: "https://api.x.ai/v1/stt"
@@ -1309,7 +1309,7 @@ providers:
   meta:
     api_key: "sk-meta"
     base_url: "https://api.meta.ai/v1"
-  grok:
+  xai:
     api_key: "sk-grok"
     base_url: "https://api.x.ai/v1"
     transcriptions_url: "https://api.x.ai/v1/stt"
@@ -1350,7 +1350,7 @@ providers:
   meta:
     api_key: "sk-meta"
     base_url: "https://api.meta.ai/v1"
-  grok:
+  xai:
     api_key: "sk-grok"
     base_url: "https://api.x.ai/v1"
     transcriptions_url: "https://api.x.ai/v1/stt"
@@ -1358,7 +1358,7 @@ providers:
 			expectedError: "provider_transcriptions_url_required: provider=zhipu field=providers.zhipu.transcriptions_url",
 		},
 		{
-			name: "missing grok transcriptions url",
+			name: "missing xai transcriptions url",
 			providersYAML: `
 providers:
   openai:
@@ -1391,12 +1391,12 @@ providers:
   meta:
     api_key: "sk-meta"
     base_url: "https://api.meta.ai/v1"
-  grok:
+  xai:
     api_key: "sk-grok"
     base_url: "https://api.x.ai/v1"
     transcriptions_url: ""
 `,
-			expectedError: "provider_transcriptions_url_required: provider=grok field=providers.grok.transcriptions_url",
+			expectedError: "provider_transcriptions_url_required: provider=xai field=providers.xai.transcriptions_url",
 		},
 		{
 			name:          "missing provider text models",
@@ -1674,16 +1674,16 @@ providers:
 		{
 			name: "dictation wire contract",
 			providersYAML: mutateCatalogOfferingYAML(completeLiteralProvidersYAML(), proxy.ProviderNameOpenAI, proxy.DefaultDictationModel, func(block string) string {
-				return strings.Replace(block, "    operations:\n", "    wire_contract: openai_responses\n    operations:\n", 1)
+				return strings.Replace(block, "wire_contract: multipart_transcription", "wire_contract: openai_responses", 1)
 			}),
-			expectedError: "text_capabilities_without_text_operation",
+			expectedError: "unsupported_dictation_route",
 		},
 		{
 			name: "dictation execution lifecycle",
 			providersYAML: mutateCatalogOfferingYAML(completeLiteralProvidersYAML(), proxy.ProviderNameOpenAI, proxy.DefaultDictationModel, func(block string) string {
-				return strings.Replace(block, "    operations:\n", "    execution_lifecycle: synchronous_completion\n    operations:\n", 1)
+				return strings.Replace(block, "execution_lifecycle: synchronous_completion", "execution_lifecycle: pollable_resource", 1)
 			}),
-			expectedError: "text_capabilities_without_text_operation",
+			expectedError: "unsupported_dictation_route",
 		},
 		{
 			name:          "blank openai request profile",
@@ -1719,7 +1719,7 @@ providers:
 			providersYAML: mutateCatalogOfferingYAML(completeLiteralProvidersYAML(), proxy.ProviderNameOpenAI, proxy.DefaultDictationModel, func(block string) string {
 				return strings.Replace(block, "    operations:\n", "    web_search: true\n    operations:\n", 1)
 			}),
-			expectedError: "text_capabilities_without_text_operation",
+			expectedError: "text_capabilities_on_dictation_route",
 		},
 	}
 
@@ -1893,9 +1893,9 @@ type providerYAMLValues struct {
 	AnthropicBaseURL             string
 	MetaAPIKey                   string
 	MetaBaseURL                  string
-	GrokAPIKey                   string
-	GrokBaseURL                  string
-	GrokTranscriptionsURL        string
+	XAIAPIKey                    string
+	XAIBaseURL                   string
+	XAITranscriptionsURL         string
 }
 
 func defaultProviderYAMLValues() providerYAMLValues {
@@ -1923,9 +1923,9 @@ func defaultProviderYAMLValues() providerYAMLValues {
 		AnthropicBaseURL:             "https://api.anthropic.com",
 		MetaAPIKey:                   "sk-meta",
 		MetaBaseURL:                  "https://api.meta.ai/v1",
-		GrokAPIKey:                   "sk-grok",
-		GrokBaseURL:                  "https://api.x.ai/v1",
-		GrokTranscriptionsURL:        "https://api.x.ai/v1/stt",
+		XAIAPIKey:                    "sk-grok",
+		XAIBaseURL:                   "https://api.x.ai/v1",
+		XAITranscriptionsURL:         "https://api.x.ai/v1/stt",
 	}
 }
 
@@ -1965,7 +1965,7 @@ providers:
   meta:
     api_key: "%s"
     base_url: "%s"
-  grok:
+  xai:
     api_key: "%s"
     base_url: "%s"
     transcriptions_url: "%s"
@@ -1993,9 +1993,9 @@ providers:
 		values.AnthropicBaseURL,
 		values.MetaAPIKey,
 		values.MetaBaseURL,
-		values.GrokAPIKey,
-		values.GrokBaseURL,
-		values.GrokTranscriptionsURL,
+		values.XAIAPIKey,
+		values.XAIBaseURL,
+		values.XAITranscriptionsURL,
 	)
 	return providersYAML + canonicalModelCatalogYAML()
 }

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -56,33 +56,75 @@ providers:
     base_url: https://api.anthropic.com
   meta:
     base_url: https://api.meta.ai/v1
-  grok:
+  xai:
     base_url: https://api.x.ai/v1
     transcriptions_url: https://api.x.ai/v1/stt
 catalog:
+  revision: 2026-08-10.i216.1
+  operations:
+  - id: text
+    input_artifacts:
+    - text
+    - image
+    - audio
+    output_artifacts:
+    - text
+  - id: dictation
+    input_artifacts:
+    - audio
+    output_artifacts:
+    - text
+  - id: video_generation
+    input_artifacts:
+    - text
+    - image
+    output_artifacts:
+    - video
   providers:
   - id: openai
     label: OpenAI
+    credential_kinds:
+    - api_key
   - id: deepseek
     label: DeepSeek
+    credential_kinds:
+    - api_key
   - id: dashscope
     label: DashScope
+    credential_kinds:
+    - api_key
   - id: moonshot
     label: Moonshot
+    credential_kinds:
+    - api_key
   - id: minimax
     label: MiniMax
+    credential_kinds:
+    - api_key
   - id: siliconflow
     label: SiliconFlow
+    credential_kinds:
+    - api_key
   - id: zhipu
     label: Zhipu
+    credential_kinds:
+    - api_key
   - id: gemini
     label: Gemini
+    credential_kinds:
+    - api_key
   - id: anthropic
     label: Anthropic
+    credential_kinds:
+    - api_key
   - id: meta
     label: Meta
-  - id: grok
-    label: Grok
+    credential_kinds:
+    - api_key
+  - id: xai
+    label: xAI
+    credential_kinds:
+    - api_key
   publishers:
   - id: openai
     label: OpenAI
@@ -173,6 +215,9 @@ catalog:
   - id: grok-code
     publisher: xai
     label: Grok Code
+  - id: grok-imagine
+    publisher: xai
+    label: Grok Imagine
   - id: xai-stt
     publisher: xai
     label: xAI STT
@@ -513,6 +558,12 @@ catalog:
     version: grok-code-fast-1-0825
     operations:
     - text
+  - id: grok-imagine-video-1.5
+    publisher: xai
+    family: grok-imagine
+    version: grok-imagine-video-1.5
+    operations:
+    - video_generation
   - id: xai-stt
     publisher: xai
     family: xai-stt
@@ -690,11 +741,15 @@ catalog:
     - dictation
     default_operations:
     - dictation
+    wire_contract: multipart_transcription
+    execution_lifecycle: synchronous_completion
   - provider: openai
     model: gpt-4o-transcribe
     provider_model: gpt-4o-transcribe
     operations:
     - dictation
+    wire_contract: multipart_transcription
+    execution_lifecycle: synchronous_completion
   - provider: deepseek
     model: deepseek-v4-flash
     provider_model: deepseek-v4-flash
@@ -790,6 +845,8 @@ catalog:
     - dictation
     default_operations:
     - dictation
+    wire_contract: multipart_transcription
+    execution_lifecycle: synchronous_completion
   - provider: zhipu
     model: glm-5.1
     provider_model: glm-5.1
@@ -814,6 +871,8 @@ catalog:
     - dictation
     default_operations:
     - dictation
+    wire_contract: multipart_transcription
+    execution_lifecycle: synchronous_completion
   - provider: gemini
     model: gemini-3.5-flash
     provider_model: gemini-3.5-flash
@@ -969,7 +1028,7 @@ catalog:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-4.3
     provider_model: grok-4.3
     operations:
@@ -978,73 +1037,546 @@ catalog:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-4.3-latest
     provider_model: grok-4.3-latest
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-4.5
     provider_model: grok-4.5
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-4.20-0309-reasoning
     provider_model: grok-4.20-0309-reasoning
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-4.20-0309-non-reasoning
     provider_model: grok-4.20-0309-non-reasoning
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-latest
     provider_model: grok-latest
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-build-0.1
     provider_model: grok-build-0.1
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-code-fast
     provider_model: grok-code-fast
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-code-fast-1
     provider_model: grok-code-fast-1
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
     model: grok-code-fast-1-0825
     provider_model: grok-code-fast-1-0825
     operations:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
-  - provider: grok
+  - provider: xai
+    model: grok-imagine-video-1.5
+    provider_model: grok-imagine-video-1.5
+    operations:
+    - video_generation
+    default_operations:
+    - video_generation
+    wire_contract: xai_videos_generations
+    execution_lifecycle: pollable_resource
+    controls:
+    - id: aspect_ratio
+      kind: enum
+      values:
+      - "1:1"
+      - "16:9"
+      - "9:16"
+      - "4:3"
+      - "3:4"
+      - "3:2"
+      - "2:3"
+    - id: duration_seconds
+      kind: integer
+      minimum: 1
+      maximum: 15
+    - id: resolution
+      kind: enum
+      values:
+      - 480p
+      - 720p
+      - 1080p
+    - id: start_image
+      kind: boolean
+    limits:
+    - id: concurrent_requests
+      unit: requests
+      account_dependent: true
+  - provider: xai
     model: xai-stt
     provider_model: xai-stt
     operations:
     - dictation
     default_operations:
     - dictation
+    wire_contract: multipart_transcription
+    execution_lifecycle: synchronous_completion
+  prices:
+  - provider: openai
+    model: gpt-4o-mini
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-4o
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-4.1
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-5-mini
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-5
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-5.5
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-5.5-pro
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-5.6
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-5.6-sol
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-5.6-terra
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-5.6-luna
+    operation: text
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-4o-mini-transcribe
+    operation: dictation
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: openai
+    model: gpt-4o-transcribe
+    operation: dictation
+    available: false
+    source: https://developers.openai.com/api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: deepseek
+    model: deepseek-v4-flash
+    operation: text
+    available: false
+    source: https://api-docs.deepseek.com/quick_start/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: deepseek
+    model: deepseek-v4-pro
+    operation: text
+    available: false
+    source: https://api-docs.deepseek.com/quick_start/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: deepseek
+    model: deepseek-chat
+    operation: text
+    available: false
+    source: https://api-docs.deepseek.com/quick_start/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: deepseek
+    model: deepseek-reasoner
+    operation: text
+    available: false
+    source: https://api-docs.deepseek.com/quick_start/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: dashscope
+    model: qwen-plus
+    operation: text
+    available: false
+    source: https://www.alibabacloud.com/help/en/model-studio/model-pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: moonshot
+    model: kimi-k2.6
+    operation: text
+    available: false
+    source: https://platform.moonshot.ai/docs/pricing/chat
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: moonshot
+    model: kimi-k3
+    operation: text
+    available: false
+    source: https://platform.moonshot.ai/docs/pricing/chat
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: moonshot
+    model: kimi-k2.7-code
+    operation: text
+    available: false
+    source: https://platform.moonshot.ai/docs/pricing/chat
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: moonshot
+    model: kimi-k2.7-code-highspeed
+    operation: text
+    available: false
+    source: https://platform.moonshot.ai/docs/pricing/chat
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: minimax
+    model: minimax-m2.7
+    operation: text
+    available: false
+    source: https://platform.minimax.io/docs/pricing/pay-as-you-go
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: siliconflow
+    model: deepseek-reasoner
+    operation: text
+    available: false
+    source: https://docs.siliconflow.com/en/userguide/introduction/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: siliconflow
+    model: sensevoice-small
+    operation: dictation
+    available: false
+    source: https://docs.siliconflow.com/en/userguide/introduction/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: zhipu
+    model: glm-5.1
+    operation: text
+    available: false
+    source: https://docs.z.ai/guides/overview/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: zhipu
+    model: glm-5.2
+    operation: text
+    available: false
+    source: https://docs.z.ai/guides/overview/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: zhipu
+    model: glm-asr-2512
+    operation: dictation
+    available: false
+    source: https://docs.z.ai/guides/overview/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: gemini
+    model: gemini-3.5-flash
+    operation: text
+    available: false
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: gemini
+    model: gemini-3.1-pro-preview
+    operation: text
+    available: false
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: gemini
+    model: gemini-3-flash-preview
+    operation: text
+    available: false
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: gemini
+    model: gemini-3.1-flash-lite
+    operation: text
+    available: false
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: gemini
+    model: gemini-2.5-flash
+    operation: text
+    available: false
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: gemini
+    model: gemini-2.5-flash-lite
+    operation: text
+    available: false
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: gemini
+    model: gemini-2.5-pro
+    operation: text
+    available: false
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-fable-5
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-sonnet-5
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-opus-4-8
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-sonnet-4-6
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-haiku-4-5-20251001
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-haiku-4-5
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-sonnet-4-5-20250929
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-sonnet-4-5
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-opus-4-1-20250805
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: anthropic
+    model: claude-opus-4-1
+    operation: text
+    available: false
+    source: https://docs.anthropic.com/en/docs/about-claude/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: meta
+    model: muse-spark-1.1
+    operation: text
+    available: false
+    source: https://dev.meta.ai/docs/pricing-rate-limits
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-4.3
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-4.3-latest
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-4.5
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-4.20-0309-reasoning
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-4.20-0309-non-reasoning
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-latest
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-build-0.1
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-code-fast
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-code-fast-1
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-code-fast-1-0825
+    operation: text
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.
+  - provider: xai
+    model: grok-imagine-video-1.5
+    operation: video_generation
+    available: true
+    rates:
+    - component: output_video
+      currency: USD
+      rate: 0.08
+      unit: USD/output_second
+      conditions:
+        resolution: 480p
+        duration: output
+    - component: output_video
+      currency: USD
+      rate: 0.14
+      unit: USD/output_second
+      conditions:
+        resolution: 720p
+        duration: output
+    - component: output_video
+      currency: USD
+      rate: 0.25
+      unit: USD/output_second
+      conditions:
+        resolution: 1080p
+        duration: output
+    - component: input_image
+      currency: USD
+      rate: 0.01
+      unit: USD/input_image
+      conditions:
+        input_media: image
+        quantity: input_image
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-08"
+  - provider: xai
+    model: xai-stt
+    operation: dictation
+    available: false
+    source: https://docs.x.ai/developers/pricing
+    last_verified: "2026-08-10"
+    unavailable_reason: Exact published pricing has not been imported for this provider offering.

--- a/docs/implementation/dictation-endpoint-plan.md
+++ b/docs/implementation/dictation-endpoint-plan.md
@@ -27,13 +27,13 @@ The endpoint returns `400`, `403`, `413`, `429`, `499`, `502`, `503`, or `504` w
 | `openai` | `gpt-4o-mini-transcribe`, `gpt-4o-transcribe` | `providers.openai.transcriptions_url` |
 | `siliconflow` | `sensevoice-small` | `providers.siliconflow.transcriptions_url` |
 | `zhipu` or `glm` | `glm-asr-2512` | `providers.zhipu.transcriptions_url` |
-| `grok` or `xai` | `xai-stt` | `providers.grok.transcriptions_url` |
+| `xai` | `xai-stt` | `providers.xai.transcriptions_url` |
 
 OpenAI is the default dictation provider. Its default model is `gpt-4o-mini-transcribe`.
 The selected provider supplies its configured transcription URL and server-side API key.
 
 OpenAI, SiliconFlow, and Zhipu receive the selected model in the upstream multipart request.
-Grok uses its configured STT endpoint and does not receive an upstream multipart model field.
+xAI uses its configured STT endpoint and does not receive an upstream multipart model field.
 
 The adapter accepts nonblank upstream `text`, `transcript`, or `output_text` JSON fields.
 It also accepts a nonblank plain-text upstream response. Empty or malformed success payloads return a sanitized provider failure.

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -76,7 +76,7 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 | `zhipu` | `glm` | `openai_chat_completions` | `synchronous_completion` | Z.AI GLM-ASR transcription | Not supported |
 | `gemini` | none | `gemini_interactions` | Model-specific: Gemini 3.x `pollable_resource`; Gemini 2.5 `synchronous_completion` | Not supported | Not supported |
 | `anthropic` | `claude` | `anthropic_messages` | `synchronous_completion` | Not supported | Not supported |
-| `grok` | `xai` | `openai_chat_completions` | `synchronous_completion` | xAI STT | Not supported |
+| `xai` | none | `openai_chat_completions` | `synchronous_completion` | xAI STT | Not supported |
 
 This matrix describes capabilities wired through `llm-proxy`. Upstream products
 can expose speech APIs that are not yet proxy adapters; do not mark them
@@ -171,11 +171,14 @@ Provider credentials and base URLs:
 - `providers.zhipu.api_key`, `providers.zhipu.base_url`, `providers.zhipu.transcriptions_url`
 - `providers.gemini.api_key`, `providers.gemini.base_url`
 - `providers.anthropic.api_key`, `providers.anthropic.base_url`
-- `providers.grok.api_key`, `providers.grok.base_url`, `providers.grok.transcriptions_url`
+- `providers.xai.api_key`, `providers.xai.base_url`, `providers.xai.transcriptions_url`
 
 Normalized model catalog:
 
+- `catalog.revision`
+- `catalog.operations[].id`, `input_artifacts`, and `output_artifacts`
 - `catalog.providers[].id` and `catalog.providers[].label`
+- `catalog.providers[].credential_kinds`
 - `catalog.publishers[].id` and `catalog.publishers[].label`
 - `catalog.families[].id`, `publisher`, and `label`
 - `catalog.models[].id`, `publisher`, `family`, and `version`
@@ -186,6 +189,9 @@ Normalized model catalog:
 - `catalog.offerings[].output_token_limit` and `media_inputs`
 - `catalog.offerings[].reasoning_effort`
 - `catalog.offerings[].request_profile` and `web_search`
+- `catalog.offerings[].controls` and `limits`
+- `catalog.prices[].provider`, `model`, `operation`, availability, rates,
+  exact conditions, minimum charge, source, and verification date
 
 The model catalog is runtime config data. Code owns provider selectors,
 aliases, allowed wire and lifecycle pairs, endpoint shapes, adapters, and
@@ -630,14 +636,14 @@ that response or structured provider-failure logs.
   non-stored synchronous request. For exact models whose catalog declares the capability, ordered
   image and audio attachments become typed interaction content after the
   message text.
-- Grok uses the shared OpenAI-compatible Chat Completions adapter against `providers.grok.base_url`.
+- xAI uses the shared OpenAI-compatible Chat Completions adapter against `providers.xai.base_url`.
 - OpenAI-compatible chat providers receive validated and sorted `messages[]` as provider-supported `role` and `content` items.
 - OpenAI Responses payload shape comes from the selected configured model's stable `request_profile`; model-specific web-search support comes from the selected model catalog entry. OpenAI Responses text calls run in background mode with stored responses so long provider work can be polled by llm-proxy while the caller waits on one REST request.
 - Gemini receives user messages as `user_input` steps, assistant messages as
   `model_output` steps, and system messages as `system_instruction`. Other
   adapters remain text-only and reject model media declarations at startup.
 - OpenAI Responses receives single-prompt requests unchanged and multi-message requests as a deterministic role-labelled transcript.
-- Dictation routing reuses the multipart transcription adapter with provider-specific URLs. OpenAI, SiliconFlow, and Zhipu send a multipart `model` field; Grok/xAI uses xAI STT and omits the multipart `model` field. Only providers that support `/dictate` expose transcription URL config fields.
+- Dictation routing reuses the multipart transcription adapter with provider-specific URLs. OpenAI, SiliconFlow, and Zhipu send a multipart `model` field. xAI STT omits the multipart `model` field. Only providers that support `/dictate` expose transcription URL config fields.
 - Response formatting keeps existing text/XML/CSV bodies and existing JSON `request`, `response`, and normalized `usage` fields. JSON responses also include OpenRouter-style `object`, `model`, and `choices[].message.content` metadata, plus caller-visible request `messages` with provided `order` values. Server-injected tenant default system prompts are sent upstream but not echoed in response metadata.
 
 ## Test Strategy

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1100,16 +1100,27 @@ components:
       type: object
       additionalProperties: false
       required:
+        - revision
+        - operations
         - providers
         - publishers
         - families
         - models
         - offerings
+        - prices
         - counts
         - max_prompt_bytes
         - max_input_audio_bytes
         - max_request_timeout_seconds
       properties:
+        revision:
+          type: string
+          minLength: 1
+        operations:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/PublicModelOperation'
         providers:
           type: array
           minItems: 1
@@ -1135,6 +1146,11 @@ components:
           minItems: 1
           items:
             $ref: '#/components/schemas/PublicProviderOffering'
+        prices:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/PublicPriceDescriptor'
         counts:
           $ref: '#/components/schemas/PublicCapabilityCounts'
         max_prompt_bytes:
@@ -1154,6 +1170,7 @@ components:
       required:
         - identifier
         - label
+        - credential_kinds
       properties:
         identifier:
           type: string
@@ -1161,6 +1178,47 @@ components:
         label:
           type: string
           minLength: 1
+        credential_kinds:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+            enum:
+              - api_key
+    PublicModelOperation:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - input_artifacts
+        - output_artifacts
+      properties:
+        id:
+          type: string
+          enum:
+            - text
+            - dictation
+            - video_generation
+        input_artifacts:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/PublicArtifactKind'
+        output_artifacts:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/PublicArtifactKind'
+    PublicArtifactKind:
+      type: string
+      enum:
+        - text
+        - image
+        - audio
+        - video
     PublicModelPublisher:
       type: object
       additionalProperties: false
@@ -1229,6 +1287,7 @@ components:
             enum:
               - text
               - dictation
+              - video_generation
         media_inputs:
           type: array
           uniqueItems: true
@@ -1250,6 +1309,7 @@ components:
               - image_input
               - audio_input
               - reasoning
+              - video_generation
         provider_offerings:
           type: array
           minItems: 1
@@ -1266,8 +1326,11 @@ components:
         - model
         - capabilities
         - wire_contract
+        - execution_lifecycle
         - output_token_limit
         - reasoning_efforts
+        - controls
+        - limits
       properties:
         identifier:
           type: string
@@ -1291,8 +1354,15 @@ components:
               - image_input
               - audio_input
               - reasoning
+              - video_generation
         wire_contract:
           type: string
+          minLength: 1
+        execution_lifecycle:
+          type: string
+          enum:
+            - synchronous_completion
+            - pollable_resource
         output_token_limit:
           type: integer
           minimum: 0
@@ -1302,6 +1372,189 @@ components:
           items:
             type: string
             minLength: 1
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicCatalogControl'
+        limits:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicCatalogLimit'
+    PublicCatalogControl:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - kind
+        - values
+        - minimum
+        - maximum
+        - account_dependent
+      properties:
+        id:
+          type: string
+          minLength: 1
+        kind:
+          type: string
+          enum:
+            - enum
+            - integer
+            - boolean
+        values:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+        minimum:
+          oneOf:
+            - type: integer
+              minimum: 0
+            - type: 'null'
+        maximum:
+          oneOf:
+            - type: integer
+              minimum: 0
+            - type: 'null'
+        account_dependent:
+          type: boolean
+    PublicCatalogLimit:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - value
+        - unit
+        - account_dependent
+      properties:
+        id:
+          type: string
+          minLength: 1
+        value:
+          oneOf:
+            - type: integer
+              minimum: 0
+            - type: 'null'
+        unit:
+          type: string
+          minLength: 1
+        account_dependent:
+          type: boolean
+    PublicPriceDescriptor:
+      type: object
+      additionalProperties: false
+      required:
+        - provider
+        - model
+        - operation
+        - available
+        - rates
+        - minimum_charge
+        - source
+        - last_verified
+        - unavailable_reason
+      properties:
+        provider:
+          type: string
+          minLength: 1
+        model:
+          type: string
+          minLength: 1
+        operation:
+          type: string
+          enum:
+            - text
+            - dictation
+            - video_generation
+        available:
+          type: boolean
+        rates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicPriceRate'
+        minimum_charge:
+          oneOf:
+            - $ref: '#/components/schemas/PublicMinimumCharge'
+            - type: 'null'
+        source:
+          type: string
+          format: uri
+          pattern: '^https://'
+        last_verified:
+          type: string
+          format: date
+        unavailable_reason:
+          type: string
+    PublicPriceRate:
+      type: object
+      additionalProperties: false
+      required:
+        - component
+        - currency
+        - rate
+        - unit
+        - conditions
+      properties:
+        component:
+          type: string
+          minLength: 1
+        currency:
+          type: string
+          const: USD
+        rate:
+          type: number
+          minimum: 0
+        unit:
+          type: string
+          minLength: 1
+        conditions:
+          $ref: '#/components/schemas/PublicPriceConditions'
+    PublicMinimumCharge:
+      type: object
+      additionalProperties: false
+      required:
+        - currency
+        - amount
+        - unit
+      properties:
+        currency:
+          type: string
+          const: USD
+        amount:
+          type: number
+          minimum: 0
+        unit:
+          type: string
+          minLength: 1
+    PublicPriceConditions:
+      type: object
+      additionalProperties: false
+      required:
+        - resolution
+        - generated_audio
+        - input_media
+        - output_media
+        - duration
+        - quantity
+        - quality
+        - mode
+        - api_version
+        - avatar_type
+        - billing_mode
+        - billing_outcome
+      properties:
+        resolution: {type: string}
+        generated_audio: {type: string}
+        input_media: {type: string}
+        output_media: {type: string}
+        duration: {type: string}
+        quantity: {type: string}
+        quality: {type: string}
+        mode: {type: string}
+        api_version: {type: string}
+        avatar_type: {type: string}
+        billing_mode: {type: string}
+        billing_outcome: {type: string}
     PublicCapabilityCounts:
       type: object
       additionalProperties: false

--- a/internal/openapitest/contract.go
+++ b/internal/openapitest/contract.go
@@ -629,6 +629,21 @@ func (contract *Contract) validateValue(schema map[string]any, value any, contex
 			}
 		}
 		return nil
+	case "number":
+		numberValue, numberError := contractNumber(value)
+		if numberError != nil {
+			return fmt.Errorf("%w: %s must be a number", errInvalidContract, context)
+		}
+		if rawMinimum, hasMinimum := resolvedSchema["minimum"]; hasMinimum {
+			minimum, minimumError := contractNumber(rawMinimum)
+			if minimumError != nil {
+				return fmt.Errorf("%w: %s minimum: %v", errInvalidContract, context, minimumError)
+			}
+			if numberValue < minimum {
+				return fmt.Errorf("%w: %s must be at least %g", errInvalidContract, context, minimum)
+			}
+		}
+		return nil
 	case "boolean":
 		if _, ok := value.(bool); !ok {
 			return fmt.Errorf("%w: %s must be a boolean", errInvalidContract, context)
@@ -703,6 +718,21 @@ func contractInteger(value any) (int64, error) {
 		return typedValue.Int64()
 	default:
 		return 0, fmt.Errorf("value=%v is not an integer", value)
+	}
+}
+
+func contractNumber(value any) (float64, error) {
+	switch typedValue := value.(type) {
+	case int:
+		return float64(typedValue), nil
+	case int64:
+		return float64(typedValue), nil
+	case float64:
+		return typedValue, nil
+	case json.Number:
+		return typedValue.Float64()
+	default:
+		return 0, fmt.Errorf("value=%v is not a number", value)
 	}
 }
 

--- a/internal/proxy/catalog_service.go
+++ b/internal/proxy/catalog_service.go
@@ -101,7 +101,7 @@ type CatalogService struct {
 
 // NewCatalogService validates one complete catalog snapshot.
 func NewCatalogService(catalog ModelCatalog) (CatalogService, error) {
-	validated, validationError := validateModelCatalog(catalog)
+	validated, validationError := validateModelCatalog(cloneModelCatalog(catalog))
 	if validationError != nil {
 		return CatalogService{}, validationError
 	}
@@ -120,7 +120,7 @@ func (service CatalogService) ResolveOffering(provider string, model string) (Pr
 	if !found {
 		return ProviderOffering{}, fmt.Errorf("%w: route=%s reason=unknown", ErrInvalidModelCatalog, offeringIdentifier)
 	}
-	return offering, nil
+	return cloneProviderOffering(offering), nil
 }
 
 // SelectPrice returns the exact component and condition match. Missing or
@@ -155,6 +155,82 @@ func (service CatalogService) SelectPrice(provider string, model string, operati
 	}
 	selection.UnavailableReason = "exact_price_unavailable"
 	return selection
+}
+
+func cloneModelCatalog(catalog ModelCatalog) ModelCatalog {
+	cloned := catalog
+	cloned.Operations = make([]ModelOperationKind, len(catalog.Operations))
+	for operationIndex, operation := range catalog.Operations {
+		cloned.Operations[operationIndex] = operation
+		cloned.Operations[operationIndex].InputArtifacts = append([]string(nil), operation.InputArtifacts...)
+		cloned.Operations[operationIndex].OutputArtifacts = append([]string(nil), operation.OutputArtifacts...)
+	}
+	cloned.Providers = make([]CatalogProvider, len(catalog.Providers))
+	for providerIndex, provider := range catalog.Providers {
+		cloned.Providers[providerIndex] = provider
+		cloned.Providers[providerIndex].CredentialKinds = append([]string(nil), provider.CredentialKinds...)
+	}
+	cloned.Publishers = append([]ModelPublisher(nil), catalog.Publishers...)
+	cloned.Families = append([]ModelFamily(nil), catalog.Families...)
+	cloned.Models = make([]ExactModel, len(catalog.Models))
+	for modelIndex, model := range catalog.Models {
+		cloned.Models[modelIndex] = model
+		cloned.Models[modelIndex].Operations = append([]string(nil), model.Operations...)
+		cloned.Models[modelIndex].MediaInputs = append([]string(nil), model.MediaInputs...)
+	}
+	cloned.Offerings = make([]ProviderOffering, len(catalog.Offerings))
+	for offeringIndex, offering := range catalog.Offerings {
+		cloned.Offerings[offeringIndex] = cloneProviderOffering(offering)
+	}
+	cloned.Prices = make([]CatalogPriceDescriptor, len(catalog.Prices))
+	for priceIndex, price := range catalog.Prices {
+		cloned.Prices[priceIndex] = cloneCatalogPriceDescriptor(price)
+	}
+	return cloned
+}
+
+func cloneProviderOffering(offering ProviderOffering) ProviderOffering {
+	cloned := offering
+	cloned.Operations = append([]string(nil), offering.Operations...)
+	cloned.DefaultOperations = append([]string(nil), offering.DefaultOperations...)
+	cloned.MediaInputs = append([]string(nil), offering.MediaInputs...)
+	if offering.ReasoningEffort != nil {
+		cloned.ReasoningEffort = &ReasoningEffortCapability{
+			Adapter: offering.ReasoningEffort.Adapter,
+			Efforts: append([]string(nil), offering.ReasoningEffort.Efforts...),
+		}
+	}
+	cloned.Controls = make([]CatalogControl, len(offering.Controls))
+	for controlIndex, control := range offering.Controls {
+		cloned.Controls[controlIndex] = control
+		cloned.Controls[controlIndex].Values = append([]string(nil), control.Values...)
+		cloned.Controls[controlIndex].Minimum = cloneInteger(control.Minimum)
+		cloned.Controls[controlIndex].Maximum = cloneInteger(control.Maximum)
+	}
+	cloned.Limits = make([]CatalogLimit, len(offering.Limits))
+	for limitIndex, limit := range offering.Limits {
+		cloned.Limits[limitIndex] = limit
+		cloned.Limits[limitIndex].Value = cloneInteger(limit.Value)
+	}
+	return cloned
+}
+
+func cloneCatalogPriceDescriptor(descriptor CatalogPriceDescriptor) CatalogPriceDescriptor {
+	cloned := descriptor
+	cloned.Rates = append([]CatalogPriceRate(nil), descriptor.Rates...)
+	if descriptor.MinimumCharge != nil {
+		minimumCharge := *descriptor.MinimumCharge
+		cloned.MinimumCharge = &minimumCharge
+	}
+	return cloned
+}
+
+func cloneInteger(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func validateCatalogRevision(revision string) error {
@@ -247,7 +323,7 @@ func validateCatalogControls(controls []CatalogControl, field string) error {
 				values[value] = struct{}{}
 			}
 		case CatalogControlInteger:
-			if len(control.Values) != 0 || control.Minimum == nil || control.Maximum == nil || *control.Minimum > *control.Maximum {
+			if len(control.Values) != 0 || control.Minimum == nil || control.Maximum == nil || *control.Minimum < 0 || *control.Maximum < 0 || *control.Minimum > *control.Maximum {
 				return fmt.Errorf("%w: field=%s[%d] kind=%s", ErrInvalidModelCatalog, field, controlIndex, control.Kind)
 			}
 		case CatalogControlBoolean:

--- a/internal/proxy/catalog_service.go
+++ b/internal/proxy/catalog_service.go
@@ -1,0 +1,359 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tyemirov/llm-proxy/internal/constants"
+)
+
+const (
+	// CatalogControlEnum identifies a control with an exact value vocabulary.
+	CatalogControlEnum = "enum"
+	// CatalogControlInteger identifies a bounded integer control.
+	CatalogControlInteger = "integer"
+	// CatalogControlBoolean identifies a Boolean control.
+	CatalogControlBoolean = "boolean"
+	// CatalogCurrencyUSD identifies published United States dollar prices.
+	CatalogCurrencyUSD = "USD"
+)
+
+// CatalogControl declares one route-specific request control.
+type CatalogControl struct {
+	ID               string   `json:"id" mapstructure:"id"`
+	Kind             string   `json:"kind" mapstructure:"kind"`
+	Values           []string `json:"values" mapstructure:"values"`
+	Minimum          *int     `json:"minimum" mapstructure:"minimum"`
+	Maximum          *int     `json:"maximum" mapstructure:"maximum"`
+	AccountDependent bool     `json:"account_dependent" mapstructure:"account_dependent"`
+}
+
+// CatalogLimit declares one fixed or account-dependent route limit.
+type CatalogLimit struct {
+	ID               string `json:"id" mapstructure:"id"`
+	Value            *int   `json:"value" mapstructure:"value"`
+	Unit             string `json:"unit" mapstructure:"unit"`
+	AccountDependent bool   `json:"account_dependent" mapstructure:"account_dependent"`
+}
+
+// CatalogPriceConditions identifies one exact published billing condition set.
+type CatalogPriceConditions struct {
+	Resolution     string `json:"resolution" mapstructure:"resolution"`
+	GeneratedAudio string `json:"generated_audio" mapstructure:"generated_audio"`
+	InputMedia     string `json:"input_media" mapstructure:"input_media"`
+	OutputMedia    string `json:"output_media" mapstructure:"output_media"`
+	Duration       string `json:"duration" mapstructure:"duration"`
+	Quantity       string `json:"quantity" mapstructure:"quantity"`
+	Quality        string `json:"quality" mapstructure:"quality"`
+	Mode           string `json:"mode" mapstructure:"mode"`
+	APIVersion     string `json:"api_version" mapstructure:"api_version"`
+	AvatarType     string `json:"avatar_type" mapstructure:"avatar_type"`
+	BillingMode    string `json:"billing_mode" mapstructure:"billing_mode"`
+	BillingOutcome string `json:"billing_outcome" mapstructure:"billing_outcome"`
+}
+
+// CatalogPriceRate is one exact published billing component.
+type CatalogPriceRate struct {
+	Component  string                 `json:"component" mapstructure:"component"`
+	Currency   string                 `json:"currency" mapstructure:"currency"`
+	Rate       float64                `json:"rate" mapstructure:"rate"`
+	Unit       string                 `json:"unit" mapstructure:"unit"`
+	Conditions CatalogPriceConditions `json:"conditions" mapstructure:"conditions"`
+}
+
+// CatalogMinimumCharge declares one published request minimum.
+type CatalogMinimumCharge struct {
+	Currency string  `json:"currency" mapstructure:"currency"`
+	Amount   float64 `json:"amount" mapstructure:"amount"`
+	Unit     string  `json:"unit" mapstructure:"unit"`
+}
+
+// CatalogPriceDescriptor owns pricing for one provider, model, and operation.
+type CatalogPriceDescriptor struct {
+	Provider          string                `json:"provider" mapstructure:"provider"`
+	Model             string                `json:"model" mapstructure:"model"`
+	Operation         string                `json:"operation" mapstructure:"operation"`
+	Available         bool                  `json:"available" mapstructure:"available"`
+	Rates             []CatalogPriceRate    `json:"rates" mapstructure:"rates"`
+	MinimumCharge     *CatalogMinimumCharge `json:"minimum_charge" mapstructure:"minimum_charge"`
+	Source            string                `json:"source" mapstructure:"source"`
+	LastVerified      string                `json:"last_verified" mapstructure:"last_verified"`
+	UnavailableReason string                `json:"unavailable_reason" mapstructure:"unavailable_reason"`
+}
+
+// CatalogPriceSelection is an exact price result. Unavailable selections carry
+// a stable reason and never guess a rate.
+type CatalogPriceSelection struct {
+	Available         bool
+	Rate              *CatalogPriceRate
+	MinimumCharge     *CatalogMinimumCharge
+	Source            string
+	LastVerified      string
+	UnavailableReason string
+}
+
+// CatalogService is the validated model-operation capability and price
+// snapshot used by routing, public discovery, management, and later planning.
+type CatalogService struct {
+	catalog validatedModelCatalog
+}
+
+// NewCatalogService validates one complete catalog snapshot.
+func NewCatalogService(catalog ModelCatalog) (CatalogService, error) {
+	validated, validationError := validateModelCatalog(catalog)
+	if validationError != nil {
+		return CatalogService{}, validationError
+	}
+	return CatalogService{catalog: validated}, nil
+}
+
+// Revision returns the exact catalog snapshot identifier.
+func (service CatalogService) Revision() string {
+	return service.catalog.revision
+}
+
+// ResolveOffering resolves one canonical provider and model pair.
+func (service CatalogService) ResolveOffering(provider string, model string) (ProviderOffering, error) {
+	offeringIdentifier := providerOfferingIdentifier(strings.TrimSpace(provider), strings.TrimSpace(model))
+	offering, found := service.catalog.offerings[offeringIdentifier]
+	if !found {
+		return ProviderOffering{}, fmt.Errorf("%w: route=%s reason=unknown", ErrInvalidModelCatalog, offeringIdentifier)
+	}
+	return offering, nil
+}
+
+// SelectPrice returns the exact component and condition match. Missing or
+// incomplete selections return a typed unavailable result.
+func (service CatalogService) SelectPrice(provider string, model string, operation string, component string, conditions CatalogPriceConditions) CatalogPriceSelection {
+	descriptor, found := service.catalog.prices[catalogPriceIdentifier(provider, model, operation)]
+	if !found {
+		return CatalogPriceSelection{UnavailableReason: "price_not_cataloged"}
+	}
+	selection := CatalogPriceSelection{
+		Source:            descriptor.Source,
+		LastVerified:      descriptor.LastVerified,
+		UnavailableReason: descriptor.UnavailableReason,
+	}
+	if descriptor.MinimumCharge != nil {
+		minimumCharge := *descriptor.MinimumCharge
+		selection.MinimumCharge = &minimumCharge
+	}
+	if !descriptor.Available {
+		return selection
+	}
+	component = strings.TrimSpace(component)
+	for rateIndex := range descriptor.Rates {
+		rate := descriptor.Rates[rateIndex]
+		if rate.Component == component && rate.Conditions == conditions {
+			selectedRate := rate
+			selection.Available = true
+			selection.Rate = &selectedRate
+			selection.UnavailableReason = constants.EmptyString
+			return selection
+		}
+	}
+	selection.UnavailableReason = "exact_price_unavailable"
+	return selection
+}
+
+func validateCatalogRevision(revision string) error {
+	if _, revisionError := canonicalCatalogIdentifier(revision, "catalog.revision"); revisionError != nil {
+		return revisionError
+	}
+	return nil
+}
+
+func validateModelOperationKinds(operations []ModelOperationKind, validated map[string]ModelOperationKind) error {
+	if len(operations) == 0 {
+		return fmt.Errorf("%w: field=catalog.operations", ErrInvalidModelCatalog)
+	}
+	for operationIndex, operation := range operations {
+		identifier, identifierError := canonicalCatalogIdentifier(operation.ID, fmt.Sprintf("catalog.operations[%d].id", operationIndex))
+		if identifierError != nil {
+			return identifierError
+		}
+		if identifier != ModelOperationText && identifier != ModelOperationDictation && identifier != ModelOperationVideoGeneration {
+			return fmt.Errorf("%w: field=catalog.operations[%d].id operation=%s", ErrInvalidModelCatalog, operationIndex, identifier)
+		}
+		if _, duplicate := validated[identifier]; duplicate {
+			return fmt.Errorf("%w: field=catalog.operations[%d].id duplicate_identifier=%s", ErrInvalidModelCatalog, operationIndex, identifier)
+		}
+		if artifactError := validateArtifactKinds(operation.InputArtifacts, fmt.Sprintf("catalog.operations[%d].input_artifacts", operationIndex)); artifactError != nil {
+			return artifactError
+		}
+		if artifactError := validateArtifactKinds(operation.OutputArtifacts, fmt.Sprintf("catalog.operations[%d].output_artifacts", operationIndex)); artifactError != nil {
+			return artifactError
+		}
+		validated[identifier] = operation
+	}
+	for _, requiredOperation := range []string{ModelOperationText, ModelOperationDictation, ModelOperationVideoGeneration} {
+		if _, found := validated[requiredOperation]; !found {
+			return fmt.Errorf("%w: field=catalog.operations operation=%s reason=missing", ErrInvalidModelCatalog, requiredOperation)
+		}
+	}
+	return nil
+}
+
+func validateArtifactKinds(artifacts []string, field string) error {
+	if len(artifacts) == 0 {
+		return fmt.Errorf("%w: field=%s", ErrInvalidModelCatalog, field)
+	}
+	seen := map[string]struct{}{}
+	for artifactIndex, artifact := range artifacts {
+		switch artifact {
+		case CatalogArtifactText, CatalogArtifactImage, CatalogArtifactAudio, CatalogArtifactVideo:
+		default:
+			return fmt.Errorf("%w: field=%s[%d] artifact=%s", ErrInvalidModelCatalog, field, artifactIndex, artifact)
+		}
+		if _, duplicate := seen[artifact]; duplicate {
+			return fmt.Errorf("%w: field=%s[%d] duplicate=%s", ErrInvalidModelCatalog, field, artifactIndex, artifact)
+		}
+		seen[artifact] = struct{}{}
+	}
+	return nil
+}
+
+func validateCredentialKinds(credentials []string, field string) error {
+	if len(credentials) != 1 || credentials[0] != CatalogCredentialAPIKey {
+		return fmt.Errorf("%w: field=%s", ErrInvalidModelCatalog, field)
+	}
+	return nil
+}
+
+func validateCatalogControls(controls []CatalogControl, field string) error {
+	seen := map[string]struct{}{}
+	for controlIndex, control := range controls {
+		identifier, identifierError := canonicalCatalogIdentifier(control.ID, fmt.Sprintf("%s[%d].id", field, controlIndex))
+		if identifierError != nil {
+			return identifierError
+		}
+		if _, duplicate := seen[identifier]; duplicate {
+			return fmt.Errorf("%w: field=%s[%d].id duplicate_identifier=%s", ErrInvalidModelCatalog, field, controlIndex, identifier)
+		}
+		switch control.Kind {
+		case CatalogControlEnum:
+			if len(control.Values) == 0 || control.Minimum != nil || control.Maximum != nil {
+				return fmt.Errorf("%w: field=%s[%d] kind=%s", ErrInvalidModelCatalog, field, controlIndex, control.Kind)
+			}
+			values := map[string]struct{}{}
+			for valueIndex, value := range control.Values {
+				if strings.TrimSpace(value) == constants.EmptyString || value != strings.TrimSpace(value) {
+					return fmt.Errorf("%w: field=%s[%d].values[%d]", ErrInvalidModelCatalog, field, controlIndex, valueIndex)
+				}
+				if _, duplicate := values[value]; duplicate {
+					return fmt.Errorf("%w: field=%s[%d].values[%d] duplicate=%s", ErrInvalidModelCatalog, field, controlIndex, valueIndex, value)
+				}
+				values[value] = struct{}{}
+			}
+		case CatalogControlInteger:
+			if len(control.Values) != 0 || control.Minimum == nil || control.Maximum == nil || *control.Minimum > *control.Maximum {
+				return fmt.Errorf("%w: field=%s[%d] kind=%s", ErrInvalidModelCatalog, field, controlIndex, control.Kind)
+			}
+		case CatalogControlBoolean:
+			if len(control.Values) != 0 || control.Minimum != nil || control.Maximum != nil {
+				return fmt.Errorf("%w: field=%s[%d] kind=%s", ErrInvalidModelCatalog, field, controlIndex, control.Kind)
+			}
+		default:
+			return fmt.Errorf("%w: field=%s[%d].kind kind=%s", ErrInvalidModelCatalog, field, controlIndex, control.Kind)
+		}
+		seen[identifier] = struct{}{}
+	}
+	return nil
+}
+
+func validateCatalogLimits(limits []CatalogLimit, field string) error {
+	seen := map[string]struct{}{}
+	for limitIndex, limit := range limits {
+		identifier, identifierError := canonicalCatalogIdentifier(limit.ID, fmt.Sprintf("%s[%d].id", field, limitIndex))
+		if identifierError != nil {
+			return identifierError
+		}
+		if _, duplicate := seen[identifier]; duplicate {
+			return fmt.Errorf("%w: field=%s[%d].id duplicate_identifier=%s", ErrInvalidModelCatalog, field, limitIndex, identifier)
+		}
+		if strings.TrimSpace(limit.Unit) == constants.EmptyString || limit.Unit != strings.TrimSpace(limit.Unit) {
+			return fmt.Errorf("%w: field=%s[%d].unit", ErrInvalidModelCatalog, field, limitIndex)
+		}
+		if limit.AccountDependent {
+			if limit.Value != nil {
+				return fmt.Errorf("%w: field=%s[%d].value reason=account_dependent", ErrInvalidModelCatalog, field, limitIndex)
+			}
+		} else if limit.Value == nil || *limit.Value <= 0 {
+			return fmt.Errorf("%w: field=%s[%d].value", ErrInvalidModelCatalog, field, limitIndex)
+		}
+		seen[identifier] = struct{}{}
+	}
+	return nil
+}
+
+func validateVideoOffering(offering ProviderOffering, field string) error {
+	if offering.Provider != ProviderNameXAI || offering.WireContract != "xai_videos_generations" || offering.ExecutionLifecycle != string(textExecutionLifecyclePollableResource) {
+		return fmt.Errorf("%w: field=%s reason=unsupported_video_route", ErrInvalidModelCatalog, field)
+	}
+	if offering.RequestProfile != constants.EmptyString || offering.WebSearch || offering.OutputTokenLimit != 0 || offering.ReasoningEffort != nil || len(offering.MediaInputs) != 0 {
+		return fmt.Errorf("%w: field=%s reason=text_capabilities_on_video_route", ErrInvalidModelCatalog, field)
+	}
+	if len(offering.Controls) == 0 || len(offering.Limits) == 0 {
+		return fmt.Errorf("%w: field=%s reason=incomplete_video_capabilities", ErrInvalidModelCatalog, field)
+	}
+	return nil
+}
+
+func validateCatalogPrices(prices []CatalogPriceDescriptor, catalog validatedModelCatalog) error {
+	if len(prices) == 0 {
+		return fmt.Errorf("%w: field=catalog.prices", ErrInvalidModelCatalog)
+	}
+	for priceIndex, descriptor := range prices {
+		field := fmt.Sprintf("catalog.prices[%d]", priceIndex)
+		offering, found := catalog.offerings[providerOfferingIdentifier(descriptor.Provider, descriptor.Model)]
+		if !found || !offeringSupportsOperation(offering, descriptor.Operation) {
+			return fmt.Errorf("%w: field=%s route=%s:%s operation=%s reason=dangling_reference", ErrInvalidModelCatalog, field, descriptor.Provider, descriptor.Model, descriptor.Operation)
+		}
+		identifier := catalogPriceIdentifier(descriptor.Provider, descriptor.Model, descriptor.Operation)
+		if _, duplicate := catalog.prices[identifier]; duplicate {
+			return fmt.Errorf("%w: field=%s price_conflict=%s", ErrInvalidModelCatalog, field, identifier)
+		}
+		if !strings.HasPrefix(descriptor.Source, "https://") || descriptor.Source != strings.TrimSpace(descriptor.Source) {
+			return fmt.Errorf("%w: field=%s.source", ErrInvalidModelCatalog, field)
+		}
+		if verifiedAt, parseError := time.Parse(time.DateOnly, descriptor.LastVerified); parseError != nil || verifiedAt.Format(time.DateOnly) != descriptor.LastVerified {
+			return fmt.Errorf("%w: field=%s.last_verified", ErrInvalidModelCatalog, field)
+		}
+		if descriptor.Available {
+			if len(descriptor.Rates) == 0 || descriptor.UnavailableReason != constants.EmptyString {
+				return fmt.Errorf("%w: field=%s reason=incomplete_available_price", ErrInvalidModelCatalog, field)
+			}
+		} else if len(descriptor.Rates) != 0 || strings.TrimSpace(descriptor.UnavailableReason) == constants.EmptyString || descriptor.UnavailableReason != strings.TrimSpace(descriptor.UnavailableReason) {
+			return fmt.Errorf("%w: field=%s reason=incomplete_unavailable_price", ErrInvalidModelCatalog, field)
+		}
+		seenRates := map[string]struct{}{}
+		for rateIndex, rate := range descriptor.Rates {
+			if strings.TrimSpace(rate.Component) == constants.EmptyString || rate.Component != strings.TrimSpace(rate.Component) || rate.Currency != CatalogCurrencyUSD || rate.Rate < 0 || strings.TrimSpace(rate.Unit) == constants.EmptyString || rate.Unit != strings.TrimSpace(rate.Unit) {
+				return fmt.Errorf("%w: field=%s.rates[%d]", ErrInvalidModelCatalog, field, rateIndex)
+			}
+			rateIdentifier := fmt.Sprintf("%s\x00%#v", rate.Component, rate.Conditions)
+			if _, duplicate := seenRates[rateIdentifier]; duplicate {
+				return fmt.Errorf("%w: field=%s.rates[%d] reason=ambiguous", ErrInvalidModelCatalog, field, rateIndex)
+			}
+			seenRates[rateIdentifier] = struct{}{}
+		}
+		if descriptor.MinimumCharge != nil && (descriptor.MinimumCharge.Currency != CatalogCurrencyUSD || descriptor.MinimumCharge.Amount < 0 || strings.TrimSpace(descriptor.MinimumCharge.Unit) == constants.EmptyString || descriptor.MinimumCharge.Unit != strings.TrimSpace(descriptor.MinimumCharge.Unit)) {
+			return fmt.Errorf("%w: field=%s.minimum_charge", ErrInvalidModelCatalog, field)
+		}
+		catalog.prices[identifier] = descriptor
+	}
+	for _, offering := range catalog.offerings {
+		for _, operation := range offering.Operations {
+			identifier := catalogPriceIdentifier(offering.Provider, offering.Model, operation)
+			if _, found := catalog.prices[identifier]; !found {
+				return fmt.Errorf("%w: field=catalog.prices route=%s:%s operation=%s reason=missing", ErrInvalidModelCatalog, offering.Provider, offering.Model, operation)
+			}
+		}
+	}
+	return nil
+}
+
+func catalogPriceIdentifier(provider string, model string, operation string) string {
+	return strings.TrimSpace(provider) + "\x00" + strings.TrimSpace(model) + "\x00" + strings.TrimSpace(operation)
+}

--- a/internal/proxy/catalog_service_internal_test.go
+++ b/internal/proxy/catalog_service_internal_test.go
@@ -8,6 +8,12 @@ import (
 func TestCatalogServiceResolvesExactRoutesAndPrices(t *testing.T) {
 	minimum := 1
 	maximum := 15
+	reasoningOffering := internalTestOffering(ProviderNameOpenAI, ModelNameGPT55, []string{ModelOperationText}, []string{ModelOperationText})
+	reasoningOffering.RequestProfile = string(requestProfileOpenAIResponsesReasoningTools)
+	reasoningOffering.ReasoningEffort = &ReasoningEffortCapability{
+		Adapter: string(reasoningEffortAdapterOpenAIResponses),
+		Efforts: []string{"minimal", "low", "medium", "high"},
+	}
 	catalog := internalTestModelCatalog(
 		internalTestOffering(ProviderNameXAI, ModelNameGrok43, []string{ModelOperationText}, []string{ModelOperationText}),
 		ProviderOffering{
@@ -17,12 +23,15 @@ func TestCatalogServiceResolvesExactRoutesAndPrices(t *testing.T) {
 			Controls: []CatalogControl{{ID: "duration", Kind: CatalogControlInteger, Minimum: &minimum, Maximum: &maximum}},
 			Limits:   []CatalogLimit{{ID: "concurrent_requests", Unit: "requests", AccountDependent: true}},
 		},
+		reasoningOffering,
 	)
 	conditions := CatalogPriceConditions{Resolution: "720p", Duration: "output"}
+	videoPriceIndex := -1
 	for priceIndex := range catalog.Prices {
 		if catalog.Prices[priceIndex].Operation != ModelOperationVideoGeneration {
 			continue
 		}
+		videoPriceIndex = priceIndex
 		catalog.Prices[priceIndex] = CatalogPriceDescriptor{
 			Provider: ProviderNameXAI, Model: "grok-imagine-video-1.5", Operation: ModelOperationVideoGeneration,
 			Available:     true,
@@ -36,11 +45,34 @@ func TestCatalogServiceResolvesExactRoutesAndPrices(t *testing.T) {
 	if serviceError != nil {
 		t.Fatalf("NewCatalogService error: %v", serviceError)
 	}
+	catalog.Offerings[1].Operations[0] = ModelOperationDictation
+	*catalog.Offerings[1].Controls[0].Minimum = 9
+	catalog.Offerings[1].Limits[0].Unit = "changed"
+	catalog.Offerings[2].ReasoningEffort.Efforts[0] = "changed"
+	catalog.Prices[videoPriceIndex].Rates[0].Rate = 9
+	catalog.Prices[videoPriceIndex].MinimumCharge.Amount = 9
 	if service.Revision() != catalog.Revision {
 		t.Fatalf("revision=%q", service.Revision())
 	}
-	if offering, offeringError := service.ResolveOffering(" xai ", " grok-imagine-video-1.5 "); offeringError != nil || offering.Model != "grok-imagine-video-1.5" {
+	offering, offeringError := service.ResolveOffering(" xai ", " grok-imagine-video-1.5 ")
+	if offeringError != nil || offering.Model != "grok-imagine-video-1.5" || offering.Operations[0] != ModelOperationVideoGeneration || *offering.Controls[0].Minimum != 1 || offering.Limits[0].Unit != "requests" {
 		t.Fatalf("ResolveOffering offering=%+v error=%v", offering, offeringError)
+	}
+	offering.Operations[0] = ModelOperationDictation
+	*offering.Controls[0].Minimum = 12
+	offering.Limits[0].Unit = "changed again"
+	resolvedAgain, resolvedAgainError := service.ResolveOffering(ProviderNameXAI, "grok-imagine-video-1.5")
+	if resolvedAgainError != nil || resolvedAgain.Operations[0] != ModelOperationVideoGeneration || *resolvedAgain.Controls[0].Minimum != 1 || resolvedAgain.Limits[0].Unit != "requests" {
+		t.Fatalf("ResolveOffering second result=%+v error=%v", resolvedAgain, resolvedAgainError)
+	}
+	reasoningResolved, reasoningResolvedError := service.ResolveOffering(ProviderNameOpenAI, ModelNameGPT55)
+	if reasoningResolvedError != nil || reasoningResolved.ReasoningEffort == nil || reasoningResolved.ReasoningEffort.Efforts[0] != "minimal" {
+		t.Fatalf("ResolveOffering reasoning result=%+v error=%v", reasoningResolved, reasoningResolvedError)
+	}
+	reasoningResolved.ReasoningEffort.Efforts[0] = "changed again"
+	reasoningResolvedAgain, reasoningResolvedAgainError := service.ResolveOffering(ProviderNameOpenAI, ModelNameGPT55)
+	if reasoningResolvedAgainError != nil || reasoningResolvedAgain.ReasoningEffort == nil || reasoningResolvedAgain.ReasoningEffort.Efforts[0] != "minimal" {
+		t.Fatalf("ResolveOffering reasoning second result=%+v error=%v", reasoningResolvedAgain, reasoningResolvedAgainError)
 	}
 	if _, offeringError := service.ResolveOffering(ProviderNameXAI, "missing"); offeringError == nil {
 		t.Fatal("ResolveOffering accepted an unknown route")
@@ -48,6 +80,12 @@ func TestCatalogServiceResolvesExactRoutesAndPrices(t *testing.T) {
 	selection := service.SelectPrice(ProviderNameXAI, "grok-imagine-video-1.5", ModelOperationVideoGeneration, " output_video ", conditions)
 	if !selection.Available || selection.Rate == nil || selection.Rate.Rate != 0.14 || selection.MinimumCharge == nil {
 		t.Fatalf("exact selection=%+v", selection)
+	}
+	selection.Rate.Rate = 12
+	selection.MinimumCharge.Amount = 12
+	selectionAgain := service.SelectPrice(ProviderNameXAI, "grok-imagine-video-1.5", ModelOperationVideoGeneration, "output_video", conditions)
+	if selectionAgain.Rate == nil || selectionAgain.Rate.Rate != 0.14 || selectionAgain.MinimumCharge == nil || selectionAgain.MinimumCharge.Amount != 0.14 {
+		t.Fatalf("exact selection after result mutation=%+v", selectionAgain)
 	}
 	if unavailable := service.SelectPrice(ProviderNameXAI, ModelNameGrok43, ModelOperationText, "input", CatalogPriceConditions{}); unavailable.Available || unavailable.UnavailableReason != "Test price is unavailable." {
 		t.Fatalf("unavailable selection=%+v", unavailable)
@@ -109,6 +147,25 @@ func TestCatalogCapabilityValidationRejectsIncompleteContracts(t *testing.T) {
 		_, validationError := NewCatalogService(catalog)
 		assertError(t, validationError, "unsupported_video_route")
 	})
+	for _, secondaryOperation := range []string{ModelOperationVideoGeneration, ModelOperationDictation} {
+		t.Run("catalog validates secondary "+secondaryOperation, func(t *testing.T) {
+			catalog := internalTestModelCatalog(internalTestOffering(
+				ProviderNameXAI,
+				ModelNameGrok43,
+				[]string{ModelOperationText, secondaryOperation},
+				[]string{ModelOperationText, secondaryOperation},
+			))
+			_, validationError := NewCatalogService(catalog)
+			assertError(t, validationError, "unsupported_"+strings.TrimSuffix(secondaryOperation, "_generation")+"_route")
+		})
+	}
+	t.Run("catalog publisher without exact model", func(t *testing.T) {
+		catalog := internalTestModelCatalog(internalTestOffering(ProviderNameOpenAI, ModelNameGPT41, []string{ModelOperationText}, []string{ModelOperationText}))
+		catalog.Publishers = append(catalog.Publishers, ModelPublisher{ID: "unused", Label: "Unused"})
+		catalog.Families = append(catalog.Families, ModelFamily{ID: "unused", Publisher: "unused", Label: "Unused"})
+		_, validationError := NewCatalogService(catalog)
+		assertError(t, validationError, "publisher=unused reason=missing_exact_model")
+	})
 	t.Run("catalog prices", func(t *testing.T) {
 		catalog := internalTestModelCatalog(internalTestOffering(ProviderNameOpenAI, ModelNameGPT41, []string{ModelOperationText}, []string{ModelOperationText}))
 		catalog.Prices = nil
@@ -151,6 +208,8 @@ func TestCatalogCapabilityValidationRejectsIncompleteContracts(t *testing.T) {
 		{name: "enum value", controls: []CatalogControl{{ID: "mode", Kind: CatalogControlEnum, Values: []string{" "}}}, expected: "values[0]"},
 		{name: "enum duplicate", controls: []CatalogControl{{ID: "mode", Kind: CatalogControlEnum, Values: []string{"fast", "fast"}}}, expected: "duplicate=fast"},
 		{name: "integer", controls: []CatalogControl{{ID: "duration", Kind: CatalogControlInteger, Minimum: integer(2), Maximum: integer(1)}}, expected: "kind=integer"},
+		{name: "negative minimum", controls: []CatalogControl{{ID: "duration", Kind: CatalogControlInteger, Minimum: integer(-1), Maximum: integer(1)}}, expected: "kind=integer"},
+		{name: "negative maximum", controls: []CatalogControl{{ID: "duration", Kind: CatalogControlInteger, Minimum: integer(0), Maximum: integer(-1)}}, expected: "kind=integer"},
 		{name: "boolean", controls: []CatalogControl{{ID: "audio", Kind: CatalogControlBoolean, Values: []string{"yes"}}}, expected: "kind=boolean"},
 		{name: "kind", controls: []CatalogControl{{ID: "mode", Kind: "future"}}, expected: "kind=future"},
 	}

--- a/internal/proxy/catalog_service_internal_test.go
+++ b/internal/proxy/catalog_service_internal_test.go
@@ -1,0 +1,249 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCatalogServiceResolvesExactRoutesAndPrices(t *testing.T) {
+	minimum := 1
+	maximum := 15
+	catalog := internalTestModelCatalog(
+		internalTestOffering(ProviderNameXAI, ModelNameGrok43, []string{ModelOperationText}, []string{ModelOperationText}),
+		ProviderOffering{
+			Provider: ProviderNameXAI, Model: "grok-imagine-video-1.5", ProviderModel: "grok-imagine-video-1.5",
+			Operations: []string{ModelOperationVideoGeneration}, DefaultOperations: []string{ModelOperationVideoGeneration},
+			WireContract: "xai_videos_generations", ExecutionLifecycle: string(textExecutionLifecyclePollableResource),
+			Controls: []CatalogControl{{ID: "duration", Kind: CatalogControlInteger, Minimum: &minimum, Maximum: &maximum}},
+			Limits:   []CatalogLimit{{ID: "concurrent_requests", Unit: "requests", AccountDependent: true}},
+		},
+	)
+	conditions := CatalogPriceConditions{Resolution: "720p", Duration: "output"}
+	for priceIndex := range catalog.Prices {
+		if catalog.Prices[priceIndex].Operation != ModelOperationVideoGeneration {
+			continue
+		}
+		catalog.Prices[priceIndex] = CatalogPriceDescriptor{
+			Provider: ProviderNameXAI, Model: "grok-imagine-video-1.5", Operation: ModelOperationVideoGeneration,
+			Available:     true,
+			Rates:         []CatalogPriceRate{{Component: "output_video", Currency: CatalogCurrencyUSD, Rate: 0.14, Unit: "USD/output_second", Conditions: conditions}},
+			MinimumCharge: &CatalogMinimumCharge{Currency: CatalogCurrencyUSD, Amount: 0.14, Unit: "USD/request"},
+			Source:        "https://docs.x.ai/developers/pricing", LastVerified: "2026-08-08",
+		}
+	}
+
+	service, serviceError := NewCatalogService(catalog)
+	if serviceError != nil {
+		t.Fatalf("NewCatalogService error: %v", serviceError)
+	}
+	if service.Revision() != catalog.Revision {
+		t.Fatalf("revision=%q", service.Revision())
+	}
+	if offering, offeringError := service.ResolveOffering(" xai ", " grok-imagine-video-1.5 "); offeringError != nil || offering.Model != "grok-imagine-video-1.5" {
+		t.Fatalf("ResolveOffering offering=%+v error=%v", offering, offeringError)
+	}
+	if _, offeringError := service.ResolveOffering(ProviderNameXAI, "missing"); offeringError == nil {
+		t.Fatal("ResolveOffering accepted an unknown route")
+	}
+	selection := service.SelectPrice(ProviderNameXAI, "grok-imagine-video-1.5", ModelOperationVideoGeneration, " output_video ", conditions)
+	if !selection.Available || selection.Rate == nil || selection.Rate.Rate != 0.14 || selection.MinimumCharge == nil {
+		t.Fatalf("exact selection=%+v", selection)
+	}
+	if unavailable := service.SelectPrice(ProviderNameXAI, ModelNameGrok43, ModelOperationText, "input", CatalogPriceConditions{}); unavailable.Available || unavailable.UnavailableReason != "Test price is unavailable." {
+		t.Fatalf("unavailable selection=%+v", unavailable)
+	}
+	if mismatch := service.SelectPrice(ProviderNameXAI, "grok-imagine-video-1.5", ModelOperationVideoGeneration, "output_video", CatalogPriceConditions{Resolution: "480p"}); mismatch.UnavailableReason != "exact_price_unavailable" {
+		t.Fatalf("mismatch=%+v", mismatch)
+	}
+	if missing := service.SelectPrice(ProviderNameXAI, "missing", ModelOperationText, "input", CatalogPriceConditions{}); missing.UnavailableReason != "price_not_cataloged" {
+		t.Fatalf("missing=%+v", missing)
+	}
+}
+
+func TestCatalogCapabilityValidationRejectsIncompleteContracts(t *testing.T) {
+	integer := func(value int) *int { return &value }
+	assertError := func(t *testing.T, validationError error, expected string) {
+		t.Helper()
+		if validationError == nil || !strings.Contains(validationError.Error(), expected) {
+			t.Fatalf("error=%v want contains %q", validationError, expected)
+		}
+	}
+
+	t.Run("catalog service", func(t *testing.T) {
+		_, validationError := NewCatalogService(ModelCatalog{})
+		assertError(t, validationError, "catalog.revision")
+	})
+	t.Run("catalog operations", func(t *testing.T) {
+		catalog := internalTestModelCatalog(internalTestOffering(ProviderNameOpenAI, ModelNameGPT41, []string{ModelOperationText}, []string{ModelOperationText}))
+		catalog.Operations = nil
+		_, validationError := NewCatalogService(catalog)
+		assertError(t, validationError, "catalog.operations")
+	})
+	t.Run("catalog credentials", func(t *testing.T) {
+		catalog := internalTestModelCatalog(internalTestOffering(ProviderNameOpenAI, ModelNameGPT41, []string{ModelOperationText}, []string{ModelOperationText}))
+		catalog.Providers[0].CredentialKinds = []string{"oauth"}
+		_, validationError := NewCatalogService(catalog)
+		assertError(t, validationError, "credential_kinds")
+	})
+	t.Run("catalog controls", func(t *testing.T) {
+		catalog := internalTestModelCatalog(internalTestOffering(ProviderNameOpenAI, ModelNameGPT41, []string{ModelOperationText}, []string{ModelOperationText}))
+		catalog.Offerings[0].Controls = []CatalogControl{{ID: "mode", Kind: "future"}}
+		_, validationError := NewCatalogService(catalog)
+		assertError(t, validationError, "controls")
+	})
+	t.Run("catalog limits", func(t *testing.T) {
+		catalog := internalTestModelCatalog(internalTestOffering(ProviderNameOpenAI, ModelNameGPT41, []string{ModelOperationText}, []string{ModelOperationText}))
+		catalog.Offerings[0].Limits = []CatalogLimit{{ID: "requests", Unit: "requests"}}
+		_, validationError := NewCatalogService(catalog)
+		assertError(t, validationError, "limits")
+	})
+	t.Run("catalog video route", func(t *testing.T) {
+		catalog := internalTestModelCatalog(ProviderOffering{
+			Provider: ProviderNameXAI, Model: "video", ProviderModel: "video",
+			Operations: []string{ModelOperationVideoGeneration}, DefaultOperations: []string{ModelOperationVideoGeneration},
+			WireContract: "xai_videos_generations", ExecutionLifecycle: string(textExecutionLifecyclePollableResource),
+			Controls: []CatalogControl{{ID: "enabled", Kind: CatalogControlBoolean}},
+			Limits:   []CatalogLimit{{ID: "requests", Unit: "requests", AccountDependent: true}},
+		})
+		catalog.Offerings[0].WireContract = "invalid"
+		_, validationError := NewCatalogService(catalog)
+		assertError(t, validationError, "unsupported_video_route")
+	})
+	t.Run("catalog prices", func(t *testing.T) {
+		catalog := internalTestModelCatalog(internalTestOffering(ProviderNameOpenAI, ModelNameGPT41, []string{ModelOperationText}, []string{ModelOperationText}))
+		catalog.Prices = nil
+		_, validationError := NewCatalogService(catalog)
+		assertError(t, validationError, "catalog.prices")
+	})
+	assertError(t, validateCatalogRevision(" Future "), "not_canonical")
+
+	operationCases := []struct {
+		name       string
+		operations []ModelOperationKind
+		expected   string
+	}{
+		{name: "empty", expected: "catalog.operations"},
+		{name: "noncanonical", operations: []ModelOperationKind{{ID: "Text"}}, expected: "not_canonical"},
+		{name: "unknown", operations: []ModelOperationKind{{ID: "future", InputArtifacts: []string{"text"}, OutputArtifacts: []string{"text"}}}, expected: "operation=future"},
+		{name: "duplicate", operations: []ModelOperationKind{{ID: "text", InputArtifacts: []string{"text"}, OutputArtifacts: []string{"text"}}, {ID: "text", InputArtifacts: []string{"text"}, OutputArtifacts: []string{"text"}}}, expected: "duplicate_identifier=text"},
+		{name: "input", operations: []ModelOperationKind{{ID: "text", OutputArtifacts: []string{"text"}}}, expected: "input_artifacts"},
+		{name: "output", operations: []ModelOperationKind{{ID: "text", InputArtifacts: []string{"text"}}}, expected: "output_artifacts"},
+		{name: "missing required", operations: []ModelOperationKind{{ID: "text", InputArtifacts: []string{"text"}, OutputArtifacts: []string{"text"}}}, expected: "reason=missing"},
+	}
+	for _, testCase := range operationCases {
+		t.Run("operation "+testCase.name, func(t *testing.T) {
+			assertError(t, validateModelOperationKinds(testCase.operations, map[string]ModelOperationKind{}), testCase.expected)
+		})
+	}
+	assertError(t, validateArtifactKinds(nil, "artifacts"), "field=artifacts")
+	assertError(t, validateArtifactKinds([]string{"future"}, "artifacts"), "artifact=future")
+	assertError(t, validateArtifactKinds([]string{"text", "text"}, "artifacts"), "duplicate=text")
+	assertError(t, validateCredentialKinds([]string{"oauth"}, "credentials"), "field=credentials")
+
+	controlCases := []struct {
+		name     string
+		controls []CatalogControl
+		expected string
+	}{
+		{name: "identifier", controls: []CatalogControl{{ID: "Future Control", Kind: CatalogControlBoolean}}, expected: "not_canonical"},
+		{name: "duplicate", controls: []CatalogControl{{ID: "mode", Kind: CatalogControlBoolean}, {ID: "mode", Kind: CatalogControlBoolean}}, expected: "duplicate_identifier=mode"},
+		{name: "enum shape", controls: []CatalogControl{{ID: "mode", Kind: CatalogControlEnum}}, expected: "kind=enum"},
+		{name: "enum value", controls: []CatalogControl{{ID: "mode", Kind: CatalogControlEnum, Values: []string{" "}}}, expected: "values[0]"},
+		{name: "enum duplicate", controls: []CatalogControl{{ID: "mode", Kind: CatalogControlEnum, Values: []string{"fast", "fast"}}}, expected: "duplicate=fast"},
+		{name: "integer", controls: []CatalogControl{{ID: "duration", Kind: CatalogControlInteger, Minimum: integer(2), Maximum: integer(1)}}, expected: "kind=integer"},
+		{name: "boolean", controls: []CatalogControl{{ID: "audio", Kind: CatalogControlBoolean, Values: []string{"yes"}}}, expected: "kind=boolean"},
+		{name: "kind", controls: []CatalogControl{{ID: "mode", Kind: "future"}}, expected: "kind=future"},
+	}
+	for _, testCase := range controlCases {
+		t.Run("control "+testCase.name, func(t *testing.T) {
+			assertError(t, validateCatalogControls(testCase.controls, "controls"), testCase.expected)
+		})
+	}
+
+	limitCases := []struct {
+		name     string
+		limits   []CatalogLimit
+		expected string
+	}{
+		{name: "identifier", limits: []CatalogLimit{{ID: "Future Limit", Unit: "requests", AccountDependent: true}}, expected: "not_canonical"},
+		{name: "duplicate", limits: []CatalogLimit{{ID: "jobs", Unit: "requests", AccountDependent: true}, {ID: "jobs", Unit: "requests", AccountDependent: true}}, expected: "duplicate_identifier=jobs"},
+		{name: "unit", limits: []CatalogLimit{{ID: "jobs", Unit: " ", AccountDependent: true}}, expected: ".unit"},
+		{name: "account dependent value", limits: []CatalogLimit{{ID: "jobs", Unit: "requests", AccountDependent: true, Value: integer(1)}}, expected: "reason=account_dependent"},
+		{name: "fixed value", limits: []CatalogLimit{{ID: "jobs", Unit: "requests"}}, expected: ".value"},
+	}
+	for _, testCase := range limitCases {
+		t.Run("limit "+testCase.name, func(t *testing.T) {
+			assertError(t, validateCatalogLimits(testCase.limits, "limits"), testCase.expected)
+		})
+	}
+
+	validVideo := ProviderOffering{
+		Provider: ProviderNameXAI, WireContract: "xai_videos_generations", ExecutionLifecycle: string(textExecutionLifecyclePollableResource),
+		Controls: []CatalogControl{{ID: "enabled", Kind: CatalogControlBoolean}},
+		Limits:   []CatalogLimit{{ID: "jobs", Unit: "requests", AccountDependent: true}},
+	}
+	invalidVideo := validVideo
+	invalidVideo.Provider = ProviderNameOpenAI
+	assertError(t, validateVideoOffering(invalidVideo, "video"), "unsupported_video_route")
+	invalidVideo = validVideo
+	invalidVideo.WebSearch = true
+	assertError(t, validateVideoOffering(invalidVideo, "video"), "text_capabilities_on_video_route")
+	invalidVideo = validVideo
+	invalidVideo.Controls = nil
+	assertError(t, validateVideoOffering(invalidVideo, "video"), "incomplete_video_capabilities")
+}
+
+func TestCatalogPriceValidationRejectsAmbiguousRecords(t *testing.T) {
+	validOffering := ProviderOffering{Provider: ProviderNameXAI, Model: "model", Operations: []string{ModelOperationVideoGeneration}}
+	validRate := CatalogPriceRate{Component: "output", Currency: CatalogCurrencyUSD, Rate: 1, Unit: "USD/second", Conditions: CatalogPriceConditions{Resolution: "720p"}}
+	validPrice := CatalogPriceDescriptor{
+		Provider: ProviderNameXAI, Model: "model", Operation: ModelOperationVideoGeneration, Available: true,
+		Rates: []CatalogPriceRate{validRate}, Source: "https://example.com/pricing", LastVerified: "2026-08-10",
+	}
+	freshPrice := func() CatalogPriceDescriptor {
+		price := validPrice
+		price.Rates = append([]CatalogPriceRate(nil), validPrice.Rates...)
+		return price
+	}
+	newCatalog := func() validatedModelCatalog {
+		return validatedModelCatalog{offerings: map[string]ProviderOffering{providerOfferingIdentifier(validOffering.Provider, validOffering.Model): validOffering}, prices: map[string]CatalogPriceDescriptor{}}
+	}
+	assertError := func(t *testing.T, prices []CatalogPriceDescriptor, catalog validatedModelCatalog, expected string) {
+		t.Helper()
+		validationError := validateCatalogPrices(prices, catalog)
+		if validationError == nil || !strings.Contains(validationError.Error(), expected) {
+			t.Fatalf("error=%v want contains %q", validationError, expected)
+		}
+	}
+	assertError(t, nil, newCatalog(), "catalog.prices")
+	dangling := freshPrice()
+	dangling.Model = "missing"
+	assertError(t, []CatalogPriceDescriptor{dangling}, newCatalog(), "dangling_reference")
+	assertError(t, []CatalogPriceDescriptor{freshPrice(), freshPrice()}, newCatalog(), "price_conflict")
+	invalid := freshPrice()
+	invalid.Source = "http://example.com"
+	assertError(t, []CatalogPriceDescriptor{invalid}, newCatalog(), ".source")
+	invalid = freshPrice()
+	invalid.LastVerified = "today"
+	assertError(t, []CatalogPriceDescriptor{invalid}, newCatalog(), ".last_verified")
+	invalid = freshPrice()
+	invalid.Rates = nil
+	assertError(t, []CatalogPriceDescriptor{invalid}, newCatalog(), "incomplete_available_price")
+	invalid = freshPrice()
+	invalid.Available = false
+	assertError(t, []CatalogPriceDescriptor{invalid}, newCatalog(), "incomplete_unavailable_price")
+	invalid = freshPrice()
+	invalid.Rates[0].Currency = "EUR"
+	assertError(t, []CatalogPriceDescriptor{invalid}, newCatalog(), ".rates[0]")
+	invalid = freshPrice()
+	invalid.Rates = append(invalid.Rates, validRate)
+	assertError(t, []CatalogPriceDescriptor{invalid}, newCatalog(), "reason=ambiguous")
+	invalid = freshPrice()
+	invalid.MinimumCharge = &CatalogMinimumCharge{Currency: "EUR", Amount: 1, Unit: "EUR/request"}
+	assertError(t, []CatalogPriceDescriptor{invalid}, newCatalog(), ".minimum_charge")
+	missingOperationCatalog := newCatalog()
+	multipleOperations := validOffering
+	multipleOperations.Operations = []string{ModelOperationVideoGeneration, ModelOperationText}
+	missingOperationCatalog.offerings[providerOfferingIdentifier(multipleOperations.Provider, multipleOperations.Model)] = multipleOperations
+	assertError(t, []CatalogPriceDescriptor{freshPrice()}, missingOperationCatalog, "reason=missing")
+}

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -54,7 +54,7 @@ type Configuration struct {
 	GeminiKey                    string
 	AnthropicKey                 string
 	MetaKey                      string
-	GrokKey                      string
+	XAIKey                       string
 	OpenAIBaseURL                string
 	OpenAITranscriptionsURL      string
 	DeepSeekBaseURL              string
@@ -68,8 +68,8 @@ type Configuration struct {
 	GeminiBaseURL                string
 	AnthropicBaseURL             string
 	MetaBaseURL                  string
-	GrokBaseURL                  string
-	GrokTranscriptionsURL        string
+	XAIBaseURL                   string
+	XAITranscriptionsURL         string
 	Port                         int
 	LogLevel                     string
 	WorkerCount                  int
@@ -210,7 +210,7 @@ func (configuration *Configuration) ApplyTunables() {
 	configuration.GeminiKey = strings.TrimSpace(configuration.GeminiKey)
 	configuration.AnthropicKey = strings.TrimSpace(configuration.AnthropicKey)
 	configuration.MetaKey = strings.TrimSpace(configuration.MetaKey)
-	configuration.GrokKey = strings.TrimSpace(configuration.GrokKey)
+	configuration.XAIKey = strings.TrimSpace(configuration.XAIKey)
 	if configuration.WorkerCount <= 0 {
 		configuration.WorkerCount = DefaultWorkers
 	}
@@ -281,13 +281,13 @@ func (configuration *Configuration) ApplyTunables() {
 	if strings.TrimSpace(configuration.MetaBaseURL) == constants.EmptyString {
 		configuration.MetaBaseURL = defaultMetaBaseURL
 	}
-	configuration.GrokBaseURL = strings.TrimSpace(configuration.GrokBaseURL)
-	if strings.TrimSpace(configuration.GrokBaseURL) == constants.EmptyString {
-		configuration.GrokBaseURL = defaultGrokBaseURL
+	configuration.XAIBaseURL = strings.TrimSpace(configuration.XAIBaseURL)
+	if strings.TrimSpace(configuration.XAIBaseURL) == constants.EmptyString {
+		configuration.XAIBaseURL = defaultXAIBaseURL
 	}
-	configuration.GrokTranscriptionsURL = strings.TrimSpace(configuration.GrokTranscriptionsURL)
-	if strings.TrimSpace(configuration.GrokTranscriptionsURL) == constants.EmptyString {
-		configuration.GrokTranscriptionsURL = defaultGrokTranscriptionsURL
+	configuration.XAITranscriptionsURL = strings.TrimSpace(configuration.XAITranscriptionsURL)
+	if strings.TrimSpace(configuration.XAITranscriptionsURL) == constants.EmptyString {
+		configuration.XAITranscriptionsURL = defaultXAITranscriptionsURL
 	}
 }
 

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -1987,7 +1987,7 @@ func TestCoverageDictationEdges(t *testing.T) {
 				wantStatus: http.StatusBadRequest,
 			},
 			{
-				name: "grok missing credential",
+				name: "xai missing credential",
 				configuration: proxy.Configuration{
 					Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
 					OpenAIKey:             TestAPIKey,
@@ -1997,7 +1997,7 @@ func TestCoverageDictationEdges(t *testing.T) {
 					RequestTimeoutSeconds: TestTimeout,
 					MaxInputAudioBytes:    1024,
 				},
-				requestURL: "/dictate?key=" + TestSecret + "&provider=grok",
+				requestURL: "/dictate?key=" + TestSecret + "&provider=xai",
 				wantStatus: http.StatusServiceUnavailable,
 			},
 			{
@@ -2005,14 +2005,14 @@ func TestCoverageDictationEdges(t *testing.T) {
 				configuration: proxy.Configuration{
 					Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
 					OpenAIKey:             TestAPIKey,
-					GrokKey:               testGrokKey,
+					XAIKey:                testXAIKey,
 					LogLevel:              proxy.LogLevelInfo,
 					WorkerCount:           1,
 					QueueSize:             1,
 					RequestTimeoutSeconds: TestTimeout,
 					MaxInputAudioBytes:    1024,
 				},
-				requestURL: "/dictate?key=" + TestSecret + "&provider=grok&model=unknown",
+				requestURL: "/dictate?key=" + TestSecret + "&provider=xai&model=unknown",
 				wantStatus: http.StatusBadRequest,
 			},
 		}

--- a/internal/proxy/management_failures_migration_internal_test.go
+++ b/internal/proxy/management_failures_migration_internal_test.go
@@ -682,6 +682,63 @@ func TestManagedXAIProviderMigrationCanonicalizesCurrentRoutesAndPreservesUsage(
 	}
 }
 
+func TestManagedTenantRouteMigrationsComposeConfirmedPredecessorIdentities(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		version int
+	}{
+		{name: "schema two", version: managedUsageOutcomeSchemaVersion},
+		{name: "schema three", version: managedKeyedRoutingSchemaVersion},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newManagedXAIProviderMigrationFixture(t)
+			fixture.addProvider(t, ProviderNameMiniMax, managedMiniMaxNativeModel, "")
+			fixture.addProvider(t, ProviderNameSiliconFlow, managedSiliconFlowDeepSeekNativeModel, "")
+			historicalUsage := []managedUsageEventRecord{
+				{ID: 102, TenantID: fixture.tenant.TenantID, Endpoint: usageEndpointText, ProviderID: ProviderNameMiniMax, ModelID: managedMiniMaxNativeModel, StatusCode: http.StatusOK, Success: true, OutcomeCode: managedUsageOutcomeSuccess, CreatedAt: fixture.tenant.CreatedAt.Add(time.Minute)},
+				{ID: 103, TenantID: fixture.tenant.TenantID, Endpoint: usageEndpointDictation, ProviderID: ProviderNameSiliconFlow, ModelID: managedSenseVoiceNativeModel, StatusCode: http.StatusOK, Success: true, OutcomeCode: managedUsageOutcomeSuccess, CreatedAt: fixture.tenant.CreatedAt.Add(2 * time.Minute)},
+			}
+			if createError := fixture.database.Create(&historicalUsage).Error; createError != nil {
+				t.Fatalf("seed predecessor historical usage: %v", createError)
+			}
+			if createError := fixture.database.Create(&managedSchemaMigrationRecord{Version: testCase.version, AppliedAt: fixture.tenant.CreatedAt}).Error; createError != nil {
+				t.Fatalf("seed predecessor schema version: %v", createError)
+			}
+
+			if migrationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers); migrationError != nil {
+				t.Fatalf("migrate predecessor routes: %v", migrationError)
+			}
+			var tenantRecord managedTenantRecord
+			if queryError := fixture.database.Preload("ProviderAPIKeys").Where(&managedTenantRecord{TenantID: fixture.tenant.TenantID}).First(&tenantRecord).Error; queryError != nil {
+				t.Fatalf("load migrated predecessor tenant: %v", queryError)
+			}
+			expectedDefaults := TenantDefaults{
+				Provider: ProviderNameXAI, Model: ModelNameGrok43,
+				DictationProvider: ProviderNameXAI, DictationModel: "xai-stt",
+				SystemPrompt: "preserve tenant prompt",
+			}
+			if tenantRecord.defaults() != expectedDefaults || len(tenantRecord.ProviderAPIKeys) != 3 {
+				t.Fatalf("migrated predecessor tenant=%+v keys=%+v", tenantRecord, tenantRecord.ProviderAPIKeys)
+			}
+			modelsByProvider := map[string]string{}
+			for _, providerKey := range tenantRecord.ProviderAPIKeys {
+				modelsByProvider[providerKey.ProviderID] = providerKey.TextModel
+			}
+			if modelsByProvider[ProviderNameXAI] != ModelNameGrok43 || modelsByProvider[ProviderNameMiniMax] != ModelNameMiniMaxM27 || modelsByProvider[ProviderNameSiliconFlow] != ModelNameSiliconFlowDeepSeek {
+				t.Fatalf("migrated predecessor provider models=%v", modelsByProvider)
+			}
+			var retainedUsage []managedUsageEventRecord
+			if queryError := fixture.database.Where("id IN ?", []uint{102, 103}).Order("id").Find(&retainedUsage).Error; queryError != nil || !slices.Equal(retainedUsage, historicalUsage) {
+				t.Fatalf("retained predecessor usage=%+v error=%v", retainedUsage, queryError)
+			}
+			var latest managedSchemaMigrationRecord
+			if queryError := fixture.database.Order("version DESC").First(&latest).Error; queryError != nil || latest.Version != managedTenantSchemaVersion {
+				t.Fatalf("latest predecessor version=%+v error=%v", latest, queryError)
+			}
+		})
+	}
+}
+
 func TestManagedXAIProviderMigrationRejectsStageFailures(t *testing.T) {
 	assertMigrationError := func(t *testing.T, migrationError error, want string) {
 		t.Helper()
@@ -985,6 +1042,27 @@ func TestManagedQwenCloudRetirementMigrationRejectsStageFailures(t *testing.T) {
 			name: "invalid remaining provider", want: "operation=preflight",
 			configure: func(t *testing.T, fixture managedQwenCloudRetirementFixture) {
 				fixture.addProvider(t, "missing", "missing-model", "")
+			},
+		},
+		{
+			name: "nonretired defaults without key", want: "operation=preflight",
+			configure: func(t *testing.T, fixture managedQwenCloudRetirementFixture) {
+				if updateError := fixture.database.Model(&managedTenantRecord{}).
+					Where(&managedTenantRecord{TenantID: fixture.tenant.TenantID}).
+					Updates(map[string]any{
+						"default_provider":         ProviderNameXAI,
+						"default_model":            ModelNameGrok43,
+						"default_reasoning_effort": "",
+					}).Error; updateError != nil {
+					t.Fatalf("seed nonretired defaults without key: %v", updateError)
+				}
+			},
+		},
+		{
+			name: "predecessor provider conflict", want: "provider_conflict=" + ProviderNameXAI,
+			configure: func(t *testing.T, fixture managedQwenCloudRetirementFixture) {
+				fixture.addProvider(t, retiredGrokProviderIdentifier, ModelNameGrok43, "")
+				fixture.addProvider(t, ProviderNameXAI, ModelNameGrok43, "")
 			},
 		},
 		{

--- a/internal/proxy/management_failures_migration_internal_test.go
+++ b/internal/proxy/management_failures_migration_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -506,6 +507,355 @@ func TestManagedModelIdentityMigrationRejectsStageFailures(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagedTenantInitializationPropagatesModelIdentityFailure(t *testing.T) {
+	fixture := newManagedModelIdentityMigrationFixture(t)
+	if createError := fixture.database.Create(&managedSchemaMigrationRecord{Version: managedQwenCloudRetirementVersion, AppliedAt: fixture.tenant.CreatedAt}).Error; createError != nil {
+		t.Fatalf("seed schema version: %v", createError)
+	}
+	if updateError := fixture.database.Model(&managedProviderAPIKeyRecord{}).
+		Where(&managedProviderAPIKeyRecord{TenantID: fixture.tenant.TenantID, ProviderID: ProviderNameMiniMax}).
+		Update("encrypted_api_key", "invalid").Error; updateError != nil {
+		t.Fatalf("seed invalid model identity provider: %v", updateError)
+	}
+	initializeError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers)
+	if !errors.Is(initializeError, errManagedTenantSchemaMigration) || !strings.Contains(initializeError.Error(), "operation=preflight") {
+		t.Fatalf("initialize error=%v", initializeError)
+	}
+}
+
+type managedXAIProviderMigrationFixture struct {
+	database          *gorm.DB
+	providerKeyCipher managedProviderKeyCipher
+	providers         *providerRegistry
+	tenant            managedTenantRecord
+	providerKey       managedProviderAPIKeyRecord
+	usage             managedUsageEventRecord
+}
+
+type managedXAIProviderFailingReader struct{}
+
+func (managedXAIProviderFailingReader) Read([]byte) (int, error) {
+	return 0, errInternalTestDatabase
+}
+
+func newManagedXAIProviderMigrationFixture(t *testing.T) managedXAIProviderMigrationFixture {
+	t.Helper()
+	database, openError := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "xai-provider-stage.db")), &gorm.Config{})
+	if openError != nil {
+		t.Fatalf("open xAI provider fixture: %v", openError)
+	}
+	if migrationError := migrateCurrentManagedSchema(database); migrationError != nil {
+		t.Fatalf("create xAI provider schema: %v", migrationError)
+	}
+	now := time.Date(2026, 8, 10, 23, 45, 0, 0, time.UTC)
+	user := managedUserRecord{UserID: "xai-provider-owner", CreatedAt: now, UpdatedAt: now}
+	if createError := database.Create(&user).Error; createError != nil {
+		t.Fatalf("seed xAI provider user: %v", createError)
+	}
+	tenantRecord := fakeTenantRecord(user.UserID, "xai-provider-tenant", "Default", now)
+	tenantRecord.DefaultProvider = retiredGrokProviderIdentifier
+	tenantRecord.DefaultModel = ModelNameGrok43
+	tenantRecord.DefaultDictationProvider = retiredGrokProviderIdentifier
+	tenantRecord.DefaultDictationModel = "xai-stt"
+	tenantRecord.DefaultSystemPrompt = "preserve tenant prompt"
+	if createError := database.Create(&tenantRecord).Error; createError != nil {
+		t.Fatalf("seed xAI provider tenant: %v", createError)
+	}
+	providerKeyCipher := internalManagedProviderKeyCipher()
+	encryptedKey, encryptionError := providerKeyCipher.encrypt(
+		strings.NewReader(strings.Repeat("x", providerKeyCipher.aeadCipher.NonceSize())),
+		tenantRecord.TenantID,
+		retiredGrokProviderIdentifier,
+		"sk-grok",
+	)
+	if encryptionError != nil {
+		t.Fatalf("encrypt xAI provider key: %v", encryptionError)
+	}
+	providerKey := managedProviderAPIKeyRecord{
+		TenantID: tenantRecord.TenantID, ProviderID: retiredGrokProviderIdentifier,
+		EncryptedAPIKey: encryptedKey, TextModel: ModelNameGrok43,
+		SystemPrompt: "preserve provider prompt", CreatedAt: now, UpdatedAt: now,
+	}
+	if createError := database.Create(&providerKey).Error; createError != nil {
+		t.Fatalf("seed xAI provider key: %v", createError)
+	}
+	usage := managedUsageEventRecord{
+		ID: 101, TenantID: tenantRecord.TenantID, Endpoint: usageEndpointText,
+		ProviderID: retiredGrokProviderIdentifier, ModelID: ModelNameGrok43,
+		StatusCode: http.StatusOK, Success: true, OutcomeCode: managedUsageOutcomeSuccess, CreatedAt: now,
+	}
+	if createError := database.Create(&usage).Error; createError != nil {
+		t.Fatalf("seed xAI provider usage: %v", createError)
+	}
+	return managedXAIProviderMigrationFixture{
+		database: database, providerKeyCipher: providerKeyCipher,
+		providers: internalManagementProviderRegistry(), tenant: tenantRecord,
+		providerKey: providerKey, usage: usage,
+	}
+}
+
+func (fixture managedXAIProviderMigrationFixture) addProvider(t *testing.T, providerIdentifier string, textModel string, encryptedAPIKey string) {
+	t.Helper()
+	if encryptedAPIKey == "" {
+		var encryptionError error
+		encryptedAPIKey, encryptionError = fixture.providerKeyCipher.encrypt(
+			strings.NewReader(strings.Repeat("p", fixture.providerKeyCipher.aeadCipher.NonceSize())),
+			fixture.tenant.TenantID,
+			providerIdentifier,
+			"sk-provider",
+		)
+		if encryptionError != nil {
+			t.Fatalf("encrypt provider=%s: %v", providerIdentifier, encryptionError)
+		}
+	}
+	if createError := fixture.database.Create(&managedProviderAPIKeyRecord{
+		TenantID: fixture.tenant.TenantID, ProviderID: providerIdentifier,
+		EncryptedAPIKey: encryptedAPIKey, TextModel: textModel,
+		CreatedAt: fixture.tenant.CreatedAt, UpdatedAt: fixture.tenant.UpdatedAt,
+	}).Error; createError != nil {
+		t.Fatalf("seed provider=%s: %v", providerIdentifier, createError)
+	}
+}
+
+func applyManagedXAIProviderDataset(t *testing.T, fixture managedXAIProviderMigrationFixture, dataset managedXAIProviderDataset) {
+	t.Helper()
+	for _, backfill := range dataset.providerKeys {
+		if updateError := fixture.database.Model(&managedProviderAPIKeyRecord{}).
+			Where(&managedProviderAPIKeyRecord{TenantID: backfill.record.TenantID, ProviderID: retiredGrokProviderIdentifier}).
+			UpdateColumns(map[string]any{"provider_id": backfill.record.ProviderID, "encrypted_api_key": backfill.record.EncryptedAPIKey}).Error; updateError != nil {
+			t.Fatalf("apply xAI provider key: %v", updateError)
+		}
+	}
+	for _, backfill := range dataset.tenants {
+		if updateError := fixture.database.Model(&managedTenantRecord{}).
+			Where(&managedTenantRecord{TenantID: backfill.tenantID}).
+			Updates(managedRoutingDefaultsDatabaseUpdates(backfill.defaults, backfill.updatedAt)).Error; updateError != nil {
+			t.Fatalf("apply xAI tenant defaults: %v", updateError)
+		}
+	}
+}
+
+func TestManagedXAIProviderMigrationCanonicalizesCurrentRoutesAndPreservesUsage(t *testing.T) {
+	fixture := newManagedXAIProviderMigrationFixture(t)
+	if createError := fixture.database.Create(&managedSchemaMigrationRecord{Version: managedModelIdentitySchemaVersion, AppliedAt: fixture.tenant.CreatedAt}).Error; createError != nil {
+		t.Fatalf("seed schema version: %v", createError)
+	}
+	if migrationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers); migrationError != nil {
+		t.Fatalf("migrate xAI provider: %v", migrationError)
+	}
+	var retiredCount int64
+	if countError := fixture.database.Model(&managedProviderAPIKeyRecord{}).Where(&managedProviderAPIKeyRecord{ProviderID: retiredGrokProviderIdentifier}).Count(&retiredCount).Error; countError != nil || retiredCount != 0 {
+		t.Fatalf("retired provider count=%d error=%v", retiredCount, countError)
+	}
+	var providerKey managedProviderAPIKeyRecord
+	if queryError := fixture.database.Where(&managedProviderAPIKeyRecord{TenantID: fixture.tenant.TenantID, ProviderID: ProviderNameXAI}).First(&providerKey).Error; queryError != nil {
+		t.Fatalf("load xAI provider key: %v", queryError)
+	}
+	apiKey, decryptError := fixture.providerKeyCipher.decrypt(providerKey)
+	if decryptError != nil || apiKey != "sk-grok" || providerKey.TextModel != fixture.providerKey.TextModel || providerKey.SystemPrompt != fixture.providerKey.SystemPrompt || !providerKey.CreatedAt.Equal(fixture.providerKey.CreatedAt) || !providerKey.UpdatedAt.Equal(fixture.providerKey.UpdatedAt) {
+		t.Fatalf("migrated provider key=%+v api_key=%q error=%v", providerKey, apiKey, decryptError)
+	}
+	var tenantRecord managedTenantRecord
+	if queryError := fixture.database.Where(&managedTenantRecord{TenantID: fixture.tenant.TenantID}).First(&tenantRecord).Error; queryError != nil {
+		t.Fatalf("load xAI tenant: %v", queryError)
+	}
+	expectedDefaults := TenantDefaults{
+		Provider: ProviderNameXAI, Model: ModelNameGrok43,
+		DictationProvider: ProviderNameXAI, DictationModel: "xai-stt",
+		SystemPrompt: "preserve tenant prompt",
+	}
+	if tenantRecord.defaults() != expectedDefaults || !tenantRecord.UpdatedAt.Equal(fixture.tenant.UpdatedAt) {
+		t.Fatalf("migrated defaults=%+v updated_at=%s", tenantRecord.defaults(), tenantRecord.UpdatedAt)
+	}
+	var historicalUsage []managedUsageEventRecord
+	if queryError := fixture.database.Where(&managedUsageEventRecord{ProviderID: retiredGrokProviderIdentifier}).Order("id").Find(&historicalUsage).Error; queryError != nil || !slices.Equal(historicalUsage, []managedUsageEventRecord{fixture.usage}) {
+		t.Fatalf("historical usage=%+v error=%v", historicalUsage, queryError)
+	}
+	var latest managedSchemaMigrationRecord
+	if queryError := fixture.database.Order("version DESC").First(&latest).Error; queryError != nil || latest.Version != managedTenantSchemaVersion {
+		t.Fatalf("latest version=%+v error=%v", latest, queryError)
+	}
+	if validationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers); validationError != nil {
+		t.Fatalf("reopen xAI provider schema: %v", validationError)
+	}
+}
+
+func TestManagedXAIProviderMigrationRejectsStageFailures(t *testing.T) {
+	assertMigrationError := func(t *testing.T, migrationError error, want string) {
+		t.Helper()
+		if !errors.Is(migrationError, errManagedTenantSchemaMigration) || !strings.Contains(migrationError.Error(), want) {
+			t.Fatalf("migration error=%v want=%q", migrationError, want)
+		}
+	}
+	t.Run("encryption", func(t *testing.T) {
+		fixture := newManagedXAIProviderMigrationFixture(t)
+		_, migrationError := preflightManagedXAIProviderWithReader(fixture.database, fixture.providerKeyCipher, fixture.providers, managedXAIProviderFailingReader{})
+		assertMigrationError(t, migrationError, "operation=preflight")
+	})
+	for _, testCase := range []struct {
+		name      string
+		want      string
+		configure func(*testing.T, managedXAIProviderMigrationFixture)
+	}{
+		{
+			name: "read tenants", want: "operation=read",
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				registerManagedGORMError(t, fixture.database, "xai_provider_read", "query", managedTenantTable, errInternalTestDatabase)
+			},
+		},
+		{
+			name: "provider conflict", want: "provider_conflict=grok:xai",
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				fixture.addProvider(t, ProviderNameXAI, ModelNameGrok43, "")
+			},
+		},
+		{
+			name: "decrypt retired provider", want: "operation=preflight",
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				if updateError := fixture.database.Model(&managedProviderAPIKeyRecord{}).Where(&managedProviderAPIKeyRecord{TenantID: fixture.tenant.TenantID, ProviderID: retiredGrokProviderIdentifier}).Update("encrypted_api_key", "invalid").Error; updateError != nil {
+					t.Fatalf("seed invalid retired provider: %v", updateError)
+				}
+			},
+		},
+		{
+			name: "decrypt retained provider", want: "operation=preflight",
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				fixture.addProvider(t, ProviderNameOpenAI, ModelNameGPT41, "invalid")
+			},
+		},
+		{
+			name: "invalid defaults", want: "operation=preflight table=" + managedTenantTable,
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				if updateError := fixture.database.Model(&managedTenantRecord{}).Where(&managedTenantRecord{TenantID: fixture.tenant.TenantID}).Update("default_model", "missing-model").Error; updateError != nil {
+					t.Fatalf("seed invalid defaults: %v", updateError)
+				}
+			},
+		},
+		{
+			name: "read historical usage", want: "operation=read table=" + managedUsageEventTable,
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				registerManagedGORMError(t, fixture.database, "xai_provider_usage_read", "query", managedUsageEventTable, errInternalTestDatabase)
+			},
+		},
+		{
+			name: "backfill provider key", want: "operation=backfill table=" + managedProviderKeyTable,
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				registerManagedGORMError(t, fixture.database, "xai_provider_key_backfill", "update", managedProviderKeyTable, errInternalTestDatabase)
+			},
+		},
+		{
+			name: "backfill tenant", want: "operation=backfill table=" + managedTenantTable,
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				registerManagedGORMError(t, fixture.database, "xai_provider_tenant_backfill", "update", managedTenantTable, errInternalTestDatabase)
+			},
+		},
+		{
+			name: "verify", want: "operation=verify",
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				if callbackError := fixture.database.Callback().Query().Before("gorm:query").Register("xai_provider_verify", func(callbackDatabase *gorm.DB) {
+					if callbackDatabase.Statement.Table == managedProviderKeyTable {
+						if _, isCount := callbackDatabase.Statement.Dest.(*int64); isCount {
+							callbackDatabase.AddError(errInternalTestDatabase)
+						}
+					}
+				}); callbackError != nil {
+					t.Fatalf("register xAI verification failure: %v", callbackError)
+				}
+			},
+		},
+		{
+			name: "record version", want: "operation=record_version",
+			configure: func(t *testing.T, fixture managedXAIProviderMigrationFixture) {
+				registerManagedGORMError(t, fixture.database, "xai_provider_record_version", "create", managedSchemaMigrationTable, errInternalTestDatabase)
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newManagedXAIProviderMigrationFixture(t)
+			testCase.configure(t, fixture)
+			assertMigrationError(t, migrateManagedXAIProvider(fixture.database, fixture.providerKeyCipher, fixture.providers), testCase.want)
+		})
+	}
+
+	t.Run("schema five validation", func(t *testing.T) {
+		fixture := newManagedXAIProviderMigrationFixture(t)
+		if createError := fixture.database.Create(&managedSchemaMigrationRecord{Version: managedModelIdentitySchemaVersion, AppliedAt: fixture.tenant.CreatedAt}).Error; createError != nil {
+			t.Fatalf("seed schema version: %v", createError)
+		}
+		if dropError := fixture.database.Migrator().DropIndex(&managedUsageEventRecord{}, managedUsageFailurePageIndex); dropError != nil {
+			t.Fatalf("drop usage failure index: %v", dropError)
+		}
+		assertMigrationError(t, initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers), "operation=validate_current_schema")
+	})
+}
+
+func TestManagedXAIProviderVerificationRejectsDrift(t *testing.T) {
+	assertVerificationError := func(t *testing.T, verificationError error, want string) {
+		t.Helper()
+		if !errors.Is(verificationError, errManagedTenantSchemaMigration) || !strings.Contains(verificationError.Error(), want) {
+			t.Fatalf("verification error=%v want=%q", verificationError, want)
+		}
+	}
+	verifiedFixture := func(t *testing.T) (managedXAIProviderMigrationFixture, managedXAIProviderDataset) {
+		t.Helper()
+		fixture := newManagedXAIProviderMigrationFixture(t)
+		dataset, preflightError := preflightManagedXAIProvider(fixture.database, fixture.providerKeyCipher, fixture.providers)
+		if preflightError != nil {
+			t.Fatalf("preflight xAI verification fixture: %v", preflightError)
+		}
+		applyManagedXAIProviderDataset(t, fixture, dataset)
+		return fixture, dataset
+	}
+
+	t.Run("retired provider remains", func(t *testing.T) {
+		fixture := newManagedXAIProviderMigrationFixture(t)
+		assertVerificationError(t, verifyManagedXAIProviderMigration(fixture.database, fixture.providerKeyCipher, fixture.providers, managedXAIProviderDataset{}), "operation=verify")
+	})
+	t.Run("provider query", func(t *testing.T) {
+		fixture, dataset := verifiedFixture(t)
+		if callbackError := fixture.database.Callback().Query().Before("gorm:query").Register("xai_verify_provider_query", func(callbackDatabase *gorm.DB) {
+			if callbackDatabase.Statement.Table == managedProviderKeyTable {
+				if _, isRecord := callbackDatabase.Statement.Dest.(*managedProviderAPIKeyRecord); isRecord {
+					callbackDatabase.AddError(errInternalTestDatabase)
+				}
+			}
+		}); callbackError != nil {
+			t.Fatalf("register provider query failure: %v", callbackError)
+		}
+		assertVerificationError(t, verifyManagedXAIProviderMigration(fixture.database, fixture.providerKeyCipher, fixture.providers, dataset), "operation=verify")
+	})
+	t.Run("provider values", func(t *testing.T) {
+		fixture, dataset := verifiedFixture(t)
+		dataset.providerKeys[0].apiKey = "changed"
+		assertVerificationError(t, verifyManagedXAIProviderMigration(fixture.database, fixture.providerKeyCipher, fixture.providers, dataset), "operation=verify")
+	})
+	t.Run("tenant query", func(t *testing.T) {
+		fixture, dataset := verifiedFixture(t)
+		registerManagedGORMError(t, fixture.database, "xai_verify_tenant_query", "query", managedTenantTable, errInternalTestDatabase)
+		assertVerificationError(t, verifyManagedXAIProviderMigration(fixture.database, fixture.providerKeyCipher, fixture.providers, dataset), "operation=verify")
+	})
+	t.Run("tenant values", func(t *testing.T) {
+		fixture, dataset := verifiedFixture(t)
+		dataset.tenants[0].updatedAt = dataset.tenants[0].updatedAt.Add(time.Second)
+		assertVerificationError(t, verifyManagedXAIProviderMigration(fixture.database, fixture.providerKeyCipher, fixture.providers, dataset), "values")
+	})
+	t.Run("current routing validation", func(t *testing.T) {
+		fixture, dataset := verifiedFixture(t)
+		fixture.addProvider(t, ProviderNameOpenAI, ModelNameGPT41, "invalid")
+		assertVerificationError(t, verifyManagedXAIProviderMigration(fixture.database, fixture.providerKeyCipher, fixture.providers, dataset), "operation=validate")
+	})
+	t.Run("usage query", func(t *testing.T) {
+		fixture, dataset := verifiedFixture(t)
+		registerManagedGORMError(t, fixture.database, "xai_verify_usage_query", "query", managedUsageEventTable, errInternalTestDatabase)
+		assertVerificationError(t, verifyManagedXAIProviderMigration(fixture.database, fixture.providerKeyCipher, fixture.providers, dataset), "operation=read")
+	})
+	t.Run("usage values", func(t *testing.T) {
+		fixture, dataset := verifiedFixture(t)
+		dataset.historicalUsage = nil
+		assertVerificationError(t, verifyManagedXAIProviderMigration(fixture.database, fixture.providerKeyCipher, fixture.providers, dataset), "historical_usage_changed")
+	})
 }
 
 type managedQwenCloudRetirementFixture struct {

--- a/internal/proxy/management_provider_key_verification_test.go
+++ b/internal/proxy/management_provider_key_verification_test.go
@@ -69,7 +69,7 @@ func TestManagementProviderKeyVerificationUsesEveryCanonicalTransportBeforePersi
 		{provider: proxy.ProviderNameGemini, model: proxy.ModelNameGemini25Flash, transport: verificationTransportGemini},
 		{provider: proxy.ProviderNameAnthropic, model: proxy.ModelNameClaudeSonnet46, transport: verificationTransportAnthropic},
 		{provider: proxy.ProviderNameMeta, model: proxy.ModelNameMuseSpark11, transport: verificationTransportChat, tokenLimitField: "max_completion_tokens"},
-		{provider: proxy.ProviderNameGrok, model: proxy.ModelNameGrok43, transport: verificationTransportChat, tokenLimitField: "max_tokens"},
+		{provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok43, transport: verificationTransportChat, tokenLimitField: "max_tokens"},
 	}
 
 	for _, transportCase := range transportCases {
@@ -505,7 +505,7 @@ func providerKeyVerificationConfiguration(upstreamURL string) proxy.Configuratio
 		GeminiBaseURL:      upstreamURL,
 		AnthropicBaseURL:   upstreamURL,
 		MetaBaseURL:        upstreamURL,
-		GrokBaseURL:        upstreamURL,
+		XAIBaseURL:         upstreamURL,
 	}
 }
 

--- a/internal/proxy/management_store.go
+++ b/internal/proxy/management_store.go
@@ -45,10 +45,12 @@ const (
 	managedUsageOutcomeSchemaVersion      = 2
 	managedKeyedRoutingSchemaVersion      = 3
 	managedQwenCloudRetirementVersion     = 4
-	managedTenantSchemaVersion            = 5
+	managedModelIdentitySchemaVersion     = 5
+	managedTenantSchemaVersion            = 6
 	managedSQLiteRuntimeQuery             = "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
 	retiredQwenCloudProviderIdentifier    = "qwencloud"
 	retiredQwenCloudModelIdentifier       = "qwen3.8-max-preview"
+	retiredGrokProviderIdentifier         = "grok"
 	managedMiniMaxNativeModel             = "MiniMax-M2.7"
 	managedSiliconFlowDeepSeekNativeModel = "deepseek-ai/DeepSeek-R1"
 	managedSenseVoiceNativeModel          = "FunAudioLLM/SenseVoiceSmall"
@@ -495,6 +497,7 @@ func initializeManagedTenantSchema(database *gorm.DB, providerKeyCipher managedP
 		return fmt.Errorf("%w: operation=read_version table=%s: %v", errManagedTenantSchemaMigration, managedSchemaMigrationTable, queryError)
 	}
 	requiresQwenCloudRetirement := false
+	requiresModelIdentityMigration := false
 	switch migration.Version {
 	case managedTenantOwnershipSchemaVersion:
 		if migrationError := migrateManagedUsageOutcomeSchema(database); migrationError != nil {
@@ -504,6 +507,7 @@ func initializeManagedTenantSchema(database *gorm.DB, providerKeyCipher managedP
 			return migrationError
 		}
 		requiresQwenCloudRetirement = true
+		requiresModelIdentityMigration = true
 	case managedUsageOutcomeSchemaVersion:
 		if !managedTableHasColumn(migrator, managedUsageEventTable, managedUsageOutcomeCodeColumn) ||
 			!migrator.HasIndex(&managedUsageEventRecord{}, managedUsageFailurePageIndex) {
@@ -513,13 +517,21 @@ func initializeManagedTenantSchema(database *gorm.DB, providerKeyCipher managedP
 			return migrationError
 		}
 		requiresQwenCloudRetirement = true
+		requiresModelIdentityMigration = true
 	case managedKeyedRoutingSchemaVersion:
 		if !managedTableHasColumn(migrator, managedUsageEventTable, managedUsageOutcomeCodeColumn) ||
 			!migrator.HasIndex(&managedUsageEventRecord{}, managedUsageFailurePageIndex) {
 			return fmt.Errorf("%w: operation=validate_current_schema table=%s", errManagedTenantSchemaMigration, managedUsageEventTable)
 		}
 		requiresQwenCloudRetirement = true
+		requiresModelIdentityMigration = true
 	case managedQwenCloudRetirementVersion:
+		if !managedTableHasColumn(migrator, managedUsageEventTable, managedUsageOutcomeCodeColumn) ||
+			!migrator.HasIndex(&managedUsageEventRecord{}, managedUsageFailurePageIndex) {
+			return fmt.Errorf("%w: operation=validate_current_schema table=%s", errManagedTenantSchemaMigration, managedUsageEventTable)
+		}
+		requiresModelIdentityMigration = true
+	case managedModelIdentitySchemaVersion:
 		if !managedTableHasColumn(migrator, managedUsageEventTable, managedUsageOutcomeCodeColumn) ||
 			!migrator.HasIndex(&managedUsageEventRecord{}, managedUsageFailurePageIndex) {
 			return fmt.Errorf("%w: operation=validate_current_schema table=%s", errManagedTenantSchemaMigration, managedUsageEventTable)
@@ -538,7 +550,12 @@ func initializeManagedTenantSchema(database *gorm.DB, providerKeyCipher managedP
 			return migrationError
 		}
 	}
-	return migrateManagedModelIdentity(database, providerKeyCipher, providers)
+	if requiresModelIdentityMigration {
+		if migrationError := migrateManagedModelIdentity(database, providerKeyCipher, providers); migrationError != nil {
+			return migrationError
+		}
+	}
+	return migrateManagedXAIProvider(database, providerKeyCipher, providers)
 }
 
 type managedUsageOutcomeBackfill struct {
@@ -883,7 +900,7 @@ func migrateManagedModelIdentity(database *gorm.DB, providerKeyCipher managedPro
 		if !slices.Equal(migratedHistoricalUsage, dataset.historicalUsage) {
 			return fmt.Errorf("%w: operation=verify table=%s historical_usage_changed", errManagedTenantSchemaMigration, managedUsageEventTable)
 		}
-		if createError := transaction.Create(&managedSchemaMigrationRecord{Version: managedTenantSchemaVersion, AppliedAt: time.Now().UTC()}).Error; createError != nil {
+		if createError := transaction.Create(&managedSchemaMigrationRecord{Version: managedModelIdentitySchemaVersion, AppliedAt: time.Now().UTC()}).Error; createError != nil {
 			return fmt.Errorf("%w: operation=record_version table=%s: %v", errManagedTenantSchemaMigration, managedSchemaMigrationTable, createError)
 		}
 		return nil
@@ -967,6 +984,187 @@ func managedModelIdentityHistoricalUsage(database *gorm.DB) ([]managedUsageEvent
 		Error
 	if queryError != nil {
 		return nil, fmt.Errorf("%w: operation=read table=%s historical_model_identity: %v", errManagedTenantSchemaMigration, managedUsageEventTable, queryError)
+	}
+	return historicalUsage, nil
+}
+
+type managedXAIProviderKeyBackfill struct {
+	record managedProviderAPIKeyRecord
+	apiKey string
+}
+
+type managedXAITenantBackfill struct {
+	tenantID  string
+	defaults  managedRoutingDefaults
+	updatedAt time.Time
+}
+
+type managedXAIProviderDataset struct {
+	providerKeys    []managedXAIProviderKeyBackfill
+	tenants         []managedXAITenantBackfill
+	historicalUsage []managedUsageEventRecord
+}
+
+func migrateManagedXAIProvider(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry) error {
+	dataset, preflightError := preflightManagedXAIProvider(database, providerKeyCipher, providers)
+	if preflightError != nil {
+		return preflightError
+	}
+	return database.Transaction(func(transaction *gorm.DB) error {
+		for _, backfill := range dataset.providerKeys {
+			result := transaction.Model(&managedProviderAPIKeyRecord{}).
+				Where(&managedProviderAPIKeyRecord{TenantID: backfill.record.TenantID, ProviderID: retiredGrokProviderIdentifier}).
+				UpdateColumns(map[string]any{
+					"provider_id":       backfill.record.ProviderID,
+					"encrypted_api_key": backfill.record.EncryptedAPIKey,
+				})
+			if result.Error != nil || result.RowsAffected != 1 {
+				return fmt.Errorf("%w: operation=backfill table=%s tenant=%s provider=%s rows=%d: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, backfill.record.TenantID, retiredGrokProviderIdentifier, result.RowsAffected, result.Error)
+			}
+		}
+		for _, backfill := range dataset.tenants {
+			result := transaction.Model(&managedTenantRecord{}).
+				Where(&managedTenantRecord{TenantID: backfill.tenantID}).
+				Updates(managedRoutingDefaultsDatabaseUpdates(backfill.defaults, backfill.updatedAt))
+			if result.Error != nil || result.RowsAffected != 1 {
+				return fmt.Errorf("%w: operation=backfill table=%s tenant=%s rows=%d: %v", errManagedTenantSchemaMigration, managedTenantTable, backfill.tenantID, result.RowsAffected, result.Error)
+			}
+		}
+		if verifyError := verifyManagedXAIProviderMigration(transaction, providerKeyCipher, providers, dataset); verifyError != nil {
+			return verifyError
+		}
+		if createError := transaction.Create(&managedSchemaMigrationRecord{Version: managedTenantSchemaVersion, AppliedAt: time.Now().UTC()}).Error; createError != nil {
+			return fmt.Errorf("%w: operation=record_version table=%s: %v", errManagedTenantSchemaMigration, managedSchemaMigrationTable, createError)
+		}
+		return nil
+	})
+}
+
+func preflightManagedXAIProvider(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry) (managedXAIProviderDataset, error) {
+	return preflightManagedXAIProviderWithReader(database, providerKeyCipher, providers, rand.Reader)
+}
+
+func preflightManagedXAIProviderWithReader(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry, randomReader io.Reader) (managedXAIProviderDataset, error) {
+	records, queryError := managedTenantRecordsForRoutingValidation(database)
+	if queryError != nil {
+		return managedXAIProviderDataset{}, queryError
+	}
+	dataset := managedXAIProviderDataset{
+		providerKeys: make([]managedXAIProviderKeyBackfill, 0),
+		tenants:      make([]managedXAITenantBackfill, 0),
+	}
+	for recordIndex := range records {
+		record := &records[recordIndex]
+		hasRetiredProvider := false
+		hasCanonicalProvider := false
+		for _, providerKey := range record.ProviderAPIKeys {
+			hasRetiredProvider = hasRetiredProvider || providerKey.ProviderID == retiredGrokProviderIdentifier
+			hasCanonicalProvider = hasCanonicalProvider || providerKey.ProviderID == ProviderNameXAI
+		}
+		if hasRetiredProvider && hasCanonicalProvider {
+			return managedXAIProviderDataset{}, fmt.Errorf("%w: operation=preflight table=%s tenant=%s provider_conflict=%s:%s", errManagedTenantSchemaMigration, managedProviderKeyTable, record.TenantID, retiredGrokProviderIdentifier, ProviderNameXAI)
+		}
+		for providerKeyIndex := range record.ProviderAPIKeys {
+			providerKey := &record.ProviderAPIKeys[providerKeyIndex]
+			if providerKey.ProviderID != retiredGrokProviderIdentifier {
+				continue
+			}
+			apiKey, decryptError := providerKeyCipher.decrypt(*providerKey)
+			if decryptError != nil {
+				return managedXAIProviderDataset{}, fmt.Errorf("%w: operation=preflight table=%s tenant=%s provider=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, record.TenantID, retiredGrokProviderIdentifier, decryptError)
+			}
+			encryptedAPIKey, encryptionError := providerKeyCipher.encrypt(randomReader, record.TenantID, ProviderNameXAI, apiKey)
+			if encryptionError != nil {
+				return managedXAIProviderDataset{}, fmt.Errorf("%w: operation=preflight table=%s tenant=%s provider=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, record.TenantID, retiredGrokProviderIdentifier, encryptionError)
+			}
+			providerKey.ProviderID = ProviderNameXAI
+			providerKey.EncryptedAPIKey = encryptedAPIKey
+			dataset.providerKeys = append(dataset.providerKeys, managedXAIProviderKeyBackfill{record: *providerKey, apiKey: apiKey})
+		}
+		providerSettings, providerSettingsError := managedProviderSettingsFromRecords(providerKeyCipher, record.ProviderAPIKeys)
+		if providerSettingsError != nil {
+			return managedXAIProviderDataset{}, fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, record.OwnerUserID, record.TenantID, providerSettingsError)
+		}
+		defaults, defaultsChanged := canonicalManagedXAIProviderDefaults(record.defaults())
+		validatedDefaults, defaultsError := validatePersistedManagedRoutingDefaults(providers, providerSettings, defaults)
+		if defaultsError != nil {
+			return managedXAIProviderDataset{}, fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, record.OwnerUserID, record.TenantID, defaultsError)
+		}
+		if defaultsChanged {
+			dataset.tenants = append(dataset.tenants, managedXAITenantBackfill{
+				tenantID: record.TenantID, defaults: validatedDefaults, updatedAt: record.UpdatedAt,
+			})
+		}
+	}
+	historicalUsage, usageError := managedXAIHistoricalUsage(database)
+	if usageError != nil {
+		return managedXAIProviderDataset{}, usageError
+	}
+	dataset.historicalUsage = historicalUsage
+	return dataset, nil
+}
+
+func canonicalManagedXAIProviderDefaults(defaults TenantDefaults) (TenantDefaults, bool) {
+	changed := false
+	if defaults.Provider == retiredGrokProviderIdentifier {
+		defaults.Provider = ProviderNameXAI
+		changed = true
+	}
+	if defaults.DictationProvider == retiredGrokProviderIdentifier {
+		defaults.DictationProvider = ProviderNameXAI
+		changed = true
+	}
+	return defaults, changed
+}
+
+func verifyManagedXAIProviderMigration(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry, dataset managedXAIProviderDataset) error {
+	var retiredProviderKeyCount int64
+	if countError := database.Model(&managedProviderAPIKeyRecord{}).
+		Where(&managedProviderAPIKeyRecord{ProviderID: retiredGrokProviderIdentifier}).
+		Count(&retiredProviderKeyCount).
+		Error; countError != nil || retiredProviderKeyCount != 0 {
+		return fmt.Errorf("%w: operation=verify table=%s provider=%s count=%d: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, retiredGrokProviderIdentifier, retiredProviderKeyCount, countError)
+	}
+	for _, expected := range dataset.providerKeys {
+		var actual managedProviderAPIKeyRecord
+		if queryError := database.Where(&managedProviderAPIKeyRecord{TenantID: expected.record.TenantID, ProviderID: ProviderNameXAI}).First(&actual).Error; queryError != nil {
+			return fmt.Errorf("%w: operation=verify table=%s tenant=%s provider=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, expected.record.TenantID, ProviderNameXAI, queryError)
+		}
+		apiKey, decryptError := providerKeyCipher.decrypt(actual)
+		if decryptError != nil || apiKey != expected.apiKey || actual.TextModel != expected.record.TextModel || actual.SystemPrompt != expected.record.SystemPrompt || !actual.CreatedAt.Equal(expected.record.CreatedAt) || !actual.UpdatedAt.Equal(expected.record.UpdatedAt) {
+			return fmt.Errorf("%w: operation=verify table=%s tenant=%s provider=%s", errManagedTenantSchemaMigration, managedProviderKeyTable, expected.record.TenantID, ProviderNameXAI)
+		}
+	}
+	for _, expected := range dataset.tenants {
+		var actual managedTenantRecord
+		if queryError := database.Where(&managedTenantRecord{TenantID: expected.tenantID}).First(&actual).Error; queryError != nil {
+			return fmt.Errorf("%w: operation=verify table=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, expected.tenantID, queryError)
+		}
+		if actual.defaults() != expected.defaults.value() || !actual.UpdatedAt.Equal(expected.updatedAt) {
+			return fmt.Errorf("%w: operation=verify table=%s tenant=%s values", errManagedTenantSchemaMigration, managedTenantTable, expected.tenantID)
+		}
+	}
+	if validationError := validateManagedKeyedRoutingDefaults(database, providerKeyCipher, providers); validationError != nil {
+		return validationError
+	}
+	historicalUsage, usageError := managedXAIHistoricalUsage(database)
+	if usageError != nil {
+		return usageError
+	}
+	if !slices.Equal(historicalUsage, dataset.historicalUsage) {
+		return fmt.Errorf("%w: operation=verify table=%s historical_usage_changed provider=%s", errManagedTenantSchemaMigration, managedUsageEventTable, retiredGrokProviderIdentifier)
+	}
+	return nil
+}
+
+func managedXAIHistoricalUsage(database *gorm.DB) ([]managedUsageEventRecord, error) {
+	var historicalUsage []managedUsageEventRecord
+	if queryError := database.
+		Where(&managedUsageEventRecord{ProviderID: retiredGrokProviderIdentifier}).
+		Order("id").
+		Find(&historicalUsage).
+		Error; queryError != nil {
+		return nil, fmt.Errorf("%w: operation=read table=%s provider=%s: %v", errManagedTenantSchemaMigration, managedUsageEventTable, retiredGrokProviderIdentifier, queryError)
 	}
 	return historicalUsage, nil
 }
@@ -1225,7 +1423,8 @@ func preflightLegacyManagedTenantSchema(database *gorm.DB, providerKeyCipher man
 		if _, identifierError := newManagedTenantIdentifier(legacyTenant.TenantID); identifierError != nil {
 			return managedTenantMigrationDataset{}, fmt.Errorf("%w: operation=preflight table=%s user=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, legacyTenant.UserID, legacyTenant.TenantID, identifierError)
 		}
-		validatedDefaults, defaultsError := validateCanonicalManagedRoutingDefaults(providers, legacyTenant.defaults())
+		canonicalDefaults, _ := canonicalManagedXAIProviderDefaults(legacyTenant.defaults())
+		validatedDefaults, defaultsError := validateCanonicalManagedRoutingDefaults(providers, canonicalDefaults)
 		if defaultsError != nil {
 			return managedTenantMigrationDataset{}, fmt.Errorf("%w: operation=preflight table=%s user=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, legacyTenant.UserID, legacyTenant.TenantID, defaultsError)
 		}
@@ -1258,12 +1457,12 @@ func preflightLegacyManagedTenantSchema(database *gorm.DB, providerKeyCipher man
 			Name:                     defaultName.display,
 			NameKey:                  defaultName.key,
 			SecretDigest:             secretDigest,
-			DefaultProvider:          legacyTenant.DefaultProvider,
-			DefaultModel:             legacyTenant.DefaultModel,
-			DefaultDictationProvider: legacyTenant.DefaultDictationProvider,
-			DefaultDictationModel:    legacyTenant.DefaultDictationModel,
-			DefaultSystemPrompt:      legacyTenant.DefaultSystemPrompt,
-			DefaultReasoningEffort:   legacyTenant.DefaultReasoningEffort,
+			DefaultProvider:          canonicalDefaults.Provider,
+			DefaultModel:             canonicalDefaults.Model,
+			DefaultDictationProvider: canonicalDefaults.DictationProvider,
+			DefaultDictationModel:    canonicalDefaults.DictationModel,
+			DefaultSystemPrompt:      canonicalDefaults.SystemPrompt,
+			DefaultReasoningEffort:   canonicalDefaults.ReasoningEffort,
 			CreatedAt:                legacyTenant.CreatedAt,
 			UpdatedAt:                legacyTenant.UpdatedAt,
 		})
@@ -1273,8 +1472,12 @@ func preflightLegacyManagedTenantSchema(database *gorm.DB, providerKeyCipher man
 		if !ownerExists {
 			return managedTenantMigrationDataset{}, fmt.Errorf("%w: operation=preflight table=%s orphan_user=%s provider=%s", errManagedTenantSchemaMigration, managedProviderKeyTable, legacyProviderKey.UserID, legacyProviderKey.ProviderID)
 		}
+		providerIdentifier := legacyProviderKey.ProviderID
+		if providerIdentifier == retiredGrokProviderIdentifier {
+			providerIdentifier = ProviderNameXAI
+		}
 		providerDefinition, textModelDefinition, modelError := providers.resolveTextModel(
-			legacyProviderKey.ProviderID,
+			providerIdentifier,
 			legacyProviderKey.TextModel,
 			constants.EmptyString,
 			constants.EmptyString,
@@ -1285,7 +1488,8 @@ func preflightLegacyManagedTenantSchema(database *gorm.DB, providerKeyCipher man
 		}
 		canonicalProviderIdentifier := providerDefinition.identifier.string()
 		canonicalTextModel := textModelDefinition.string()
-		if legacyProviderKey.ProviderID != canonicalProviderIdentifier || legacyProviderKey.TextModel != canonicalTextModel {
+		providerIdentifierMigrated := legacyProviderKey.ProviderID == retiredGrokProviderIdentifier && canonicalProviderIdentifier == ProviderNameXAI
+		if (!providerIdentifierMigrated && legacyProviderKey.ProviderID != canonicalProviderIdentifier) || legacyProviderKey.TextModel != canonicalTextModel {
 			return managedTenantMigrationDataset{}, fmt.Errorf(
 				"%w: operation=preflight table=%s user=%s tenant=%s provider=%s model=%s reason=not_canonical",
 				errManagedTenantSchemaMigration,

--- a/internal/proxy/management_store.go
+++ b/internal/proxy/management_store.go
@@ -643,11 +643,12 @@ func migrateManagedKeyedRoutingDefaults(database *gorm.DB, providerKeyCipher man
 	}
 	backfills := make([]managedRoutingDefaultsBackfill, 0, len(records))
 	for _, record := range records {
-		providerSettings, providerSettingsError := managedProviderSettingsFromRecords(providerKeyCipher, record.ProviderAPIKeys)
+		providerSettings, providerSettingsError := managedProviderSettingsFromPredecessorRecords(providerKeyCipher, record.ProviderAPIKeys)
 		if providerSettingsError != nil {
 			return fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, record.OwnerUserID, record.TenantID, providerSettingsError)
 		}
-		currentDefaults, defaultsError := validateCanonicalManagedRoutingDefaults(providers, record.defaults())
+		projectedDefaults, _ := canonicalManagedPredecessorDefaults(record.defaults())
+		currentDefaults, defaultsError := validateCanonicalManagedRoutingDefaults(providers, projectedDefaults)
 		if defaultsError != nil {
 			return fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, record.OwnerUserID, record.TenantID, defaultsError)
 		}
@@ -677,7 +678,7 @@ func migrateManagedKeyedRoutingDefaults(database *gorm.DB, providerKeyCipher man
 				)
 			}
 		}
-		if validationError := validateManagedKeyedRoutingDefaults(transaction, providerKeyCipher, providers); validationError != nil {
+		if validationError := validateManagedPendingRouteIdentities(transaction, providerKeyCipher, providers); validationError != nil {
 			return validationError
 		}
 		if createError := transaction.Create(&managedSchemaMigrationRecord{Version: managedKeyedRoutingSchemaVersion, AppliedAt: time.Now().UTC()}).Error; createError != nil {
@@ -761,13 +762,19 @@ func preflightManagedQwenCloudRetirement(database *gorm.DB, providerKeyCipher ma
 			}
 			remainingProviderKeys = append(remainingProviderKeys, providerKeyRecord)
 		}
-		providerSettings, providerSettingsError := managedProviderSettingsFromRecords(providerKeyCipher, remainingProviderKeys)
+		providerSettings, providerSettingsError := managedProviderSettingsFromPredecessorRecords(providerKeyCipher, remainingProviderKeys)
 		if providerSettingsError != nil {
 			return managedQwenCloudRetirementDataset{}, fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, record.OwnerUserID, record.TenantID, providerSettingsError)
 		}
 		currentDefaults, defaultsError := validateManagedQwenCloudRetirementDefaults(providers, record.defaults())
 		if defaultsError != nil {
 			return managedQwenCloudRetirementDataset{}, fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, record.OwnerUserID, record.TenantID, defaultsError)
+		}
+		if strings.TrimSpace(record.DefaultProvider) != retiredQwenCloudProviderIdentifier {
+			if _, validationError := validatePersistedManagedRoutingDefaults(providers, providerSettings, currentDefaults.value()); validationError != nil {
+				return managedQwenCloudRetirementDataset{}, fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, record.OwnerUserID, record.TenantID, validationError)
+			}
+			continue
 		}
 		reconciledDefaults, reconciliationError := reconcileManagedRoutingDefaults(providers, providerSettings, currentDefaults)
 		if reconciliationError != nil {
@@ -791,7 +798,8 @@ func preflightManagedQwenCloudRetirement(database *gorm.DB, providerKeyCipher ma
 
 func validateManagedQwenCloudRetirementDefaults(providers *providerRegistry, rawDefaults TenantDefaults) (managedRoutingDefaults, error) {
 	if strings.TrimSpace(rawDefaults.Provider) != retiredQwenCloudProviderIdentifier {
-		return validateCanonicalManagedRoutingDefaults(providers, rawDefaults)
+		projectedDefaults, _ := canonicalManagedPredecessorDefaults(rawDefaults)
+		return validateCanonicalManagedRoutingDefaults(providers, projectedDefaults)
 	}
 	if rawDefaults.Provider != retiredQwenCloudProviderIdentifier || strings.TrimSpace(rawDefaults.Model) != retiredQwenCloudModelIdentifier || rawDefaults.Model != retiredQwenCloudModelIdentifier {
 		return managedRoutingDefaults{}, managedRoutingDefaultsCanonicalError(endpointKindText, rawDefaults.Provider, rawDefaults.Model)
@@ -800,7 +808,8 @@ func validateManagedQwenCloudRetirementDefaults(providers *providerRegistry, raw
 	currentWithoutRetiredTextRoute.Provider = constants.EmptyString
 	currentWithoutRetiredTextRoute.Model = constants.EmptyString
 	currentWithoutRetiredTextRoute.ReasoningEffort = constants.EmptyString
-	validatedCurrent, validationError := validateCanonicalManagedRoutingDefaults(providers, currentWithoutRetiredTextRoute)
+	projectedDefaults, _ := canonicalManagedPredecessorDefaults(currentWithoutRetiredTextRoute)
+	validatedCurrent, validationError := validateCanonicalManagedRoutingDefaults(providers, projectedDefaults)
 	if validationError != nil {
 		return managedRoutingDefaults{}, validationError
 	}
@@ -828,7 +837,7 @@ func verifyManagedQwenCloudRetirement(database *gorm.DB, providerKeyCipher manag
 			return fmt.Errorf("%w: operation=verify table=%s tenant=%s values", errManagedTenantSchemaMigration, managedTenantTable, backfill.tenantID)
 		}
 	}
-	if validationError := validateManagedKeyedRoutingDefaults(database, providerKeyCipher, providers); validationError != nil {
+	if validationError := validateManagedPendingRouteIdentities(database, providerKeyCipher, providers); validationError != nil {
 		return validationError
 	}
 	var historicalUsage []managedUsageEventRecord
@@ -890,7 +899,7 @@ func migrateManagedModelIdentity(database *gorm.DB, providerKeyCipher managedPro
 				return fmt.Errorf("%w: operation=backfill table=%s tenant=%s rows=%d: %v", errManagedTenantSchemaMigration, managedTenantTable, backfill.tenantID, result.RowsAffected, result.Error)
 			}
 		}
-		if validationError := validateManagedKeyedRoutingDefaults(transaction, providerKeyCipher, providers); validationError != nil {
+		if validationError := validateManagedPendingRouteIdentities(transaction, providerKeyCipher, providers); validationError != nil {
 			return validationError
 		}
 		migratedHistoricalUsage, usageError := managedModelIdentityHistoricalUsage(transaction)
@@ -928,18 +937,19 @@ func preflightManagedModelIdentity(database *gorm.DB, providerKeyCipher managedP
 				})
 			}
 		}
-		providerSettings, providerSettingsError := managedProviderSettingsFromRecords(providerKeyCipher, record.ProviderAPIKeys)
+		providerSettings, providerSettingsError := managedProviderSettingsFromPredecessorRecords(providerKeyCipher, record.ProviderAPIKeys)
 		if providerSettingsError != nil {
 			return managedModelIdentityDataset{}, fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, record.OwnerUserID, record.TenantID, providerSettingsError)
 		}
-		defaults, defaultsChanged := canonicalManagedTenantDefaults(record.defaults())
-		validatedDefaults, defaultsError := validatePersistedManagedRoutingDefaults(providers, providerSettings, defaults)
+		modelIdentityDefaults, defaultsChanged := canonicalManagedTenantDefaults(record.defaults())
+		projectedDefaults, _ := canonicalManagedXAIProviderDefaults(modelIdentityDefaults)
+		_, defaultsError := validatePersistedManagedRoutingDefaults(providers, providerSettings, projectedDefaults)
 		if defaultsError != nil {
 			return managedModelIdentityDataset{}, fmt.Errorf("%w: operation=preflight table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, record.OwnerUserID, record.TenantID, defaultsError)
 		}
 		if defaultsChanged {
 			dataset.tenants = append(dataset.tenants, managedModelIdentityTenantBackfill{
-				tenantID: record.TenantID, defaults: validatedDefaults, updatedAt: record.UpdatedAt,
+				tenantID: record.TenantID, defaults: managedRoutingDefaults{tenantDefaults: modelIdentityDefaults}, updatedAt: record.UpdatedAt,
 			})
 		}
 	}
@@ -973,6 +983,12 @@ func canonicalManagedTenantDefaults(defaults TenantDefaults) (TenantDefaults, bo
 		changed = true
 	}
 	return defaults, changed
+}
+
+func canonicalManagedPredecessorDefaults(defaults TenantDefaults) (TenantDefaults, bool) {
+	modelIdentityDefaults, modelIdentityChanged := canonicalManagedTenantDefaults(defaults)
+	currentDefaults, providerChanged := canonicalManagedXAIProviderDefaults(modelIdentityDefaults)
+	return currentDefaults, modelIdentityChanged || providerChanged
 }
 
 func managedModelIdentityHistoricalUsage(database *gorm.DB) ([]managedUsageEventRecord, error) {
@@ -1170,16 +1186,43 @@ func managedXAIHistoricalUsage(database *gorm.DB) ([]managedUsageEventRecord, er
 }
 
 func validateManagedKeyedRoutingDefaults(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry) error {
+	return validateManagedRoutingDefaults(
+		database,
+		providerKeyCipher,
+		providers,
+		managedProviderSettingsFromRecords,
+		func(defaults TenantDefaults) TenantDefaults { return defaults },
+	)
+}
+
+func validateManagedPendingRouteIdentities(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry) error {
+	return validateManagedRoutingDefaults(
+		database,
+		providerKeyCipher,
+		providers,
+		managedProviderSettingsFromPredecessorRecords,
+		func(defaults TenantDefaults) TenantDefaults {
+			projectedDefaults, _ := canonicalManagedPredecessorDefaults(defaults)
+			return projectedDefaults
+		},
+	)
+}
+
+type managedProviderSettingsProjection func(managedProviderKeyCipher, []managedProviderAPIKeyRecord) (map[providerID]managedProviderSettings, error)
+
+type managedRoutingDefaultsProjection func(TenantDefaults) TenantDefaults
+
+func validateManagedRoutingDefaults(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry, providerSettingsProjection managedProviderSettingsProjection, defaultsProjection managedRoutingDefaultsProjection) error {
 	records, queryError := managedTenantRecordsForRoutingValidation(database)
 	if queryError != nil {
 		return queryError
 	}
 	for _, record := range records {
-		providerSettings, providerSettingsError := managedProviderSettingsFromRecords(providerKeyCipher, record.ProviderAPIKeys)
+		providerSettings, providerSettingsError := providerSettingsProjection(providerKeyCipher, record.ProviderAPIKeys)
 		if providerSettingsError != nil {
 			return fmt.Errorf("%w: operation=validate table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, record.OwnerUserID, record.TenantID, providerSettingsError)
 		}
-		if _, defaultsError := validatePersistedManagedRoutingDefaults(providers, providerSettings, record.defaults()); defaultsError != nil {
+		if _, defaultsError := validatePersistedManagedRoutingDefaults(providers, providerSettings, defaultsProjection(record.defaults())); defaultsError != nil {
 			return fmt.Errorf("%w: operation=validate table=%s owner=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, record.OwnerUserID, record.TenantID, defaultsError)
 		}
 	}
@@ -1423,7 +1466,7 @@ func preflightLegacyManagedTenantSchema(database *gorm.DB, providerKeyCipher man
 		if _, identifierError := newManagedTenantIdentifier(legacyTenant.TenantID); identifierError != nil {
 			return managedTenantMigrationDataset{}, fmt.Errorf("%w: operation=preflight table=%s user=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, legacyTenant.UserID, legacyTenant.TenantID, identifierError)
 		}
-		canonicalDefaults, _ := canonicalManagedXAIProviderDefaults(legacyTenant.defaults())
+		canonicalDefaults, _ := canonicalManagedPredecessorDefaults(legacyTenant.defaults())
 		validatedDefaults, defaultsError := validateCanonicalManagedRoutingDefaults(providers, canonicalDefaults)
 		if defaultsError != nil {
 			return managedTenantMigrationDataset{}, fmt.Errorf("%w: operation=preflight table=%s user=%s tenant=%s: %v", errManagedTenantSchemaMigration, managedTenantTable, legacyTenant.UserID, legacyTenant.TenantID, defaultsError)
@@ -1476,9 +1519,10 @@ func preflightLegacyManagedTenantSchema(database *gorm.DB, providerKeyCipher man
 		if providerIdentifier == retiredGrokProviderIdentifier {
 			providerIdentifier = ProviderNameXAI
 		}
+		textModel, _ := canonicalManagedTextModel(providerIdentifier, legacyProviderKey.TextModel)
 		providerDefinition, textModelDefinition, modelError := providers.resolveTextModel(
 			providerIdentifier,
-			legacyProviderKey.TextModel,
+			textModel,
 			constants.EmptyString,
 			constants.EmptyString,
 			false,
@@ -1488,8 +1532,7 @@ func preflightLegacyManagedTenantSchema(database *gorm.DB, providerKeyCipher man
 		}
 		canonicalProviderIdentifier := providerDefinition.identifier.string()
 		canonicalTextModel := textModelDefinition.string()
-		providerIdentifierMigrated := legacyProviderKey.ProviderID == retiredGrokProviderIdentifier && canonicalProviderIdentifier == ProviderNameXAI
-		if (!providerIdentifierMigrated && legacyProviderKey.ProviderID != canonicalProviderIdentifier) || legacyProviderKey.TextModel != canonicalTextModel {
+		if providerIdentifier != canonicalProviderIdentifier || textModel != canonicalTextModel {
 			return managedTenantMigrationDataset{}, fmt.Errorf(
 				"%w: operation=preflight table=%s user=%s tenant=%s provider=%s model=%s reason=not_canonical",
 				errManagedTenantSchemaMigration,
@@ -2509,6 +2552,32 @@ func managedProviderSettingsFromRecords(providerKeyCipher managedProviderKeyCiph
 				textModel:    strings.TrimSpace(providerKeyRecord.TextModel),
 				systemPrompt: providerKeyRecord.SystemPrompt,
 			}
+		}
+	}
+	return providerSettings, nil
+}
+
+func managedProviderSettingsFromPredecessorRecords(providerKeyCipher managedProviderKeyCipher, providerKeyRecords []managedProviderAPIKeyRecord) (map[providerID]managedProviderSettings, error) {
+	predecessorSettings, settingsError := managedProviderSettingsFromRecords(providerKeyCipher, providerKeyRecords)
+	if settingsError != nil {
+		return nil, settingsError
+	}
+	providerSettings := make(map[providerID]managedProviderSettings, len(predecessorSettings))
+	for predecessorProviderIdentifier, settings := range predecessorSettings {
+		providerIdentifier := predecessorProviderIdentifier.string()
+		if providerIdentifier == retiredGrokProviderIdentifier {
+			providerIdentifier = ProviderNameXAI
+		}
+		textModel, _ := canonicalManagedTextModel(providerIdentifier, settings.textModel)
+		canonicalProviderIdentifier := newProviderID(providerIdentifier)
+		if _, duplicate := providerSettings[canonicalProviderIdentifier]; duplicate {
+			return nil, fmt.Errorf("%w: provider_conflict=%s", errManagedRoutingDefaultsInvalid, canonicalProviderIdentifier.string())
+		}
+		settings.textModel = strings.TrimSpace(textModel)
+		providerSettings[canonicalProviderIdentifier] = managedProviderSettings{
+			apiKey:       settings.apiKey,
+			textModel:    settings.textModel,
+			systemPrompt: settings.systemPrompt,
 		}
 	}
 	return providerSettings, nil

--- a/internal/proxy/management_tenants_internal_test.go
+++ b/internal/proxy/management_tenants_internal_test.go
@@ -174,6 +174,86 @@ func TestManagedTenantSQLiteOwnershipMigrationPreservesAndRebindsData(t *testing
 	}
 }
 
+func TestManagedTenantSQLiteOwnershipMigrationCanonicalizesConfirmedRouteIdentities(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "legacy-native-models.db")
+	providerKeyCipher := internalManagedProviderKeyCipher()
+	providers := internalManagementProviderRegistry()
+	legacyDatabase := openLegacyManagedTenantDatabase(t, databasePath)
+	fixedTime := time.Date(2026, 8, 11, 7, 0, 0, 0, time.UTC)
+	legacyTenant := legacyManagedTenantRecord{
+		UserID: "native-model-owner", TenantID: "native-model-tenant",
+		DefaultProvider: ProviderNameMiniMax, DefaultModel: managedMiniMaxNativeModel,
+		DefaultDictationProvider: ProviderNameSiliconFlow, DefaultDictationModel: managedSenseVoiceNativeModel,
+		DefaultSystemPrompt: "preserve native prompt", CreatedAt: fixedTime, UpdatedAt: fixedTime.Add(time.Minute),
+	}
+	if createError := legacyDatabase.Table(managedTenantTable).Create(&legacyTenant).Error; createError != nil {
+		t.Fatalf("seed native legacy tenant: %v", createError)
+	}
+	encryptLegacyProviderKey := func(providerIdentifier string, rawAPIKey string, nonceByte byte) string {
+		t.Helper()
+		encryptedKey, encryptionError := providerKeyCipher.encrypt(
+			bytes.NewReader(bytes.Repeat([]byte{nonceByte}, providerKeyCipher.aeadCipher.NonceSize())),
+			legacyTenant.UserID,
+			providerIdentifier,
+			rawAPIKey,
+		)
+		if encryptionError != nil {
+			t.Fatalf("encrypt native legacy provider=%s: %v", providerIdentifier, encryptionError)
+		}
+		return encryptedKey
+	}
+	legacyProviderKeys := []legacyManagedProviderAPIKeyRecord{
+		{UserID: legacyTenant.UserID, ProviderID: ProviderNameMiniMax, EncryptedAPIKey: encryptLegacyProviderKey(ProviderNameMiniMax, "sk-minimax", 1), TextModel: managedMiniMaxNativeModel, CreatedAt: fixedTime, UpdatedAt: fixedTime},
+		{UserID: legacyTenant.UserID, ProviderID: ProviderNameSiliconFlow, EncryptedAPIKey: encryptLegacyProviderKey(ProviderNameSiliconFlow, "sk-siliconflow", 2), TextModel: managedSiliconFlowDeepSeekNativeModel, CreatedAt: fixedTime, UpdatedAt: fixedTime},
+	}
+	if createError := legacyDatabase.Table(managedProviderKeyTable).Create(&legacyProviderKeys).Error; createError != nil {
+		t.Fatalf("seed native legacy provider keys: %v", createError)
+	}
+	legacyUsage := legacyManagedUsageEventRecord{
+		ID: 51, UserID: legacyTenant.UserID, TenantID: legacyTenant.TenantID, Endpoint: usageEndpointText,
+		ProviderID: ProviderNameMiniMax, ModelID: managedMiniMaxNativeModel,
+		StatusCode: http.StatusOK, Success: true, CreatedAt: fixedTime.Add(2 * time.Minute),
+	}
+	if createError := legacyDatabase.Table(managedUsageEventTable).Create(&legacyUsage).Error; createError != nil {
+		t.Fatalf("seed native legacy usage: %v", createError)
+	}
+
+	database, databaseError := newGORMManagedTenantDatabase(
+		ManagementConfiguration{DatabasePath: databasePath, DatabaseDialector: sqlite.Open(databasePath)},
+		providerKeyCipher,
+		providers,
+	)
+	if databaseError != nil {
+		t.Fatalf("migrate native legacy database: %v", databaseError)
+	}
+	migratedTenant, tenantError := database.tenantByOwnerAndID(legacyTenant.UserID, legacyTenant.TenantID)
+	if tenantError != nil {
+		t.Fatalf("load migrated native legacy tenant: %v", tenantError)
+	}
+	expectedDefaults := TenantDefaults{
+		Provider: ProviderNameMiniMax, Model: ModelNameMiniMaxM27,
+		DictationProvider: ProviderNameSiliconFlow, DictationModel: "sensevoice-small",
+		SystemPrompt: "preserve native prompt",
+	}
+	if migratedTenant.defaults() != expectedDefaults || len(migratedTenant.ProviderAPIKeys) != 2 || !migratedTenant.UpdatedAt.Equal(legacyTenant.UpdatedAt) {
+		t.Fatalf("migrated native legacy tenant=%+v", migratedTenant)
+	}
+	modelsByProvider := map[string]string{}
+	for _, providerKey := range migratedTenant.ProviderAPIKeys {
+		modelsByProvider[providerKey.ProviderID] = providerKey.TextModel
+	}
+	if modelsByProvider[ProviderNameMiniMax] != ModelNameMiniMaxM27 || modelsByProvider[ProviderNameSiliconFlow] != ModelNameSiliconFlowDeepSeek {
+		t.Fatalf("migrated native legacy provider models=%v", modelsByProvider)
+	}
+	var migratedUsage managedUsageEventRecord
+	if queryError := database.database.First(&migratedUsage, legacyUsage.ID).Error; queryError != nil || migratedUsage.ProviderID != legacyUsage.ProviderID || migratedUsage.ModelID != legacyUsage.ModelID {
+		t.Fatalf("migrated native legacy usage=%+v error=%v", migratedUsage, queryError)
+	}
+	if initializeError := initializeManagedTenantSchema(database.database, providerKeyCipher, providers); initializeError != nil {
+		t.Fatalf("reopen native legacy schema: %v", initializeError)
+	}
+}
+
 func TestManagedTenantKeyedRoutingDefaultsMigrationReconcilesExistingTenants(t *testing.T) {
 	databasePath := filepath.Join(t.TempDir(), "keyed-routing-defaults.db")
 	database, openError := gorm.Open(sqlite.Open(databasePath), &gorm.Config{})

--- a/internal/proxy/management_tenants_internal_test.go
+++ b/internal/proxy/management_tenants_internal_test.go
@@ -77,6 +77,8 @@ func TestManagedTenantSQLiteOwnershipMigrationPreservesAndRebindsData(t *testing
 		UpdatedAt:       fixedTime.Add(2 * time.Hour),
 	}
 	secondTenant.applyDefaults(defaultManagedRoutingDefaults())
+	secondTenant.DefaultProvider = retiredGrokProviderIdentifier
+	secondTenant.DefaultModel = ModelNameGrok43
 	if createError := legacyDatabase.Table(managedTenantTable).Create(&[]legacyManagedTenantRecord{firstTenant, secondTenant}).Error; createError != nil {
 		t.Fatalf("seed legacy tenants: %v", createError)
 	}
@@ -84,20 +86,20 @@ func TestManagedTenantSQLiteOwnershipMigrationPreservesAndRebindsData(t *testing
 	if firstEncryptionError != nil {
 		t.Fatalf("encrypt first key: %v", firstEncryptionError)
 	}
-	secondCiphertext, secondEncryptionError := providerKeyCipher.encrypt(bytes.NewReader(bytes.Repeat([]byte{1}, providerKeyCipher.aeadCipher.NonceSize())), secondTenant.UserID, ProviderNameOpenAI, "sk-second")
+	secondCiphertext, secondEncryptionError := providerKeyCipher.encrypt(bytes.NewReader(bytes.Repeat([]byte{1}, providerKeyCipher.aeadCipher.NonceSize())), secondTenant.UserID, retiredGrokProviderIdentifier, "sk-second")
 	if secondEncryptionError != nil {
 		t.Fatalf("encrypt second key: %v", secondEncryptionError)
 	}
 	legacyProviderKeys := []legacyManagedProviderAPIKeyRecord{
 		{UserID: firstTenant.UserID, ProviderID: ProviderNameOpenAI, EncryptedAPIKey: firstCiphertext, TextModel: ModelNameGPT41, SystemPrompt: "first system", CreatedAt: fixedTime, UpdatedAt: fixedTime.Add(time.Minute)},
-		{UserID: secondTenant.UserID, ProviderID: ProviderNameOpenAI, EncryptedAPIKey: secondCiphertext, TextModel: ModelNameGPT41, SystemPrompt: "second system", CreatedAt: fixedTime.Add(time.Hour), UpdatedAt: fixedTime.Add(2 * time.Hour)},
+		{UserID: secondTenant.UserID, ProviderID: retiredGrokProviderIdentifier, EncryptedAPIKey: secondCiphertext, TextModel: ModelNameGrok43, SystemPrompt: "second system", CreatedAt: fixedTime.Add(time.Hour), UpdatedAt: fixedTime.Add(2 * time.Hour)},
 	}
 	if createError := legacyDatabase.Table(managedProviderKeyTable).Create(&legacyProviderKeys).Error; createError != nil {
 		t.Fatalf("seed legacy provider keys: %v", createError)
 	}
 	legacyUsage := []legacyManagedUsageEventRecord{
 		{ID: 11, UserID: firstTenant.UserID, TenantID: firstTenant.TenantID, Endpoint: usageEndpointText, ProviderID: ProviderNameOpenAI, ModelID: ModelNameGPT41, StatusCode: http.StatusOK, Success: true, LatencyMilliseconds: 17, RequestTokens: 2, ResponseTokens: 3, TotalTokens: 5, CreatedAt: fixedTime.Add(3 * time.Hour)},
-		{ID: 29, UserID: secondTenant.UserID, TenantID: secondTenant.TenantID, Endpoint: usageEndpointText, ProviderID: ProviderNameOpenAI, ModelID: ModelNameGPT41, StatusCode: http.StatusBadGateway, Success: false, LatencyMilliseconds: 31, CreatedAt: fixedTime.Add(4 * time.Hour)},
+		{ID: 29, UserID: secondTenant.UserID, TenantID: secondTenant.TenantID, Endpoint: usageEndpointText, ProviderID: retiredGrokProviderIdentifier, ModelID: ModelNameGrok43, StatusCode: http.StatusBadGateway, Success: false, LatencyMilliseconds: 31, CreatedAt: fixedTime.Add(4 * time.Hour)},
 		{ID: 41, UserID: firstTenant.UserID, TenantID: firstTenant.TenantID, Endpoint: usageEndpointText, ProviderID: ProviderNameOpenAI, ModelID: ModelNameGPT41, StatusCode: statusClientClosedRequest, Success: false, LatencyMilliseconds: 7, CreatedAt: fixedTime.Add(5 * time.Hour)},
 	}
 	if createError := legacyDatabase.Table(managedUsageEventTable).Create(&legacyUsage).Error; createError != nil {
@@ -724,6 +726,8 @@ func internalManagementProviderRegistry() *providerRegistry {
 			internalTestOffering(ProviderNameMiniMax, ModelNameMiniMaxM27, []string{ModelOperationText}, []string{ModelOperationText}),
 			internalTestOffering(ProviderNameSiliconFlow, ModelNameSiliconFlowDeepSeek, []string{ModelOperationText}, []string{ModelOperationText}),
 			internalTestOffering(ProviderNameSiliconFlow, "sensevoice-small", []string{ModelOperationDictation}, []string{ModelOperationDictation}),
+			internalTestOffering(ProviderNameXAI, ModelNameGrok43, []string{ModelOperationText}, []string{ModelOperationText}),
+			internalTestOffering(ProviderNameXAI, "xai-stt", []string{ModelOperationDictation}, []string{ModelOperationDictation}),
 		),
 	})
 }

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -1555,7 +1555,7 @@ func TestManagementProfileListsCurrentCatalogModels(t *testing.T) {
 		proxy.ProviderNameZhipu:     {"glm-5.2"},
 		proxy.ProviderNameGemini:    {"gemini-3.1-pro-preview", "gemini-3-flash-preview"},
 		proxy.ProviderNameAnthropic: {"claude-fable-5", "claude-sonnet-5"},
-		proxy.ProviderNameGrok:      {"grok-4.5", "grok-4.20-0309-reasoning", "grok-4.20-0309-non-reasoning"},
+		proxy.ProviderNameXAI:       {"grok-4.5", "grok-4.20-0309-reasoning", "grok-4.20-0309-non-reasoning"},
 	}
 	for providerIdentifier, expectedProviderModels := range expectedModels {
 		configuredModels, configured := modelsByProvider[providerIdentifier]

--- a/internal/proxy/model_catalog.go
+++ b/internal/proxy/model_catalog.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/tyemirov/llm-proxy/internal/constants"
@@ -274,6 +275,20 @@ func validateExactModels(models []ExactModel, publishers map[string]ModelPublish
 		}
 		validated[identifier] = model
 	}
+	referencedPublishers := make(map[string]struct{}, len(validated))
+	for _, model := range validated {
+		referencedPublishers[model.Publisher] = struct{}{}
+	}
+	publisherIdentifiers := make([]string, 0, len(publishers))
+	for publisherIdentifier := range publishers {
+		publisherIdentifiers = append(publisherIdentifiers, publisherIdentifier)
+	}
+	sort.Strings(publisherIdentifiers)
+	for _, publisherIdentifier := range publisherIdentifiers {
+		if _, referenced := referencedPublishers[publisherIdentifier]; !referenced {
+			return fmt.Errorf("%w: field=catalog.publishers publisher=%s reason=missing_exact_model", ErrInvalidModelCatalog, publisherIdentifier)
+		}
+	}
 	return nil
 }
 
@@ -344,16 +359,17 @@ func validateProviderOfferings(offerings []ProviderOffering, catalog validatedMo
 		if limitError := validateCatalogLimits(offering.Limits, fieldPrefix+".limits"); limitError != nil {
 			return limitError
 		}
-		if _, supportsText := offeredOperations[ModelOperationText]; supportsText {
-			if routeError := validateTextOffering(offering, fieldPrefix); routeError != nil {
-				return routeError
+		for _, operation := range offering.Operations {
+			var routeError error
+			switch operation {
+			case ModelOperationText:
+				routeError = validateTextOffering(offering, fieldPrefix)
+			case ModelOperationVideoGeneration:
+				routeError = validateVideoOffering(offering, fieldPrefix)
+			case ModelOperationDictation:
+				routeError = validateDictationOffering(offering, fieldPrefix)
 			}
-		} else if _, supportsVideo := offeredOperations[ModelOperationVideoGeneration]; supportsVideo {
-			if routeError := validateVideoOffering(offering, fieldPrefix); routeError != nil {
-				return routeError
-			}
-		} else if _, supportsDictation := offeredOperations[ModelOperationDictation]; supportsDictation {
-			if routeError := validateDictationOffering(offering, fieldPrefix); routeError != nil {
+			if routeError != nil {
 				return routeError
 			}
 		}

--- a/internal/proxy/model_catalog.go
+++ b/internal/proxy/model_catalog.go
@@ -12,75 +12,105 @@ const (
 	ModelOperationText = "text"
 	// ModelOperationDictation identifies audio transcription through the proxy dictation contract.
 	ModelOperationDictation = "dictation"
+	// ModelOperationVideoGeneration identifies provider-backed video generation.
+	ModelOperationVideoGeneration = "video_generation"
+	// CatalogCredentialAPIKey identifies one opaque provider API key.
+	CatalogCredentialAPIKey = "api_key"
+	// CatalogArtifactText identifies text input or output.
+	CatalogArtifactText = "text"
+	// CatalogArtifactImage identifies image input or output.
+	CatalogArtifactImage = "image"
+	// CatalogArtifactAudio identifies audio input or output.
+	CatalogArtifactAudio = "audio"
+	// CatalogArtifactVideo identifies video input or output.
+	CatalogArtifactVideo = "video"
+	// CatalogWireContractMultipartTranscription identifies normalized multipart dictation.
+	CatalogWireContractMultipartTranscription = "multipart_transcription"
 )
 
 // ModelCatalog is the canonical normalized model and provider-offering registry.
 type ModelCatalog struct {
-	Providers  []CatalogProvider
-	Publishers []ModelPublisher
-	Families   []ModelFamily
-	Models     []ExactModel
-	Offerings  []ProviderOffering
+	Revision   string                   `mapstructure:"revision"`
+	Operations []ModelOperationKind     `mapstructure:"operations"`
+	Providers  []CatalogProvider        `mapstructure:"providers"`
+	Publishers []ModelPublisher         `mapstructure:"publishers"`
+	Families   []ModelFamily            `mapstructure:"families"`
+	Models     []ExactModel             `mapstructure:"models"`
+	Offerings  []ProviderOffering       `mapstructure:"offerings"`
+	Prices     []CatalogPriceDescriptor `mapstructure:"prices"`
+}
+
+// ModelOperationKind declares one operation and its possible artifact types.
+type ModelOperationKind struct {
+	ID              string   `json:"id" mapstructure:"id"`
+	InputArtifacts  []string `json:"input_artifacts" mapstructure:"input_artifacts"`
+	OutputArtifacts []string `json:"output_artifacts" mapstructure:"output_artifacts"`
 }
 
 // CatalogProvider declares one provider that can own provider offerings.
 type CatalogProvider struct {
-	ID    string
-	Label string
+	ID              string   `mapstructure:"id"`
+	Label           string   `mapstructure:"label"`
+	CredentialKinds []string `mapstructure:"credential_kinds"`
 }
 
 // ModelPublisher declares the organization or community that publishes models.
 type ModelPublisher struct {
-	ID    string
-	Label string
+	ID    string `mapstructure:"id"`
+	Label string `mapstructure:"label"`
 }
 
 // ModelFamily groups exact models from one publisher.
 type ModelFamily struct {
-	ID        string
-	Publisher string
-	Label     string
+	ID        string `mapstructure:"id"`
+	Publisher string `mapstructure:"publisher"`
+	Label     string `mapstructure:"label"`
 }
 
 // ExactModel declares provider-independent identity and model capabilities.
 type ExactModel struct {
-	ID          string
-	Publisher   string
-	Family      string
-	Version     string
-	Operations  []string
-	MediaInputs []string
+	ID          string   `mapstructure:"id"`
+	Publisher   string   `mapstructure:"publisher"`
+	Family      string   `mapstructure:"family"`
+	Version     string   `mapstructure:"version"`
+	Operations  []string `mapstructure:"operations"`
+	MediaInputs []string `mapstructure:"media_inputs"`
 }
 
 // ProviderOffering declares one provider route for one exact model.
 type ProviderOffering struct {
-	Provider           string
-	Model              string
-	ProviderModel      string
-	Operations         []string
-	DefaultOperations  []string
-	WireContract       string
-	ExecutionLifecycle string
-	RequestProfile     string
-	WebSearch          bool
-	OutputTokenLimit   int
-	ReasoningEffort    *ReasoningEffortCapability
-	MediaInputs        []string
+	Provider           string                     `mapstructure:"provider"`
+	Model              string                     `mapstructure:"model"`
+	ProviderModel      string                     `mapstructure:"provider_model"`
+	Operations         []string                   `mapstructure:"operations"`
+	DefaultOperations  []string                   `mapstructure:"default_operations"`
+	WireContract       string                     `mapstructure:"wire_contract"`
+	ExecutionLifecycle string                     `mapstructure:"execution_lifecycle"`
+	RequestProfile     string                     `mapstructure:"request_profile"`
+	WebSearch          bool                       `mapstructure:"web_search"`
+	OutputTokenLimit   int                        `mapstructure:"output_token_limit"`
+	ReasoningEffort    *ReasoningEffortCapability `mapstructure:"reasoning_effort"`
+	MediaInputs        []string                   `mapstructure:"media_inputs"`
+	Controls           []CatalogControl           `mapstructure:"controls"`
+	Limits             []CatalogLimit             `mapstructure:"limits"`
 }
 
 // ReasoningEffortCapability declares the configured upstream mapping for one
 // exact provider offering.
 type ReasoningEffortCapability struct {
-	Adapter string
-	Efforts []string
+	Adapter string   `mapstructure:"adapter"`
+	Efforts []string `mapstructure:"efforts"`
 }
 
 type validatedModelCatalog struct {
+	revision   string
+	operations map[string]ModelOperationKind
 	providers  map[string]CatalogProvider
 	publishers map[string]ModelPublisher
 	families   map[string]ModelFamily
 	models     map[string]ExactModel
 	offerings  map[string]ProviderOffering
+	prices     map[string]CatalogPriceDescriptor
 }
 
 var providerTextRouteCapabilities = map[string]map[textRouteCapabilities]struct{}{
@@ -97,16 +127,25 @@ var providerTextRouteCapabilities = map[string]map[textRouteCapabilities]struct{
 	},
 	ProviderNameAnthropic: {anthropicMessagesSynchronousRouteCapabilities: {}},
 	ProviderNameMeta:      {openAIChatCompletionsSynchronousRouteCapabilities: {}},
-	ProviderNameGrok:      {openAIChatCompletionsSynchronousRouteCapabilities: {}},
+	ProviderNameXAI:       {openAIChatCompletionsSynchronousRouteCapabilities: {}},
 }
 
 func validateModelCatalog(catalog ModelCatalog) (validatedModelCatalog, error) {
 	validated := validatedModelCatalog{
+		revision:   catalog.Revision,
+		operations: map[string]ModelOperationKind{},
 		providers:  map[string]CatalogProvider{},
 		publishers: map[string]ModelPublisher{},
 		families:   map[string]ModelFamily{},
 		models:     map[string]ExactModel{},
 		offerings:  map[string]ProviderOffering{},
+		prices:     map[string]CatalogPriceDescriptor{},
+	}
+	if revisionError := validateCatalogRevision(catalog.Revision); revisionError != nil {
+		return validatedModelCatalog{}, revisionError
+	}
+	if operationError := validateModelOperationKinds(catalog.Operations, validated.operations); operationError != nil {
+		return validatedModelCatalog{}, operationError
 	}
 	if catalogError := validateCatalogProviders(catalog.Providers, validated.providers); catalogError != nil {
 		return validatedModelCatalog{}, catalogError
@@ -121,6 +160,9 @@ func validateModelCatalog(catalog ModelCatalog) (validatedModelCatalog, error) {
 		return validatedModelCatalog{}, catalogError
 	}
 	if catalogError := validateProviderOfferings(catalog.Offerings, validated); catalogError != nil {
+		return validatedModelCatalog{}, catalogError
+	}
+	if catalogError := validateCatalogPrices(catalog.Prices, validated); catalogError != nil {
 		return validatedModelCatalog{}, catalogError
 	}
 	return validated, nil
@@ -140,6 +182,9 @@ func validateCatalogProviders(providers []CatalogProvider, validated map[string]
 		}
 		if strings.TrimSpace(provider.Label) == constants.EmptyString || provider.Label != strings.TrimSpace(provider.Label) {
 			return fmt.Errorf("%w: field=catalog.providers[%d].label", ErrInvalidModelCatalog, index)
+		}
+		if credentialError := validateCredentialKinds(provider.CredentialKinds, fmt.Sprintf("catalog.providers[%d].credential_kinds", index)); credentialError != nil {
+			return credentialError
 		}
 		if _, supported := providerTextRouteCapabilities[identifier]; !supported {
 			return fmt.Errorf("%w: field=catalog.providers[%d].id provider=%s reason=unknown", ErrInvalidModelCatalog, index, identifier)
@@ -293,12 +338,24 @@ func validateProviderOfferings(offerings []ProviderOffering, catalog validatedMo
 		if offering.OutputTokenLimit < 0 {
 			return fmt.Errorf("%w: field=%s.output_token_limit", ErrInvalidModelCatalog, fieldPrefix)
 		}
+		if controlError := validateCatalogControls(offering.Controls, fieldPrefix+".controls"); controlError != nil {
+			return controlError
+		}
+		if limitError := validateCatalogLimits(offering.Limits, fieldPrefix+".limits"); limitError != nil {
+			return limitError
+		}
 		if _, supportsText := offeredOperations[ModelOperationText]; supportsText {
 			if routeError := validateTextOffering(offering, fieldPrefix); routeError != nil {
 				return routeError
 			}
-		} else if offering.WireContract != constants.EmptyString || offering.ExecutionLifecycle != constants.EmptyString || offering.RequestProfile != constants.EmptyString || offering.WebSearch || offering.OutputTokenLimit != 0 || offering.ReasoningEffort != nil || len(offering.MediaInputs) != 0 {
-			return fmt.Errorf("%w: field=%s reason=text_capabilities_without_text_operation", ErrInvalidModelCatalog, fieldPrefix)
+		} else if _, supportsVideo := offeredOperations[ModelOperationVideoGeneration]; supportsVideo {
+			if routeError := validateVideoOffering(offering, fieldPrefix); routeError != nil {
+				return routeError
+			}
+		} else if _, supportsDictation := offeredOperations[ModelOperationDictation]; supportsDictation {
+			if routeError := validateDictationOffering(offering, fieldPrefix); routeError != nil {
+				return routeError
+			}
 		}
 		modelMediaInputs, _ := validatedExactModelMediaInputs(exactModel.MediaInputs, "catalog.models.media_inputs")
 		offeringMediaInputs, mediaError := validatedMediaInputSet(offering.Provider, offering.MediaInputs, fieldPrefix+".media_inputs")
@@ -326,6 +383,16 @@ func validateProviderOfferings(offerings []ProviderOffering, catalog validatedMo
 				return fmt.Errorf("%w: model=%s operation=%s reason=missing_provider_offering", ErrInvalidModelCatalog, modelIdentifier, operation)
 			}
 		}
+	}
+	return nil
+}
+
+func validateDictationOffering(offering ProviderOffering, fieldPrefix string) error {
+	if offering.WireContract != CatalogWireContractMultipartTranscription || offering.ExecutionLifecycle != string(textExecutionLifecycleSynchronousCompletion) {
+		return fmt.Errorf("%w: field=%s reason=unsupported_dictation_route", ErrInvalidModelCatalog, fieldPrefix)
+	}
+	if offering.RequestProfile != constants.EmptyString || offering.WebSearch || offering.OutputTokenLimit != 0 || offering.ReasoningEffort != nil || len(offering.MediaInputs) != 0 || len(offering.Controls) != 0 || len(offering.Limits) != 0 {
+		return fmt.Errorf("%w: field=%s reason=text_capabilities_on_dictation_route", ErrInvalidModelCatalog, fieldPrefix)
 	}
 	return nil
 }
@@ -395,7 +462,7 @@ func validatedOperationSet(rawOperations []string, field string) (map[string]str
 	}
 	operations := make(map[string]struct{}, len(rawOperations))
 	for index, operation := range rawOperations {
-		if operation != ModelOperationText && operation != ModelOperationDictation {
+		if operation != ModelOperationText && operation != ModelOperationDictation && operation != ModelOperationVideoGeneration {
 			return nil, fmt.Errorf("%w: field=%s[%d] operation=%s", ErrInvalidModelCatalog, field, index, operation)
 		}
 		if _, duplicate := operations[operation]; duplicate {

--- a/internal/proxy/model_catalog_internal_test.go
+++ b/internal/proxy/model_catalog_internal_test.go
@@ -4,17 +4,17 @@ import "slices"
 
 func internalTestModelCatalog(offerings ...ProviderOffering) ModelCatalog {
 	providers := []CatalogProvider{
-		{ID: ProviderNameOpenAI, Label: "OpenAI"},
-		{ID: ProviderNameDeepSeek, Label: "DeepSeek"},
-		{ID: ProviderNameDashScope, Label: "DashScope"},
-		{ID: ProviderNameMoonshot, Label: "Moonshot"},
-		{ID: ProviderNameMiniMax, Label: "MiniMax"},
-		{ID: ProviderNameSiliconFlow, Label: "SiliconFlow"},
-		{ID: ProviderNameZhipu, Label: "Zhipu"},
-		{ID: ProviderNameGemini, Label: "Gemini"},
-		{ID: ProviderNameAnthropic, Label: "Anthropic"},
-		{ID: ProviderNameMeta, Label: "Meta"},
-		{ID: ProviderNameGrok, Label: "Grok"},
+		{ID: ProviderNameOpenAI, Label: "OpenAI", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameDeepSeek, Label: "DeepSeek", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameDashScope, Label: "DashScope", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameMoonshot, Label: "Moonshot", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameMiniMax, Label: "MiniMax", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameSiliconFlow, Label: "SiliconFlow", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameZhipu, Label: "Zhipu", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameGemini, Label: "Gemini", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameAnthropic, Label: "Anthropic", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameMeta, Label: "Meta", CredentialKinds: []string{CatalogCredentialAPIKey}},
+		{ID: ProviderNameXAI, Label: "xAI", CredentialKinds: []string{CatalogCredentialAPIKey}},
 	}
 	models := []ExactModel{}
 	modelIndexes := map[string]int{}
@@ -25,6 +25,9 @@ func internalTestModelCatalog(offerings ...ProviderOffering) ModelCatalog {
 		}
 		if slices.Contains(offering.Operations, ModelOperationText) {
 			internalConfigureTextOffering(offering)
+		} else if slices.Contains(offering.Operations, ModelOperationDictation) {
+			offering.WireContract = CatalogWireContractMultipartTranscription
+			offering.ExecutionLifecycle = string(textExecutionLifecycleSynchronousCompletion)
 		}
 		modelIndex, found := modelIndexes[offering.Model]
 		if !found {
@@ -45,12 +48,28 @@ func internalTestModelCatalog(offerings ...ProviderOffering) ModelCatalog {
 			}
 		}
 	}
+	prices := make([]CatalogPriceDescriptor, 0)
+	for _, offering := range offerings {
+		for _, operation := range offering.Operations {
+			prices = append(prices, CatalogPriceDescriptor{
+				Provider: offering.Provider, Model: offering.Model, Operation: operation,
+				Source: "https://example.com/pricing", LastVerified: "2026-08-10", UnavailableReason: "Test price is unavailable.",
+			})
+		}
+	}
 	return ModelCatalog{
+		Revision: "2026-08-10.test.1",
+		Operations: []ModelOperationKind{
+			{ID: ModelOperationText, InputArtifacts: []string{CatalogArtifactText, CatalogArtifactImage, CatalogArtifactAudio}, OutputArtifacts: []string{CatalogArtifactText}},
+			{ID: ModelOperationDictation, InputArtifacts: []string{CatalogArtifactAudio}, OutputArtifacts: []string{CatalogArtifactText}},
+			{ID: ModelOperationVideoGeneration, InputArtifacts: []string{CatalogArtifactText, CatalogArtifactImage}, OutputArtifacts: []string{CatalogArtifactVideo}},
+		},
 		Providers:  providers,
 		Publishers: []ModelPublisher{{ID: "test", Label: "Test"}},
 		Families:   []ModelFamily{{ID: "test", Publisher: "test", Label: "Test"}},
 		Models:     models,
 		Offerings:  offerings,
+		Prices:     prices,
 	}
 }
 
@@ -61,6 +80,9 @@ func internalTestOffering(provider string, model string, operations []string, de
 	}
 	if slices.Contains(operations, ModelOperationText) {
 		internalConfigureTextOffering(&offering)
+	} else if slices.Contains(operations, ModelOperationDictation) {
+		offering.WireContract = CatalogWireContractMultipartTranscription
+		offering.ExecutionLifecycle = string(textExecutionLifecycleSynchronousCompletion)
 	}
 	return offering
 }

--- a/internal/proxy/provider_registry.go
+++ b/internal/proxy/provider_registry.go
@@ -136,9 +136,9 @@ func configuredProviderDefinitions(configuration Configuration) map[providerID]p
 			identifier: providerID(ProviderNameMeta), textAPIKey: configuration.MetaKey, textBaseURL: configuration.MetaBaseURL,
 			textModels: map[string]textModelDefinition{}, transcriptionModels: map[string]dictationModelDefinition{}, chatTokenLimitParameter: chatCompletionTokenLimitMaxCompletionTokens,
 		},
-		providerID(ProviderNameGrok): {
-			identifier: providerID(ProviderNameGrok), aliases: []string{providerAliasXAI}, textAPIKey: configuration.GrokKey, textBaseURL: configuration.GrokBaseURL,
-			transcriptionAPIKey: configuration.GrokKey, transcriptionsURL: configuration.GrokTranscriptionsURL, transcriptionModelField: constants.EmptyString,
+		providerID(ProviderNameXAI): {
+			identifier: providerID(ProviderNameXAI), textAPIKey: configuration.XAIKey, textBaseURL: configuration.XAIBaseURL,
+			transcriptionAPIKey: configuration.XAIKey, transcriptionsURL: configuration.XAITranscriptionsURL, transcriptionModelField: constants.EmptyString,
 			textModels: map[string]textModelDefinition{}, transcriptionModels: map[string]dictationModelDefinition{}, chatTokenLimitParameter: chatCompletionTokenLimitMaxTokens,
 		},
 	}
@@ -156,7 +156,7 @@ func configuredProviderAPIKeys(configuration Configuration) map[providerID]strin
 	configuredProviderAPIKey(configuration.GeminiKey, ProviderNameGemini, providerAPIKeys)
 	configuredProviderAPIKey(configuration.AnthropicKey, ProviderNameAnthropic, providerAPIKeys)
 	configuredProviderAPIKey(configuration.MetaKey, ProviderNameMeta, providerAPIKeys)
-	configuredProviderAPIKey(configuration.GrokKey, ProviderNameGrok, providerAPIKeys)
+	configuredProviderAPIKey(configuration.XAIKey, ProviderNameXAI, providerAPIKeys)
 	return providerAPIKeys
 }
 

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -27,7 +27,7 @@ const (
 	testGeminiKey      = "sk-gemini"
 	testAnthropicKey   = "sk-ant"
 	testMetaKey        = "sk-meta"
-	testGrokKey        = "sk-xai"
+	testXAIKey         = "sk-xai"
 )
 
 func openAIResponsesReasoningEffortCapability() *proxy.ReasoningEffortCapability {
@@ -114,7 +114,7 @@ func TestProviderRoutingEnumeratesConfiguredTextRouteCapabilities(t *testing.T) 
 		proxy.ProviderNameGemini,
 		proxy.ProviderNameAnthropic,
 		proxy.ProviderNameMeta,
-		proxy.ProviderNameGrok,
+		proxy.ProviderNameXAI,
 	}
 	expectedCapabilities := map[string]struct {
 		wireContract       string
@@ -129,7 +129,7 @@ func TestProviderRoutingEnumeratesConfiguredTextRouteCapabilities(t *testing.T) 
 		proxy.ProviderNameZhipu:       {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
 		proxy.ProviderNameAnthropic:   {wireContract: "anthropic_messages", executionLifecycle: "synchronous_completion"},
 		proxy.ProviderNameMeta:        {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
-		proxy.ProviderNameGrok:        {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
+		proxy.ProviderNameXAI:         {wireContract: "openai_chat_completions", executionLifecycle: "synchronous_completion"},
 	}
 	catalogs := testfixtures.ModelCatalog(t)
 	type providerRoute struct {
@@ -222,7 +222,7 @@ func TestProviderRoutingEnumeratesConfiguredTextRouteCapabilities(t *testing.T) 
 		GeminiKey:                    testGeminiKey,
 		AnthropicKey:                 testAnthropicKey,
 		MetaKey:                      testMetaKey,
-		GrokKey:                      testGrokKey,
+		XAIKey:                       testXAIKey,
 		OpenAIBaseURL:                upstreamServer.URL,
 		OpenAITranscriptionsURL:      upstreamServer.URL + "/audio/transcriptions",
 		DeepSeekBaseURL:              upstreamServer.URL,
@@ -236,8 +236,8 @@ func TestProviderRoutingEnumeratesConfiguredTextRouteCapabilities(t *testing.T) 
 		GeminiBaseURL:                upstreamServer.URL,
 		AnthropicBaseURL:             upstreamServer.URL,
 		MetaBaseURL:                  upstreamServer.URL,
-		GrokBaseURL:                  upstreamServer.URL,
-		GrokTranscriptionsURL:        upstreamServer.URL + "/audio/transcriptions",
+		XAIBaseURL:                   upstreamServer.URL,
+		XAITranscriptionsURL:         upstreamServer.URL + "/audio/transcriptions",
 		LogLevel:                     proxy.LogLevelInfo,
 		WorkerCount:                  1,
 		QueueSize:                    1,
@@ -376,8 +376,8 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 		{name: "MiniMax M2.7", provider: proxy.ProviderNameMiniMax, model: proxy.ModelNameMiniMaxM27, providerModel: "MiniMax-M2.7", tokenParameterField: "max_completion_tokens", expectedAPIKey: "sk-minimax", forbiddenFields: []string{"max_tokens"}},
 		{name: "SiliconFlow DeepSeek R1", provider: proxy.ProviderNameSiliconFlow, model: proxy.ModelNameSiliconFlowDeepSeek, providerModel: "deepseek-ai/DeepSeek-R1", tokenParameterField: "max_tokens", expectedAPIKey: testSiliconFlowKey},
 		{name: "Zhipu GLM 5.2", provider: proxy.ProviderNameZhipu, model: "glm-5.2", tokenParameterField: "max_tokens", forbiddenFields: []string{"thinking", "reasoning_effort"}},
-		{name: "Grok 4.5", provider: proxy.ProviderNameGrok, model: "grok-4.5", tokenParameterField: "max_tokens"},
-		{name: "Grok 4.20 reasoning", provider: proxy.ProviderNameGrok, model: "grok-4.20-0309-reasoning", tokenParameterField: "max_tokens"},
+		{name: "Grok 4.5", provider: proxy.ProviderNameXAI, model: "grok-4.5", tokenParameterField: "max_tokens"},
+		{name: "Grok 4.20 reasoning", provider: proxy.ProviderNameXAI, model: "grok-4.20-0309-reasoning", tokenParameterField: "max_tokens"},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(subTest *testing.T) {
@@ -423,8 +423,8 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 				SiliconFlowBaseURL:    upstreamServer.URL,
 				ZhipuKey:              testZhipuKey,
 				ZhipuBaseURL:          upstreamServer.URL,
-				GrokKey:               testGrokKey,
-				GrokBaseURL:           upstreamServer.URL,
+				XAIKey:                testXAIKey,
+				XAIBaseURL:            upstreamServer.URL,
 				LogLevel:              proxy.LogLevelInfo,
 				WorkerCount:           1,
 				QueueSize:             1,
@@ -737,6 +737,11 @@ func TestProviderRoutingUsesConfiguredTextModelCatalog(t *testing.T) {
 	configuredOffering.DefaultOperations = nil
 	configuredCatalogs.Models = append(configuredCatalogs.Models, configuredModel)
 	configuredCatalogs.Offerings = append(configuredCatalogs.Offerings, configuredOffering)
+	configuredCatalogs.Prices = append(configuredCatalogs.Prices, proxy.CatalogPriceDescriptor{
+		Provider: configuredOffering.Provider, Model: configuredDeepSeekModel, Operation: proxy.ModelOperationText,
+		Source: "https://api-docs.deepseek.com/quick_start/pricing", LastVerified: "2026-08-10",
+		UnavailableReason: "Exact published pricing has not been imported for this provider offering.",
+	})
 
 	var capturedPayload map[string]any
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
@@ -1880,8 +1885,8 @@ func TestProviderRoutingSupportsGrokChatCompletions(t *testing.T) {
 		if request.URL.Path != "/chat/completions" {
 			t.Fatalf("path=%s want=%s", request.URL.Path, "/chat/completions")
 		}
-		if authorizationHeader := request.Header.Get("Authorization"); authorizationHeader != "Bearer "+testGrokKey {
-			t.Fatalf("authorization=%q want=%q", authorizationHeader, "Bearer "+testGrokKey)
+		if authorizationHeader := request.Header.Get("Authorization"); authorizationHeader != "Bearer "+testXAIKey {
+			t.Fatalf("authorization=%q want=%q", authorizationHeader, "Bearer "+testXAIKey)
 		}
 		bodyBytes, readError := io.ReadAll(request.Body)
 		if readError != nil {
@@ -1898,8 +1903,8 @@ func TestProviderRoutingSupportsGrokChatCompletions(t *testing.T) {
 	router, buildError := buildRouterWithCatalogs(t, proxy.Configuration{
 		Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
 		OpenAIKey:             TestAPIKey,
-		GrokKey:               testGrokKey,
-		GrokBaseURL:           upstreamServer.URL,
+		XAIKey:                testXAIKey,
+		XAIBaseURL:            upstreamServer.URL,
 		LogLevel:              proxy.LogLevelInfo,
 		WorkerCount:           1,
 		QueueSize:             1,
@@ -2108,10 +2113,10 @@ func TestProviderRoutingRejectsAnthropicMetaAndGrokUnsupportedCapabilities(t *te
 		OpenAIKey:             TestAPIKey,
 		AnthropicKey:          testAnthropicKey,
 		MetaKey:               testMetaKey,
-		GrokKey:               testGrokKey,
+		XAIKey:                testXAIKey,
 		AnthropicBaseURL:      "https://anthropic.invalid",
 		MetaBaseURL:           "https://meta.invalid",
-		GrokBaseURL:           "https://grok.invalid",
+		XAIBaseURL:            "https://xai.invalid",
 		LogLevel:              proxy.LogLevelInfo,
 		WorkerCount:           1,
 		QueueSize:             1,
@@ -2128,7 +2133,7 @@ func TestProviderRoutingRejectsAnthropicMetaAndGrokUnsupportedCapabilities(t *te
 	}{
 		{name: "anthropic web search", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=anthropic&web_search=true"},
 		{name: "meta web search", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=meta&web_search=true"},
-		{name: "grok web search", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=grok&web_search=true"},
+		{name: "xai web search", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=xai&web_search=true"},
 		{name: "anthropic dictation", method: http.MethodPost, target: "/dictate?key=" + TestSecret + "&provider=anthropic"},
 		{name: "meta dictation", method: http.MethodPost, target: "/dictate?key=" + TestSecret + "&provider=meta"},
 	}
@@ -2196,7 +2201,7 @@ func TestProviderRoutingRejectsAnthropicMetaAndGrokMissingCredentials(t *testing
 		OpenAIKey:             TestAPIKey,
 		AnthropicBaseURL:      "https://anthropic.invalid",
 		MetaBaseURL:           "https://meta.invalid",
-		GrokBaseURL:           "https://grok.invalid",
+		XAIBaseURL:            "https://xai.invalid",
 		LogLevel:              proxy.LogLevelInfo,
 		WorkerCount:           1,
 		QueueSize:             1,
@@ -2213,7 +2218,7 @@ func TestProviderRoutingRejectsAnthropicMetaAndGrokMissingCredentials(t *testing
 	}{
 		{name: "anthropic", provider: proxy.ProviderNameAnthropic, model: proxy.ModelNameClaudeSonnet46},
 		{name: "meta", provider: proxy.ProviderNameMeta, model: proxy.ModelNameMuseSpark11},
-		{name: "grok", provider: proxy.ProviderNameGrok, model: proxy.ModelNameGrok43},
+		{name: "xai", provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok43},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(subTest *testing.T) {
@@ -2261,9 +2266,9 @@ func TestProviderRoutingRejectsMissingAnthropicMetaAndGrokDefaultCredentials(t *
 			expectedError: "provider not configured: provider=meta",
 		},
 		{
-			name:          "grok",
-			defaults:      proxy.TenantDefaults{Provider: proxy.ProviderNameGrok, Model: proxy.ModelNameGrok43, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel},
-			expectedError: "provider not configured: provider=grok",
+			name:          "xai",
+			defaults:      proxy.TenantDefaults{Provider: proxy.ProviderNameXAI, Model: proxy.ModelNameGrok43, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel},
+			expectedError: "provider not configured: provider=xai",
 		},
 	}
 	for _, testCase := range testCases {
@@ -2647,14 +2652,14 @@ func TestProviderRoutingRejectsInvalidDefaultDictationProvider(t *testing.T) {
 		{
 			name: "missing_grok_credential",
 			configuration: proxy.Configuration{
-				Tenants:               proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: proxy.ProviderNameGrok}),
+				Tenants:               proxy.SingleTenantConfigurationsWithDefaults("test", TestSecret, proxy.TenantDefaults{Provider: proxy.ProviderNameOpenAI, Model: proxy.DefaultModel, DictationProvider: proxy.ProviderNameXAI}),
 				OpenAIKey:             TestAPIKey,
 				LogLevel:              proxy.LogLevelInfo,
 				WorkerCount:           1,
 				QueueSize:             1,
 				RequestTimeoutSeconds: TestTimeout,
 			},
-			expectedError: "provider not configured: provider=grok endpoint=dictation",
+			expectedError: "provider not configured: provider=xai endpoint=dictation",
 		},
 	}
 	for _, testCase := range testCases {
@@ -2802,18 +2807,18 @@ func TestProviderRoutingSupportsZhipuAndGrokDictation(t *testing.T) {
 			},
 		},
 		{
-			name:             "grok",
-			providerName:     proxy.ProviderNameGrok,
-			apiKey:           testGrokKey,
+			name:             "xai",
+			providerName:     proxy.ProviderNameXAI,
+			apiKey:           testXAIKey,
 			expectedModel:    "",
 			expectModelField: false,
-			expectedResponse: "grok dictation ok",
+			expectedResponse: "xai dictation ok",
 			configuration: func(transcriptionsURL string) proxy.Configuration {
 				return proxy.Configuration{
 					Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
 					OpenAIKey:             TestAPIKey,
-					GrokKey:               testGrokKey,
-					GrokTranscriptionsURL: transcriptionsURL,
+					XAIKey:                testXAIKey,
+					XAITranscriptionsURL:  transcriptionsURL,
 					LogLevel:              proxy.LogLevelInfo,
 					WorkerCount:           1,
 					QueueSize:             1,

--- a/internal/proxy/provider_types.go
+++ b/internal/proxy/provider_types.go
@@ -25,8 +25,8 @@ const (
 	ProviderNameAnthropic = "anthropic"
 	// ProviderNameMeta identifies Meta Model API routing.
 	ProviderNameMeta = "meta"
-	// ProviderNameGrok identifies xAI Grok routing.
-	ProviderNameGrok = "grok"
+	// ProviderNameXAI identifies the xAI credential and routing boundary.
+	ProviderNameXAI = "xai"
 )
 
 const (
@@ -34,7 +34,6 @@ const (
 	providerAliasKimi   = "kimi"
 	providerAliasGLM    = "glm"
 	providerAliasClaude = "claude"
-	providerAliasXAI    = "xai"
 )
 
 const (
@@ -48,8 +47,8 @@ const (
 	defaultGeminiBaseURL          = "https://generativelanguage.googleapis.com/v1beta"
 	defaultAnthropicBaseURL       = "https://api.anthropic.com"
 	defaultMetaBaseURL            = "https://api.meta.ai/v1"
-	defaultGrokBaseURL            = "https://api.x.ai/v1"
-	defaultGrokTranscriptionsURL  = "https://api.x.ai/v1/stt"
+	defaultXAIBaseURL             = "https://api.x.ai/v1"
+	defaultXAITranscriptionsURL   = "https://api.x.ai/v1/stt"
 )
 
 const (

--- a/internal/proxy/public_capabilities.go
+++ b/internal/proxy/public_capabilities.go
@@ -15,11 +15,14 @@ const PublicCapabilitiesPath = "/api/public/capabilities"
 
 // PublicCapabilityCatalog is the normalized tenant-safe model discovery contract.
 type PublicCapabilityCatalog struct {
+	Revision                 string                       `json:"revision"`
+	Operations               []ModelOperationKind         `json:"operations"`
 	Providers                []PublicProviderCapability   `json:"providers"`
 	Publishers               []PublicModelPublisher       `json:"publishers"`
 	Families                 []PublicModelFamily          `json:"families"`
 	Models                   []PublicExactModelCapability `json:"models"`
 	Offerings                []PublicProviderOffering     `json:"offerings"`
+	Prices                   []CatalogPriceDescriptor     `json:"prices"`
 	Counts                   PublicCapabilityCounts       `json:"counts"`
 	MaxPromptBytes           int64                        `json:"max_prompt_bytes"`
 	MaxInputAudioBytes       int64                        `json:"max_input_audio_bytes"`
@@ -37,8 +40,9 @@ type PublicCapabilityCounts struct {
 
 // PublicProviderCapability identifies one selectable provider.
 type PublicProviderCapability struct {
-	Identifier string `json:"identifier"`
-	Label      string `json:"label"`
+	Identifier      string   `json:"identifier"`
+	Label           string   `json:"label"`
+	CredentialKinds []string `json:"credential_kinds"`
 }
 
 // PublicModelPublisher identifies one model publisher and its exact-model count.
@@ -69,13 +73,16 @@ type PublicExactModelCapability struct {
 
 // PublicProviderOffering describes one selectable provider and exact-model route.
 type PublicProviderOffering struct {
-	Identifier       string   `json:"identifier"`
-	Provider         string   `json:"provider"`
-	Model            string   `json:"model"`
-	Capabilities     []string `json:"capabilities"`
-	WireContract     string   `json:"wire_contract"`
-	OutputTokenLimit int      `json:"output_token_limit"`
-	ReasoningEfforts []string `json:"reasoning_efforts"`
+	Identifier         string           `json:"identifier"`
+	Provider           string           `json:"provider"`
+	Model              string           `json:"model"`
+	Capabilities       []string         `json:"capabilities"`
+	WireContract       string           `json:"wire_contract"`
+	ExecutionLifecycle string           `json:"execution_lifecycle"`
+	OutputTokenLimit   int              `json:"output_token_limit"`
+	ReasoningEfforts   []string         `json:"reasoning_efforts"`
+	Controls           []CatalogControl `json:"controls"`
+	Limits             []CatalogLimit   `json:"limits"`
 }
 
 // Public model capability identifiers are the stable filter vocabulary for the
@@ -87,6 +94,7 @@ const (
 	PublicModelCapabilityImageInput = "image_input"
 	PublicModelCapabilityAudioInput = "audio_input"
 	PublicModelCapabilityReasoning  = "reasoning"
+	PublicModelCapabilityVideo      = "video_generation"
 )
 
 // NewPublicCapabilityCatalog validates and projects the runtime catalog into a
@@ -100,9 +108,18 @@ func NewPublicCapabilityCatalog(configuration Configuration) (PublicCapabilityCa
 }
 
 func newPublicCapabilityCatalog(configuration Configuration) PublicCapabilityCatalog {
+	operations := append([]ModelOperationKind(nil), configuration.ModelCatalog.Operations...)
+	for operationIndex := range operations {
+		operations[operationIndex].InputArtifacts = append([]string{}, operations[operationIndex].InputArtifacts...)
+		operations[operationIndex].OutputArtifacts = append([]string{}, operations[operationIndex].OutputArtifacts...)
+	}
+	sort.Slice(operations, func(first int, second int) bool { return operations[first].ID < operations[second].ID })
+
 	providers := make([]PublicProviderCapability, 0, len(configuration.ModelCatalog.Providers))
 	for _, provider := range configuration.ModelCatalog.Providers {
-		providers = append(providers, PublicProviderCapability{Identifier: provider.ID, Label: provider.Label})
+		providers = append(providers, PublicProviderCapability{
+			Identifier: provider.ID, Label: provider.Label, CredentialKinds: append([]string{}, provider.CredentialKinds...),
+		})
 	}
 	sort.Slice(providers, func(first int, second int) bool { return providers[first].Identifier < providers[second].Identifier })
 
@@ -156,12 +173,25 @@ func newPublicCapabilityCatalog(configuration Configuration) PublicCapabilityCat
 	}
 	sort.Slice(models, func(first int, second int) bool { return models[first].Identifier < models[second].Identifier })
 
+	prices := append([]CatalogPriceDescriptor(nil), configuration.ModelCatalog.Prices...)
+	for priceIndex := range prices {
+		prices[priceIndex].Rates = append([]CatalogPriceRate{}, prices[priceIndex].Rates...)
+	}
+	sort.Slice(prices, func(first int, second int) bool {
+		firstIdentifier := catalogPriceIdentifier(prices[first].Provider, prices[first].Model, prices[first].Operation)
+		secondIdentifier := catalogPriceIdentifier(prices[second].Provider, prices[second].Model, prices[second].Operation)
+		return firstIdentifier < secondIdentifier
+	})
+
 	return PublicCapabilityCatalog{
+		Revision:   configuration.ModelCatalog.Revision,
+		Operations: operations,
 		Providers:  providers,
 		Publishers: publishers,
 		Families:   families,
 		Models:     models,
 		Offerings:  offerings,
+		Prices:     prices,
 		Counts: PublicCapabilityCounts{
 			Providers:         len(providers),
 			ModelPublishers:   len(publishers),
@@ -189,14 +219,29 @@ func publicProviderOffering(offering ProviderOffering) PublicProviderOffering {
 	}
 	sort.Strings(capabilities)
 	return PublicProviderOffering{
-		Identifier:       providerOfferingIdentifier(offering.Provider, offering.Model),
-		Provider:         offering.Provider,
-		Model:            offering.Model,
-		Capabilities:     capabilities,
-		WireContract:     offering.WireContract,
-		OutputTokenLimit: offering.OutputTokenLimit,
-		ReasoningEfforts: reasoningEfforts,
+		Identifier:         providerOfferingIdentifier(offering.Provider, offering.Model),
+		Provider:           offering.Provider,
+		Model:              offering.Model,
+		Capabilities:       capabilities,
+		WireContract:       offering.WireContract,
+		ExecutionLifecycle: offering.ExecutionLifecycle,
+		OutputTokenLimit:   offering.OutputTokenLimit,
+		ReasoningEfforts:   reasoningEfforts,
+		Controls:           publicCatalogControls(offering.Controls),
+		Limits:             publicCatalogLimits(offering.Limits),
 	}
+}
+
+func publicCatalogControls(controls []CatalogControl) []CatalogControl {
+	result := append([]CatalogControl{}, controls...)
+	for controlIndex := range result {
+		result[controlIndex].Values = append([]string{}, result[controlIndex].Values...)
+	}
+	return result
+}
+
+func publicCatalogLimits(limits []CatalogLimit) []CatalogLimit {
+	return append([]CatalogLimit{}, limits...)
 }
 
 func sortedPublicCapabilities(capabilities map[string]struct{}) []string {

--- a/internal/testfixtures/provider_models.go
+++ b/internal/testfixtures/provider_models.go
@@ -10,60 +10,7 @@ import (
 )
 
 type modelCatalogFileConfiguration struct {
-	Catalog modelCatalogConfiguration `mapstructure:"catalog"`
-}
-
-type modelCatalogConfiguration struct {
-	Providers  []catalogProviderConfiguration  `mapstructure:"providers"`
-	Publishers []modelPublisherConfiguration   `mapstructure:"publishers"`
-	Families   []modelFamilyConfiguration      `mapstructure:"families"`
-	Models     []exactModelConfiguration       `mapstructure:"models"`
-	Offerings  []providerOfferingConfiguration `mapstructure:"offerings"`
-}
-
-type catalogProviderConfiguration struct {
-	ID    string `mapstructure:"id"`
-	Label string `mapstructure:"label"`
-}
-
-type modelPublisherConfiguration struct {
-	ID    string `mapstructure:"id"`
-	Label string `mapstructure:"label"`
-}
-
-type modelFamilyConfiguration struct {
-	ID        string `mapstructure:"id"`
-	Publisher string `mapstructure:"publisher"`
-	Label     string `mapstructure:"label"`
-}
-
-type exactModelConfiguration struct {
-	ID          string   `mapstructure:"id"`
-	Publisher   string   `mapstructure:"publisher"`
-	Family      string   `mapstructure:"family"`
-	Version     string   `mapstructure:"version"`
-	Operations  []string `mapstructure:"operations"`
-	MediaInputs []string `mapstructure:"media_inputs"`
-}
-
-type providerOfferingConfiguration struct {
-	Provider           string                           `mapstructure:"provider"`
-	Model              string                           `mapstructure:"model"`
-	ProviderModel      string                           `mapstructure:"provider_model"`
-	Operations         []string                         `mapstructure:"operations"`
-	DefaultOperations  []string                         `mapstructure:"default_operations"`
-	WireContract       string                           `mapstructure:"wire_contract"`
-	ExecutionLifecycle string                           `mapstructure:"execution_lifecycle"`
-	RequestProfile     string                           `mapstructure:"request_profile"`
-	WebSearch          bool                             `mapstructure:"web_search"`
-	OutputTokenLimit   int                              `mapstructure:"output_token_limit"`
-	ReasoningEffort    *reasoningEffortCapabilityConfig `mapstructure:"reasoning_effort"`
-	MediaInputs        []string                         `mapstructure:"media_inputs"`
-}
-
-type reasoningEffortCapabilityConfig struct {
-	Adapter string   `mapstructure:"adapter"`
-	Efforts []string `mapstructure:"efforts"`
+	Catalog proxy.ModelCatalog `mapstructure:"catalog"`
 }
 
 // ModelCatalog loads the repository model catalog for tests that build proxy.Configuration directly.
@@ -84,7 +31,7 @@ func ModelCatalog(testingInstance testing.TB) proxy.ModelCatalog {
 	if unmarshalError := configReader.Unmarshal(&parsedConfiguration); unmarshalError != nil {
 		testingInstance.Fatalf("parse model catalog config: %v", unmarshalError)
 	}
-	return parsedConfiguration.Catalog.proxyCatalog()
+	return parsedConfiguration.Catalog
 }
 
 // WithModelCatalog returns a configuration with the explicit model catalog from configs/config.yml.
@@ -92,47 +39,4 @@ func WithModelCatalog(testingInstance testing.TB, configuration proxy.Configurat
 	testingInstance.Helper()
 	configuration.ModelCatalog = ModelCatalog(testingInstance)
 	return configuration
-}
-
-func (configuration modelCatalogConfiguration) proxyCatalog() proxy.ModelCatalog {
-	providers := make([]proxy.CatalogProvider, 0, len(configuration.Providers))
-	for _, provider := range configuration.Providers {
-		providers = append(providers, proxy.CatalogProvider{ID: provider.ID, Label: provider.Label})
-	}
-	publishers := make([]proxy.ModelPublisher, 0, len(configuration.Publishers))
-	for _, publisher := range configuration.Publishers {
-		publishers = append(publishers, proxy.ModelPublisher{ID: publisher.ID, Label: publisher.Label})
-	}
-	families := make([]proxy.ModelFamily, 0, len(configuration.Families))
-	for _, family := range configuration.Families {
-		families = append(families, proxy.ModelFamily{ID: family.ID, Publisher: family.Publisher, Label: family.Label})
-	}
-	models := make([]proxy.ExactModel, 0, len(configuration.Models))
-	for _, model := range configuration.Models {
-		models = append(models, proxy.ExactModel{
-			ID: model.ID, Publisher: model.Publisher, Family: model.Family, Version: model.Version,
-			Operations: append([]string(nil), model.Operations...), MediaInputs: append([]string(nil), model.MediaInputs...),
-		})
-	}
-	offerings := make([]proxy.ProviderOffering, 0, len(configuration.Offerings))
-	for _, offering := range configuration.Offerings {
-		offerings = append(offerings, proxy.ProviderOffering{
-			Provider: offering.Provider, Model: offering.Model, ProviderModel: offering.ProviderModel,
-			Operations: append([]string(nil), offering.Operations...), DefaultOperations: append([]string(nil), offering.DefaultOperations...),
-			WireContract: offering.WireContract, ExecutionLifecycle: offering.ExecutionLifecycle, RequestProfile: offering.RequestProfile,
-			WebSearch: offering.WebSearch, OutputTokenLimit: offering.OutputTokenLimit,
-			ReasoningEffort: reasoningEffortCapability(offering.ReasoningEffort), MediaInputs: append([]string(nil), offering.MediaInputs...),
-		})
-	}
-	return proxy.ModelCatalog{Providers: providers, Publishers: publishers, Families: families, Models: models, Offerings: offerings}
-}
-
-func reasoningEffortCapability(configuration *reasoningEffortCapabilityConfig) *proxy.ReasoningEffortCapability {
-	if configuration == nil {
-		return nil
-	}
-	return &proxy.ReasoningEffortCapability{
-		Adapter: configuration.Adapter,
-		Efforts: append([]string(nil), configuration.Efforts...),
-	}
 }

--- a/scripts/generate_seo_resources.mjs
+++ b/scripts/generate_seo_resources.mjs
@@ -1340,7 +1340,7 @@ text = client.post_messages(
     problem: "Speech providers use different URLs, models, and multipart details. Client apps should not carry those differences.",
     solution: "LLM Proxy exposes dictation-capable providers through configured catalogs and provider-specific transcription URLs while preserving one /dictate endpoint.",
     steps: [
-      "Configure dictation catalogs for OpenAI, SiliconFlow, Zhipu, or Grok/xAI as needed.",
+      "Configure dictation catalogs for OpenAI, SiliconFlow, Zhipu, or xAI as needed.",
       "Send multipart audio to /dictate with key=<tenant secret>.",
       "Omit provider/model for tenant defaults or select a dictation-capable provider and model.",
       "Receive JSON text output from the proxy.",
@@ -1353,7 +1353,7 @@ text = client.post_messages(
     examples: [
       ["OpenAI default dictation", "A caller omits provider and model to use tenant dictation defaults."],
       ["Zhipu transcription", "A caller chooses provider=zhipu when that tenant has GLM-ASR configured."],
-      ["Grok/xAI STT", "The proxy routes provider=grok to the configured xAI STT endpoint."],
+      ["xAI STT", "The proxy routes provider=xai to the configured xAI STT endpoint."],
     ],
     limitations: [
       "Text-only providers do not support /dictate through the proxy.",
@@ -1372,20 +1372,20 @@ text = client.post_messages(
     solution: "LLM Proxy uses a shared compatible chat adapter for configured providers while keeping provider URLs, keys, and model catalogs in config.",
     steps: [
       "Configure provider base_url, api_key, and normalized provider offerings.",
-      "Use provider selectors such as meta, deepseek, dashscope, moonshot, minimax, siliconflow, zhipu, or grok.",
+      "Use provider selectors such as meta, deepseek, dashscope, moonshot, minimax, siliconflow, zhipu, or xai.",
       "Send GET, compatibility POST, or canonical /v2 requests.",
       "Let omitted model use the selected provider's configured default.",
     ],
     features: [
       ["Shared adapter", "Compatible chat providers use one proxy integration pattern.", "Provider-specific logic stays centralized."],
-      ["Provider aliases", "Some providers expose aliases such as qwen, kimi, glm, or xai.", "Callers can use documented selectors."],
+      ["Provider aliases", "Some providers expose aliases such as qwen, kimi, or glm.", "Callers can use documented selectors."],
       ["Disabled-provider behavior", "Blank non-default provider keys keep startup working and return 503 when selected.", "Operators can stage provider support before credentials exist."],
     ],
     examples: [
       ["Meta Muse route", "A caller sends provider=meta and model=muse-spark-1.1 through Chat Completions."],
       ["Qwen alias", "A caller uses provider=qwen for DashScope routing."],
       ["MiniMax route", "A caller uses provider=minimax and model=minimax-m2.7 through the shared Chat Completions adapter."],
-      ["xAI route", "A Grok text request uses the OpenAI-compatible chat adapter behind provider=grok."],
+      ["xAI route", "A Grok text request uses the OpenAI-compatible chat adapter behind provider=xai."],
     ],
     limitations: [
       "Meta support is text-only; the proxy does not expose Meta dictation, web search, tools, multimodal inputs, or a Responses fallback.",

--- a/scripts/render_public_site.mjs
+++ b/scripts/render_public_site.mjs
@@ -14,6 +14,7 @@ const binaryBytesPerMiB = 1024 * 1024;
 const capabilityDefinitions = Object.freeze([
   { identifier: "text", label: "Text generation", className: "capability-badge--primary" },
   { identifier: "dictation", label: "Dictation", className: "capability-badge--info" },
+  { identifier: "video_generation", label: "Video generation", className: "capability-badge--info" },
   { identifier: "image_input", label: "Image input", className: "capability-badge--info" },
   { identifier: "audio_input", label: "Audio message input", className: "capability-badge--info" },
   { identifier: "web_search", label: "Web search", className: "capability-badge--success" },
@@ -35,7 +36,8 @@ await renderPublicSite(options);
  * }} RenderOptions
  */
 
-/** @typedef {{identifier: string, label: string}} PublicProviderCapability */
+/** @typedef {{id: string, input_artifacts: string[], output_artifacts: string[]}} PublicModelOperation */
+/** @typedef {{identifier: string, label: string, credential_kinds: string[]}} PublicProviderCapability */
 /** @typedef {{identifier: string, label: string, model_count: number}} PublicModelPublisher */
 /** @typedef {{identifier: string, publisher: string, label: string}} PublicModelFamily */
 /**
@@ -57,10 +59,19 @@ await renderPublicSite(options);
  *   model: string,
  *   capabilities: string[],
  *   wire_contract: string,
+ *   execution_lifecycle: string,
  *   output_token_limit: number,
  *   reasoning_efforts: string[],
+ *   controls: PublicCatalogControl[],
+ *   limits: PublicCatalogLimit[],
  * }} PublicProviderOffering
  */
+/** @typedef {{id: string, kind: string, values: string[], minimum: number | null, maximum: number | null, account_dependent: boolean}} PublicCatalogControl */
+/** @typedef {{id: string, value: number | null, unit: string, account_dependent: boolean}} PublicCatalogLimit */
+/** @typedef {{resolution: string, generated_audio: string, input_media: string, output_media: string, duration: string, quantity: string, quality: string, mode: string, api_version: string, avatar_type: string, billing_mode: string, billing_outcome: string}} PublicPriceConditions */
+/** @typedef {{component: string, currency: string, rate: number, unit: string, conditions: PublicPriceConditions}} PublicPriceRate */
+/** @typedef {{currency: string, amount: number, unit: string}} PublicMinimumCharge */
+/** @typedef {{provider: string, model: string, operation: string, available: boolean, rates: PublicPriceRate[], minimum_charge: PublicMinimumCharge | null, source: string, last_verified: string, unavailable_reason: string}} PublicPriceDescriptor */
 /**
  * @typedef {{
  *   providers: number,
@@ -72,11 +83,14 @@ await renderPublicSite(options);
  */
 /**
  * @typedef {{
+ *   revision: string,
+ *   operations: PublicModelOperation[],
  *   providers: PublicProviderCapability[],
  *   publishers: PublicModelPublisher[],
  *   families: PublicModelFamily[],
  *   models: PublicExactModelCapability[],
  *   offerings: PublicProviderOffering[],
+ *   prices: PublicPriceDescriptor[],
  *   counts: PublicCapabilityCounts,
  *   max_prompt_bytes: number,
  *   max_input_audio_bytes: number,
@@ -175,24 +189,47 @@ async function fetchCapabilityCatalog(capabilitiesURL) {
 function parseCapabilityCatalog(rawCatalog) {
   const catalog = requiredRecord(rawCatalog, "catalog");
   requireExactKeys(catalog, [
+    "revision",
+    "operations",
     "providers",
     "publishers",
     "families",
     "models",
     "offerings",
+    "prices",
     "counts",
     "max_prompt_bytes",
     "max_input_audio_bytes",
     "max_request_timeout_seconds",
   ], "catalog");
 
+  const operations = requiredNonemptyArray(catalog.operations, "catalog.operations").map((rawOperation, operationIndex) => {
+    const field = `catalog.operations[${operationIndex}]`;
+    const operation = requiredRecord(rawOperation, field);
+    requireExactKeys(operation, ["id", "input_artifacts", "output_artifacts"], field);
+    const identifier = requiredString(operation.id, `${field}.id`);
+    if (identifier !== "text" && identifier !== "dictation" && identifier !== "video_generation") {
+      throw new Error(`public_capabilities_invalid: ${field}.id value=${identifier}`);
+    }
+    return {
+      id: identifier,
+      input_artifacts: parseArtifactKinds(operation.input_artifacts, `${field}.input_artifacts`),
+      output_artifacts: parseArtifactKinds(operation.output_artifacts, `${field}.output_artifacts`),
+    };
+  });
+
   const providers = requiredNonemptyArray(catalog.providers, "catalog.providers").map((rawProvider, providerIndex) => {
     const field = `catalog.providers[${providerIndex}]`;
     const provider = requiredRecord(rawProvider, field);
-    requireExactKeys(provider, ["identifier", "label"], field);
+    requireExactKeys(provider, ["identifier", "label", "credential_kinds"], field);
+    const credentialKinds = requiredNonemptyStringArray(provider.credential_kinds, `${field}.credential_kinds`);
+    if (credentialKinds.length !== 1 || credentialKinds[0] !== "api_key") {
+      throw new Error(`public_capabilities_invalid: ${field}.credential_kinds`);
+    }
     return {
       identifier: requiredString(provider.identifier, `${field}.identifier`),
       label: requiredString(provider.label, `${field}.label`),
+      credential_kinds: credentialKinds,
     };
   });
 
@@ -226,7 +263,7 @@ function parseCapabilityCatalog(rawCatalog) {
     ], field);
     const operations = requiredNonemptyStringArray(model.operations, `${field}.operations`);
     for (const operation of operations) {
-      if (operation !== "text" && operation !== "dictation") {
+      if (operation !== "text" && operation !== "dictation" && operation !== "video_generation") {
         throw new Error(`public_capabilities_invalid: ${field}.operations value=${operation}`);
       }
     }
@@ -252,7 +289,8 @@ function parseCapabilityCatalog(rawCatalog) {
     const field = `catalog.offerings[${offeringIndex}]`;
     const offering = requiredRecord(rawOffering, field);
     requireExactKeys(offering, [
-      "identifier", "provider", "model", "capabilities", "wire_contract", "output_token_limit", "reasoning_efforts",
+      "identifier", "provider", "model", "capabilities", "wire_contract", "execution_lifecycle",
+      "output_token_limit", "reasoning_efforts", "controls", "limits",
     ], field);
     return {
       identifier: requiredString(offering.identifier, `${field}.identifier`),
@@ -260,10 +298,17 @@ function parseCapabilityCatalog(rawCatalog) {
       model: requiredString(offering.model, `${field}.model`),
       capabilities: parseCapabilities(offering.capabilities, `${field}.capabilities`),
       wire_contract: requiredString(offering.wire_contract, `${field}.wire_contract`, true),
+      execution_lifecycle: requiredExecutionLifecycle(offering.execution_lifecycle, `${field}.execution_lifecycle`),
       output_token_limit: requiredNonnegativeInteger(offering.output_token_limit, `${field}.output_token_limit`),
       reasoning_efforts: requiredStringArray(offering.reasoning_efforts, `${field}.reasoning_efforts`),
+      controls: requiredArray(offering.controls, `${field}.controls`).map((control, controlIndex) => parseCatalogControl(control, `${field}.controls[${controlIndex}]`)),
+      limits: requiredArray(offering.limits, `${field}.limits`).map((limit, limitIndex) => parseCatalogLimit(limit, `${field}.limits[${limitIndex}]`)),
     };
   });
+
+  const prices = requiredNonemptyArray(catalog.prices, "catalog.prices").map((price, priceIndex) => (
+    parsePriceDescriptor(price, `catalog.prices[${priceIndex}]`)
+  ));
 
   const countsRecord = requiredRecord(catalog.counts, "catalog.counts");
   requireExactKeys(countsRecord, [
@@ -278,6 +323,7 @@ function parseCapabilityCatalog(rawCatalog) {
   };
 
   const providersByIdentifier = uniqueByIdentifier(providers, "catalog.providers");
+  const operationsByIdentifier = uniqueByIdentifier(operations.map((operation) => ({ identifier: operation.id })), "catalog.operations");
   const publishersByIdentifier = uniqueByIdentifier(publishers, "catalog.publishers");
   const familiesByIdentifier = uniqueByIdentifier(families, "catalog.families");
   const modelsByIdentifier = uniqueByIdentifier(models, "catalog.models");
@@ -294,6 +340,9 @@ function parseCapabilityCatalog(rawCatalog) {
       throw new Error(`public_capabilities_invalid: model=${model.identifier} family_publisher_mismatch`);
     }
     actualModelCounts.set(model.publisher, (actualModelCounts.get(model.publisher) ?? 0) + 1);
+    for (const operation of model.operations) {
+      requireReference(operationsByIdentifier, operation, `model=${model.identifier} operation`);
+    }
     for (const offeringIdentifier of model.provider_offerings) {
       const offering = requireReference(offeringsByIdentifier, offeringIdentifier, `model=${model.identifier} offering`);
       if (offering.model !== model.identifier || referencedOfferings.has(offeringIdentifier)) {
@@ -314,6 +363,17 @@ function parseCapabilityCatalog(rawCatalog) {
       throw new Error(`public_capabilities_invalid: offering=${offering.identifier} route_identity`);
     }
   }
+  const priceIdentifiers = new Set();
+  for (const price of prices) {
+    requireReference(providersByIdentifier, price.provider, `price provider`);
+    requireReference(modelsByIdentifier, price.model, `price model`);
+    requireReference(operationsByIdentifier, price.operation, `price operation`);
+    const priceIdentifier = `${price.provider}:${price.model}:${price.operation}`;
+    if (priceIdentifiers.has(priceIdentifier) || !offeringsByIdentifier.has(`${price.provider}:${price.model}`)) {
+      throw new Error(`public_capabilities_invalid: price=${priceIdentifier}`);
+    }
+    priceIdentifiers.add(priceIdentifier);
+  }
   requireCount(counts.providers, providers.length, "catalog.counts.providers");
   requireCount(counts.model_publishers, publishers.length, "catalog.counts.model_publishers");
   requireCount(counts.model_families, families.length, "catalog.counts.model_families");
@@ -321,11 +381,14 @@ function parseCapabilityCatalog(rawCatalog) {
   requireCount(counts.provider_offerings, offerings.length, "catalog.counts.provider_offerings");
 
   return {
+    revision: requiredString(catalog.revision, "catalog.revision"),
+    operations,
     providers,
     publishers,
     families,
     models,
     offerings,
+    prices,
     counts,
     max_prompt_bytes: requiredPositiveInteger(catalog.max_prompt_bytes, "catalog.max_prompt_bytes"),
     max_input_audio_bytes: requiredPositiveInteger(catalog.max_input_audio_bytes, "catalog.max_input_audio_bytes"),
@@ -349,6 +412,132 @@ function parseCapabilities(rawCapabilities, field) {
     }
   }
   return capabilities;
+}
+
+/**
+ * @param {unknown} rawArtifacts
+ * @param {string} field
+ */
+function parseArtifactKinds(rawArtifacts, field) {
+  const artifacts = requiredNonemptyStringArray(rawArtifacts, field);
+  for (const artifact of artifacts) {
+    if (artifact !== "text" && artifact !== "image" && artifact !== "audio" && artifact !== "video") {
+      throw new Error(`public_capabilities_invalid: ${field} value=${artifact}`);
+    }
+  }
+  return artifacts;
+}
+
+/**
+ * @param {unknown} rawLifecycle
+ * @param {string} field
+ */
+function requiredExecutionLifecycle(rawLifecycle, field) {
+  const lifecycle = requiredString(rawLifecycle, field);
+  if (lifecycle !== "synchronous_completion" && lifecycle !== "pollable_resource") {
+    throw new Error(`public_capabilities_invalid: ${field} value=${lifecycle}`);
+  }
+  return lifecycle;
+}
+
+/**
+ * @param {unknown} rawControl
+ * @param {string} field
+ * @returns {PublicCatalogControl}
+ */
+function parseCatalogControl(rawControl, field) {
+  const control = requiredRecord(rawControl, field);
+  requireExactKeys(control, ["id", "kind", "values", "minimum", "maximum", "account_dependent"], field);
+  const kind = requiredString(control.kind, `${field}.kind`);
+  if (kind !== "enum" && kind !== "integer" && kind !== "boolean") {
+    throw new Error(`public_capabilities_invalid: ${field}.kind value=${kind}`);
+  }
+  return {
+    id: requiredString(control.id, `${field}.id`),
+    kind,
+    values: requiredStringArray(control.values, `${field}.values`),
+    minimum: nullableNonnegativeInteger(control.minimum, `${field}.minimum`),
+    maximum: nullableNonnegativeInteger(control.maximum, `${field}.maximum`),
+    account_dependent: requiredBoolean(control.account_dependent, `${field}.account_dependent`),
+  };
+}
+
+/**
+ * @param {unknown} rawLimit
+ * @param {string} field
+ * @returns {PublicCatalogLimit}
+ */
+function parseCatalogLimit(rawLimit, field) {
+  const limit = requiredRecord(rawLimit, field);
+  requireExactKeys(limit, ["id", "value", "unit", "account_dependent"], field);
+  return {
+    id: requiredString(limit.id, `${field}.id`),
+    value: nullableNonnegativeInteger(limit.value, `${field}.value`),
+    unit: requiredString(limit.unit, `${field}.unit`),
+    account_dependent: requiredBoolean(limit.account_dependent, `${field}.account_dependent`),
+  };
+}
+
+/**
+ * @param {unknown} rawPrice
+ * @param {string} field
+ * @returns {PublicPriceDescriptor}
+ */
+function parsePriceDescriptor(rawPrice, field) {
+  const price = requiredRecord(rawPrice, field);
+  requireExactKeys(price, [
+    "provider", "model", "operation", "available", "rates", "minimum_charge", "source", "last_verified", "unavailable_reason",
+  ], field);
+  const rates = requiredArray(price.rates, `${field}.rates`).map((rawRate, rateIndex) => {
+    const rateField = `${field}.rates[${rateIndex}]`;
+    const rate = requiredRecord(rawRate, rateField);
+    requireExactKeys(rate, ["component", "currency", "rate", "unit", "conditions"], rateField);
+    return {
+      component: requiredString(rate.component, `${rateField}.component`),
+      currency: requiredString(rate.currency, `${rateField}.currency`),
+      rate: requiredNonnegativeNumber(rate.rate, `${rateField}.rate`),
+      unit: requiredString(rate.unit, `${rateField}.unit`),
+      conditions: parsePriceConditions(rate.conditions, `${rateField}.conditions`),
+    };
+  });
+  let minimumCharge = null;
+  if (price.minimum_charge !== null) {
+    const minimum = requiredRecord(price.minimum_charge, `${field}.minimum_charge`);
+    requireExactKeys(minimum, ["currency", "amount", "unit"], `${field}.minimum_charge`);
+    minimumCharge = {
+      currency: requiredString(minimum.currency, `${field}.minimum_charge.currency`),
+      amount: requiredNonnegativeNumber(minimum.amount, `${field}.minimum_charge.amount`),
+      unit: requiredString(minimum.unit, `${field}.minimum_charge.unit`),
+    };
+  }
+  return {
+    provider: requiredString(price.provider, `${field}.provider`),
+    model: requiredString(price.model, `${field}.model`),
+    operation: requiredString(price.operation, `${field}.operation`),
+    available: requiredBoolean(price.available, `${field}.available`),
+    rates,
+    minimum_charge: minimumCharge,
+    source: requiredString(price.source, `${field}.source`),
+    last_verified: requiredString(price.last_verified, `${field}.last_verified`),
+    unavailable_reason: requiredString(price.unavailable_reason, `${field}.unavailable_reason`, true),
+  };
+}
+
+/**
+ * @param {unknown} rawConditions
+ * @param {string} field
+ * @returns {PublicPriceConditions}
+ */
+function parsePriceConditions(rawConditions, field) {
+  const conditions = requiredRecord(rawConditions, field);
+  const keys = [
+    "resolution", "generated_audio", "input_media", "output_media", "duration", "quantity",
+    "quality", "mode", "api_version", "avatar_type", "billing_mode", "billing_outcome",
+  ];
+  requireExactKeys(conditions, keys, field);
+  return /** @type {PublicPriceConditions} */ (Object.fromEntries(
+    keys.map((key) => [key, requiredString(conditions[key], `${field}.${key}`, true)]),
+  ));
 }
 
 /**
@@ -457,7 +646,7 @@ function renderRoutingTree(catalog) {
   <form class="routing-tree__filters" data-route-picker role="search" aria-label="Find an exact model">
     <input type="search" aria-label="Search exact models" placeholder="Search publisher, family, or model" autocomplete="off" data-route-search disabled>
     <select aria-label="Filter model family" data-route-family-filter disabled><option value="">All families</option>${familyOptions}</select>
-    <select aria-label="Filter model operation" data-route-operation-filter disabled><option value="">All operations</option><option value="text">Text</option><option value="dictation">Dictation</option></select>
+    <select aria-label="Filter model operation" data-route-operation-filter disabled><option value="">All operations</option><option value="text">Text</option><option value="dictation">Dictation</option><option value="video_generation">Video generation</option></select>
     <button type="reset" data-route-reset disabled>Reset</button>
   </form>
   <div class="routing-tree__catalog">
@@ -796,6 +985,39 @@ function requiredNonnegativeInteger(value, field) {
     throw new Error(`public_capabilities_invalid: ${field} must be a nonnegative integer`);
   }
   return Number(value);
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} field
+ */
+function nullableNonnegativeInteger(value, field) {
+  if (value === null) {
+    return null;
+  }
+  return requiredNonnegativeInteger(value, field);
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} field
+ */
+function requiredNonnegativeNumber(value, field) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`public_capabilities_invalid: ${field} must be a nonnegative number`);
+  }
+  return value;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} field
+ */
+function requiredBoolean(value, field) {
+  if (typeof value !== "boolean") {
+    throw new Error(`public_capabilities_invalid: ${field} must be a boolean`);
+  }
+  return value;
 }
 
 /**

--- a/scripts/test_live_providers.sh
+++ b/scripts/test_live_providers.sh
@@ -53,7 +53,7 @@ Per-provider model overrides:
   LLM_PROXY_LIVE_GEMINI_MODEL
   LLM_PROXY_LIVE_ANTHROPIC_MODEL
   LLM_PROXY_LIVE_META_MODEL
-  LLM_PROXY_LIVE_GROK_MODEL'
+  LLM_PROXY_LIVE_XAI_MODEL'
 }
 
 env_or_default() {
@@ -138,7 +138,7 @@ provider_key_variable() {
     gemini) printf "%s\n" "GEMINI_API_KEY" ;;
     anthropic) printf "%s\n" "ANTHROPIC_API_KEY" ;;
     meta) printf "%s\n" "MODEL_API_KEY" ;;
-    grok) printf "%s\n" "XAI_API_KEY" ;;
+    xai) printf "%s\n" "XAI_API_KEY" ;;
     *) return 1 ;;
   esac
 }
@@ -155,7 +155,7 @@ provider_model_override() {
     gemini) env_or_default LLM_PROXY_LIVE_GEMINI_MODEL "" ;;
     anthropic) env_or_default LLM_PROXY_LIVE_ANTHROPIC_MODEL "" ;;
     meta) env_or_default LLM_PROXY_LIVE_META_MODEL "" ;;
-    grok) env_or_default LLM_PROXY_LIVE_GROK_MODEL "" ;;
+    xai) env_or_default LLM_PROXY_LIVE_XAI_MODEL "" ;;
     *) return 1 ;;
   esac
 }
@@ -263,7 +263,7 @@ write_static_live_config() {
       provider_keys["gemini"] = "GEMINI_API_KEY"
       provider_keys["anthropic"] = "ANTHROPIC_API_KEY"
       provider_keys["meta"] = "MODEL_API_KEY"
-      provider_keys["grok"] = "XAI_API_KEY"
+      provider_keys["xai"] = "XAI_API_KEY"
     }
     /^  port: / && replaced == 0 {
       print "  port: " port
@@ -608,7 +608,7 @@ if [[ "${PREFLIGHT_ONLY}" == "true" && -n "${WRITE_CONFIG_PATH}" ]]; then
   exit 1
 fi
 
-SUPPORTED_PROVIDERS=(openai deepseek dashscope moonshot minimax siliconflow zhipu gemini anthropic meta grok)
+SUPPORTED_PROVIDERS=(openai deepseek dashscope moonshot minimax siliconflow zhipu gemini anthropic meta xai)
 LIVE_PROVIDERS=()
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="58579ec3520f8be4a8cec867b6fe95492ce320019bf3b9c4b55aff6c1a643a6f">
+    <meta name="openapi-source-sha256" content="8db5f2e1ba42fdaf9ddd28eda8ccb8f2c0dee460addbb035adafd097c7fa2b32">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.css">
     <link rel="stylesheet" href="/assets/llm-proxy/public-shell.css">
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="58579ec3520f8be4a8cec867b6fe95492ce320019bf3b9c4b55aff6c1a643a6f">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="8db5f2e1ba42fdaf9ddd28eda8ccb8f2c0dee460addbb035adafd097c7fa2b32">
     <mpr-header
       class="public-site-header"
       data-config-url="/config-ui.yaml"
@@ -49,7 +49,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>58579ec3520f8be4a8cec867b6fe95492ce320019bf3b9c4b55aff6c1a643a6f</code></span>
+          <span>Source SHA-256 <code>8db5f2e1ba42fdaf9ddd28eda8ccb8f2c0dee460addbb035adafd097c7fa2b32</code></span>
         </div>
         <div class="resource-actions" aria-label="OpenAPI schema actions">
           <a class="resource-button" href="#openapi-yaml">View YAML</a>
@@ -1162,16 +1162,27 @@ components:
       type: object
       additionalProperties: false
       required:
+        - revision
+        - operations
         - providers
         - publishers
         - families
         - models
         - offerings
+        - prices
         - counts
         - max_prompt_bytes
         - max_input_audio_bytes
         - max_request_timeout_seconds
       properties:
+        revision:
+          type: string
+          minLength: 1
+        operations:
+          type: array
+          minItems: 1
+          items:
+            $ref: &#39;#/components/schemas/PublicModelOperation&#39;
         providers:
           type: array
           minItems: 1
@@ -1197,6 +1208,11 @@ components:
           minItems: 1
           items:
             $ref: &#39;#/components/schemas/PublicProviderOffering&#39;
+        prices:
+          type: array
+          minItems: 1
+          items:
+            $ref: &#39;#/components/schemas/PublicPriceDescriptor&#39;
         counts:
           $ref: &#39;#/components/schemas/PublicCapabilityCounts&#39;
         max_prompt_bytes:
@@ -1216,6 +1232,7 @@ components:
       required:
         - identifier
         - label
+        - credential_kinds
       properties:
         identifier:
           type: string
@@ -1223,6 +1240,47 @@ components:
         label:
           type: string
           minLength: 1
+        credential_kinds:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+            enum:
+              - api_key
+    PublicModelOperation:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - input_artifacts
+        - output_artifacts
+      properties:
+        id:
+          type: string
+          enum:
+            - text
+            - dictation
+            - video_generation
+        input_artifacts:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: &#39;#/components/schemas/PublicArtifactKind&#39;
+        output_artifacts:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: &#39;#/components/schemas/PublicArtifactKind&#39;
+    PublicArtifactKind:
+      type: string
+      enum:
+        - text
+        - image
+        - audio
+        - video
     PublicModelPublisher:
       type: object
       additionalProperties: false
@@ -1291,6 +1349,7 @@ components:
             enum:
               - text
               - dictation
+              - video_generation
         media_inputs:
           type: array
           uniqueItems: true
@@ -1312,6 +1371,7 @@ components:
               - image_input
               - audio_input
               - reasoning
+              - video_generation
         provider_offerings:
           type: array
           minItems: 1
@@ -1328,8 +1388,11 @@ components:
         - model
         - capabilities
         - wire_contract
+        - execution_lifecycle
         - output_token_limit
         - reasoning_efforts
+        - controls
+        - limits
       properties:
         identifier:
           type: string
@@ -1353,8 +1416,15 @@ components:
               - image_input
               - audio_input
               - reasoning
+              - video_generation
         wire_contract:
           type: string
+          minLength: 1
+        execution_lifecycle:
+          type: string
+          enum:
+            - synchronous_completion
+            - pollable_resource
         output_token_limit:
           type: integer
           minimum: 0
@@ -1364,6 +1434,189 @@ components:
           items:
             type: string
             minLength: 1
+        controls:
+          type: array
+          items:
+            $ref: &#39;#/components/schemas/PublicCatalogControl&#39;
+        limits:
+          type: array
+          items:
+            $ref: &#39;#/components/schemas/PublicCatalogLimit&#39;
+    PublicCatalogControl:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - kind
+        - values
+        - minimum
+        - maximum
+        - account_dependent
+      properties:
+        id:
+          type: string
+          minLength: 1
+        kind:
+          type: string
+          enum:
+            - enum
+            - integer
+            - boolean
+        values:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+        minimum:
+          oneOf:
+            - type: integer
+              minimum: 0
+            - type: &#39;null&#39;
+        maximum:
+          oneOf:
+            - type: integer
+              minimum: 0
+            - type: &#39;null&#39;
+        account_dependent:
+          type: boolean
+    PublicCatalogLimit:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - value
+        - unit
+        - account_dependent
+      properties:
+        id:
+          type: string
+          minLength: 1
+        value:
+          oneOf:
+            - type: integer
+              minimum: 0
+            - type: &#39;null&#39;
+        unit:
+          type: string
+          minLength: 1
+        account_dependent:
+          type: boolean
+    PublicPriceDescriptor:
+      type: object
+      additionalProperties: false
+      required:
+        - provider
+        - model
+        - operation
+        - available
+        - rates
+        - minimum_charge
+        - source
+        - last_verified
+        - unavailable_reason
+      properties:
+        provider:
+          type: string
+          minLength: 1
+        model:
+          type: string
+          minLength: 1
+        operation:
+          type: string
+          enum:
+            - text
+            - dictation
+            - video_generation
+        available:
+          type: boolean
+        rates:
+          type: array
+          items:
+            $ref: &#39;#/components/schemas/PublicPriceRate&#39;
+        minimum_charge:
+          oneOf:
+            - $ref: &#39;#/components/schemas/PublicMinimumCharge&#39;
+            - type: &#39;null&#39;
+        source:
+          type: string
+          format: uri
+          pattern: &#39;^https://&#39;
+        last_verified:
+          type: string
+          format: date
+        unavailable_reason:
+          type: string
+    PublicPriceRate:
+      type: object
+      additionalProperties: false
+      required:
+        - component
+        - currency
+        - rate
+        - unit
+        - conditions
+      properties:
+        component:
+          type: string
+          minLength: 1
+        currency:
+          type: string
+          const: USD
+        rate:
+          type: number
+          minimum: 0
+        unit:
+          type: string
+          minLength: 1
+        conditions:
+          $ref: &#39;#/components/schemas/PublicPriceConditions&#39;
+    PublicMinimumCharge:
+      type: object
+      additionalProperties: false
+      required:
+        - currency
+        - amount
+        - unit
+      properties:
+        currency:
+          type: string
+          const: USD
+        amount:
+          type: number
+          minimum: 0
+        unit:
+          type: string
+          minLength: 1
+    PublicPriceConditions:
+      type: object
+      additionalProperties: false
+      required:
+        - resolution
+        - generated_audio
+        - input_media
+        - output_media
+        - duration
+        - quantity
+        - quality
+        - mode
+        - api_version
+        - avatar_type
+        - billing_mode
+        - billing_outcome
+      properties:
+        resolution: {type: string}
+        generated_audio: {type: string}
+        input_media: {type: string}
+        output_media: {type: string}
+        duration: {type: string}
+        quantity: {type: string}
+        quality: {type: string}
+        mode: {type: string}
+        api_version: {type: string}
+        avatar_type: {type: string}
+        billing_mode: {type: string}
+        billing_outcome: {type: string}
     PublicCapabilityCounts:
       type: object
       additionalProperties: false

--- a/site/resources/dictation-provider-routing/index.html
+++ b/site/resources/dictation-provider-routing/index.html
@@ -87,7 +87,7 @@
           <section>
             <h2>How it works</h2>
             <ol class="resource-steps">
-              <li>Configure dictation catalogs for OpenAI, SiliconFlow, Zhipu, or Grok/xAI as needed.</li>
+              <li>Configure dictation catalogs for OpenAI, SiliconFlow, Zhipu, or xAI as needed.</li>
 <li>Send multipart audio to /dictate with key=&lt;tenant secret&gt;.</li>
 <li>Omit provider/model for tenant defaults or select a dictation-capable provider and model.</li>
 <li>Receive JSON text output from the proxy.</li>
@@ -149,8 +149,8 @@
 
 
                     <section class="resource-card">
-                      <h3>Grok/xAI STT</h3>
-                      <p>The proxy routes provider=grok to the configured xAI STT endpoint.</p>
+                      <h3>xAI STT</h3>
+                      <p>The proxy routes provider=xai to the configured xAI STT endpoint.</p>
                     </section>
 
             </div>

--- a/site/resources/openai-compatible-provider-gateway/index.html
+++ b/site/resources/openai-compatible-provider-gateway/index.html
@@ -88,7 +88,7 @@
             <h2>How it works</h2>
             <ol class="resource-steps">
               <li>Configure provider base_url, api_key, and normalized provider offerings.</li>
-<li>Use provider selectors such as meta, deepseek, dashscope, moonshot, minimax, siliconflow, zhipu, or grok.</li>
+<li>Use provider selectors such as meta, deepseek, dashscope, moonshot, minimax, siliconflow, zhipu, or xai.</li>
 <li>Send GET, compatibility POST, or canonical /v2 requests.</li>
 <li>Let omitted model use the selected provider's configured default.</li>
             </ol>
@@ -116,7 +116,7 @@
 
                         <tr>
                           <td>Provider aliases</td>
-                          <td>Some providers expose aliases such as qwen, kimi, glm, or xai.</td>
+                          <td>Some providers expose aliases such as qwen, kimi, or glm.</td>
                           <td>Callers can use documented selectors.</td>
                         </tr>
 
@@ -156,7 +156,7 @@
 
                     <section class="resource-card">
                       <h3>xAI route</h3>
-                      <p>A Grok text request uses the OpenAI-compatible chat adapter behind provider=grok.</p>
+                      <p>A Grok text request uses the OpenAI-compatible chat adapter behind provider=xai.</p>
                     </section>
 
             </div>

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -127,7 +127,7 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 	if catalogError != nil {
 		testingInstance.Fatalf("NewPublicCapabilityCatalog error: %v", catalogError)
 	}
-	if catalog.Counts.Providers != 11 || catalog.Counts.ModelPublishers != 11 || catalog.Counts.ExactModels != len(catalog.Models) || catalog.Counts.ProviderOfferings != len(catalog.Offerings) || catalog.MaxPromptBytes != proxy.DefaultMaxPromptBytes || catalog.MaxInputAudioBytes != proxy.DefaultMaxInputAudioBytes {
+	if catalog.Revision == "" || len(catalog.Operations) != 3 || len(catalog.Prices) != len(catalog.Offerings) || catalog.Counts.Providers != 11 || catalog.Counts.ModelPublishers != 11 || catalog.Counts.ExactModels != len(catalog.Models) || catalog.Counts.ProviderOfferings != len(catalog.Offerings) || catalog.MaxPromptBytes != proxy.DefaultMaxPromptBytes || catalog.MaxInputAudioBytes != proxy.DefaultMaxInputAudioBytes {
 		testingInstance.Fatalf("catalog summary=%+v", catalog)
 	}
 	geminiCapabilityFound := false
@@ -193,6 +193,11 @@ func TestPublicCapabilityRESTResourceProjectsChangedCatalogWithoutPrivateConfig(
 	changedOffering.DefaultOperations = nil
 	catalogs.Models = append(catalogs.Models, changedModel)
 	catalogs.Offerings = append(catalogs.Offerings, changedOffering)
+	catalogs.Prices = append(catalogs.Prices, proxy.CatalogPriceDescriptor{
+		Provider: changedOffering.Provider, Model: changedModelID, Operation: proxy.ModelOperationText,
+		Source: "https://platform.moonshot.ai/docs/pricing/chat", LastVerified: "2026-08-10",
+		UnavailableReason: "Exact published pricing has not been imported for this provider offering.",
+	})
 	router, buildError := proxy.BuildRouter(proxy.Configuration{
 		Tenants:       proxy.SingleTenantConfigurations("private-tenant", privateSecret),
 		OpenAIKey:     privateAPIKey,
@@ -213,7 +218,7 @@ func TestPublicCapabilityRESTResourceProjectsChangedCatalogWithoutPrivateConfig(
 		testingInstance.Fatalf("cache control=%q", response.Header().Get("Cache-Control"))
 	}
 	responseBody := response.Body.String()
-	for _, privateValue := range []string{privateAPIKey, privateBaseURL, privateSecret, changedOffering.ProviderModel, "api_key", "base_url", "provider_model", "default_operations"} {
+	for _, privateValue := range []string{privateAPIKey, privateBaseURL, privateSecret, changedOffering.ProviderModel, "base_url", "provider_model", "default_operations"} {
 		if strings.Contains(responseBody, privateValue) {
 			testingInstance.Fatalf("public capability response exposed %q: %s", privateValue, responseBody)
 		}
@@ -221,6 +226,9 @@ func TestPublicCapabilityRESTResourceProjectsChangedCatalogWithoutPrivateConfig(
 	var catalog proxy.PublicCapabilityCatalog
 	if decodeError := json.Unmarshal(response.Body.Bytes(), &catalog); decodeError != nil {
 		testingInstance.Fatalf("decode public capability response: %v", decodeError)
+	}
+	if !slices.Equal(catalog.Providers[0].CredentialKinds, []string{proxy.CatalogCredentialAPIKey}) {
+		testingInstance.Fatalf("public provider credential kinds=%v", catalog.Providers[0].CredentialKinds)
 	}
 	changedModelFound := false
 	for _, model := range catalog.Models {

--- a/tests/e2e/management-ui.spec.js
+++ b/tests/e2e/management-ui.spec.js
@@ -367,7 +367,7 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).toContain('<routing-tree class="routing-tree" data-enhanced="false" aria-label="Interactive LLM routing map">');
   expect(html).toContain("One integration. Choose the exact route.");
   expect(html).toContain('<canvas class="routing-tree__connectors" data-route-canvas aria-hidden="true"></canvas>');
-  expect(html).toContain('<span>11 publishers · 56 exact models · 57 offerings</span>');
+  expect(html).toContain('<span>11 publishers · 57 exact models · 58 offerings</span>');
   expect(html).toContain('data-route-publisher="deepseek"');
   expect(html).toContain('data-route-publisher="alibaba"');
   expect(html).toContain('data-route-publisher="moonshot"');
@@ -378,9 +378,9 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).toContain('<table class="catalog-table">');
   expect(html).toContain('<strong>11</strong><span>Providers</span>');
   expect(html).toContain('<strong>11</strong><span>Publishers</span>');
-  expect(html).toContain('<strong>23</strong><span>Families</span>');
-  expect(html).toContain('<strong>56</strong><span>Exact models</span>');
-  expect(html).toContain('<strong>57</strong><span>Offerings</span>');
+  expect(html).toContain('<strong>24</strong><span>Families</span>');
+  expect(html).toContain('<strong>57</strong><span>Exact models</span>');
+  expect(html).toContain('<strong>58</strong><span>Offerings</span>');
   expect(html).toContain('data-catalog-sort-header="publisher"');
   expect(html).toContain('data-catalog-sort-header="model"');
   expect(html).toContain('data-catalog-sort-header="capabilities"');
@@ -404,6 +404,8 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).toContain("gemini-2.5-flash");
   expect(html).toContain("claude-sonnet-4-6");
   expect(html).toContain("grok-4.3");
+  expect(html).toContain("grok-imagine-video-1.5");
+  expect(html).toContain('<option value="video_generation">Video generation</option>');
   expect(html).not.toContain("api_key");
   expect(html).not.toContain("base_url");
   expect(html).not.toContain("provider_model");
@@ -755,8 +757,8 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(page.locator("#models > routing-tree")).toHaveCount(0);
   await expect(routingTree).toHaveAttribute("data-enhanced", "false");
   await expect(routingTree.locator("[data-route-publisher]")).toHaveCount(11);
-  await expect(routingTree.locator("[data-route-provider]")).toHaveCount(57);
-  await expect(routingTree.locator("[data-route-model]")).toHaveCount(56);
+  await expect(routingTree.locator("[data-route-provider]")).toHaveCount(58);
+  await expect(routingTree.locator("[data-route-model]")).toHaveCount(57);
   await expect(routingTree.locator('[data-route-publisher="alibaba"]')).toHaveAttribute("aria-pressed", "true");
   await expect(routingTree.locator('[data-route-model-group="alibaba"]')).toBeVisible();
   await expect(routingTree.locator('[data-route-model-group="moonshot"]')).toBeHidden();
@@ -770,7 +772,7 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(catalog).toHaveAttribute("data-enhanced", "false");
   await expect(catalog.locator("[data-catalog-toolbar]")).toBeHidden();
   await expect(catalog.getByRole("columnheader")).toHaveText(["Publisher", "Model", "Provider offerings and capabilities"]);
-  await expect(catalog.locator("[data-catalog-row]")).toHaveCount(56);
+  await expect(catalog.locator("[data-catalog-row]")).toHaveCount(57);
   await expect(catalog.locator('[data-model="gpt-4o-mini-transcribe"]')).toContainText("Dictation");
 
   const footer = page.locator(".public-site-footer-fallback");
@@ -801,8 +803,8 @@ test("visitors can choose a publisher, exact model, and provider offering", asyn
   await expect(routingTree).toHaveAttribute("data-enhanced", "true");
   await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "true");
   await expect(routingTree.locator("[data-route-publisher]")).toHaveCount(11);
-  await expect(routingTree.locator("[data-route-model]")).toHaveCount(56);
-  await expect(routingTree.locator("[data-route-provider]")).toHaveCount(57);
+  await expect(routingTree.locator("[data-route-model]")).toHaveCount(57);
+  await expect(routingTree.locator("[data-route-provider]")).toHaveCount(58);
   await expect(routingTree.locator("[data-route-provider]:visible")).toHaveCount(1);
   await expect(selectedPublisher).toHaveText("Alibaba");
   await expect(selectedModel).toHaveText("qwen-plus");
@@ -872,6 +874,9 @@ test("visitors can choose a publisher, exact model, and provider offering", asyn
   await operationFilter.selectOption("dictation");
   await expect(routingTree.locator("[data-route-publisher]:visible")).toHaveCount(4);
   await expect(routingTree.locator("[data-route-model]:not([hidden])")).toHaveCount(5);
+  await operationFilter.selectOption("video_generation");
+  await expect(routingTree.locator("[data-route-publisher]:visible")).toHaveCount(1);
+  await expect(routingTree.locator("[data-route-model]:not([hidden])")).toHaveCount(1);
 
   if (process.env.I220_SCREENSHOTS === "1") {
     await mkdir(i220ScreenshotDirectory, { recursive: true });
@@ -912,8 +917,8 @@ test("visitors can disclose filters, search every characteristic, and sort throu
   const modelHeader = catalog.locator('[data-catalog-sort-header="model"]');
   const capabilitiesHeader = catalog.locator('[data-catalog-sort-header="capabilities"]');
   await expect(catalog).toHaveAttribute("data-enhanced", "true");
-  await expect(rows).toHaveCount(56);
-  await expect(resultCount).toHaveText("56 of 56 models");
+  await expect(rows).toHaveCount(57);
+  await expect(resultCount).toHaveText("57 of 57 models");
   await expect(filterPanel).toBeHidden();
   await expect(searchSubmit).toHaveAttribute("aria-expanded", "false");
 
@@ -935,20 +940,20 @@ test("visitors can disclose filters, search every characteristic, and sort throu
   await expect(catalog.locator('[data-catalog-search-text*="synchronous"]')).toHaveCount(0);
   await searchInput.fill("gemini-3.5-flash image_input audio_input");
   await expect(filterPanel).toBeVisible();
-  await expect(resultCount).toHaveText("1 of 56 model");
+  await expect(resultCount).toHaveText("1 of 57 model");
   await expect(visibleRows).toHaveAttribute("data-model", "gemini-3.5-flash");
 
   await searchInput.fill("gpt-5.5-pro openai_responses xhigh");
-  await expect(resultCount).toHaveText("1 of 56 model");
+  await expect(resultCount).toHaveText("1 of 57 model");
   await expect(visibleRows).toHaveAttribute("data-model", "gpt-5.5-pro");
 
   await searchInput.fill("glm-5.2 131072 token");
-  await expect(resultCount).toHaveText("1 of 56 model");
+  await expect(resultCount).toHaveText("1 of 57 model");
   await expect(visibleRows).toHaveAttribute("data-model", "glm-5.2");
 
   await catalog.getByRole("button", { name: "Reset" }).click();
   await searchInput.fill("dictation");
-  await expect(resultCount).toHaveText("5 of 56 models");
+  await expect(resultCount).toHaveText("5 of 57 models");
   for (const visibleRow of await visibleRows.all()) {
     await expect(visibleRow).toHaveAttribute("data-capabilities", "dictation");
   }
@@ -956,28 +961,28 @@ test("visitors can disclose filters, search every characteristic, and sort throu
   await catalog.getByRole("button", { name: "Reset" }).click();
   await catalog.getByRole("checkbox", { name: "Image input" }).check();
   await catalog.getByRole("checkbox", { name: "Audio message input" }).check();
-  await expect(resultCount).toHaveText("2 of 56 models");
+  await expect(resultCount).toHaveText("2 of 57 models");
   await expect(visibleRows).toHaveCount(2);
 
   await searchSubmit.click();
   await expect(filterPanel).toBeHidden();
-  await expect(resultCount).toHaveText("2 of 56 models");
+  await expect(resultCount).toHaveText("2 of 57 models");
   await searchSubmit.click();
   await expect(filterPanel).toBeVisible();
   await expect(catalog.getByRole("checkbox", { name: "Image input" })).toBeChecked();
   await expect(catalog.getByRole("checkbox", { name: "Audio message input" })).toBeChecked();
 
   await catalog.getByRole("checkbox", { name: "Dictation" }).check();
-  await expect(resultCount).toHaveText("0 of 56 models");
+  await expect(resultCount).toHaveText("0 of 57 models");
   await expect(catalog.locator("[data-catalog-empty]")).toBeVisible();
 
   await catalog.getByRole("button", { name: "Reset" }).click();
-  await expect(resultCount).toHaveText("56 of 56 models");
+  await expect(resultCount).toHaveText("57 of 57 models");
   await searchInput.press("Escape");
   await catalog.getByRole("button", { name: "Filter by Dictation" }).first().click();
   await expect(filterPanel).toBeVisible();
   await expect(catalog.getByRole("checkbox", { name: "Dictation" })).toBeChecked();
-  await expect(resultCount).toHaveText("5 of 56 models");
+  await expect(resultCount).toHaveText("5 of 57 models");
 
   await catalog.getByRole("button", { name: "Reset" }).click();
   await expect(publisherHeader).toHaveAttribute("aria-sort", "ascending");
@@ -2725,8 +2730,8 @@ test("provider selection autosaves its exact editor while transient removal stay
   const providerEditor = settingsDialog.locator("provider-editor");
   const providerSelector = providerEditor.getByRole("combobox", { name: "Provider", exact: true });
 
-  await providerSelector.selectOption("grok");
-  const grokKeyInput = providerEditor.getByRole("textbox", { name: "Grok API key" });
+  await providerSelector.selectOption("xai");
+  const grokKeyInput = providerEditor.getByRole("textbox", { name: "xAI API key" });
   await grokKeyInput.fill(firstGrokKey);
   const providerRemovalButton = providerEditor.getByRole("button", { name: "Remove provider key and settings" });
   await expect(providerRemovalButton).toBeVisible();
@@ -2742,7 +2747,7 @@ test("provider selection autosaves its exact editor while transient removal stay
   await expect.poll(() => providerMutations.length).toBe(1);
   expect(providerMutations.at(-1)).toMatchObject({
     method: "PUT",
-    url: providerKeyEndpointURL("grok"),
+    url: providerKeyEndpointURL("xai"),
     payload: { api_key: firstGrokKey, text_model: "grok-4.3", system_prompt: "" },
   });
   const metaKeyInput = providerEditor.getByRole("textbox", { name: "Meta API key" });
@@ -2750,7 +2755,7 @@ test("provider selection autosaves its exact editor while transient removal stay
   await expect(metaKeyInput).toHaveAttribute("readonly", "readonly");
   await expect(providerEditor.getByRole("combobox", { name: "Provider default model" })).toHaveValue("muse-spark-1.1");
 
-  await providerSelector.selectOption("grok");
+  await providerSelector.selectOption("xai");
   await expect(grokKeyInput).toHaveValue("****aved");
   await expect(grokKeyInput).toHaveAttribute("readonly", "readonly");
   await providerEditor.getByRole("button", { name: "Show key" }).click();
@@ -2762,7 +2767,7 @@ test("provider selection autosaves its exact editor while transient removal stay
   await expect.poll(() => providerMutations.length).toBe(2);
   expect(providerMutations.at(-1)).toMatchObject({
     method: "PUT",
-    url: providerKeyEndpointURL("grok"),
+    url: providerKeyEndpointURL("xai"),
     payload: { api_key: secondGrokKey, text_model: "grok-4.3", system_prompt: "" },
   });
   const deepSeekKeyInput = providerEditor.getByRole("textbox", { name: "DeepSeek API key" });
@@ -2770,7 +2775,7 @@ test("provider selection autosaves its exact editor while transient removal stay
   await providerEditor.getByRole("button", { name: "Show key" }).click();
   await expect(deepSeekKeyInput).toHaveValue(deepSeekProviderKey);
 
-  await providerSelector.selectOption("grok");
+  await providerSelector.selectOption("xai");
   await expect(grokKeyInput).toHaveValue("****aved");
   await providerEditor.getByRole("button", { name: "Show key" }).click();
   await expect(grokKeyInput).toHaveValue(secondGrokKey);
@@ -2779,7 +2784,7 @@ test("provider selection autosaves its exact editor while transient removal stay
   await expect(deepSeekKeyInput).not.toHaveValue(deepSeekProviderKey);
   await expect(deepSeekKeyInput).toHaveAttribute("readonly", "readonly");
 
-  await providerSelector.selectOption("grok");
+  await providerSelector.selectOption("xai");
   await expect(grokKeyInput).not.toHaveValue(secondGrokKey);
   expect(await browserStorageContains(page, firstGrokKey)).toBe(false);
   expect(await browserStorageContains(page, secondGrokKey)).toBe(false);
@@ -2807,7 +2812,7 @@ test("provider selection autosaves its exact editor while transient removal stay
   await expect.poll(() => providerMutations.filter((mutation) => mutation.method === "DELETE").length).toBe(1);
   expect(providerMutations.at(-1)).toMatchObject({
     method: "DELETE",
-    url: providerKeyEndpointURL("grok"),
+    url: providerKeyEndpointURL("xai"),
   });
   await expect(grokKeyInput).toHaveValue("");
 });
@@ -3211,7 +3216,7 @@ test("routing defaults autosave complete provider and model pairs without a manu
     }
   });
   await installAssetRoutes(page);
-  await installManagementRoutes(page, { savedProviderIDs: ["openai", "deepseek", "meta", "grok"] });
+  await installManagementRoutes(page, { savedProviderIDs: ["openai", "deepseek", "meta", "xai"] });
 
   await page.goto(`${baseURL}${applicationPath}`);
   await page.getByTestId("avatar-menu").click();
@@ -3245,13 +3250,13 @@ test("routing defaults autosave complete provider and model pairs without a manu
     reasoning_effort: "",
   });
 
-  await dictationProvider.selectOption("grok");
+  await dictationProvider.selectOption("xai");
   await expect(dictationModel).toHaveValue("xai-stt");
   await expect.poll(() => defaultsMutations.length).toBe(2);
   expect(defaultsMutations.at(-1)).toEqual({
     provider: "deepseek",
     model: "deepseek-chat",
-    dictation_provider: "grok",
+    dictation_provider: "xai",
     dictation_model: "xai-stt",
     system_prompt: "",
     reasoning_effort: "",
@@ -3265,7 +3270,7 @@ test("routing defaults autosave complete provider and model pairs without a manu
   expect(defaultsMutations.at(-1)).toEqual({
     provider: "deepseek",
     model: "deepseek-chat",
-    dictation_provider: "grok",
+    dictation_provider: "xai",
     dictation_model: "xai-stt",
     system_prompt: "Use tenant-wide autosaved guidance.",
     reasoning_effort: "",
@@ -3284,7 +3289,7 @@ test("routing defaults autosave complete provider and model pairs without a manu
   await page.getByTestId("avatar-menu-item").nth(0).click();
   await expect(settingsDialog.getByRole("combobox", { name: "Text provider" })).toHaveValue("deepseek");
   await expect(settingsDialog.getByRole("combobox", { name: "Text model" }).first()).toHaveValue("deepseek-chat");
-  await expect(settingsDialog.getByRole("combobox", { name: "Dictation provider" })).toHaveValue("grok");
+  await expect(settingsDialog.getByRole("combobox", { name: "Dictation provider" })).toHaveValue("xai");
   await expect(settingsDialog.getByRole("combobox", { name: "Dictation model" })).toHaveValue("xai-stt");
   await expect(settingsDialog.locator("#routing-system-prompt-input")).toHaveValue(
     "Use tenant-wide autosaved guidance.",
@@ -3345,7 +3350,7 @@ test("routing-default autosave queues newer edits without resetting the provider
   await installAssetRoutes(page);
   await installManagementRoutes(page, {
     providerKeys: { openai: revealedProviderKey },
-    savedProviderIDs: ["openai", "deepseek", "meta", "grok"],
+    savedProviderIDs: ["openai", "deepseek", "meta", "xai"],
   });
   await page.route(`${baseURL}${managementDefaultTenantPath}/defaults`, async (route) => {
     defaultsMutations.push(route.request().postDataJSON());
@@ -3369,7 +3374,7 @@ test("routing-default autosave queues newer edits without resetting the provider
   const defaultsForm = settingsDialog.locator(".settings-grid-form");
   await defaultsForm.getByRole("combobox", { name: "Text provider" }).selectOption("deepseek");
   await firstDefaultsSaveRequested;
-  await defaultsForm.getByRole("combobox", { name: "Dictation provider" }).selectOption("grok");
+  await defaultsForm.getByRole("combobox", { name: "Dictation provider" }).selectOption("xai");
   await defaultsForm.locator("summary.system-prompt-summary").click();
   await defaultsForm.getByRole("textbox", { name: "System prompt" }).fill("Keep the latest defaults only.");
   await page.keyboard.press("Tab");
@@ -3379,7 +3384,7 @@ test("routing-default autosave queues newer edits without resetting the provider
   expect(defaultsMutations.at(-1)).toEqual({
     provider: "deepseek",
     model: "deepseek-chat",
-    dictation_provider: "grok",
+    dictation_provider: "xai",
     dictation_model: "xai-stt",
     system_prompt: "Keep the latest defaults only.",
     reasoning_effort: "",
@@ -6009,8 +6014,8 @@ function managementProfile(isAdmin = false, hasSecret = true) {
         dictation_models: [],
       },
       {
-        id: "grok",
-        label: "Grok",
+        id: "xai",
+        label: "xAI",
         aliases: ["xai"],
         has_key: false,
         text_model: "grok-4.3",

--- a/tests/e2e/public-site-renderer.spec.js
+++ b/tests/e2e/public-site-renderer.spec.js
@@ -58,7 +58,13 @@ test("public site rendering writes the normalized exact model catalog", async ()
 
 function normalizedCapabilityFixture() {
   return {
-    providers: [{ identifier: "example-provider", label: "Example Provider" }],
+    revision: "2026-08-10.test.1",
+    operations: [
+      { id: "text", input_artifacts: ["text"], output_artifacts: ["text"] },
+      { id: "dictation", input_artifacts: ["audio"], output_artifacts: ["text"] },
+      { id: "video_generation", input_artifacts: ["text", "image"], output_artifacts: ["video"] },
+    ],
+    providers: [{ identifier: "example-provider", label: "Example Provider", credential_kinds: ["api_key"] }],
     publishers: [{ identifier: "example-publisher", label: "Example Publisher", model_count: 1 }],
     families: [{ identifier: "example-family", publisher: "example-publisher", label: "Example Family" }],
     models: [{
@@ -77,8 +83,22 @@ function normalizedCapabilityFixture() {
       model: "example-model",
       capabilities: ["text"],
       wire_contract: "openai_chat_completions",
+      execution_lifecycle: "synchronous_completion",
       output_token_limit: 0,
       reasoning_efforts: [],
+      controls: [],
+      limits: [],
+    }],
+    prices: [{
+      provider: "example-provider",
+      model: "example-model",
+      operation: "text",
+      available: false,
+      rates: [],
+      minimum_charge: null,
+      source: "https://example.com/pricing",
+      last_verified: "2026-08-10",
+      unavailable_reason: "Test price is unavailable.",
     }],
     counts: {
       providers: 1,


### PR DESCRIPTION
## Summary

- add one revisioned catalog for credentials, operations, artifacts, controls, limits, prices, and exact price selection
- make `xai` the sole current provider selector and migrate persisted `grok` routes through the bounded schema-v6 operation
- project the tenant-safe catalog through public capabilities, management choices, OpenAPI, generated resources, and official client contracts
- archive I216, remove satisfied dependency markers, and reorder the active backlog into an executable priority chain

## Stack

- base: #270 (I221 normalized model catalog)
- transitive base: #269 (I039 Qwen Cloud retirement)

## Validation

- `timeout -k 350s -s SIGKILL 350s make ci` — all 11 gates passed, 90 browser scenarios passed, Go statement coverage 100.0%
- active tracker integrity — 41 active and 210 archived entries, unique section-aware IDs, active prerequisites, and concrete blocker bodies
- scoped ASD-STE100 mechanical check — passed
- `git diff --check` — passed