### PR TITLE
gix/add-tenant-assets-and-gemini-files-api-routing

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1059,7 +1059,7 @@ retain satisfied historical dependencies.
 
 ## Features
 
-- [ ] [F033] (P0) {F022} Pass canonical message media to selected providers.
+- [x] [F033] (P0) {F022} Pass canonical message media to selected providers.
   Goal:
   Let `/v2` accept provider-neutral media without a smaller LLM Proxy media
   limit. Translate each attachment into the selected provider's supported
@@ -1078,7 +1078,7 @@ retain satisfied historical dependencies.
     MediaOps operation.
 
   Provider limit evidence:
-  - The following provider limits were verified on 2026-08-10.
+  - The following provider limits were verified on 2026-08-11.
   - Gemini Interactions permits 20 MB for a request with inline image data.
     This total includes text, system instructions, and inline bytes. Gemini
     permits 3,600 image files per request. Gemini directs larger requests to
@@ -1174,6 +1174,14 @@ retain satisfied historical dependencies.
     providers.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair.
+
+  Resolution:
+  - Added tenant asset upload, deletion, strict resolution, and official client
+    support.
+  - Added offering-owned media limits and Gemini inline or Files API routing.
+  - Added OpenAPI, public capability, Go client, Python client, and browser
+    contracts.
+  - Passed the final 11-gate CI run with 100.0% Go statement coverage.
 
 - [ ] [F032] (P1) Add Baidu Qianfan as a user-configurable text provider.
   Goal:
@@ -1274,6 +1282,10 @@ retain satisfied historical dependencies.
   Extend LLM Proxy from blocking text and dictation into a shared model-provider
   data plane while keeping MediaOps and other callers responsible for their
   product operations.
+  Progress:
+  - F033 added the tenant asset upload, store, reference, and official-client
+    foundation.
+  - The durable model-operation and worker foundation remains open.
   Requirements:
   - Keep `/v2` as the canonical blocking messages contract and `/v3` as the
     planned sampling contract. Add a distinct `/model/v1` namespace to the

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1181,6 +1181,13 @@ retain satisfied historical dependencies.
   - Added offering-owned media limits and Gemini inline or Files API routing.
   - Added OpenAPI, public capability, Go client, Python client, and browser
     contracts.
+  - Kept asset and management data on the hosted retained `/data` volume.
+  - Bounded `/v2` request ingestion from the catalog contract and applied the
+    authenticated request budget to asset uploads.
+  - Removed upload-stream lock contention and added restart-safe scheduled
+    expiry reclamation.
+  - Made Gemini Files API deletion authoritative after every finalized upload,
+    including polling and cancellation failures.
   - Passed the final 11-gate CI run with 100.0% Go statement coverage.
 
 - [ ] [F032] (P1) Add Baidu Qianfan as a user-configurable text provider.

--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -40,7 +40,7 @@ mprlab_resources:
               resource: public-api
               output: origin
             LLM_PROXY_MANAGEMENT_DATABASE_PATH:
-              value: /app/data/llm-proxy-management.sqlite
+              value: /data/llm-proxy-management.sqlite
             LLM_PROXY_MANAGEMENT_ENABLED:
               value: "true"
             LLM_PROXY_MANAGEMENT_GOOGLE_CLIENT_ID:
@@ -88,7 +88,7 @@ mprlab_resources:
               mode: "0444"
           mounts:
             - volume: data
-              target: /app/data
+              target: /data
               read_only: false
           ports:
             - container_port: 8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Added the shared MPR header and compact footer to public pages, resource pages, legal pages, and the application.
 - Migrated Gemini text routing to the native Interactions API with explicit synchronous and background execution lifecycles.
 - Added provider-neutral image and audio attachments to canonical `POST /v2` requests for compatible models.
+- Added tenant asset uploads, asset-backed message attachments, published provider media limits, and automatic Gemini inline or Files API media transport.
 - Added shared missing-suffix continuation for provider output-budget stops and sanitized provider failure responses.
 - Added typed, sanitized non-success HTTP failures to the official Go client.
 - Make every public frontend validation path install the pinned npm graph and project-local Chromium before use, including clean `make test` and `make ci` executions.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the public **Log In** action authenticates the user through MPR UI and TAuth.
 - Set optional nonblank `reasoning_effort=...` on `GET /`, or in a JSON body for `POST /` and `POST /v2`, to select a capability-supported reasoning level for that exact resolved route. An explicit value overrides the tenant default; an omitted value retains it. Blank or unsupported values fail before an upstream call.
 - Choose the dictation model per request via `model=...` on `/dictate`; omitted model uses the tenant default when `provider` is omitted, otherwise the selected provider's configured default
 - Optional per-request web search via exact `web_search=true`; `false` or omission keeps it disabled
-- Optional exact image and audio attachments on canonical `POST /v2` user messages when the selected model declares the corresponding `media_inputs`
+- Optional exact inline or tenant-asset-backed image and audio attachments on canonical `POST /v2` user messages
 - Optional logging at `debug` or `info` levels
 - Forwards requests using server-side provider API keys, loaded from the database in management mode
 - Optional TAuth-protected self-service UI where signed-in users automatically receive an llm-proxy client key and their provider settings plus routing defaults autosave
@@ -488,8 +488,14 @@ Provider-specific details:
   totals map from `total_input_tokens`, `total_output_tokens`, and
   `total_tokens`, preserving provider-counted thought tokens. For exact models
   whose catalog declares `media_inputs`, ordered image and audio attachments
-  become native typed interaction content after the message text. See Google's
+  become native typed interaction content after the message text. The adapter
+  sends an inline request when the complete encoded request is at most the
+  offering's inline limit. It streams exact media bytes through the Gemini
+  Files API when the encoded request is larger, then deletes each provider
+  file after the interaction ends. See Google's
   [Interactions overview](https://ai.google.dev/gemini-api/docs/interactions-overview),
+  [file input methods](https://ai.google.dev/gemini-api/docs/file-input-methods),
+  [Files API guide](https://ai.google.dev/gemini-api/docs/files),
   [background execution guide](https://ai.google.dev/gemini-api/docs/background-execution),
   and [Interactions API reference](https://ai.google.dev/api/interactions-api).
 * Anthropic text requests use `POST /v1/messages` with `x-api-key` and
@@ -1607,6 +1613,31 @@ representations at the HTTP edge, preserves attachment order, rejects media on
 non-user messages or unsupported model routes before upstream work, and never
 echoes media bytes in response metadata.
 
+Use `UploadAsset` when the application needs a reusable tenant asset. The
+returned record contains the opaque asset id, MIME type, byte count, SHA-256,
+state, and expiry. Construct the attachment from that exact record:
+
+```go
+asset, err := client.UploadAsset(ctx, llmproxyclient.AssetUploadInput{
+    MIMEType: "image/png",
+    Data:     frameBytes,
+})
+if err != nil {
+    return err
+}
+frame, err := llmproxyclient.NewImageAssetAttachment(
+    llmproxyclient.ImageAssetAttachmentInput{
+        AssetID:  asset.AssetID,
+        MIMEType: asset.MIMEType,
+        SHA256:   asset.SHA256,
+    },
+)
+```
+
+`NewAudioAssetAttachment` provides the corresponding audio constructor. Both
+asset constructors serialize `asset_id` instead of `data` and preserve the
+same hash-bound attachment union.
+
 The request value controls only the proxy budget header. `ctx` remains the Go
 caller's independent cancellation authority, and the injected `HTTPDoer` may
 have its own explicitly selected transport policy. The package does not add a
@@ -1721,7 +1752,13 @@ For reproducible application builds, replace `master` with the desired released
 repository tag.
 
 ```python
-from llm_proxy_client import Client, ClientConfig, ClientMessagesRequest, ClientMessage
+from llm_proxy_client import (
+    Client,
+    ClientConfig,
+    ClientMessage,
+    ClientMessagesRequest,
+    image_asset_attachment,
+)
 
 client = Client(
     ClientConfig(
@@ -1735,6 +1772,25 @@ text = client.post_messages(
         messages=(ClientMessage(role="user", content="Summarize this"),),
         max_tokens=512,
         request_timeout_seconds=900,
+    )
+)
+```
+
+The Python client has the same asset contract:
+
+```python
+asset = client.upload_asset(frame_bytes, "image/png")
+frame = image_asset_attachment(asset.asset_id, asset.mime_type, asset.sha256)
+text = client.post_messages(
+    ClientMessagesRequest(
+        messages=(
+            ClientMessage(
+                role="user",
+                content="Inspect this exact frame.",
+                attachments=(frame,),
+            ),
+        ),
+        model="gemini-2.5-flash",
     )
 )
 ```
@@ -1936,9 +1992,50 @@ the OpenAPI schema, including the omission-versus-explicit-value contract for
 prepended when the submitted messages do not include a system message.
 Only `POST /v2` user messages may include `attachments`; compatibility
 `POST /`, `GET /`, and `/dictate` do not accept that field. Each attachment
-contains exactly `type`, `mime_type`, canonical padded base64 `data`, and the
-matching lowercase hexadecimal `sha256`. The request body remains bounded by
-`server.max_prompt_bytes`.
+is one exact union variant. An inline attachment contains `type`, `mime_type`,
+canonical padded base64 `data`, and the matching lowercase hexadecimal
+`sha256`. An asset attachment contains `type`, `asset_id`, `mime_type`, and the
+matching lowercase hexadecimal `sha256`. The proxy validates tenant ownership,
+asset state, expiry, MIME type, byte count, and digest before provider dispatch.
+`server.max_prompt_bytes` applies to compatibility `POST /`. Canonical
+`POST /v2` applies the selected provider offering's published media limits and
+transport rules.
+
+Upload an asset with the exact media content type and digest:
+
+```shell
+asset_sha256="$(shasum -a 256 ./frame.png | awk '{print $1}')"
+curl -X POST \
+  -H "Content-Type: image/png" \
+  -H "X-LLM-Proxy-Asset-SHA256: ${asset_sha256}" \
+  --data-binary @./frame.png \
+  "http://localhost:8080/model/v1/assets?key=mysecret"
+```
+
+Use the returned asset record in the canonical message:
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Inspect this exact frame.",
+      "attachments": [
+        {
+          "type": "image",
+          "asset_id": "ast_0123456789abcdef0123456789abcdef",
+          "mime_type": "image/png",
+          "sha256": "RETURNED_SHA256"
+        }
+      ]
+    }
+  ],
+  "model": "gemini-2.5-flash"
+}
+```
+
+`DELETE /model/v1/assets/{asset_id}?key=...` deletes the tenant asset. The
+default store retains an available asset for 48 hours.
 
 ### Choose an OpenAI model
 
@@ -2167,8 +2264,11 @@ and [latest-model guide](https://developers.openai.com/api/docs/guides/latest-mo
 * `200 OK` - success
 * `400 Bad Request` - missing/invalid parameters, invalid request timeout, invalid multipart audio form, unknown provider/model, or unsupported provider capability. Invalid timeout headers return `{"error":{"code":"invalid_request_timeout","max_request_timeout_seconds":M}}`.
 * `403 Forbidden` - missing or invalid `key`
-* `413 Payload Too Large` - JSON prompt body exceeds `max_prompt_bytes`, or
-  dictation audio exceeds `max_input_audio_bytes`
+* `413 Payload Too Large` - compatibility JSON exceeds `max_prompt_bytes`,
+  dictation audio exceeds `max_input_audio_bytes`, an asset upload exceeds
+  `max_asset_bytes`, or media exceeds every transport limit for the selected
+  provider offering. Provider media failures use
+  `provider_media_limit_exceeded`.
 * `429 Too Many Requests` - upstream provider rate limit; returns the sanitized `provider_rate_limited` JSON contract
 * `503 Service Unavailable` - selected provider credential is unavailable because that non-default provider is disabled or missing its API key
 * `504 Gateway Timeout` - the accepted proxy work budget expired; the response is `{"error":{"code":"request_timeout","request_timeout_seconds":N}}`

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ the client to poll llm-proxy.
 
 ### Request work budgets
 
-Every authenticated operation that can start upstream work accepts one optional
+Every authenticated operation that can run long work accepts one optional
 header:
 
 ```text
@@ -115,9 +115,10 @@ X-LLM-Proxy-Request-Timeout-Seconds: N
 ```
 
 `N` is the positive whole-number wall-clock budget, in seconds, for that
-request. The budget begins before body parsing and covers validation, queue
-admission, every provider call, OpenAI background polling, and response
-construction for `GET /`, `POST /`, `POST /v2`, and `POST /dictate`.
+request. The budget begins before body parsing and covers validation, asset
+upload, queue admission, every provider call, OpenAI background polling, and
+response construction for `GET /`, `POST /`, `POST /v2`,
+`POST /model/v1/assets`, and `POST /dictate`.
 
 If the header is omitted, `server.request_timeout_seconds` is the effective
 budget. A supplied value must be in the inclusive range
@@ -1998,8 +1999,11 @@ canonical padded base64 `data`, and the matching lowercase hexadecimal
 matching lowercase hexadecimal `sha256`. The proxy validates tenant ownership,
 asset state, expiry, MIME type, byte count, and digest before provider dispatch.
 `server.max_prompt_bytes` applies to compatibility `POST /`. Canonical
-`POST /v2` applies the selected provider offering's published media limits and
-transport rules.
+`POST /v2` bounds its encoded JSON envelope with the configured text allowance
+plus the largest bounded inline request in the provider catalog. It applies
+the selected provider offering's published media limits and transport rules.
+Upload larger media through `POST /model/v1/assets` and send its asset
+reference through `/v2`.
 
 Upload an asset with the exact media content type and digest:
 
@@ -2264,8 +2268,9 @@ and [latest-model guide](https://developers.openai.com/api/docs/guides/latest-mo
 * `200 OK` - success
 * `400 Bad Request` - missing/invalid parameters, invalid request timeout, invalid multipart audio form, unknown provider/model, or unsupported provider capability. Invalid timeout headers return `{"error":{"code":"invalid_request_timeout","max_request_timeout_seconds":M}}`.
 * `403 Forbidden` - missing or invalid `key`
-* `413 Payload Too Large` - compatibility JSON exceeds `max_prompt_bytes`,
-  dictation audio exceeds `max_input_audio_bytes`, an asset upload exceeds
+* `413 Payload Too Large` - compatibility JSON exceeds `max_prompt_bytes`, a
+  `/v2` JSON envelope exceeds its catalog-derived ingress bound, dictation
+  audio exceeds `max_input_audio_bytes`, an asset upload exceeds
   `max_asset_bytes`, or media exceeds every transport limit for the selected
   provider offering. Provider media failures use
   `provider_media_limit_exceeded`.

--- a/cmd/cli/config_file.go
+++ b/cmd/cli/config_file.go
@@ -60,6 +60,9 @@ type serverConfiguration struct {
 	RequestTimeoutSeconds    *int                             `mapstructure:"request_timeout_seconds"`
 	MaxRequestTimeoutSeconds *int                             `mapstructure:"max_request_timeout_seconds"`
 	MaxPromptBytes           int64                            `mapstructure:"max_prompt_bytes"`
+	MaxAssetBytes            int64                            `mapstructure:"max_asset_bytes"`
+	AssetRetentionSeconds    int                              `mapstructure:"asset_retention_seconds"`
+	AssetStorePath           string                           `mapstructure:"asset_store_path"`
 	MaxInputAudioBytes       int64                            `mapstructure:"max_input_audio_bytes"`
 	UpstreamRateLimits       []upstreamRateLimitConfiguration `mapstructure:"upstream_rate_limits"`
 }
@@ -310,6 +313,9 @@ func (configuration fileConfiguration) toProxyConfiguration() (proxy.Configurati
 		RequestTimeoutSeconds:        requestTimeoutSeconds,
 		MaxRequestTimeoutSeconds:     maxRequestTimeoutSeconds,
 		MaxPromptBytes:               configuration.Server.MaxPromptBytes,
+		MaxAssetBytes:                configuration.Server.MaxAssetBytes,
+		AssetRetentionSeconds:        configuration.Server.AssetRetentionSeconds,
+		AssetStorePath:               configuration.Server.AssetStorePath,
 		MaxInputAudioBytes:           configuration.Server.MaxInputAudioBytes,
 		UpstreamRateLimits:           proxyUpstreamRateLimitConfigurations(configuration.Server.UpstreamRateLimits),
 		ModelCatalog:                 configuration.Catalog,

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -6,6 +6,9 @@ server:
   request_timeout_seconds: 360
   max_request_timeout_seconds: 3600
   max_prompt_bytes: 4194304
+  max_asset_bytes: 2000000000
+  asset_retention_seconds: 172800
+  asset_store_path: /data/assets
   max_input_audio_bytes: 26214400
   upstream_rate_limits: []
 management:
@@ -59,7 +62,7 @@ providers:
     base_url: https://api.x.ai/v1
     transcriptions_url: https://api.x.ai/v1/stt
 catalog:
-  revision: 2026-08-10.i216.1
+  revision: 2026-08-11.f033.1
   operations:
   - id: text
     input_artifacts:
@@ -883,6 +886,51 @@ catalog:
     media_inputs:
     - image
     - audio
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 20000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://ai.google.dev/gemini-api/docs/file-input-methods
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 3600
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/image-understanding
+      last_verified: "2026-08-11"
+    - id: audio_count
+      media_type: audio
+      transport: any
+      status: unknown
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/audio
+      last_verified: "2026-08-11"
+    - id: image_file_bytes
+      media_type: image
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
+    - id: audio_file_bytes
+      media_type: audio
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
   - provider: gemini
     model: gemini-3.1-pro-preview
     provider_model: gemini-3.1-pro-preview
@@ -920,6 +968,51 @@ catalog:
     media_inputs:
     - image
     - audio
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 20000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://ai.google.dev/gemini-api/docs/file-input-methods
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 3600
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/image-understanding
+      last_verified: "2026-08-11"
+    - id: audio_count
+      media_type: audio
+      transport: any
+      status: unknown
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/audio
+      last_verified: "2026-08-11"
+    - id: image_file_bytes
+      media_type: image
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
+    - id: audio_file_bytes
+      media_type: audio
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
   - provider: gemini
     model: gemini-2.5-flash-lite
     provider_model: gemini-2.5-flash-lite

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -38,9 +38,12 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
   hash-bound metadata. `DELETE /model/v1/assets/{asset_id}` marks the asset as
   deleted and removes its stored bytes.
 - `server.max_prompt_bytes` limits compatibility `POST /`. Canonical
-  `POST /v2` uses the resolved provider offering's media limits. The proxy
-  validates asset ownership, state, expiry, MIME type, size, and SHA-256 before
-  it dispatches provider work.
+  `POST /v2` bounds the encoded JSON envelope with the configured text
+  allowance plus the largest bounded inline request in the provider catalog.
+  Larger media uses the asset endpoint and an asset reference. The proxy uses
+  the resolved provider offering's media limits and validates asset ownership,
+  state, expiry, MIME type, size, and SHA-256 before it dispatches provider
+  work.
 - `messages[].order` is optional. When any submitted message includes `order`, every submitted message must include a unique non-negative integer `order`; the proxy sorts submitted messages by ascending `order` before adding a request or tenant system prompt and before routing upstream.
 - With `messages[]` on `POST /`, body `system_prompt` is prepended as a system message only when the transcript does not already contain a `system` message. A body containing both `system_prompt` and a system message is invalid. With `POST /v2`, callers send system instructions as `system` role messages.
 - `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies. It is the initial per-attempt output budget and is reused for missing-suffix attempts.
@@ -49,9 +52,10 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 - Known provider-specific output-token ceilings are validated before upstream calls; MiniMax M2.7 rejects `max_tokens` above `2048`, Gemini text models reject values above `65536`, and Claude models reject values above their configured synchronous Messages output limits with `400 Bad Request`.
 - `reasoning_effort` is optional on `GET /` as a query parameter and on JSON `POST /` and `POST /v2` as a body field. Omission retains the resolved tenant default. A supplied value must be nonblank and supported by the exact resolved text provider/model route; blank, `null`, or unsupported values return `400 Bad Request` before a provider call.
 - `X-LLM-Proxy-Request-Timeout-Seconds` is an optional positive whole-number
-  header on `GET /`, `POST /`, `POST /v2`, and `POST /dictate`. Omission uses
-  `server.request_timeout_seconds`; a supplied value must be in the inclusive
-  range `1..server.max_request_timeout_seconds`.
+  header on `GET /`, `POST /`, `POST /v2`, `POST /model/v1/assets`, and
+  `POST /dictate`. Omission uses `server.request_timeout_seconds`; a supplied
+  value must be in the inclusive range
+  `1..server.max_request_timeout_seconds`.
 - The effective request budget begins at authenticated ingress before body
   parsing and covers validation, queue admission, provider work, OpenAI
   background polling, and response construction. Provider adapters propagate

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -26,10 +26,21 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 - `messages[]` items contain `role` and nonblank string `content`. Supported
   roles are `system`, `user`, and `assistant`; at least one `user` message is
   required. `attachments[]` is allowed only on a user message and each item
-  contains exactly `type`, `mime_type`, canonical padded base64 `data`, and
-  the matching lowercase hexadecimal `sha256`. Image accepts `image/jpeg`,
-  `image/png`, and `image/webp`; audio accepts `audio/m4a`, `audio/mpeg`, and
+  uses one exact union variant. Inline media contains `type`, `mime_type`,
+  canonical padded base64 `data`, and the matching lowercase hexadecimal
+  `sha256`. Asset media contains `type`, `asset_id`, `mime_type`, and the
+  matching lowercase hexadecimal `sha256`. Image accepts `image/jpeg`,
+  `image/png`, and `image/webp`. Audio accepts `audio/m4a`, `audio/mpeg`, and
   `audio/wav`.
+- `POST /model/v1/assets` stores exact image or audio bytes for the
+  authenticated tenant. The request supplies the exact media content type and
+  `X-LLM-Proxy-Asset-SHA256`. The response supplies one opaque asset id and its
+  hash-bound metadata. `DELETE /model/v1/assets/{asset_id}` marks the asset as
+  deleted and removes its stored bytes.
+- `server.max_prompt_bytes` limits compatibility `POST /`. Canonical
+  `POST /v2` uses the resolved provider offering's media limits. The proxy
+  validates asset ownership, state, expiry, MIME type, size, and SHA-256 before
+  it dispatches provider work.
 - `messages[].order` is optional. When any submitted message includes `order`, every submitted message must include a unique non-negative integer `order`; the proxy sorts submitted messages by ascending `order` before adding a request or tenant system prompt and before routing upstream.
 - With `messages[]` on `POST /`, body `system_prompt` is prepended as a system message only when the transcript does not already contain a `system` message. A body containing both `system_prompt` and a system message is invalid. With `POST /v2`, callers send system instructions as `system` role messages.
 - `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies. It is the initial per-attempt output budget and is reused for missing-suffix attempts.
@@ -127,6 +138,9 @@ Shared config fields:
 - `server.request_timeout_seconds`
 - `server.max_request_timeout_seconds`
 - `server.max_prompt_bytes`
+- `server.max_asset_bytes`
+- `server.asset_retention_seconds`
+- `server.asset_store_path`
 - `server.max_input_audio_bytes`
 - `server.upstream_rate_limits[].origin`
 - `server.upstream_rate_limits[].max_requests`
@@ -187,6 +201,8 @@ Normalized model catalog:
 - `catalog.offerings[].operations` and `default_operations`
 - `catalog.offerings[].wire_contract` and `execution_lifecycle`
 - `catalog.offerings[].output_token_limit` and `media_inputs`
+- `catalog.offerings[].media_limits[].id`, `media_type`, `transport`, `status`,
+  `value`, `unit`, `scope`, `source`, and `last_verified`
 - `catalog.offerings[].reasoning_effort`
 - `catalog.offerings[].request_profile` and `web_search`
 - `catalog.offerings[].controls` and `limits`
@@ -265,6 +281,22 @@ for one interaction; input, output, and total counts are taken from
 provider-counted thought tokens remain represented. Active-resource cancel and
 delete operations use independent bounded contexts, so cancel exhaustion cannot
 prevent the delete request from starting.
+
+Gemini offering media limits are part of the validated catalog and public
+capability resource. The inline request limit is 20,000,000 encoded request
+bytes. The image-count limit is 3,600 files for one request. The published
+audio-count limit is `unknown`. Each image or audio Files API upload is limited
+to 2,000,000,000 bytes. The adapter builds the complete inline interaction and
+uses inline `data` when its encoded size is within the limit. A larger request
+streams each exact attachment to the Gemini Files API and uses the returned
+`uri` in the same attachment order. The adapter verifies the provider file's
+MIME type, byte count, SHA-256, URI, and active state. It deletes every uploaded
+provider file when the interaction ends. The catalog records Google's
+[file input methods](https://ai.google.dev/gemini-api/docs/file-input-methods),
+[image input](https://ai.google.dev/gemini-api/docs/image-understanding),
+[audio input](https://ai.google.dev/gemini-api/docs/audio), and
+[Files API](https://ai.google.dev/gemini-api/docs/files) guides as the verified
+sources.
 
 OpenAI background Responses are stored upstream. llm-proxy keeps their ids only
 in memory for the active request and never returns or persists them, but the
@@ -605,7 +637,9 @@ When the selected Usage snapshot contains failures, the success-rate card expose
 
 - `400`: unknown provider, unknown model, unsupported capability, unsupported endpoint, conflicting model parameters, or client-supplied provider API key fields on public proxy requests.
 - `403`: missing or invalid client `key`.
-- `413`: prompt or audio payload too large.
+- `413`: compatibility prompt, dictation audio, tenant asset, or selected
+  provider media limit exceeded. Provider media failures use the stable
+  `provider_media_limit_exceeded` JSON code.
 - `429`: upstream provider rate limiting.
 - `503`: registered non-default provider credential is unavailable, so the selected provider is disabled until its API key is configured.
 - `504`: the overall proxy request timed out before the selected upstream provider returned a final result.
@@ -633,9 +667,10 @@ that response or structured provider-failure logs.
   `providers.gemini.base_url`; `incomplete` continues through the shared
   coordinator as a new interaction, while `completed` with visible model text
   succeeds. Gemini 3.x uses stored background polling; Gemini 2.5 uses a
-  non-stored synchronous request. For exact models whose catalog declares the capability, ordered
-  image and audio attachments become typed interaction content after the
-  message text.
+  non-stored synchronous request. For exact models whose catalog declares the
+  capability, ordered image and audio attachments become typed interaction
+  content after the message text. The adapter selects inline `data` or Files
+  API `uri` content from the exact provider offering limits.
 - xAI uses the shared OpenAI-compatible Chat Completions adapter against `providers.xai.base_url`.
 - OpenAI-compatible chat providers receive validated and sorted `messages[]` as provider-supported `role` and `content` items.
 - OpenAI Responses payload shape comes from the selected configured model's stable `request_profile`; model-specific web-search support comes from the selected model catalog entry. OpenAI Responses text calls run in background mode with stored responses so long provider work can be polled by llm-proxy while the caller waits on one REST request.
@@ -660,10 +695,12 @@ Black-box router tests cover:
   shared continuation transcript, completion order, suffix assembly, and usage
   aggregation for Chat Completions, Gemini, Anthropic, and OpenAI.
 - Ordered images and audio through canonical `POST /v2` and Gemini native
-  `inlineData`, with no media echo in response metadata.
+  inline `data` or Files API `uri`, with no media echo in response metadata.
+- Inline and asset-backed media admission, exact-limit and one-unit-above
+  provider boundaries, tenant isolation, asset expiry and deletion, and
+  provider file cleanup.
 - Malformed, digest-mismatched, misplaced, unsupported-model, and
-  compatibility-route media rejection before any upstream request, plus the
-  existing bounded-body `413` response.
+  compatibility-route media rejection before any upstream request.
 - Deadline exhaustion and nonrecoverable safety, refusal, tool, malformed,
   missing, and unknown signals, proving partial text is never exposed as a
   failure response.
@@ -677,5 +714,5 @@ Black-box router tests cover:
 - SiliconFlow dictation routing.
 - Configured text model routing without code changes.
 - Invalid configured model catalog startup failures, including noncanonical,
-  duplicate, and adapter-incompatible `media_inputs`.
+  duplicate, and adapter-incompatible `media_inputs` or `media_limits`.
 - Existing OpenAI dictation and response-format tests.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -171,6 +171,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/TenantClientKey'
         - $ref: '#/components/parameters/AssetSHA256'
+        - $ref: '#/components/parameters/RequestTimeout'
       requestBody:
         $ref: '#/components/requestBodies/AssetUpload'
       responses:
@@ -182,6 +183,10 @@ paths:
           $ref: '#/components/responses/ProxyForbidden'
         '413':
           $ref: '#/components/responses/AssetFailure'
+        '499':
+          $ref: '#/components/responses/CallerClosed'
+        '504':
+          $ref: '#/components/responses/ProxyTimeout'
         '500':
           $ref: '#/components/responses/AssetFailure'
   /model/v1/assets/{asset_id}:
@@ -1007,12 +1012,18 @@ components:
               - $ref: '#/components/schemas/AssetErrorEnvelope'
     AssetCreated:
       description: The asset is available to its authenticated tenant.
+      headers:
+        X-LLM-Proxy-Request-Timeout-Seconds:
+          $ref: '#/components/headers/ResolvedRequestTimeout'
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/TenantAsset'
     AssetFailure:
       description: The asset operation failed with a stable safe code.
+      headers:
+        X-LLM-Proxy-Request-Timeout-Seconds:
+          $ref: '#/components/headers/OptionalResolvedRequestTimeout'
       content:
         application/json:
           schema:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -110,7 +110,15 @@ paths:
     post:
       operationId: postV2Messages
       summary: Generate text from canonical messages
-      description: The current messages-only operation. `messages` is required. User messages may include provider-neutral ordered image or audio attachments with canonical base64 bytes and matching SHA-256 digests. `model`, `web_search`, `max_tokens`, and `reasoning_effort` are optional. Omitting `reasoning_effort` selects the tenant or route default; an explicitly supplied value must be non-blank and supported by the resolved provider/model route. Unsupported media or route capabilities return the canonical plain-text 400 error response before an upstream call.
+      description: >-
+        The current messages-only operation. `messages` is required. User
+        messages may include ordered inline or tenant-asset-backed image and
+        audio attachments. `model`, `web_search`, `max_tokens`, and
+        `reasoning_effort` are optional. Omitting `reasoning_effort` selects
+        the tenant or route default. A supplied value must be non-blank and
+        supported by the resolved route. The selected provider offering owns
+        media admission and transport limits. Unsupported media or route
+        capabilities return HTTP 400 before an upstream call.
       tags:
         - Proxy
       security:
@@ -128,9 +136,13 @@ paths:
         '200':
           $ref: '#/components/responses/TextSuccess'
         '400':
-          $ref: '#/components/responses/ProxyBadRequest'
+          $ref: '#/components/responses/V2BadRequest'
         '403':
           $ref: '#/components/responses/ProxyForbidden'
+        '404':
+          $ref: '#/components/responses/AssetFailure'
+        '410':
+          $ref: '#/components/responses/AssetFailure'
         '413':
           $ref: '#/components/responses/ProxyPayloadTooLarge'
         '429':
@@ -143,6 +155,57 @@ paths:
           $ref: '#/components/responses/ProxyUnavailable'
         '504':
           $ref: '#/components/responses/ProxyTimeout'
+        '500':
+          $ref: '#/components/responses/AssetFailure'
+  /model/v1/assets:
+    post:
+      operationId: uploadTenantAsset
+      summary: Upload exact tenant media bytes
+      description: >-
+        Stores one hash-bound image or audio asset for the configured retention
+        period. The authenticated tenant owns the returned opaque asset id.
+      tags:
+        - Proxy
+      security:
+        - TenantClientKey: []
+      parameters:
+        - $ref: '#/components/parameters/TenantClientKey'
+        - $ref: '#/components/parameters/AssetSHA256'
+      requestBody:
+        $ref: '#/components/requestBodies/AssetUpload'
+      responses:
+        '201':
+          $ref: '#/components/responses/AssetCreated'
+        '400':
+          $ref: '#/components/responses/AssetFailure'
+        '403':
+          $ref: '#/components/responses/ProxyForbidden'
+        '413':
+          $ref: '#/components/responses/AssetFailure'
+        '500':
+          $ref: '#/components/responses/AssetFailure'
+  /model/v1/assets/{asset_id}:
+    delete:
+      operationId: deleteTenantAsset
+      summary: Delete one tenant asset
+      tags:
+        - Proxy
+      security:
+        - TenantClientKey: []
+      parameters:
+        - $ref: '#/components/parameters/TenantClientKey'
+        - $ref: '#/components/parameters/AssetID'
+      responses:
+        '204':
+          description: The asset is deleted.
+        '403':
+          $ref: '#/components/responses/ProxyForbidden'
+        '404':
+          $ref: '#/components/responses/AssetFailure'
+        '410':
+          $ref: '#/components/responses/AssetFailure'
+        '500':
+          $ref: '#/components/responses/AssetFailure'
   /dictate:
     post:
       operationId: postDictation
@@ -713,6 +776,22 @@ components:
       schema:
         type: integer
         minimum: 1
+    AssetSHA256:
+      name: X-LLM-Proxy-Asset-SHA256
+      in: header
+      required: true
+      description: Lowercase hexadecimal SHA-256 of the exact request body.
+      schema:
+        type: string
+        pattern: ^[0-9a-f]{64}$
+    AssetID:
+      name: asset_id
+      in: path
+      required: true
+      description: Opaque tenant asset identifier.
+      schema:
+        type: string
+        pattern: ^ast_[0-9a-f]{32}$
     TenantID:
       name: tenant_id
       in: path
@@ -796,6 +875,33 @@ components:
           encoding:
             audio:
               contentType: audio/*,application/octet-stream
+    AssetUpload:
+      required: true
+      content:
+        image/jpeg:
+          schema:
+            type: string
+            format: binary
+        image/png:
+          schema:
+            type: string
+            format: binary
+        image/webp:
+          schema:
+            type: string
+            format: binary
+        audio/m4a:
+          schema:
+            type: string
+            format: binary
+        audio/mpeg:
+          schema:
+            type: string
+            format: binary
+        audio/wav:
+          schema:
+            type: string
+            format: binary
     TenantNameRequest:
       required: true
       content:
@@ -874,7 +980,7 @@ components:
             type: string
             const: unknown client key
     ProxyPayloadTooLarge:
-      description: The configured JSON request or dictation audio payload limit was exceeded.
+      description: The compatibility JSON request limit, dictation audio limit, tenant asset limit, or selected provider media limit was exceeded.
       headers:
         X-LLM-Proxy-Request-Timeout-Seconds:
           $ref: '#/components/headers/ResolvedRequestTimeout'
@@ -882,6 +988,35 @@ components:
         text/plain:
           schema:
             type: string
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProviderErrorEnvelope'
+    V2BadRequest:
+      description: The canonical message input or referenced asset is invalid.
+      headers:
+        X-LLM-Proxy-Request-Timeout-Seconds:
+          $ref: '#/components/headers/OptionalResolvedRequestTimeout'
+      content:
+        text/plain:
+          schema:
+            type: string
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/ProxyErrorEnvelope'
+              - $ref: '#/components/schemas/AssetErrorEnvelope'
+    AssetCreated:
+      description: The asset is available to its authenticated tenant.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TenantAsset'
+    AssetFailure:
+      description: The asset operation failed with a stable safe code.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AssetErrorEnvelope'
     ProxyRateLimited:
       description: The selected upstream provider returned HTTP 429. The proxy preserves 429 at its public boundary and returns only sanitized provider metadata; it never exposes the raw provider body or message.
       headers:
@@ -1333,6 +1468,7 @@ components:
         - reasoning_efforts
         - controls
         - limits
+        - media_limits
       properties:
         identifier:
           type: string
@@ -1382,6 +1518,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PublicCatalogLimit'
+        media_limits:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicCatalogMediaLimit'
     PublicCatalogControl:
       type: object
       additionalProperties: false
@@ -1442,6 +1582,64 @@ components:
           minLength: 1
         account_dependent:
           type: boolean
+    PublicCatalogMediaLimit:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - media_type
+        - transport
+        - status
+        - value
+        - unit
+        - scope
+        - source
+        - last_verified
+      properties:
+        id:
+          type: string
+          minLength: 1
+        media_type:
+          type: string
+          enum:
+            - all
+            - image
+            - audio
+        transport:
+          type: string
+          enum:
+            - any
+            - inline
+            - file
+        status:
+          type: string
+          enum:
+            - bounded
+            - unbounded
+            - unknown
+        value:
+          oneOf:
+            - type: integer
+              minimum: 1
+            - type: 'null'
+        unit:
+          type: string
+          enum:
+            - bytes
+            - files
+        scope:
+          type: string
+          enum:
+            - attachment
+            - request
+            - request_encoded_bytes
+        source:
+          type: string
+          format: uri
+          pattern: '^https://'
+        last_verified:
+          type: string
+          format: date
     PublicPriceDescriptor:
       type: object
       additionalProperties: false
@@ -1606,6 +1804,8 @@ components:
       oneOf:
         - $ref: '#/components/schemas/ImageMessageAttachment'
         - $ref: '#/components/schemas/AudioMessageAttachment'
+        - $ref: '#/components/schemas/ImageAssetMessageAttachment'
+        - $ref: '#/components/schemas/AudioAssetMessageAttachment'
     ImageMessageAttachment:
       type: object
       additionalProperties: false
@@ -1658,6 +1858,117 @@ components:
           type: string
           pattern: ^[0-9a-f]{64}$
           description: Lowercase hexadecimal SHA-256 of the decoded media bytes.
+    ImageAssetMessageAttachment:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - mime_type
+        - asset_id
+        - sha256
+      properties:
+        type:
+          type: string
+          const: image
+        mime_type:
+          type: string
+          enum:
+            - image/jpeg
+            - image/png
+            - image/webp
+        asset_id:
+          type: string
+          pattern: ^ast_[0-9a-f]{32}$
+        sha256:
+          type: string
+          pattern: ^[0-9a-f]{64}$
+    AudioAssetMessageAttachment:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - mime_type
+        - asset_id
+        - sha256
+      properties:
+        type:
+          type: string
+          const: audio
+        mime_type:
+          type: string
+          enum:
+            - audio/m4a
+            - audio/mpeg
+            - audio/wav
+        asset_id:
+          type: string
+          pattern: ^ast_[0-9a-f]{32}$
+        sha256:
+          type: string
+          pattern: ^[0-9a-f]{64}$
+    TenantAsset:
+      type: object
+      additionalProperties: false
+      required:
+        - asset_id
+        - mime_type
+        - size_bytes
+        - sha256
+        - state
+        - created_at
+        - expires_at
+      properties:
+        asset_id:
+          type: string
+          pattern: ^ast_[0-9a-f]{32}$
+        mime_type:
+          type: string
+          enum:
+            - image/jpeg
+            - image/png
+            - image/webp
+            - audio/m4a
+            - audio/mpeg
+            - audio/wav
+        size_bytes:
+          type: integer
+          format: int64
+          minimum: 1
+        sha256:
+          type: string
+          pattern: ^[0-9a-f]{64}$
+        state:
+          type: string
+          const: available
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+    AssetErrorEnvelope:
+      type: object
+      additionalProperties: false
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          additionalProperties: false
+          required:
+            - code
+          properties:
+            code:
+              type: string
+              enum:
+                - asset_invalid
+                - asset_not_found
+                - asset_expired
+                - asset_deleted
+                - asset_mime_mismatch
+                - asset_digest_mismatch
+                - asset_too_large
+                - asset_store_error
     V2ChatMessage:
       description: A user message that may carry attachments, or a text-only system or assistant message.
       oneOf:
@@ -1900,6 +2211,7 @@ components:
               type: string
               enum:
                 - provider_error
+                - provider_media_limit_exceeded
                 - provider_rate_limited
             provider:
               type: string

--- a/internal/proxy/assets.go
+++ b/internal/proxy/assets.go
@@ -89,6 +89,8 @@ type tenantAssetStore struct {
 	retention     time.Duration
 	now           func() time.Time
 	mutex         sync.Mutex
+	initialized   bool
+	cleanupError  error
 }
 
 var (
@@ -100,9 +102,11 @@ var (
 	assetRename     = os.Rename
 	assetRemove     = os.Remove
 	assetOpen       = os.Open
+	assetReadDir    = os.ReadDir
 	assetStat       = func(file *os.File) (os.FileInfo, error) { return file.Stat() }
 	assetSeek       = func(file *os.File, offset int64, whence int) (int64, error) { return file.Seek(offset, whence) }
 	assetWrite      = func(file *os.File, data []byte) (int, error) { return file.Write(data) }
+	assetAfterFunc  = time.AfterFunc
 )
 
 func newTenantAssetStore(root string, maxAssetBytes int64, retentionSeconds int) *tenantAssetStore {
@@ -119,12 +123,10 @@ func (store *tenantAssetStore) upload(requestTenant tenant, mimeType string, exp
 		return tenantAssetMetadata{}, errAssetInvalid
 	}
 	store.mutex.Lock()
-	defer store.mutex.Unlock()
-	if directoryError := assetMkdirAll(store.root, assetDirectoryMode); directoryError != nil {
-		return tenantAssetMetadata{}, fmt.Errorf("%w: create directory", errAssetStore)
-	}
-	if chmodError := assetChmod(store.root, assetDirectoryMode); chmodError != nil {
-		return tenantAssetMetadata{}, fmt.Errorf("%w: set directory mode", errAssetStore)
+	initializationError := store.initializeLocked()
+	store.mutex.Unlock()
+	if initializationError != nil {
+		return tenantAssetMetadata{}, initializationError
 	}
 	temporaryFile, temporaryError := assetCreateTemp(store.root, ".asset-upload-*")
 	if temporaryError != nil {
@@ -152,6 +154,11 @@ func (store *tenantAssetStore) upload(requestTenant tenant, mimeType string, exp
 	if !bytes.Equal([]byte(actualDigest), []byte(expectedDigest)) {
 		return tenantAssetMetadata{}, errAssetDigestMismatch
 	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	if store.cleanupError != nil {
+		return tenantAssetMetadata{}, store.cleanupError
+	}
 	assetID := newAssetIdentifier()
 	createdAt := store.now().UTC()
 	metadata := tenantAssetMetadata{
@@ -173,6 +180,7 @@ func (store *tenantAssetStore) upload(requestTenant tenant, mimeType string, exp
 		assetRemove(dataPath)
 		return tenantAssetMetadata{}, metadataError
 	}
+	store.scheduleExpirationLocked(metadata)
 	return metadata, nil
 }
 
@@ -181,33 +189,45 @@ func (store *tenantAssetStore) resolve(requestTenant tenant, assetID string, exp
 		return nil, errAssetInvalid
 	}
 	store.mutex.Lock()
-	defer store.mutex.Unlock()
+	if initializationError := store.initializeLocked(); initializationError != nil {
+		store.mutex.Unlock()
+		return nil, initializationError
+	}
 	metadata, metadataError := store.readMetadata(assetID)
 	if metadataError != nil {
+		store.mutex.Unlock()
 		return nil, metadataError
 	}
 	if metadata.TenantID != requestTenant.identifier.string() {
+		store.mutex.Unlock()
 		return nil, errAssetNotFound
 	}
 	if metadata.State == assetStateDeleted {
+		store.mutex.Unlock()
 		return nil, errAssetDeleted
 	}
 	if !store.now().UTC().Before(metadata.ExpiresAt) {
 		if removeError := assetRemove(store.dataPath(assetID)); removeError != nil && !errors.Is(removeError, os.ErrNotExist) {
+			store.mutex.Unlock()
 			return nil, errAssetStore
 		}
+		store.mutex.Unlock()
 		return nil, errAssetExpired
 	}
 	if metadata.MIMEType != expectedMIMEType {
+		store.mutex.Unlock()
 		return nil, errAssetMIMEMismatch
 	}
 	if metadata.SHA256 != expectedDigest {
+		store.mutex.Unlock()
 		return nil, errAssetDigestMismatch
 	}
 	dataFile, openError := assetOpen(store.dataPath(assetID))
 	if openError != nil {
+		store.mutex.Unlock()
 		return nil, errAssetStore
 	}
+	store.mutex.Unlock()
 	valid := false
 	defer func() {
 		if !valid {
@@ -238,6 +258,9 @@ func (store *tenantAssetStore) delete(requestTenant tenant, assetID string) erro
 	}
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
+	if initializationError := store.initializeLocked(); initializationError != nil {
+		return initializationError
+	}
 	metadata, metadataError := store.readMetadata(assetID)
 	if metadataError != nil {
 		return metadataError
@@ -267,6 +290,84 @@ func (store *tenantAssetStore) delete(requestTenant tenant, assetID string) erro
 		return errAssetStore
 	}
 	return nil
+}
+
+func (store *tenantAssetStore) initializeLocked() error {
+	if store.cleanupError != nil {
+		return store.cleanupError
+	}
+	if store.initialized {
+		return nil
+	}
+	if directoryError := assetMkdirAll(store.root, assetDirectoryMode); directoryError != nil {
+		return fmt.Errorf("%w: create directory", errAssetStore)
+	}
+	if chmodError := assetChmod(store.root, assetDirectoryMode); chmodError != nil {
+		return fmt.Errorf("%w: set directory mode", errAssetStore)
+	}
+	entries, readDirectoryError := assetReadDir(store.root)
+	if readDirectoryError != nil {
+		return fmt.Errorf("%w: read directory", errAssetStore)
+	}
+	availableAssets := make([]tenantAssetMetadata, 0)
+	for _, entry := range entries {
+		entryName := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(entryName, ".json") {
+			continue
+		}
+		assetID := strings.TrimSuffix(entryName, ".json")
+		if !assetIdentifierPattern.MatchString(assetID) {
+			continue
+		}
+		metadata, metadataError := store.readMetadata(assetID)
+		if metadataError != nil {
+			return metadataError
+		}
+		if metadata.State == assetStateDeleted || !store.now().UTC().Before(metadata.ExpiresAt) {
+			if removeError := assetRemove(store.dataPath(assetID)); removeError != nil && !errors.Is(removeError, os.ErrNotExist) {
+				return fmt.Errorf("%w: reclaim asset", errAssetStore)
+			}
+			continue
+		}
+		availableAssets = append(availableAssets, metadata)
+	}
+	store.initialized = true
+	for _, metadata := range availableAssets {
+		store.scheduleExpirationLocked(metadata)
+	}
+	return nil
+}
+
+func (store *tenantAssetStore) scheduleExpirationLocked(metadata tenantAssetMetadata) {
+	delay := metadata.ExpiresAt.Sub(store.now().UTC())
+	if delay < 0 {
+		delay = 0
+	}
+	assetAfterFunc(delay, func() {
+		store.expireAsset(metadata.AssetID, metadata.ExpiresAt)
+	})
+}
+
+func (store *tenantAssetStore) expireAsset(assetID string, expectedExpiry time.Time) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	if store.cleanupError != nil {
+		return
+	}
+	metadata, metadataError := store.readMetadata(assetID)
+	if errors.Is(metadataError, errAssetNotFound) {
+		return
+	}
+	if metadataError != nil {
+		store.cleanupError = metadataError
+		return
+	}
+	if metadata.ExpiresAt != expectedExpiry || metadata.State == assetStateDeleted || store.now().UTC().Before(metadata.ExpiresAt) {
+		return
+	}
+	if removeError := assetRemove(store.dataPath(assetID)); removeError != nil && !errors.Is(removeError, os.ErrNotExist) {
+		store.cleanupError = fmt.Errorf("%w: expire asset", errAssetStore)
+	}
 }
 
 func (store *tenantAssetStore) readMetadata(assetID string) (tenantAssetMetadata, error) {
@@ -352,9 +453,13 @@ func tenantAssetUploadHandler(store *tenantAssetStore) gin.HandlerFunc {
 			ginContext.Request.Body,
 		)
 		if uploadError != nil {
+			if requestContextEnded(ginContext) {
+				return
+			}
 			writeTenantAssetError(ginContext, uploadError)
 			return
 		}
+		markRequestOutcome(ginContext, requestOutcomeSuccess, managedUsageOutcomeSuccess)
 		ginContext.JSON(http.StatusCreated, tenantAssetResponse{
 			AssetID: metadata.AssetID, MIMEType: metadata.MIMEType, SizeBytes: metadata.SizeBytes,
 			SHA256: metadata.SHA256, State: metadata.State, CreatedAt: metadata.CreatedAt, ExpiresAt: metadata.ExpiresAt,

--- a/internal/proxy/assets.go
+++ b/internal/proxy/assets.go
@@ -1,0 +1,399 @@
+package proxy
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tyemirov/llm-proxy/internal/constants"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
+)
+
+const (
+	assetMetadataVersion = 1
+	assetStateAvailable  = "available"
+	assetStateDeleted    = "deleted"
+	assetFileMode        = 0o600
+	assetDirectoryMode   = 0o700
+)
+
+var (
+	errAssetInvalid        = errors.New("asset_invalid")
+	errAssetNotFound       = errors.New("asset_not_found")
+	errAssetExpired        = errors.New("asset_expired")
+	errAssetDeleted        = errors.New("asset_deleted")
+	errAssetMIMEMismatch   = errors.New("asset_mime_mismatch")
+	errAssetDigestMismatch = errors.New("asset_digest_mismatch")
+	errAssetTooLarge       = errors.New("asset_too_large")
+	errAssetStore          = errors.New("asset_store_error")
+
+	assetIdentifierPattern = regexp.MustCompile(`^ast_[0-9a-f]{32}$`)
+)
+
+type tenantAssetMetadata struct {
+	Version   int        `json:"version"`
+	AssetID   string     `json:"asset_id"`
+	TenantID  string     `json:"tenant_id"`
+	MIMEType  string     `json:"mime_type"`
+	SizeBytes int64      `json:"size_bytes"`
+	SHA256    string     `json:"sha256"`
+	State     string     `json:"state"`
+	CreatedAt time.Time  `json:"created_at"`
+	ExpiresAt time.Time  `json:"expires_at"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+}
+
+type tenantAssetResponse struct {
+	AssetID   string    `json:"asset_id"`
+	MIMEType  string    `json:"mime_type"`
+	SizeBytes int64     `json:"size_bytes"`
+	SHA256    string    `json:"sha256"`
+	State     string    `json:"state"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type tenantAssetErrorEnvelope struct {
+	Error tenantAssetErrorDetail `json:"error"`
+}
+
+type tenantAssetErrorDetail struct {
+	Code string `json:"code"`
+}
+
+type tenantAssetReader struct {
+	metadata tenantAssetMetadata
+	file     *os.File
+}
+
+func (reader *tenantAssetReader) Close() error {
+	return reader.file.Close()
+}
+
+type tenantAssetStore struct {
+	root          string
+	maxAssetBytes int64
+	retention     time.Duration
+	now           func() time.Time
+	mutex         sync.Mutex
+}
+
+var (
+	assetMkdirAll   = os.MkdirAll
+	assetChmod      = os.Chmod
+	assetCreateTemp = os.CreateTemp
+	assetCopy       = io.Copy
+	assetClose      = func(file *os.File) error { return file.Close() }
+	assetRename     = os.Rename
+	assetRemove     = os.Remove
+	assetOpen       = os.Open
+	assetStat       = func(file *os.File) (os.FileInfo, error) { return file.Stat() }
+	assetSeek       = func(file *os.File, offset int64, whence int) (int64, error) { return file.Seek(offset, whence) }
+	assetWrite      = func(file *os.File, data []byte) (int, error) { return file.Write(data) }
+)
+
+func newTenantAssetStore(root string, maxAssetBytes int64, retentionSeconds int) *tenantAssetStore {
+	return &tenantAssetStore{
+		root:          root,
+		maxAssetBytes: maxAssetBytes,
+		retention:     time.Duration(retentionSeconds) * time.Second,
+		now:           time.Now,
+	}
+}
+
+func (store *tenantAssetStore) upload(requestTenant tenant, mimeType string, expectedDigest string, source io.Reader) (tenantAssetMetadata, error) {
+	if !supportedMessageMediaMIME(mimeType) || !canonicalSHA256(expectedDigest) {
+		return tenantAssetMetadata{}, errAssetInvalid
+	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	if directoryError := assetMkdirAll(store.root, assetDirectoryMode); directoryError != nil {
+		return tenantAssetMetadata{}, fmt.Errorf("%w: create directory", errAssetStore)
+	}
+	if chmodError := assetChmod(store.root, assetDirectoryMode); chmodError != nil {
+		return tenantAssetMetadata{}, fmt.Errorf("%w: set directory mode", errAssetStore)
+	}
+	temporaryFile, temporaryError := assetCreateTemp(store.root, ".asset-upload-*")
+	if temporaryError != nil {
+		return tenantAssetMetadata{}, fmt.Errorf("%w: create temporary file", errAssetStore)
+	}
+	temporaryPath := temporaryFile.Name()
+	defer assetRemove(temporaryPath)
+	if chmodError := assetChmod(temporaryPath, assetFileMode); chmodError != nil {
+		assetClose(temporaryFile)
+		return tenantAssetMetadata{}, fmt.Errorf("%w: set file mode", errAssetStore)
+	}
+	hasher := sha256.New()
+	written, copyError := assetCopy(io.MultiWriter(temporaryFile, hasher), io.LimitReader(source, store.maxAssetBytes+1))
+	closeError := assetClose(temporaryFile)
+	if copyError != nil || closeError != nil {
+		return tenantAssetMetadata{}, fmt.Errorf("%w: write asset", errAssetStore)
+	}
+	if written == 0 {
+		return tenantAssetMetadata{}, errAssetInvalid
+	}
+	if written > store.maxAssetBytes {
+		return tenantAssetMetadata{}, errAssetTooLarge
+	}
+	actualDigest := hex.EncodeToString(hasher.Sum(nil))
+	if !bytes.Equal([]byte(actualDigest), []byte(expectedDigest)) {
+		return tenantAssetMetadata{}, errAssetDigestMismatch
+	}
+	assetID := newAssetIdentifier()
+	createdAt := store.now().UTC()
+	metadata := tenantAssetMetadata{
+		Version:   assetMetadataVersion,
+		AssetID:   assetID,
+		TenantID:  requestTenant.identifier.string(),
+		MIMEType:  mimeType,
+		SizeBytes: written,
+		SHA256:    actualDigest,
+		State:     assetStateAvailable,
+		CreatedAt: createdAt,
+		ExpiresAt: createdAt.Add(store.retention),
+	}
+	dataPath := store.dataPath(assetID)
+	if renameError := assetRename(temporaryPath, dataPath); renameError != nil {
+		return tenantAssetMetadata{}, fmt.Errorf("%w: publish data", errAssetStore)
+	}
+	if metadataError := store.writeMetadata(metadata); metadataError != nil {
+		assetRemove(dataPath)
+		return tenantAssetMetadata{}, metadataError
+	}
+	return metadata, nil
+}
+
+func (store *tenantAssetStore) resolve(requestTenant tenant, assetID string, expectedMIMEType string, expectedDigest string) (*tenantAssetReader, error) {
+	if !assetIdentifierPattern.MatchString(assetID) || !supportedMessageMediaMIME(expectedMIMEType) || !canonicalSHA256(expectedDigest) {
+		return nil, errAssetInvalid
+	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	metadata, metadataError := store.readMetadata(assetID)
+	if metadataError != nil {
+		return nil, metadataError
+	}
+	if metadata.TenantID != requestTenant.identifier.string() {
+		return nil, errAssetNotFound
+	}
+	if metadata.State == assetStateDeleted {
+		return nil, errAssetDeleted
+	}
+	if !store.now().UTC().Before(metadata.ExpiresAt) {
+		if removeError := assetRemove(store.dataPath(assetID)); removeError != nil && !errors.Is(removeError, os.ErrNotExist) {
+			return nil, errAssetStore
+		}
+		return nil, errAssetExpired
+	}
+	if metadata.MIMEType != expectedMIMEType {
+		return nil, errAssetMIMEMismatch
+	}
+	if metadata.SHA256 != expectedDigest {
+		return nil, errAssetDigestMismatch
+	}
+	dataFile, openError := assetOpen(store.dataPath(assetID))
+	if openError != nil {
+		return nil, errAssetStore
+	}
+	valid := false
+	defer func() {
+		if !valid {
+			assetClose(dataFile)
+		}
+	}()
+	fileInfo, statError := assetStat(dataFile)
+	if statError != nil || !fileInfo.Mode().IsRegular() || fileInfo.Size() != metadata.SizeBytes {
+		return nil, errAssetStore
+	}
+	hasher := sha256.New()
+	if _, hashError := assetCopy(hasher, dataFile); hashError != nil {
+		return nil, errAssetStore
+	}
+	if hex.EncodeToString(hasher.Sum(nil)) != metadata.SHA256 {
+		return nil, errAssetStore
+	}
+	if _, seekError := assetSeek(dataFile, 0, io.SeekStart); seekError != nil {
+		return nil, errAssetStore
+	}
+	valid = true
+	return &tenantAssetReader{metadata: metadata, file: dataFile}, nil
+}
+
+func (store *tenantAssetStore) delete(requestTenant tenant, assetID string) error {
+	if !assetIdentifierPattern.MatchString(assetID) {
+		return errAssetNotFound
+	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	metadata, metadataError := store.readMetadata(assetID)
+	if metadataError != nil {
+		return metadataError
+	}
+	if metadata.TenantID != requestTenant.identifier.string() {
+		return errAssetNotFound
+	}
+	if metadata.State == assetStateDeleted {
+		if removeError := assetRemove(store.dataPath(assetID)); removeError != nil && !errors.Is(removeError, os.ErrNotExist) {
+			return errAssetStore
+		}
+		return errAssetDeleted
+	}
+	if !store.now().UTC().Before(metadata.ExpiresAt) {
+		if removeError := assetRemove(store.dataPath(assetID)); removeError != nil && !errors.Is(removeError, os.ErrNotExist) {
+			return errAssetStore
+		}
+		return errAssetExpired
+	}
+	deletedAt := store.now().UTC()
+	metadata.State = assetStateDeleted
+	metadata.DeletedAt = &deletedAt
+	if metadataError := store.writeMetadata(metadata); metadataError != nil {
+		return metadataError
+	}
+	if removeError := assetRemove(store.dataPath(assetID)); removeError != nil && !errors.Is(removeError, os.ErrNotExist) {
+		return errAssetStore
+	}
+	return nil
+}
+
+func (store *tenantAssetStore) readMetadata(assetID string) (tenantAssetMetadata, error) {
+	metadataFile, openError := assetOpen(store.metadataPath(assetID))
+	if errors.Is(openError, os.ErrNotExist) {
+		return tenantAssetMetadata{}, errAssetNotFound
+	}
+	if openError != nil {
+		return tenantAssetMetadata{}, errAssetStore
+	}
+	defer assetClose(metadataFile)
+	var metadata tenantAssetMetadata
+	decoder := json.NewDecoder(io.LimitReader(metadataFile, 4097))
+	decoder.DisallowUnknownFields()
+	if decodeError := decoder.Decode(&metadata); decodeError != nil {
+		return tenantAssetMetadata{}, errAssetStore
+	}
+	if trailingError := decoder.Decode(&struct{}{}); !errors.Is(trailingError, io.EOF) {
+		return tenantAssetMetadata{}, errAssetStore
+	}
+	validState := metadata.State == assetStateAvailable && metadata.DeletedAt == nil
+	validState = validState || (metadata.State == assetStateDeleted && metadata.DeletedAt != nil && !metadata.DeletedAt.Before(metadata.CreatedAt))
+	if metadata.Version != assetMetadataVersion || metadata.AssetID != assetID || metadata.TenantID == constants.EmptyString || !supportedMessageMediaMIME(metadata.MIMEType) || metadata.SizeBytes <= 0 || !canonicalSHA256(metadata.SHA256) || metadata.CreatedAt.IsZero() || !metadata.ExpiresAt.After(metadata.CreatedAt) || !validState {
+		return tenantAssetMetadata{}, errAssetStore
+	}
+	return metadata, nil
+}
+
+func (store *tenantAssetStore) writeMetadata(metadata tenantAssetMetadata) error {
+	metadataBytes, _ := json.Marshal(metadata)
+	temporaryFile, temporaryError := assetCreateTemp(store.root, ".asset-metadata-*")
+	if temporaryError != nil {
+		return errAssetStore
+	}
+	temporaryPath := temporaryFile.Name()
+	defer assetRemove(temporaryPath)
+	if chmodError := assetChmod(temporaryPath, assetFileMode); chmodError != nil {
+		assetClose(temporaryFile)
+		return errAssetStore
+	}
+	if _, writeError := assetWrite(temporaryFile, metadataBytes); writeError != nil {
+		assetClose(temporaryFile)
+		return errAssetStore
+	}
+	if closeError := assetClose(temporaryFile); closeError != nil {
+		return errAssetStore
+	}
+	if renameError := assetRename(temporaryPath, store.metadataPath(metadata.AssetID)); renameError != nil {
+		return errAssetStore
+	}
+	return nil
+}
+
+func (store *tenantAssetStore) dataPath(assetID string) string {
+	return filepath.Join(store.root, assetID+".data")
+}
+
+func (store *tenantAssetStore) metadataPath(assetID string) string {
+	return filepath.Join(store.root, assetID+".json")
+}
+
+func newAssetIdentifier() string {
+	randomBytes := make([]byte, 16)
+	_, _ = rand.Read(randomBytes)
+	return "ast_" + hex.EncodeToString(randomBytes)
+}
+
+func canonicalSHA256(rawDigest string) bool {
+	digestBytes, digestError := hex.DecodeString(rawDigest)
+	return digestError == nil && len(digestBytes) == sha256.Size && strings.ToLower(rawDigest) == rawDigest
+}
+
+func tenantAssetUploadHandler(store *tenantAssetStore) gin.HandlerFunc {
+	return func(ginContext *gin.Context) {
+		if ginContext.Request.ContentLength > store.maxAssetBytes {
+			writeTenantAssetError(ginContext, errAssetTooLarge)
+			return
+		}
+		metadata, uploadError := store.upload(
+			authenticatedTenantFromContext(ginContext),
+			strings.TrimSpace(ginContext.GetHeader(headerContentType)),
+			strings.TrimSpace(ginContext.GetHeader(llmproxycontract.HeaderAssetSHA256)),
+			ginContext.Request.Body,
+		)
+		if uploadError != nil {
+			writeTenantAssetError(ginContext, uploadError)
+			return
+		}
+		ginContext.JSON(http.StatusCreated, tenantAssetResponse{
+			AssetID: metadata.AssetID, MIMEType: metadata.MIMEType, SizeBytes: metadata.SizeBytes,
+			SHA256: metadata.SHA256, State: metadata.State, CreatedAt: metadata.CreatedAt, ExpiresAt: metadata.ExpiresAt,
+		})
+	}
+}
+
+func tenantAssetDeleteHandler(store *tenantAssetStore) gin.HandlerFunc {
+	return func(ginContext *gin.Context) {
+		if deleteError := store.delete(authenticatedTenantFromContext(ginContext), ginContext.Param("asset_id")); deleteError != nil {
+			writeTenantAssetError(ginContext, deleteError)
+			return
+		}
+		ginContext.Status(http.StatusNoContent)
+	}
+}
+
+func writeTenantAssetError(ginContext *gin.Context, assetError error) {
+	statusCode := http.StatusBadRequest
+	code := errAssetInvalid.Error()
+	switch {
+	case errors.Is(assetError, errAssetNotFound):
+		statusCode, code = http.StatusNotFound, errAssetNotFound.Error()
+	case errors.Is(assetError, errAssetExpired):
+		statusCode, code = http.StatusGone, errAssetExpired.Error()
+	case errors.Is(assetError, errAssetDeleted):
+		statusCode, code = http.StatusGone, errAssetDeleted.Error()
+	case errors.Is(assetError, errAssetMIMEMismatch):
+		code = errAssetMIMEMismatch.Error()
+	case errors.Is(assetError, errAssetDigestMismatch):
+		code = errAssetDigestMismatch.Error()
+	case errors.Is(assetError, errAssetTooLarge):
+		statusCode, code = http.StatusRequestEntityTooLarge, errAssetTooLarge.Error()
+	case errors.Is(assetError, errAssetStore):
+		statusCode, code = http.StatusInternalServerError, errAssetStore.Error()
+	}
+	ginContext.JSON(statusCode, tenantAssetErrorEnvelope{Error: tenantAssetErrorDetail{Code: code}})
+}
+
+func isTenantAssetError(assetError error) bool {
+	return errors.Is(assetError, errAssetInvalid) || errors.Is(assetError, errAssetNotFound) || errors.Is(assetError, errAssetExpired) || errors.Is(assetError, errAssetDeleted) || errors.Is(assetError, errAssetMIMEMismatch) || errors.Is(assetError, errAssetDigestMismatch) || errors.Is(assetError, errAssetTooLarge) || errors.Is(assetError, errAssetStore)
+}

--- a/internal/proxy/catalog_service.go
+++ b/internal/proxy/catalog_service.go
@@ -194,6 +194,7 @@ func cloneProviderOffering(offering ProviderOffering) ProviderOffering {
 	cloned.Operations = append([]string(nil), offering.Operations...)
 	cloned.DefaultOperations = append([]string(nil), offering.DefaultOperations...)
 	cloned.MediaInputs = append([]string(nil), offering.MediaInputs...)
+	cloned.MediaLimits = cloneCatalogMediaLimits(offering.MediaLimits)
 	if offering.ReasoningEffort != nil {
 		cloned.ReasoningEffort = &ReasoningEffortCapability{
 			Adapter: offering.ReasoningEffort.Adapter,

--- a/internal/proxy/chat_messages.go
+++ b/internal/proxy/chat_messages.go
@@ -73,8 +73,13 @@ func newPayloadChatMessages(payloadMessages []chatMessagePayload, defaultSystemP
 	return newCandidateChatMessages(candidates, defaultSystemPrompt, requestSystemPrompt)
 }
 
-func newV2PayloadChatMessages(payloadMessages []chatV2MessagePayload, defaultSystemPrompt string) (chatMessages, error) {
+func newV2PayloadChatMessages(payloadMessages []chatV2MessagePayload, defaultSystemPrompt string, requestTenant tenant, assetStore *tenantAssetStore) (messages chatMessages, messagesError error) {
 	candidates := make([]chatMessageCandidate, 0, len(payloadMessages))
+	defer func() {
+		if messagesError != nil {
+			chatMessagesFromCandidates(candidates).closeMedia()
+		}
+	}()
 	for messageIndex, payloadMessage := range payloadMessages {
 		attachmentPayloads, attachmentsError := decodeChatMessageAttachments(payloadMessage.Attachments)
 		if attachmentsError != nil {
@@ -82,8 +87,9 @@ func newV2PayloadChatMessages(payloadMessages []chatV2MessagePayload, defaultSys
 		}
 		attachments := make([]messageMedia, 0, len(attachmentPayloads))
 		for attachmentIndex, attachmentPayload := range attachmentPayloads {
-			attachment, attachmentError := newMessageMedia(attachmentPayload)
+			attachment, attachmentError := newMessageMedia(attachmentPayload, requestTenant, assetStore)
 			if attachmentError != nil {
+				candidates = append(candidates, chatMessageCandidate{attachments: attachments})
 				return nil, fmt.Errorf("messages[%d].attachments[%d]: %w", messageIndex, attachmentIndex, attachmentError)
 			}
 			attachments = append(attachments, attachment)
@@ -96,6 +102,14 @@ func newV2PayloadChatMessages(payloadMessages []chatV2MessagePayload, defaultSys
 		})
 	}
 	return newCandidateChatMessages(candidates, defaultSystemPrompt, constants.EmptyString)
+}
+
+func chatMessagesFromCandidates(candidates []chatMessageCandidate) chatMessages {
+	messages := make(chatMessages, 0, len(candidates))
+	for _, candidate := range candidates {
+		messages = append(messages, chatMessage{attachments: candidate.attachments})
+	}
+	return messages
 }
 
 func decodeChatMessageAttachments(rawAttachments json.RawMessage) ([]chatMessageAttachmentPayload, error) {

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/mail"
+	"path/filepath"
 	"strings"
 
 	"github.com/tyemirov/llm-proxy/internal/constants"
@@ -30,7 +31,13 @@ const (
 	// DefaultMaxRequestTimeoutSeconds is the one-hour operator capacity ceiling for a request.
 	DefaultMaxRequestTimeoutSeconds = 60 * 60
 	// DefaultMaxPromptBytes limits JSON LLM request bodies accepted by POST /.
-	DefaultMaxPromptBytes      = 4 * 1024 * 1024
+	DefaultMaxPromptBytes = 4 * 1024 * 1024
+	// DefaultMaxAssetBytes bounds one tenant asset upload at the largest supported provider file size.
+	DefaultMaxAssetBytes int64 = 2_000_000_000
+	// DefaultAssetRetentionSeconds keeps uploaded tenant assets for 48 hours.
+	DefaultAssetRetentionSeconds = 48 * 60 * 60
+	// DefaultAssetStorePath is the persistent filesystem location for tenant assets.
+	DefaultAssetStorePath      = "/data/assets"
 	DefaultDictationModel      = "gpt-4o-mini-transcribe"
 	DefaultMaxInputAudioBytes  = 25 * 1024 * 1024
 	DefaultManagementJWTIssuer = "tauth"
@@ -77,6 +84,9 @@ type Configuration struct {
 	RequestTimeoutSeconds        int
 	MaxRequestTimeoutSeconds     int
 	MaxPromptBytes               int64
+	MaxAssetBytes                int64
+	AssetRetentionSeconds        int
+	AssetStorePath               string
 	MaxInputAudioBytes           int64
 	UpstreamRateLimits           []UpstreamRateLimitConfiguration
 	Endpoints                    *Endpoints
@@ -152,6 +162,9 @@ func ensureValidatedConfiguration(configuration Configuration) (Configuration, e
 }
 
 func validateConfig(configuration Configuration) (tenantRegistry, error) {
+	if !filepath.IsAbs(configuration.AssetStorePath) || filepath.Clean(configuration.AssetStorePath) != configuration.AssetStorePath {
+		return tenantRegistry{}, fmt.Errorf("invalid asset_store_path")
+	}
 	if managementValidationError := validateManagementConfiguration(configuration.Management); managementValidationError != nil {
 		return tenantRegistry{}, managementValidationError
 	}
@@ -225,6 +238,16 @@ func (configuration *Configuration) ApplyTunables() {
 	}
 	if configuration.MaxPromptBytes <= 0 {
 		configuration.MaxPromptBytes = DefaultMaxPromptBytes
+	}
+	if configuration.MaxAssetBytes <= 0 {
+		configuration.MaxAssetBytes = DefaultMaxAssetBytes
+	}
+	if configuration.AssetRetentionSeconds <= 0 {
+		configuration.AssetRetentionSeconds = DefaultAssetRetentionSeconds
+	}
+	configuration.AssetStorePath = strings.TrimSpace(configuration.AssetStorePath)
+	if configuration.AssetStorePath == constants.EmptyString {
+		configuration.AssetStorePath = DefaultAssetStorePath
 	}
 	if configuration.MaxInputAudioBytes <= 0 {
 		configuration.MaxInputAudioBytes = DefaultMaxInputAudioBytes

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -346,7 +346,14 @@ func TestCoverageFormatsAndRequestEdges(t *testing.T) {
 		}
 	})
 
-	t.Run("v2 json body rejects oversized payload", func(subTest *testing.T) {
+	t.Run("v2 json body is independent from the compatibility prompt limit", func(subTest *testing.T) {
+		upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = responseWriter.Write([]byte(`{"status":"completed","output_text":"accepted"}`))
+		}))
+		defer upstreamServer.Close()
+		endpoints := proxy.NewEndpoints()
+		endpoints.SetResponsesURL(upstreamServer.URL)
 		smallRouter := coverageRouter(subTest, proxy.Configuration{
 			Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
 			OpenAIKey:             TestAPIKey,
@@ -355,12 +362,13 @@ func TestCoverageFormatsAndRequestEdges(t *testing.T) {
 			QueueSize:             1,
 			RequestTimeoutSeconds: TestTimeout,
 			MaxPromptBytes:        4,
+			Endpoints:             endpoints,
 		})
 		request := httptest.NewRequest(http.MethodPost, "/v2?key="+TestSecret, strings.NewReader(`{"messages":[{"role":"user","content":"hello"}]}`))
 		request.Header.Set("Content-Type", "application/json")
 		responseRecorder := httptest.NewRecorder()
 		smallRouter.ServeHTTP(responseRecorder, request)
-		if responseRecorder.Code != http.StatusRequestEntityTooLarge {
+		if responseRecorder.Code != http.StatusOK {
 			subTest.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
 		}
 	})

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -133,7 +133,19 @@ func (client *geminiInteractionsClient) generateText(parentContext context.Conte
 	background := executionLifecycle == textExecutionLifecyclePollableResource
 	payload, uploadedFiles, payloadError := client.prepareInteractionPayload(parentContext, apiKey, baseURL, modelIdentifier, messages, maxTokens, background)
 	if len(uploadedFiles) > 0 {
-		defer client.releaseGeminiFiles(parentContext, apiKey, baseURL, uploadedFiles, structuredLogger)
+		defer func() {
+			cleanupError := client.releaseGeminiFiles(parentContext, apiKey, baseURL, uploadedFiles)
+			if cleanupError == nil {
+				return
+			}
+			client.logFileCleanupError(cleanupError, structuredLogger)
+			generation = textGenerationResult{usage: generation.usage}
+			if errors.Is(generationError, errProviderOutputLimitReached) {
+				generationError = cleanupError
+				return
+			}
+			generationError = errors.Join(generationError, cleanupError)
+		}()
 	}
 	if payloadError != nil {
 		return textGenerationResult{}, payloadError
@@ -308,6 +320,13 @@ func (client *geminiInteractionsClient) logInteractionCleanupError(cleanupError 
 	)
 }
 
+func (client *geminiInteractionsClient) logFileCleanupError(cleanupError error, structuredLogger *zap.SugaredLogger) {
+	structuredLogger.Errorw(
+		"Gemini file cleanup error",
+		constants.LogFieldError, cleanupError,
+	)
+}
+
 func (client *geminiInteractionsClient) prepareInteractionPayload(parentContext context.Context, apiKey string, baseURL string, model textModelDefinition, messages chatMessages, maxTokens *int, background bool) (geminiInteractionRequest, []geminiUploadedFile, error) {
 	inlineLimit, hasInlineLimit := catalogMediaLimit(model.mediaLimits, CatalogMediaLimitIDInlineRequestBytes, messageMediaTypeImage)
 	mediaCount := messages.mediaCount()
@@ -342,10 +361,12 @@ func (client *geminiInteractionsClient) prepareInteractionPayload(parentContext 
 				return geminiInteractionRequest{}, uploadedFiles, limitError
 			}
 			uploadedFile, uploadError := client.uploadGeminiFile(parentContext, apiKey, baseURL, attachment)
+			if uploadedFile.name != constants.EmptyString {
+				uploadedFiles = append(uploadedFiles, uploadedFile)
+			}
 			if uploadError != nil {
 				return geminiInteractionRequest{}, uploadedFiles, uploadError
 			}
-			uploadedFiles = append(uploadedFiles, uploadedFile)
 			mediaURIs = append(mediaURIs, uploadedFile.uri)
 		}
 	}
@@ -461,23 +482,25 @@ func (client *geminiInteractionsClient) uploadGeminiFile(parentContext context.C
 	if parseError != nil {
 		return geminiUploadedFile{}, parseError
 	}
+	uploadedFile := geminiUploadedFile{name: file.Name, uri: file.URI}
 	for file.State == geminiFileStateProcessing {
 		waitTimer := time.NewTimer(geminiFilePollInterval)
 		select {
 		case <-parentContext.Done():
 			waitTimer.Stop()
-			return geminiUploadedFile{}, parentContext.Err()
+			return uploadedFile, parentContext.Err()
 		case <-waitTimer.C:
 		}
 		file, parseError = client.getGeminiFile(parentContext, apiKey, baseURL, file.Name, attachment)
 		if parseError != nil {
-			return geminiUploadedFile{}, parseError
+			return uploadedFile, parseError
 		}
+		uploadedFile = geminiUploadedFile{name: file.Name, uri: file.URI}
 	}
 	if file.State != geminiFileStateActive {
-		return geminiUploadedFile{}, ErrProviderAPI
+		return uploadedFile, ErrProviderAPI
 	}
-	return geminiUploadedFile{name: file.Name, uri: file.URI}, nil
+	return uploadedFile, nil
 }
 
 func (client *geminiInteractionsClient) getGeminiFile(parentContext context.Context, apiKey string, baseURL string, fileName string, attachment *messageMedia) (geminiFile, error) {
@@ -544,11 +567,12 @@ func (client *geminiInteractionsClient) performGeminiFileRequest(request *http.R
 	return responseBytes, response.Header, nil
 }
 
-func (client *geminiInteractionsClient) releaseGeminiFiles(parentContext context.Context, apiKey string, baseURL string, files []geminiUploadedFile, structuredLogger *zap.SugaredLogger) {
+func (client *geminiInteractionsClient) releaseGeminiFiles(parentContext context.Context, apiKey string, baseURL string, files []geminiUploadedFile) error {
+	cleanupErrors := make([]error, 0)
 	for _, file := range files {
 		requestURL, urlError := geminiFileResourceURL(baseURL, file.name)
 		if urlError != nil {
-			structuredLogger.Errorw("Gemini file cleanup error")
+			cleanupErrors = append(cleanupErrors, urlError)
 			continue
 		}
 		cleanupContext, cancelCleanup := context.WithTimeout(context.WithoutCancel(parentContext), geminiInteractionCleanupTimeout)
@@ -559,9 +583,10 @@ func (client *geminiInteractionsClient) releaseGeminiFiles(parentContext context
 		}
 		cancelCleanup()
 		if buildError != nil {
-			structuredLogger.Errorw("Gemini file cleanup error")
+			cleanupErrors = append(cleanupErrors, buildError)
 		}
 	}
+	return errors.Join(cleanupErrors...)
 }
 
 func geminiFilesUploadURL(baseURL string) string {

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +31,23 @@ const (
 	geminiInteractionStepModelOutput      = "model_output"
 	geminiInteractionContentText          = "text"
 	geminiInteractionCleanupTimeout       = 5 * time.Second
+	geminiFileStateActive                 = "ACTIVE"
+	geminiFileStateProcessing             = "PROCESSING"
+	geminiFilePollInterval                = 500 * time.Millisecond
+)
+
+var geminiFileNamePattern = regexp.MustCompile(`^files/[A-Za-z0-9_-]+$`)
+
+const (
+	geminiUploadProtocolHeader     = "X-Goog-Upload-Protocol"
+	geminiUploadCommandHeader      = "X-Goog-Upload-Command"
+	geminiUploadHeaderLengthHeader = "X-Goog-Upload-Header-Content-Length"
+	geminiUploadHeaderTypeHeader   = "X-Goog-Upload-Header-Content-Type"
+	geminiUploadOffsetHeader       = "X-Goog-Upload-Offset"
+	geminiUploadURLHeader          = "X-Goog-Upload-URL"
+	geminiUploadProtocolResumable  = "resumable"
+	geminiUploadCommandStart       = "start"
+	geminiUploadCommandFinalize    = "upload, finalize"
 )
 
 type geminiInteractionsClient struct {
@@ -63,7 +83,26 @@ type geminiInteractionContent struct {
 	Type     string `json:"type"`
 	Text     string `json:"text,omitempty"`
 	Data     string `json:"data,omitempty"`
+	URI      string `json:"uri,omitempty"`
 	MIMEType string `json:"mime_type,omitempty"`
+}
+
+type geminiFileResponse struct {
+	File geminiFile `json:"file"`
+}
+
+type geminiFile struct {
+	Name       string `json:"name"`
+	MIMEType   string `json:"mimeType"`
+	SizeBytes  string `json:"sizeBytes"`
+	SHA256Hash string `json:"sha256Hash"`
+	URI        string `json:"uri"`
+	State      string `json:"state"`
+}
+
+type geminiUploadedFile struct {
+	name string
+	uri  string
 }
 
 type geminiInteractionResponse struct {
@@ -91,17 +130,13 @@ func newGeminiInteractionsClient(httpClient HTTPDoer) *geminiInteractionsClient 
 }
 
 func (client *geminiInteractionsClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier textModelDefinition, messages chatMessages, maxTokens *int, executionLifecycle textExecutionLifecycle, structuredLogger *zap.SugaredLogger) (generation textGenerationResult, generationError error) {
-	input, systemInstruction := messages.geminiInteractionInput()
 	background := executionLifecycle == textExecutionLifecyclePollableResource
-	payload := geminiInteractionRequest{
-		Model:             modelIdentifier.providerString(),
-		Input:             input,
-		SystemInstruction: systemInstruction,
-		Background:        background,
-		Store:             background,
+	payload, uploadedFiles, payloadError := client.prepareInteractionPayload(parentContext, apiKey, baseURL, modelIdentifier, messages, maxTokens, background)
+	if len(uploadedFiles) > 0 {
+		defer client.releaseGeminiFiles(parentContext, apiKey, baseURL, uploadedFiles, structuredLogger)
 	}
-	if maxTokens != nil {
-		payload.GenerationConfig = &geminiInteractionGeneration{MaxOutputTokens: *maxTokens}
+	if payloadError != nil {
+		return textGenerationResult{}, payloadError
 	}
 
 	snapshot, createError := client.createInteraction(parentContext, apiKey, baseURL, payload, structuredLogger)
@@ -242,10 +277,28 @@ func (client *geminiInteractionsClient) performInteractionRequest(parentContext 
 	}
 
 	statusCode, responseBytes, responseHeader, _, requestError := utils.PerformHTTPRequest(client.httpClient.Do, httpRequest, structuredLogger, logEventProviderRequestError)
+	if statusCode == http.StatusRequestEntityTooLarge && geminiInteractionPayloadHasMedia(payload) {
+		return nil, newProviderMediaLimitHTTPError(statusCode, responseHeader)
+	}
 	if responseError := providerResponseError(statusCode, responseHeader, requestError); responseError != nil {
 		return nil, responseError
 	}
 	return responseBytes, nil
+}
+
+func geminiInteractionPayloadHasMedia(payload any) bool {
+	interaction, isInteraction := payload.(geminiInteractionRequest)
+	if !isInteraction {
+		return false
+	}
+	for _, step := range interaction.Input {
+		for _, content := range step.Content {
+			if content.Type == string(messageMediaTypeImage) || content.Type == string(messageMediaTypeAudio) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (client *geminiInteractionsClient) logInteractionCleanupError(cleanupError error, structuredLogger *zap.SugaredLogger) {
@@ -255,9 +308,299 @@ func (client *geminiInteractionsClient) logInteractionCleanupError(cleanupError 
 	)
 }
 
-func (messages chatMessages) geminiInteractionInput() ([]geminiInteractionStep, string) {
+func (client *geminiInteractionsClient) prepareInteractionPayload(parentContext context.Context, apiKey string, baseURL string, model textModelDefinition, messages chatMessages, maxTokens *int, background bool) (geminiInteractionRequest, []geminiUploadedFile, error) {
+	inlineLimit, hasInlineLimit := catalogMediaLimit(model.mediaLimits, CatalogMediaLimitIDInlineRequestBytes, messageMediaTypeImage)
+	mediaCount := messages.mediaCount()
+	if mediaCount == 0 {
+		payload, payloadError := newGeminiInteractionRequest(model, messages, nil, maxTokens, background)
+		return payload, nil, payloadError
+	}
+	if !hasInlineLimit {
+		return geminiInteractionRequest{}, nil, ErrProviderMediaLimit
+	}
+	if countError := validateGeminiMediaCounts(model, messages); countError != nil {
+		return geminiInteractionRequest{}, nil, countError
+	}
+	inlinePossible := inlineLimit.Status != CatalogMediaLimitStatusBounded || messages.base64MediaBytes() < *inlineLimit.Value
+	if inlinePossible {
+		inlinePayload, payloadError := newGeminiInteractionRequest(model, messages, nil, maxTokens, background)
+		if payloadError != nil {
+			return geminiInteractionRequest{}, nil, payloadError
+		}
+		payloadBytes, _ := json.Marshal(inlinePayload)
+		if inlineLimit.Status != CatalogMediaLimitStatusBounded || int64(len(payloadBytes)) <= *inlineLimit.Value {
+			return inlinePayload, nil, nil
+		}
+	}
+
+	uploadedFiles := make([]geminiUploadedFile, 0, mediaCount)
+	mediaURIs := make([]string, 0, mediaCount)
+	for messageIndex := range messages {
+		for attachmentIndex := range messages[messageIndex].attachments {
+			attachment := &messages[messageIndex].attachments[attachmentIndex]
+			if limitError := validateGeminiFileLimit(model, attachment); limitError != nil {
+				return geminiInteractionRequest{}, uploadedFiles, limitError
+			}
+			uploadedFile, uploadError := client.uploadGeminiFile(parentContext, apiKey, baseURL, attachment)
+			if uploadError != nil {
+				return geminiInteractionRequest{}, uploadedFiles, uploadError
+			}
+			uploadedFiles = append(uploadedFiles, uploadedFile)
+			mediaURIs = append(mediaURIs, uploadedFile.uri)
+		}
+	}
+	payload, payloadError := newGeminiInteractionRequest(model, messages, mediaURIs, maxTokens, background)
+	return payload, uploadedFiles, payloadError
+}
+
+func newGeminiInteractionRequest(model textModelDefinition, messages chatMessages, mediaURIs []string, maxTokens *int, background bool) (geminiInteractionRequest, error) {
+	input, systemInstruction, inputError := messages.geminiInteractionInput(mediaURIs)
+	if inputError != nil {
+		return geminiInteractionRequest{}, inputError
+	}
+	payload := geminiInteractionRequest{
+		Model:             model.providerString(),
+		Input:             input,
+		SystemInstruction: systemInstruction,
+		Background:        background,
+		Store:             background,
+	}
+	if maxTokens != nil {
+		payload.GenerationConfig = &geminiInteractionGeneration{MaxOutputTokens: *maxTokens}
+	}
+	return payload, nil
+}
+
+func (messages chatMessages) mediaCount() int {
+	count := 0
+	for _, message := range messages {
+		count += len(message.attachments)
+	}
+	return count
+}
+
+func (messages chatMessages) mediaTypeCount(mediaType messageMediaType) int64 {
+	var count int64
+	for _, message := range messages {
+		for _, attachment := range message.attachments {
+			if attachment.mediaType == mediaType {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func (messages chatMessages) base64MediaBytes() int64 {
+	var encodedBytes int64
+	for _, message := range messages {
+		for _, attachment := range message.attachments {
+			encodedBytes += ((attachment.sizeBytes + 2) / 3) * 4
+		}
+	}
+	return encodedBytes
+}
+
+func validateGeminiMediaCounts(model textModelDefinition, messages chatMessages) error {
+	for _, mediaType := range []messageMediaType{messageMediaTypeImage, messageMediaTypeAudio} {
+		limitID := CatalogMediaLimitIDImageCount
+		if mediaType == messageMediaTypeAudio {
+			limitID = CatalogMediaLimitIDAudioCount
+		}
+		limit, bounded := boundedCatalogMediaLimit(model.mediaLimits, limitID, mediaType)
+		if bounded && messages.mediaTypeCount(mediaType) > limit {
+			return ErrProviderMediaLimit
+		}
+	}
+	return nil
+}
+
+func validateGeminiFileLimit(model textModelDefinition, attachment *messageMedia) error {
+	limitID := CatalogMediaLimitIDImageFileBytes
+	if attachment.mediaType == messageMediaTypeAudio {
+		limitID = CatalogMediaLimitIDAudioFileBytes
+	}
+	limit, bounded := boundedCatalogMediaLimit(model.mediaLimits, limitID, attachment.mediaType)
+	if bounded && attachment.sizeBytes > limit {
+		return ErrProviderMediaLimit
+	}
+	return nil
+}
+
+func (client *geminiInteractionsClient) uploadGeminiFile(parentContext context.Context, apiKey string, baseURL string, attachment *messageMedia) (geminiUploadedFile, error) {
+	startPayload := []byte(`{"file":{"display_name":"llm-proxy-media"}}`)
+	startRequest, _ := http.NewRequestWithContext(parentContext, http.MethodPost, geminiFilesUploadURL(baseURL), bytes.NewReader(startPayload))
+	startRequest.Header.Set(geminiAPIKeyHeader, strings.TrimSpace(apiKey))
+	startRequest.Header.Set(headerContentType, mimeApplicationJSON)
+	startRequest.Header.Set(geminiUploadProtocolHeader, geminiUploadProtocolResumable)
+	startRequest.Header.Set(geminiUploadCommandHeader, geminiUploadCommandStart)
+	startRequest.Header.Set(geminiUploadHeaderLengthHeader, strconv.FormatInt(attachment.sizeBytes, 10))
+	startRequest.Header.Set(geminiUploadHeaderTypeHeader, attachment.mimeType)
+	_, startHeader, startError := client.performGeminiFileRequest(startRequest)
+	if startError != nil {
+		return geminiUploadedFile{}, startError
+	}
+	uploadURL := strings.TrimSpace(startHeader.Get(geminiUploadURLHeader))
+	if !providerOwnedURL(uploadURL, baseURL) {
+		return geminiUploadedFile{}, ErrProviderAPI
+	}
+	mediaReader, readerError := attachment.reader()
+	if readerError != nil {
+		return geminiUploadedFile{}, readerError
+	}
+	uploadRequest, _ := http.NewRequestWithContext(parentContext, http.MethodPost, uploadURL, mediaReader)
+	uploadRequest.ContentLength = attachment.sizeBytes
+	uploadRequest.Header.Set(headerContentType, attachment.mimeType)
+	uploadRequest.Header.Set(geminiUploadCommandHeader, geminiUploadCommandFinalize)
+	uploadRequest.Header.Set(geminiUploadOffsetHeader, "0")
+	responseBytes, _, uploadError := client.performGeminiFileRequest(uploadRequest)
+	if uploadError != nil {
+		return geminiUploadedFile{}, uploadError
+	}
+	file, parseError := validatedGeminiFile(responseBytes, attachment, baseURL)
+	if parseError != nil {
+		return geminiUploadedFile{}, parseError
+	}
+	for file.State == geminiFileStateProcessing {
+		waitTimer := time.NewTimer(geminiFilePollInterval)
+		select {
+		case <-parentContext.Done():
+			waitTimer.Stop()
+			return geminiUploadedFile{}, parentContext.Err()
+		case <-waitTimer.C:
+		}
+		file, parseError = client.getGeminiFile(parentContext, apiKey, baseURL, file.Name, attachment)
+		if parseError != nil {
+			return geminiUploadedFile{}, parseError
+		}
+	}
+	if file.State != geminiFileStateActive {
+		return geminiUploadedFile{}, ErrProviderAPI
+	}
+	return geminiUploadedFile{name: file.Name, uri: file.URI}, nil
+}
+
+func (client *geminiInteractionsClient) getGeminiFile(parentContext context.Context, apiKey string, baseURL string, fileName string, attachment *messageMedia) (geminiFile, error) {
+	requestURL, urlError := geminiFileResourceURL(baseURL, fileName)
+	if urlError != nil {
+		return geminiFile{}, urlError
+	}
+	request, buildError := http.NewRequestWithContext(parentContext, http.MethodGet, requestURL, nil)
+	if buildError != nil {
+		return geminiFile{}, ErrProviderAPI
+	}
+	request.Header.Set(geminiAPIKeyHeader, strings.TrimSpace(apiKey))
+	responseBytes, _, requestError := client.performGeminiFileRequest(request)
+	if requestError != nil {
+		return geminiFile{}, requestError
+	}
+	var file geminiFile
+	if decodeError := json.Unmarshal(responseBytes, &file); decodeError != nil {
+		return geminiFile{}, ErrProviderAPI
+	}
+	return validatedGeminiFileObject(file, attachment, baseURL)
+}
+
+func validatedGeminiFile(responseBytes []byte, attachment *messageMedia, baseURL string) (geminiFile, error) {
+	var response geminiFileResponse
+	if decodeError := json.Unmarshal(responseBytes, &response); decodeError != nil {
+		return geminiFile{}, ErrProviderAPI
+	}
+	return validatedGeminiFileObject(response.File, attachment, baseURL)
+}
+
+func validatedGeminiFileObject(file geminiFile, attachment *messageMedia, baseURL string) (geminiFile, error) {
+	sizeBytes, sizeError := strconv.ParseInt(file.SizeBytes, 10, 64)
+	digestBytes, digestError := base64.StdEncoding.DecodeString(file.SHA256Hash)
+	expectedDigest, expectedDigestError := hex.DecodeString(attachment.sha256)
+	if sizeError != nil || sizeBytes != attachment.sizeBytes || digestError != nil || expectedDigestError != nil || !bytes.Equal(digestBytes, expectedDigest) || file.MIMEType != attachment.mimeType || !geminiFileNamePattern.MatchString(file.Name) || !providerOwnedFileURI(file.URI, baseURL, file.Name) {
+		return geminiFile{}, ErrProviderAPI
+	}
+	return file, nil
+}
+
+func (client *geminiInteractionsClient) performGeminiFileRequest(request *http.Request) ([]byte, http.Header, error) {
+	response, requestError := client.httpClient.Do(request)
+	if requestError != nil {
+		if contextError := request.Context().Err(); contextError != nil {
+			return nil, nil, contextError
+		}
+		if errors.Is(requestError, errQueueFull) {
+			return nil, nil, requestError
+		}
+		return nil, nil, ErrProviderAPI
+	}
+	defer response.Body.Close()
+	responseBytes, readError := io.ReadAll(io.LimitReader(response.Body, 1024*1024+1))
+	if readError != nil || len(responseBytes) > 1024*1024 {
+		return nil, nil, ErrProviderAPI
+	}
+	if response.StatusCode == http.StatusRequestEntityTooLarge {
+		return nil, response.Header, newProviderMediaLimitHTTPError(response.StatusCode, response.Header)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, response.Header, newProviderHTTPError(response.StatusCode, response.Header)
+	}
+	return responseBytes, response.Header, nil
+}
+
+func (client *geminiInteractionsClient) releaseGeminiFiles(parentContext context.Context, apiKey string, baseURL string, files []geminiUploadedFile, structuredLogger *zap.SugaredLogger) {
+	for _, file := range files {
+		requestURL, urlError := geminiFileResourceURL(baseURL, file.name)
+		if urlError != nil {
+			structuredLogger.Errorw("Gemini file cleanup error")
+			continue
+		}
+		cleanupContext, cancelCleanup := context.WithTimeout(context.WithoutCancel(parentContext), geminiInteractionCleanupTimeout)
+		request, buildError := http.NewRequestWithContext(cleanupContext, http.MethodDelete, requestURL, nil)
+		if buildError == nil {
+			request.Header.Set(geminiAPIKeyHeader, strings.TrimSpace(apiKey))
+			_, _, buildError = client.performGeminiFileRequest(request)
+		}
+		cancelCleanup()
+		if buildError != nil {
+			structuredLogger.Errorw("Gemini file cleanup error")
+		}
+	}
+}
+
+func geminiFilesUploadURL(baseURL string) string {
+	parsedURL, parseError := url.Parse(strings.TrimRight(strings.TrimSpace(baseURL), "/"))
+	if parseError != nil {
+		return constants.EmptyString
+	}
+	parsedURL.Path = strings.TrimSuffix(parsedURL.Path, "/v1beta") + "/upload/v1beta/files"
+	parsedURL.RawQuery = constants.EmptyString
+	parsedURL.Fragment = constants.EmptyString
+	return parsedURL.String()
+}
+
+func geminiFileResourceURL(baseURL string, fileName string) (string, error) {
+	identifier := strings.TrimPrefix(fileName, "files/")
+	if identifier == fileName || identifier == constants.EmptyString || strings.Contains(identifier, "/") {
+		return constants.EmptyString, ErrProviderAPI
+	}
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/files/" + url.PathEscape(identifier), nil
+}
+
+func providerOwnedURL(candidate string, baseURL string) bool {
+	candidateURL, candidateError := url.Parse(candidate)
+	providerURL, providerError := url.Parse(baseURL)
+	return candidateError == nil && providerError == nil && candidateURL.IsAbs() && candidateURL.Scheme == providerURL.Scheme && candidateURL.Host == providerURL.Host && candidateURL.User == nil && candidateURL.Fragment == constants.EmptyString
+}
+
+func providerOwnedFileURI(candidate string, baseURL string, fileName string) bool {
+	if !providerOwnedURL(candidate, baseURL) {
+		return false
+	}
+	candidateURL, parseError := url.Parse(candidate)
+	return parseError == nil && strings.HasSuffix(strings.TrimRight(candidateURL.Path, "/"), "/"+fileName)
+}
+
+func (messages chatMessages) geminiInteractionInput(mediaURIs []string) ([]geminiInteractionStep, string, error) {
 	input := make([]geminiInteractionStep, 0, len(messages))
 	systemInstructions := []string{}
+	mediaIndex := 0
 	for _, message := range messages {
 		if message.role == chatRoleSystem {
 			systemInstructions = append(systemInstructions, message.content)
@@ -272,16 +615,30 @@ func (messages chatMessages) geminiInteractionInput() ([]geminiInteractionStep, 
 			Type: geminiInteractionContentText,
 			Text: message.content,
 		}}
-		for _, attachment := range message.attachments {
-			content = append(content, geminiInteractionContent{
-				Type:     string(attachment.mediaType),
-				Data:     base64.StdEncoding.EncodeToString(attachment.data),
-				MIMEType: attachment.mimeType,
-			})
+		for attachmentIndex := range message.attachments {
+			attachment := &message.attachments[attachmentIndex]
+			mediaContent := geminiInteractionContent{Type: string(attachment.mediaType), MIMEType: attachment.mimeType}
+			if len(mediaURIs) > 0 {
+				if mediaIndex >= len(mediaURIs) {
+					return nil, constants.EmptyString, ErrProviderAPI
+				}
+				mediaContent.URI = mediaURIs[mediaIndex]
+			} else {
+				attachmentBytes, attachmentError := attachment.bytes()
+				if attachmentError != nil {
+					return nil, constants.EmptyString, attachmentError
+				}
+				mediaContent.Data = base64.StdEncoding.EncodeToString(attachmentBytes)
+			}
+			mediaIndex++
+			content = append(content, mediaContent)
 		}
 		input = append(input, geminiInteractionStep{Type: stepType, Content: content})
 	}
-	return input, strings.Join(systemInstructions, "\n\n")
+	if len(mediaURIs) > 0 && mediaIndex != len(mediaURIs) {
+		return nil, constants.EmptyString, ErrProviderAPI
+	}
+	return input, strings.Join(systemInstructions, "\n\n"), nil
 }
 
 func geminiInteractionsURL(baseURL string) string {

--- a/internal/proxy/gemini_media_edges_internal_test.go
+++ b/internal/proxy/gemini_media_edges_internal_test.go
@@ -11,8 +11,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"go.uber.org/zap"
 )
 
 type geminiEdgeDoer func(*http.Request) (*http.Response, error)
@@ -208,8 +206,9 @@ func TestGeminiFileUploadValidationAndPollingContracts(t *testing.T) {
 			cancelRequest()
 			return geminiEdgeResponse(http.StatusOK, strings.NewReader(fileJSON(geminiFileStateProcessing)), nil), nil
 		}))
-		if _, uploadError := client.uploadGeminiFile(requestContext, "key", baseURL, attachment); !errors.Is(uploadError, context.Canceled) {
-			subTest.Fatalf("error=%v", uploadError)
+		uploadedFile, uploadError := client.uploadGeminiFile(requestContext, "key", baseURL, attachment)
+		if !errors.Is(uploadError, context.Canceled) || uploadedFile.name != "files/media_1" {
+			subTest.Fatalf("file=%+v error=%v", uploadedFile, uploadError)
 		}
 	})
 
@@ -226,8 +225,9 @@ func TestGeminiFileUploadValidationAndPollingContracts(t *testing.T) {
 				return nil, errAssetEdge
 			}
 		}))
-		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment); !errors.Is(uploadError, ErrProviderAPI) {
-			subTest.Fatalf("error=%v", uploadError)
+		uploadedFile, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment)
+		if !errors.Is(uploadError, ErrProviderAPI) || uploadedFile.name != "files/media_1" {
+			subTest.Fatalf("file=%+v error=%v", uploadedFile, uploadError)
 		}
 	})
 
@@ -259,8 +259,9 @@ func TestGeminiFileUploadValidationAndPollingContracts(t *testing.T) {
 			}
 			return geminiEdgeResponse(http.StatusOK, strings.NewReader(fileJSON("FAILED")), nil), nil
 		}))
-		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment); !errors.Is(uploadError, ErrProviderAPI) {
-			subTest.Fatalf("error=%v", uploadError)
+		uploadedFile, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment)
+		if !errors.Is(uploadError, ErrProviderAPI) || uploadedFile.name != "files/media_1" {
+			subTest.Fatalf("file=%+v error=%v", uploadedFile, uploadError)
 		}
 	})
 
@@ -380,7 +381,9 @@ func TestGeminiFileResourceAndInteractionInputEdges(t *testing.T) {
 	}
 
 	cleanupClient := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) { return nil, errAssetEdge }))
-	cleanupClient.releaseGeminiFiles(context.Background(), "key", "https://provider.test", []geminiUploadedFile{{name: "bad"}, {name: "files/media"}}, zap.NewNop().Sugar())
+	if cleanupError := cleanupClient.releaseGeminiFiles(context.Background(), "key", "https://provider.test", []geminiUploadedFile{{name: "bad"}, {name: "files/media"}}); !errors.Is(cleanupError, ErrProviderAPI) {
+		t.Fatalf("cleanup error=%v", cleanupError)
+	}
 }
 
 func TestGeminiPrepareInteractionPayloadFailureContracts(t *testing.T) {
@@ -422,6 +425,51 @@ func TestGeminiPrepareInteractionPayloadFailureContracts(t *testing.T) {
 	}
 	if _, requestError := newGeminiInteractionRequest(textModelDefinition{}, messages, []string{"one", "two"}, nil, false); !errors.Is(requestError, ErrProviderAPI) {
 		t.Fatalf("request input error=%v", requestError)
+	}
+}
+
+func TestGeminiFinalizedFileIsCleanedAfterProcessingCancellation(t *testing.T) {
+	data := []byte("processing-media")
+	digest := sha256.Sum256(data)
+	attachment := messageMedia{mediaType: messageMediaTypeImage, mimeType: "image/png", sha256: hex.EncodeToString(digest[:]), sizeBytes: int64(len(data)), data: data}
+	messages := chatMessages{{role: chatRoleUser, content: "inspect", attachments: []messageMedia{attachment}}}
+	model := textModelDefinition{mediaLimits: []CatalogMediaLimit{
+		{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(1)},
+		{ID: CatalogMediaLimitIDImageCount, MediaType: "image", Status: CatalogMediaLimitStatusUnbounded},
+		{ID: CatalogMediaLimitIDImageFileBytes, MediaType: "image", Status: CatalogMediaLimitStatusUnbounded},
+	}}
+	requestContext, cancelRequest := context.WithCancel(context.Background())
+	calls := 0
+	cleanupCalls := 0
+	encodedDigest := base64.StdEncoding.EncodeToString(digest[:])
+	processingBody := `{"file":{"name":"files/processing","mimeType":"image/png","sizeBytes":"16","sha256Hash":"` + encodedDigest + `","uri":"https://provider.test/files/processing","state":"PROCESSING"}}`
+	if _, validationError := validatedGeminiFile([]byte(processingBody), &attachment, "https://provider.test"); validationError != nil {
+		t.Fatalf("processing file validation: %v", validationError)
+	}
+	startHeaders := http.Header{}
+	startHeaders.Set(geminiUploadURLHeader, "https://provider.test/upload-session")
+	client := newGeminiInteractionsClient(geminiEdgeDoer(func(request *http.Request) (*http.Response, error) {
+		calls++
+		switch calls {
+		case 1:
+			return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), startHeaders), nil
+		case 2:
+			cancelRequest()
+			return geminiEdgeResponse(http.StatusOK, strings.NewReader(processingBody), nil), nil
+		default:
+			if request.Method != http.MethodDelete || request.URL.Path != "/files/processing" || request.Context().Err() != nil {
+				t.Errorf("cleanup request method=%s path=%s context_error=%v", request.Method, request.URL.Path, request.Context().Err())
+			}
+			cleanupCalls++
+			return geminiEdgeResponse(http.StatusNoContent, strings.NewReader(""), nil), nil
+		}
+	}))
+	_, uploadedFiles, prepareError := client.prepareInteractionPayload(requestContext, "key", "https://provider.test", model, messages, nil, false)
+	if !errors.Is(prepareError, context.Canceled) || len(uploadedFiles) != 1 || uploadedFiles[0].name != "files/processing" {
+		t.Fatalf("calls=%d files=%+v error=%v", calls, uploadedFiles, prepareError)
+	}
+	if cleanupError := client.releaseGeminiFiles(requestContext, "key", "https://provider.test", uploadedFiles); cleanupError != nil || cleanupCalls != 1 {
+		t.Fatalf("cleanup_error=%v cleanup_calls=%d", cleanupError, cleanupCalls)
 	}
 }
 

--- a/internal/proxy/gemini_media_edges_internal_test.go
+++ b/internal/proxy/gemini_media_edges_internal_test.go
@@ -1,0 +1,434 @@
+package proxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+type geminiEdgeDoer func(*http.Request) (*http.Response, error)
+
+func (doer geminiEdgeDoer) Do(request *http.Request) (*http.Response, error) {
+	return doer(request)
+}
+
+type geminiErrorReader struct{}
+
+func (geminiErrorReader) Read([]byte) (int, error) {
+	return 0, errAssetEdge
+}
+
+func geminiEdgeResponse(status int, body io.Reader, headers http.Header) *http.Response {
+	if headers == nil {
+		headers = http.Header{}
+	}
+	return &http.Response{StatusCode: status, Body: io.NopCloser(body), Header: headers}
+}
+
+func TestGeminiFileRequestFailureContracts(t *testing.T) {
+	newRequest := func(requestContext context.Context) *http.Request {
+		request, requestError := http.NewRequestWithContext(requestContext, http.MethodGet, "https://provider.test/files/media", nil)
+		if requestError != nil {
+			t.Fatalf("request: %v", requestError)
+		}
+		return request
+	}
+
+	cancelledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	testCases := []struct {
+		name      string
+		context   context.Context
+		do        geminiEdgeDoer
+		wantError error
+	}{
+		{
+			name:      "context error",
+			context:   cancelledContext,
+			do:        func(*http.Request) (*http.Response, error) { return nil, errAssetEdge },
+			wantError: context.Canceled,
+		},
+		{
+			name:      "queue full",
+			context:   context.Background(),
+			do:        func(*http.Request) (*http.Response, error) { return nil, errQueueFull },
+			wantError: errQueueFull,
+		},
+		{
+			name:      "provider transport",
+			context:   context.Background(),
+			do:        func(*http.Request) (*http.Response, error) { return nil, errAssetEdge },
+			wantError: ErrProviderAPI,
+		},
+		{
+			name:    "read response",
+			context: context.Background(),
+			do: func(*http.Request) (*http.Response, error) {
+				return geminiEdgeResponse(http.StatusOK, geminiErrorReader{}, nil), nil
+			},
+			wantError: ErrProviderAPI,
+		},
+		{
+			name:    "oversized response",
+			context: context.Background(),
+			do: func(*http.Request) (*http.Response, error) {
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(strings.Repeat("x", 1024*1024+1)), nil), nil
+			},
+			wantError: ErrProviderAPI,
+		},
+		{
+			name:    "media limit",
+			context: context.Background(),
+			do: func(*http.Request) (*http.Response, error) {
+				return geminiEdgeResponse(http.StatusRequestEntityTooLarge, strings.NewReader("limit"), nil), nil
+			},
+			wantError: ErrProviderMediaLimit,
+		},
+		{
+			name:    "provider status",
+			context: context.Background(),
+			do: func(*http.Request) (*http.Response, error) {
+				return geminiEdgeResponse(http.StatusInternalServerError, strings.NewReader("failure"), nil), nil
+			},
+			wantError: ErrProviderAPI,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			client := newGeminiInteractionsClient(testCase.do)
+			_, _, requestError := client.performGeminiFileRequest(newRequest(testCase.context))
+			if !errors.Is(requestError, testCase.wantError) {
+				subTest.Fatalf("error=%v want=%v", requestError, testCase.wantError)
+			}
+		})
+	}
+	client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		return geminiEdgeResponse(http.StatusOK, strings.NewReader("ok"), http.Header{"X-Test": []string{"yes"}}), nil
+	}))
+	body, headers, requestError := client.performGeminiFileRequest(newRequest(context.Background()))
+	if requestError != nil || string(body) != "ok" || headers.Get("X-Test") != "yes" {
+		t.Fatalf("body=%q headers=%v error=%v", body, headers, requestError)
+	}
+}
+
+func TestGeminiFileUploadValidationAndPollingContracts(t *testing.T) {
+	baseURL := "https://provider.test/v1beta"
+	mediaBytes := []byte("gemini-file")
+	digestBytes := sha256.Sum256(mediaBytes)
+	digest := hex.EncodeToString(digestBytes[:])
+	encodedDigest := base64.StdEncoding.EncodeToString(digestBytes[:])
+	attachment := &messageMedia{mediaType: messageMediaTypeImage, mimeType: "image/png", sha256: digest, sizeBytes: int64(len(mediaBytes)), data: mediaBytes}
+	fileJSON := func(state string) string {
+		return `{"file":{"name":"files/media_1","mimeType":"image/png","sizeBytes":"11","sha256Hash":"` + encodedDigest + `","uri":"https://provider.test/v1beta/files/media_1","state":"` + state + `"}}`
+	}
+	directFileJSON := func(state string) string {
+		return `{"name":"files/media_1","mimeType":"image/png","sizeBytes":"11","sha256Hash":"` + encodedDigest + `","uri":"https://provider.test/v1beta/files/media_1","state":"` + state + `"}`
+	}
+	startHeaders := http.Header{}
+	startHeaders.Set(geminiUploadURLHeader, "https://provider.test/upload-session")
+
+	t.Run("start request failure", func(subTest *testing.T) {
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) { return nil, errAssetEdge }))
+		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment); !errors.Is(uploadError, ErrProviderAPI) {
+			subTest.Fatalf("error=%v", uploadError)
+		}
+	})
+
+	t.Run("foreign upload URL", func(subTest *testing.T) {
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+			return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), http.Header{geminiUploadURLHeader: []string{"https://foreign.test/upload"}}), nil
+		}))
+		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment); !errors.Is(uploadError, ErrProviderAPI) {
+			subTest.Fatalf("error=%v", uploadError)
+		}
+	})
+
+	t.Run("asset reader", func(subTest *testing.T) {
+		closedFile, fileError := os.CreateTemp(subTest.TempDir(), "closed")
+		if fileError != nil {
+			subTest.Fatalf("file: %v", fileError)
+		}
+		_ = closedFile.Close()
+		assetAttachment := *attachment
+		assetAttachment.data = nil
+		assetAttachment.asset = &tenantAssetReader{file: closedFile}
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+			return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), startHeaders), nil
+		}))
+		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, &assetAttachment); !errors.Is(uploadError, errAssetStore) {
+			subTest.Fatalf("error=%v", uploadError)
+		}
+	})
+
+	t.Run("upload request failure", func(subTest *testing.T) {
+		calls := 0
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), startHeaders), nil
+			}
+			return nil, errAssetEdge
+		}))
+		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment); !errors.Is(uploadError, ErrProviderAPI) {
+			subTest.Fatalf("error=%v", uploadError)
+		}
+	})
+
+	t.Run("invalid upload response", func(subTest *testing.T) {
+		calls := 0
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), startHeaders), nil
+			}
+			return geminiEdgeResponse(http.StatusOK, strings.NewReader("{"), nil), nil
+		}))
+		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment); !errors.Is(uploadError, ErrProviderAPI) {
+			subTest.Fatalf("error=%v", uploadError)
+		}
+	})
+
+	t.Run("processing cancellation", func(subTest *testing.T) {
+		requestContext, cancelRequest := context.WithCancel(context.Background())
+		calls := 0
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), startHeaders), nil
+			}
+			cancelRequest()
+			return geminiEdgeResponse(http.StatusOK, strings.NewReader(fileJSON(geminiFileStateProcessing)), nil), nil
+		}))
+		if _, uploadError := client.uploadGeminiFile(requestContext, "key", baseURL, attachment); !errors.Is(uploadError, context.Canceled) {
+			subTest.Fatalf("error=%v", uploadError)
+		}
+	})
+
+	t.Run("processing poll failure", func(subTest *testing.T) {
+		calls := 0
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+			calls++
+			switch calls {
+			case 1:
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), startHeaders), nil
+			case 2:
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(fileJSON(geminiFileStateProcessing)), nil), nil
+			default:
+				return nil, errAssetEdge
+			}
+		}))
+		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment); !errors.Is(uploadError, ErrProviderAPI) {
+			subTest.Fatalf("error=%v", uploadError)
+		}
+	})
+
+	t.Run("processing becomes active", func(subTest *testing.T) {
+		calls := 0
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+			calls++
+			switch calls {
+			case 1:
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), startHeaders), nil
+			case 2:
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(fileJSON(geminiFileStateProcessing)), nil), nil
+			default:
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(directFileJSON(geminiFileStateActive)), nil), nil
+			}
+		}))
+		uploadedFile, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment)
+		if uploadError != nil || uploadedFile.name != "files/media_1" {
+			subTest.Fatalf("file=%+v error=%v", uploadedFile, uploadError)
+		}
+	})
+
+	t.Run("terminal non-active state", func(subTest *testing.T) {
+		calls := 0
+		client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return geminiEdgeResponse(http.StatusOK, strings.NewReader(""), startHeaders), nil
+			}
+			return geminiEdgeResponse(http.StatusOK, strings.NewReader(fileJSON("FAILED")), nil), nil
+		}))
+		if _, uploadError := client.uploadGeminiFile(context.Background(), "key", baseURL, attachment); !errors.Is(uploadError, ErrProviderAPI) {
+			subTest.Fatalf("error=%v", uploadError)
+		}
+	})
+
+	if _, validationError := validatedGeminiFile([]byte("{"), attachment, baseURL); !errors.Is(validationError, ErrProviderAPI) {
+		t.Fatalf("decode validation error=%v", validationError)
+	}
+	validFile, validationError := validatedGeminiFile([]byte(fileJSON(geminiFileStateActive)), attachment, baseURL)
+	if validationError != nil || validFile.Name != "files/media_1" {
+		t.Fatalf("file=%+v error=%v", validFile, validationError)
+	}
+	invalidAttachment := *attachment
+	invalidAttachment.sha256 = "bad"
+	if _, validationError := validatedGeminiFileObject(validFile, &invalidAttachment, baseURL); !errors.Is(validationError, ErrProviderAPI) {
+		t.Fatalf("object validation error=%v", validationError)
+	}
+}
+
+func TestGeminiFileResourceAndInteractionInputEdges(t *testing.T) {
+	if geminiFilesUploadURL("%") != "" {
+		t.Fatal("invalid upload base URL accepted")
+	}
+	for _, fileName := range []string{"media", "files/", "files/a/b"} {
+		if _, resourceError := geminiFileResourceURL("https://provider.test", fileName); !errors.Is(resourceError, ErrProviderAPI) {
+			t.Fatalf("file=%q error=%v", fileName, resourceError)
+		}
+	}
+	resourceURL, resourceError := geminiFileResourceURL("https://provider.test", "files/media")
+	if resourceError != nil || resourceURL != "https://provider.test/files/media" {
+		t.Fatalf("url=%q error=%v", resourceURL, resourceError)
+	}
+	if providerOwnedFileURI("https://foreign.test/files/media", "https://provider.test", "files/media") {
+		t.Fatal("foreign file URI accepted")
+	}
+
+	client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		return nil, errAssetEdge
+	}))
+	attachmentData := []byte("a")
+	digest := sha256.Sum256(attachmentData)
+	attachment := &messageMedia{mediaType: messageMediaTypeAudio, mimeType: "audio/wav", sha256: hex.EncodeToString(digest[:]), sizeBytes: 1, data: attachmentData}
+	if _, getError := client.getGeminiFile(context.Background(), "key", "https://provider.test", "bad", attachment); !errors.Is(getError, ErrProviderAPI) {
+		t.Fatalf("invalid name error=%v", getError)
+	}
+	if _, getError := client.getGeminiFile(context.Background(), "key", "%", "files/media", attachment); !errors.Is(getError, ErrProviderAPI) {
+		t.Fatalf("invalid URL error=%v", getError)
+	}
+	if _, getError := client.getGeminiFile(context.Background(), "key", "https://provider.test", "files/media", attachment); !errors.Is(getError, ErrProviderAPI) {
+		t.Fatalf("request error=%v", getError)
+	}
+
+	client.httpClient = geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		return geminiEdgeResponse(http.StatusOK, strings.NewReader("{"), nil), nil
+	})
+	if _, getError := client.getGeminiFile(context.Background(), "key", "https://provider.test", "files/media", attachment); !errors.Is(getError, ErrProviderAPI) {
+		t.Fatalf("decode error=%v", getError)
+	}
+
+	fileDigest := base64.StdEncoding.EncodeToString(digest[:])
+	client.httpClient = geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		body := `{"name":"files/media","mimeType":"audio/wav","sizeBytes":"1","sha256Hash":"` + fileDigest + `","uri":"https://provider.test/files/media","state":"ACTIVE"}`
+		return geminiEdgeResponse(http.StatusOK, strings.NewReader(body), nil), nil
+	})
+	if file, getError := client.getGeminiFile(context.Background(), "key", "https://provider.test", "files/media", attachment); getError != nil || file.Name != "files/media" {
+		t.Fatalf("file=%+v error=%v", file, getError)
+	}
+
+	model := textModelDefinition{providerIdentifier: newModelID("models/gemini"), mediaLimits: []CatalogMediaLimit{
+		{ID: CatalogMediaLimitIDImageCount, MediaType: "image", Status: CatalogMediaLimitStatusUnbounded},
+		{ID: CatalogMediaLimitIDAudioCount, MediaType: "audio", Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(1)},
+		{ID: CatalogMediaLimitIDAudioFileBytes, MediaType: "audio", Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(1)},
+	}}
+	messages := chatMessages{{role: chatRoleSystem, content: "system"}, {role: chatRoleAssistant, content: "answer"}, {role: chatRoleUser, content: "listen", attachments: []messageMedia{*attachment, *attachment}}}
+	if countError := validateGeminiMediaCounts(model, messages); !errors.Is(countError, ErrProviderMediaLimit) {
+		t.Fatalf("count error=%v", countError)
+	}
+	largeAudio := *attachment
+	largeAudio.sizeBytes = 2
+	if limitError := validateGeminiFileLimit(model, &largeAudio); !errors.Is(limitError, ErrProviderMediaLimit) {
+		t.Fatalf("file limit error=%v", limitError)
+	}
+	if limitError := validateGeminiFileLimit(model, attachment); limitError != nil {
+		t.Fatalf("boundary file error=%v", limitError)
+	}
+
+	if _, _, inputError := messages.geminiInteractionInput([]string{"only-one"}); !errors.Is(inputError, ErrProviderAPI) {
+		t.Fatalf("URI count error=%v", inputError)
+	}
+	if _, _, inputError := messages.geminiInteractionInput([]string{"one", "two", "three"}); !errors.Is(inputError, ErrProviderAPI) {
+		t.Fatalf("extra URI error=%v", inputError)
+	}
+	if input, systemInstruction, inputError := messages.geminiInteractionInput([]string{"one", "two"}); inputError != nil || systemInstruction != "system" || len(input) != 2 || input[0].Type != geminiInteractionStepModelOutput {
+		t.Fatalf("input=%+v system=%q error=%v", input, systemInstruction, inputError)
+	}
+
+	closedFile, fileError := os.CreateTemp(t.TempDir(), "closed-input")
+	if fileError != nil {
+		t.Fatalf("file: %v", fileError)
+	}
+	_ = closedFile.Close()
+	closedMessages := chatMessages{{role: chatRoleUser, content: "listen", attachments: []messageMedia{{mediaType: messageMediaTypeAudio, mimeType: "audio/wav", sizeBytes: 1, asset: &tenantAssetReader{file: closedFile}}}}}
+	if _, _, inputError := closedMessages.geminiInteractionInput(nil); !errors.Is(inputError, errAssetStore) {
+		t.Fatalf("closed input error=%v", inputError)
+	}
+
+	if geminiInteractionPayloadHasMedia("not a payload") || geminiInteractionPayloadHasMedia(geminiInteractionRequest{}) {
+		t.Fatal("non-media payload classified as media")
+	}
+	if !geminiInteractionPayloadHasMedia(geminiInteractionRequest{Input: []geminiInteractionStep{{Content: []geminiInteractionContent{{Type: "audio"}}}}}) {
+		t.Fatal("audio payload not classified as media")
+	}
+	usage, usageError := parseGeminiInteractionTokenUsage(&geminiInteractionTokenUsage{TotalInputTokens: intPointer(1), TotalOutputTokens: intPointer(2), TotalTokens: intPointer(3)})
+	if usageError != nil || usage == nil {
+		t.Fatalf("usage=%+v error=%v", usage, usageError)
+	}
+	if nilUsage, usageError := parseGeminiInteractionTokenUsage(nil); usageError != nil || nilUsage != nil {
+		t.Fatalf("nil usage=%+v error=%v", nilUsage, usageError)
+	}
+
+	cleanupClient := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) { return nil, errAssetEdge }))
+	cleanupClient.releaseGeminiFiles(context.Background(), "key", "https://provider.test", []geminiUploadedFile{{name: "bad"}, {name: "files/media"}}, zap.NewNop().Sugar())
+}
+
+func TestGeminiPrepareInteractionPayloadFailureContracts(t *testing.T) {
+	data := []byte("media")
+	digest := sha256.Sum256(data)
+	inlineAttachment := messageMedia{mediaType: messageMediaTypeImage, mimeType: "image/png", sha256: hex.EncodeToString(digest[:]), sizeBytes: int64(len(data)), data: data}
+	messages := chatMessages{{role: chatRoleUser, content: "inspect", attachments: []messageMedia{inlineAttachment}}}
+	client := newGeminiInteractionsClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		return nil, errAssetEdge
+	}))
+	if _, _, prepareError := client.prepareInteractionPayload(context.Background(), "key", "https://provider.test", textModelDefinition{}, messages, nil, false); !errors.Is(prepareError, ErrProviderMediaLimit) {
+		t.Fatalf("missing inline limit error=%v", prepareError)
+	}
+
+	closedFile, fileError := os.CreateTemp(t.TempDir(), "closed-prepare")
+	if fileError != nil {
+		t.Fatalf("file: %v", fileError)
+	}
+	_ = closedFile.Close()
+	closedAttachment := inlineAttachment
+	closedAttachment.data = nil
+	closedAttachment.asset = &tenantAssetReader{file: closedFile}
+	unboundedModel := textModelDefinition{mediaLimits: []CatalogMediaLimit{
+		{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Status: CatalogMediaLimitStatusUnbounded},
+		{ID: CatalogMediaLimitIDImageCount, MediaType: "image", Status: CatalogMediaLimitStatusUnbounded},
+	}}
+	closedMessages := chatMessages{{role: chatRoleUser, content: "inspect", attachments: []messageMedia{closedAttachment}}}
+	if _, _, prepareError := client.prepareInteractionPayload(context.Background(), "key", "https://provider.test", unboundedModel, closedMessages, nil, false); !errors.Is(prepareError, errAssetStore) {
+		t.Fatalf("inline payload error=%v", prepareError)
+	}
+
+	boundedModel := textModelDefinition{mediaLimits: []CatalogMediaLimit{
+		{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(1)},
+		{ID: CatalogMediaLimitIDImageCount, MediaType: "image", Status: CatalogMediaLimitStatusUnbounded},
+		{ID: CatalogMediaLimitIDImageFileBytes, MediaType: "image", Status: CatalogMediaLimitStatusUnbounded},
+	}}
+	if _, _, prepareError := client.prepareInteractionPayload(context.Background(), "key", "https://provider.test", boundedModel, messages, nil, false); !errors.Is(prepareError, ErrProviderAPI) {
+		t.Fatalf("upload error=%v", prepareError)
+	}
+	if _, requestError := newGeminiInteractionRequest(textModelDefinition{}, messages, []string{"one", "two"}, nil, false); !errors.Is(requestError, ErrProviderAPI) {
+		t.Fatalf("request input error=%v", requestError)
+	}
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}
+
+func intPointer(value int) *int {
+	return &value
+}

--- a/internal/proxy/management_failures_test.go
+++ b/internal/proxy/management_failures_test.go
@@ -733,7 +733,7 @@ func TestManagementUsageFailuresExposeSafeCanonicalRowsWithStableSnapshotPaginat
 		{
 			request: httptest.NewRequest(
 				http.MethodPost,
-				"/v2?key="+secretQuery,
+				"/?key="+secretQuery,
 				bytes.NewBufferString(`{"messages":[{"role":"user","content":"payload that exceeds the configured request boundary"}]}`),
 			),
 			wantStatus: http.StatusRequestEntityTooLarge,

--- a/internal/proxy/media_assets_edges_internal_test.go
+++ b/internal/proxy/media_assets_edges_internal_test.go
@@ -1,0 +1,504 @@
+package proxy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+var errAssetEdge = errors.New("asset edge failure")
+
+func TestTenantAssetStoreFailureContracts(t *testing.T) {
+	originalMkdirAll := assetMkdirAll
+	originalChmod := assetChmod
+	originalCreateTemp := assetCreateTemp
+	originalCopy := assetCopy
+	originalClose := assetClose
+	originalRename := assetRename
+	originalRemove := assetRemove
+	originalOpen := assetOpen
+	originalStat := assetStat
+	originalSeek := assetSeek
+	originalWrite := assetWrite
+	reset := func() {
+		assetMkdirAll = originalMkdirAll
+		assetChmod = originalChmod
+		assetCreateTemp = originalCreateTemp
+		assetCopy = originalCopy
+		assetClose = originalClose
+		assetRename = originalRename
+		assetRemove = originalRemove
+		assetOpen = originalOpen
+		assetStat = originalStat
+		assetSeek = originalSeek
+		assetWrite = originalWrite
+	}
+	t.Cleanup(reset)
+
+	requestTenant, tenantError := newTenant(TenantConfiguration{ID: "asset-edge", Secret: "secret"})
+	if tenantError != nil {
+		t.Fatalf("new tenant: %v", tenantError)
+	}
+	assetBytes := []byte("asset-edge-bytes")
+	digestBytes := sha256.Sum256(assetBytes)
+	digest := hex.EncodeToString(digestBytes[:])
+	newStore := func() *tenantAssetStore {
+		store := newTenantAssetStore(t.TempDir(), int64(len(assetBytes)), 60)
+		store.now = func() time.Time { return time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC) }
+		return store
+	}
+	requireUploadError := func(store *tenantAssetStore, source io.Reader, mimeType string, expectedDigest string, expected error) {
+		t.Helper()
+		_, uploadError := store.upload(requestTenant, mimeType, expectedDigest, source)
+		if !errors.Is(uploadError, expected) {
+			t.Fatalf("upload error=%v want=%v", uploadError, expected)
+		}
+	}
+
+	requireUploadError(newStore(), bytes.NewReader(assetBytes), "text/plain", digest, errAssetInvalid)
+
+	store := newStore()
+	assetMkdirAll = func(string, os.FileMode) error { return errAssetEdge }
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+
+	store = newStore()
+	assetChmod = func(string, os.FileMode) error { return errAssetEdge }
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+
+	store = newStore()
+	assetCreateTemp = func(string, string) (*os.File, error) { return nil, errAssetEdge }
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+
+	store = newStore()
+	chmodCalls := 0
+	assetChmod = func(path string, mode os.FileMode) error {
+		chmodCalls++
+		if chmodCalls == 2 {
+			return errAssetEdge
+		}
+		return originalChmod(path, mode)
+	}
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+
+	store = newStore()
+	assetCopy = func(io.Writer, io.Reader) (int64, error) { return 0, errAssetEdge }
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+
+	store = newStore()
+	closeCalls := 0
+	assetClose = func(file *os.File) error {
+		closeCalls++
+		closeError := originalClose(file)
+		if closeCalls == 1 {
+			return errAssetEdge
+		}
+		return closeError
+	}
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+
+	requireUploadError(newStore(), bytes.NewReader(nil), "image/png", hex.EncodeToString(sha256.New().Sum(nil)), errAssetInvalid)
+	tooLargeStore := newStore()
+	tooLargeStore.maxAssetBytes--
+	requireUploadError(tooLargeStore, bytes.NewReader(assetBytes), "image/png", digest, errAssetTooLarge)
+	requireUploadError(newStore(), bytes.NewReader(assetBytes), "image/png", strings.Repeat("0", 64), errAssetDigestMismatch)
+
+	store = newStore()
+	assetRename = func(string, string) error { return errAssetEdge }
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+
+	store = newStore()
+	renameCalls := 0
+	assetRename = func(oldPath string, newPath string) error {
+		renameCalls++
+		if renameCalls == 2 {
+			return errAssetEdge
+		}
+		return originalRename(oldPath, newPath)
+	}
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+}
+
+func TestTenantAssetMetadataAndResolutionFailureContracts(t *testing.T) {
+	originalChmod := assetChmod
+	originalCreateTemp := assetCreateTemp
+	originalCopy := assetCopy
+	originalClose := assetClose
+	originalRename := assetRename
+	originalRemove := assetRemove
+	originalOpen := assetOpen
+	originalStat := assetStat
+	originalSeek := assetSeek
+	originalWrite := assetWrite
+	reset := func() {
+		assetChmod = originalChmod
+		assetCreateTemp = originalCreateTemp
+		assetCopy = originalCopy
+		assetClose = originalClose
+		assetRename = originalRename
+		assetRemove = originalRemove
+		assetOpen = originalOpen
+		assetStat = originalStat
+		assetSeek = originalSeek
+		assetWrite = originalWrite
+	}
+	t.Cleanup(reset)
+
+	requestTenant, _ := newTenant(TenantConfiguration{ID: "asset-owner", Secret: "secret"})
+	foreignTenant, _ := newTenant(TenantConfiguration{ID: "asset-foreign", Secret: "other"})
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	store := newTenantAssetStore(t.TempDir(), 1024, 60)
+	store.now = func() time.Time { return now }
+	assetBytes := []byte("resolved-asset")
+	digestBytes := sha256.Sum256(assetBytes)
+	digest := hex.EncodeToString(digestBytes[:])
+	metadata, uploadError := store.upload(requestTenant, "image/png", digest, bytes.NewReader(assetBytes))
+	if uploadError != nil {
+		t.Fatalf("upload: %v", uploadError)
+	}
+
+	if _, resolveError := store.resolve(requestTenant, "bad", "image/png", digest); !errors.Is(resolveError, errAssetInvalid) {
+		t.Fatalf("invalid resolve error=%v", resolveError)
+	}
+	if _, resolveError := store.resolve(requestTenant, "ast_00000000000000000000000000000000", "image/png", digest); !errors.Is(resolveError, errAssetNotFound) {
+		t.Fatalf("missing resolve error=%v", resolveError)
+	}
+	if _, resolveError := store.resolve(foreignTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetNotFound) {
+		t.Fatalf("foreign resolve error=%v", resolveError)
+	}
+
+	metadataPath := store.metadataPath(metadata.AssetID)
+	validMetadataBytes, readError := os.ReadFile(metadataPath)
+	if readError != nil {
+		t.Fatalf("read metadata: %v", readError)
+	}
+	if writeError := os.WriteFile(metadataPath, []byte("{"), assetFileMode); writeError != nil {
+		t.Fatalf("write malformed metadata: %v", writeError)
+	}
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("malformed metadata error=%v", resolveError)
+	}
+	if writeError := os.WriteFile(metadataPath, append(validMetadataBytes, []byte("{}")...), assetFileMode); writeError != nil {
+		t.Fatalf("write trailing metadata: %v", writeError)
+	}
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("trailing metadata error=%v", resolveError)
+	}
+	invalidMetadata := bytes.Replace(validMetadataBytes, []byte(`"version":1`), []byte(`"version":2`), 1)
+	if writeError := os.WriteFile(metadataPath, invalidMetadata, assetFileMode); writeError != nil {
+		t.Fatalf("write invalid metadata: %v", writeError)
+	}
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("invalid metadata error=%v", resolveError)
+	}
+	if writeError := os.WriteFile(metadataPath, validMetadataBytes, assetFileMode); writeError != nil {
+		t.Fatalf("restore metadata: %v", writeError)
+	}
+
+	assetOpen = func(path string) (*os.File, error) {
+		if path == metadataPath {
+			return nil, errAssetEdge
+		}
+		return originalOpen(path)
+	}
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("metadata open error=%v", resolveError)
+	}
+	reset()
+
+	changed := metadata
+	changed.State = "processing"
+	if metadataError := store.writeMetadata(changed); metadataError != nil {
+		t.Fatalf("write state metadata: %v", metadataError)
+	}
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("state error=%v", resolveError)
+	}
+	if writeError := os.WriteFile(metadataPath, validMetadataBytes, assetFileMode); writeError != nil {
+		t.Fatalf("restore metadata: %v", writeError)
+	}
+
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/jpeg", digest); !errors.Is(resolveError, errAssetMIMEMismatch) {
+		t.Fatalf("MIME error=%v", resolveError)
+	}
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", strings.Repeat("0", 64)); !errors.Is(resolveError, errAssetDigestMismatch) {
+		t.Fatalf("digest error=%v", resolveError)
+	}
+
+	dataPath := store.dataPath(metadata.AssetID)
+	assetOpen = func(path string) (*os.File, error) {
+		if path == dataPath {
+			return nil, errAssetEdge
+		}
+		return originalOpen(path)
+	}
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("data open error=%v", resolveError)
+	}
+	reset()
+
+	assetStat = func(*os.File) (os.FileInfo, error) { return nil, errAssetEdge }
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("stat error=%v", resolveError)
+	}
+	reset()
+
+	assetCopy = func(io.Writer, io.Reader) (int64, error) { return 0, errAssetEdge }
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("hash error=%v", resolveError)
+	}
+	reset()
+
+	if writeError := os.WriteFile(dataPath, bytes.Repeat([]byte("x"), len(assetBytes)), assetFileMode); writeError != nil {
+		t.Fatalf("write altered data: %v", writeError)
+	}
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("hash mismatch error=%v", resolveError)
+	}
+	if writeError := os.WriteFile(dataPath, assetBytes, assetFileMode); writeError != nil {
+		t.Fatalf("restore data: %v", writeError)
+	}
+
+	assetSeek = func(*os.File, int64, int) (int64, error) { return 0, errAssetEdge }
+	if _, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("seek error=%v", resolveError)
+	}
+	reset()
+
+	reader, resolveError := store.resolve(requestTenant, metadata.AssetID, "image/png", digest)
+	if resolveError != nil {
+		t.Fatalf("valid resolve: %v", resolveError)
+	}
+	if closeError := reader.Close(); closeError != nil {
+		t.Fatalf("close resolved asset: %v", closeError)
+	}
+	expiringMetadata, uploadError := store.upload(requestTenant, "image/png", digest, bytes.NewReader(assetBytes))
+	if uploadError != nil {
+		t.Fatalf("upload expiring asset: %v", uploadError)
+	}
+	store.now = func() time.Time { return now.Add(2 * time.Minute) }
+	assetRemove = func(string) error { return errAssetEdge }
+	if _, resolveError := store.resolve(requestTenant, expiringMetadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetStore) {
+		t.Fatalf("expired resolve remove error=%v", resolveError)
+	}
+	reset()
+	store.now = func() time.Time { return now }
+
+	writeMetadata := func(configure func()) {
+		t.Helper()
+		configure()
+		if metadataError := store.writeMetadata(metadata); !errors.Is(metadataError, errAssetStore) {
+			t.Fatalf("metadata error=%v", metadataError)
+		}
+		reset()
+	}
+	writeMetadata(func() { assetCreateTemp = func(string, string) (*os.File, error) { return nil, errAssetEdge } })
+	writeMetadata(func() { assetChmod = func(string, os.FileMode) error { return errAssetEdge } })
+	writeMetadata(func() { assetWrite = func(*os.File, []byte) (int, error) { return 0, errAssetEdge } })
+	writeMetadata(func() {
+		assetClose = func(file *os.File) error {
+			_ = originalClose(file)
+			return errAssetEdge
+		}
+	})
+	writeMetadata(func() { assetRename = func(string, string) error { return errAssetEdge } })
+}
+
+func TestTenantAssetDeletionAndHTTPErrorContracts(t *testing.T) {
+	requestTenant, _ := newTenant(TenantConfiguration{ID: "asset-delete", Secret: "secret"})
+	foreignTenant, _ := newTenant(TenantConfiguration{ID: "asset-foreign", Secret: "other"})
+	store := newTenantAssetStore(t.TempDir(), 128, 60)
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+	data := []byte("delete-asset")
+	digestBytes := sha256.Sum256(data)
+	digest := hex.EncodeToString(digestBytes[:])
+	upload := func() tenantAssetMetadata {
+		metadata, uploadError := store.upload(requestTenant, "image/png", digest, bytes.NewReader(data))
+		if uploadError != nil {
+			t.Fatalf("upload: %v", uploadError)
+		}
+		return metadata
+	}
+
+	if deleteError := store.delete(requestTenant, "bad"); !errors.Is(deleteError, errAssetNotFound) {
+		t.Fatalf("invalid delete error=%v", deleteError)
+	}
+	if deleteError := store.delete(requestTenant, "ast_00000000000000000000000000000000"); !errors.Is(deleteError, errAssetNotFound) {
+		t.Fatalf("missing delete error=%v", deleteError)
+	}
+	metadata := upload()
+	if deleteError := store.delete(foreignTenant, metadata.AssetID); !errors.Is(deleteError, errAssetNotFound) {
+		t.Fatalf("foreign delete error=%v", deleteError)
+	}
+	if deleteError := store.delete(requestTenant, metadata.AssetID); deleteError != nil {
+		t.Fatalf("delete: %v", deleteError)
+	}
+	if deleteError := store.delete(requestTenant, metadata.AssetID); !errors.Is(deleteError, errAssetDeleted) {
+		t.Fatalf("second delete error=%v", deleteError)
+	}
+
+	originalRemove := assetRemove
+	originalWrite := assetWrite
+	t.Cleanup(func() {
+		assetRemove = originalRemove
+		assetWrite = originalWrite
+	})
+	metadata = upload()
+	assetRemove = func(string) error { return errAssetEdge }
+	if deleteError := store.delete(requestTenant, metadata.AssetID); !errors.Is(deleteError, errAssetStore) {
+		t.Fatalf("remove delete error=%v", deleteError)
+	}
+	assetRemove = originalRemove
+
+	metadata = upload()
+	if deleteError := store.delete(requestTenant, metadata.AssetID); deleteError != nil {
+		t.Fatalf("delete before repeated failure: %v", deleteError)
+	}
+	assetRemove = func(string) error { return errAssetEdge }
+	if deleteError := store.delete(requestTenant, metadata.AssetID); !errors.Is(deleteError, errAssetStore) {
+		t.Fatalf("repeated delete remove error=%v", deleteError)
+	}
+	assetRemove = originalRemove
+
+	metadata = upload()
+	assetWrite = func(*os.File, []byte) (int, error) { return 0, errAssetEdge }
+	if deleteError := store.delete(requestTenant, metadata.AssetID); !errors.Is(deleteError, errAssetStore) {
+		t.Fatalf("metadata delete error=%v", deleteError)
+	}
+	assetWrite = originalWrite
+
+	metadata = upload()
+	store.now = func() time.Time { return now.Add(2 * time.Minute) }
+	assetRemove = func(string) error { return errAssetEdge }
+	if deleteError := store.delete(requestTenant, metadata.AssetID); !errors.Is(deleteError, errAssetStore) {
+		t.Fatalf("expired remove error=%v", deleteError)
+	}
+	assetRemove = originalRemove
+	if deleteError := store.delete(requestTenant, metadata.AssetID); !errors.Is(deleteError, errAssetExpired) {
+		t.Fatalf("expired delete error=%v", deleteError)
+	}
+
+	for _, assetError := range []error{errAssetInvalid, errAssetNotFound, errAssetExpired, errAssetDeleted, errAssetMIMEMismatch, errAssetDigestMismatch, errAssetTooLarge, errAssetStore} {
+		response := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(response)
+		writeTenantAssetError(ginContext, assetError)
+		if response.Code == 0 || !isTenantAssetError(assetError) {
+			t.Fatalf("asset error=%v status=%d", assetError, response.Code)
+		}
+	}
+	if isTenantAssetError(errAssetEdge) {
+		t.Fatal("unexpected asset error classification")
+	}
+	if statusCodeForError(errAssetNotFound) != http.StatusNotFound || statusCodeForError(errAssetDeleted) != http.StatusGone {
+		t.Fatal("asset status mapping mismatch")
+	}
+
+	handlerStore := newTenantAssetStore(t.TempDir(), 4, 60)
+	router := gin.New()
+	router.Use(func(ginContext *gin.Context) {
+		ginContext.Set(contextKeyTenant, requestTenant)
+		ginContext.Next()
+	})
+	router.POST("/assets", tenantAssetUploadHandler(handlerStore))
+	router.DELETE("/assets/:asset_id", tenantAssetDeleteHandler(handlerStore))
+	tooLargeRequest := httptest.NewRequest(http.MethodPost, "/assets", strings.NewReader("12345"))
+	tooLargeRequest.Header.Set("Content-Type", "image/png")
+	tooLargeRequest.Header.Set("X-Asset-SHA256", strings.Repeat("0", 64))
+	tooLargeResponse := httptest.NewRecorder()
+	router.ServeHTTP(tooLargeResponse, tooLargeRequest)
+	if tooLargeResponse.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("upload status=%d", tooLargeResponse.Code)
+	}
+	invalidRequest := httptest.NewRequest(http.MethodPost, "/assets", strings.NewReader("x"))
+	invalidResponse := httptest.NewRecorder()
+	router.ServeHTTP(invalidResponse, invalidRequest)
+	if invalidResponse.Code != http.StatusBadRequest {
+		t.Fatalf("invalid upload status=%d", invalidResponse.Code)
+	}
+	deleteResponse := httptest.NewRecorder()
+	router.ServeHTTP(deleteResponse, httptest.NewRequest(http.MethodDelete, "/assets/bad", nil))
+	if deleteResponse.Code != http.StatusNotFound {
+		t.Fatalf("invalid delete status=%d", deleteResponse.Code)
+	}
+}
+
+func TestMediaLimitAndMessageMediaEdgeContracts(t *testing.T) {
+	if _, configError := validateConfig(Configuration{AssetStorePath: "relative"}); configError == nil {
+		t.Fatal("relative asset store path accepted")
+	}
+	value := int64(1)
+	validSource := "https://example.com/limits"
+	validDate := "2026-08-11"
+	base := CatalogMediaLimit{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Transport: CatalogMediaTransportInline, Status: CatalogMediaLimitStatusBounded, Value: &value, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeRequestEncodedBytes, Source: validSource, LastVerified: validDate}
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base}, nil, "limits"); validationError == nil {
+		t.Fatal("expected limits without inputs rejection")
+	}
+	invalidLimits := []CatalogMediaLimit{
+		{ID: "INVALID", MediaType: "all", Transport: "inline", Status: "bounded", Value: &value, Unit: "bytes", Scope: "request_encoded_bytes", Source: validSource, LastVerified: validDate},
+		base,
+		{ID: "other", MediaType: "video", Transport: "inline", Status: "bounded", Value: &value, Unit: "bytes", Scope: "request", Source: validSource, LastVerified: validDate},
+		{ID: "other", MediaType: "image", Transport: "wire", Status: "bounded", Value: &value, Unit: "bytes", Scope: "request", Source: validSource, LastVerified: validDate},
+		{ID: "other", MediaType: "image", Transport: "inline", Status: "bounded", Value: &value, Unit: "items", Scope: "request", Source: validSource, LastVerified: validDate},
+		{ID: "other", MediaType: "image", Transport: "inline", Status: "bounded", Value: &value, Unit: "bytes", Scope: "turn", Source: validSource, LastVerified: validDate},
+		{ID: "other", MediaType: "image", Transport: "inline", Status: "unbounded", Value: &value, Unit: "bytes", Scope: "request", Source: validSource, LastVerified: validDate},
+		{ID: "other", MediaType: "image", Transport: "inline", Status: "invalid", Unit: "bytes", Scope: "request", Source: validSource, LastVerified: validDate},
+		{ID: "other", MediaType: "image", Transport: "inline", Status: "bounded", Value: &value, Unit: "bytes", Scope: "request", Source: "http://example.com", LastVerified: validDate},
+		{ID: "other", MediaType: "image", Transport: "inline", Status: "bounded", Value: &value, Unit: "bytes", Scope: "request", Source: validSource, LastVerified: "bad"},
+	}
+	for limitIndex, invalidLimit := range invalidLimits {
+		limits := []CatalogMediaLimit{invalidLimit}
+		if limitIndex == 1 {
+			limits = []CatalogMediaLimit{base, base}
+		}
+		if validationError := validateCatalogMediaLimits(limits, []string{"image"}, "limits"); validationError == nil {
+			t.Fatalf("invalid limit index=%d accepted", limitIndex)
+		}
+	}
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base}, []string{"image"}, "limits"); validationError == nil {
+		t.Fatal("expected missing required limit rejection")
+	}
+
+	assetID := " ast_0123456789abcdef0123456789abcdef"
+	if _, mediaError := newMessageMedia(chatMessageAttachmentPayload{Type: "image", MIMEType: "image/png", AssetID: &assetID, SHA256: strings.Repeat("0", 64)}, tenant{}, newTenantAssetStore(t.TempDir(), 10, 60)); mediaError == nil {
+		t.Fatal("expected noncanonical asset id rejection")
+	}
+	dataFile, fileError := os.CreateTemp(t.TempDir(), "closed-asset")
+	if fileError != nil {
+		t.Fatalf("create asset file: %v", fileError)
+	}
+	_ = dataFile.Close()
+	media := messageMedia{asset: &tenantAssetReader{file: dataFile}, sizeBytes: 1}
+	if _, readerError := media.reader(); readerError == nil {
+		t.Fatal("expected closed asset reader rejection")
+	}
+	if _, bytesError := media.bytes(); bytesError == nil {
+		t.Fatal("expected closed asset byte rejection")
+	}
+	shortFile, shortError := os.CreateTemp(t.TempDir(), "short-asset")
+	if shortError != nil {
+		t.Fatalf("create short asset: %v", shortError)
+	}
+	defer shortFile.Close()
+	media = messageMedia{asset: &tenantAssetReader{file: shortFile}, sizeBytes: 1}
+	if _, bytesError := media.bytes(); bytesError == nil {
+		t.Fatal("expected short asset byte rejection")
+	}
+}

--- a/internal/proxy/media_assets_edges_internal_test.go
+++ b/internal/proxy/media_assets_edges_internal_test.go
@@ -2,14 +2,18 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +21,262 @@ import (
 )
 
 var errAssetEdge = errors.New("asset edge failure")
+
+type gatedAssetReader struct {
+	reader  *bytes.Reader
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (reader *gatedAssetReader) Read(data []byte) (int, error) {
+	reader.once.Do(func() { close(reader.started) })
+	<-reader.release
+	return reader.reader.Read(data)
+}
+
+func TestTenantAssetUploadDoesNotBlockExistingAssetResolution(t *testing.T) {
+	requestTenant, tenantError := newTenant(TenantConfiguration{ID: "asset-concurrency", Secret: "secret"})
+	if tenantError != nil {
+		t.Fatalf("new tenant: %v", tenantError)
+	}
+	store := newTenantAssetStore(t.TempDir(), 1024, 60)
+	existingData := []byte("existing")
+	existingDigestBytes := sha256.Sum256(existingData)
+	existingDigest := hex.EncodeToString(existingDigestBytes[:])
+	existing, uploadError := store.upload(requestTenant, "image/png", existingDigest, bytes.NewReader(existingData))
+	if uploadError != nil {
+		t.Fatalf("existing upload: %v", uploadError)
+	}
+
+	slowData := []byte("slow upload")
+	slowDigestBytes := sha256.Sum256(slowData)
+	slowDigest := hex.EncodeToString(slowDigestBytes[:])
+	started := make(chan struct{})
+	release := make(chan struct{})
+	uploadComplete := make(chan error, 1)
+	go func() {
+		_, slowUploadError := store.upload(requestTenant, "image/png", slowDigest, &gatedAssetReader{reader: bytes.NewReader(slowData), started: started, release: release})
+		uploadComplete <- slowUploadError
+	}()
+	<-started
+	resolveComplete := make(chan error, 1)
+	go func() {
+		reader, resolveError := store.resolve(requestTenant, existing.AssetID, existing.MIMEType, existing.SHA256)
+		if resolveError == nil {
+			resolveError = reader.Close()
+		}
+		resolveComplete <- resolveError
+	}()
+	select {
+	case resolveError := <-resolveComplete:
+		if resolveError != nil {
+			close(release)
+			t.Fatalf("resolve during upload: %v", resolveError)
+		}
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("existing asset resolution blocked behind upload stream")
+	}
+	close(release)
+	if slowUploadError := <-uploadComplete; slowUploadError != nil {
+		t.Fatalf("slow upload: %v", slowUploadError)
+	}
+}
+
+func TestTenantAssetStoreRecoversPersistedExpiryState(t *testing.T) {
+	requestTenant, tenantError := newTenant(TenantConfiguration{ID: "asset-recovery", Secret: "secret"})
+	if tenantError != nil {
+		t.Fatalf("new tenant: %v", tenantError)
+	}
+	root := t.TempDir()
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	store := newTenantAssetStore(root, 1024, 60)
+	store.now = func() time.Time { return now }
+	data := []byte("recovered")
+	digestBytes := sha256.Sum256(data)
+	digest := hex.EncodeToString(digestBytes[:])
+	upload := func() tenantAssetMetadata {
+		t.Helper()
+		metadata, uploadError := store.upload(requestTenant, "image/png", digest, bytes.NewReader(data))
+		if uploadError != nil {
+			t.Fatalf("upload: %v", uploadError)
+		}
+		return metadata
+	}
+	available := upload()
+	available.ExpiresAt = now.Add(10 * time.Minute)
+	if metadataError := store.writeMetadata(available); metadataError != nil {
+		t.Fatalf("available metadata: %v", metadataError)
+	}
+	expired := upload()
+	expired.ExpiresAt = now.Add(time.Minute)
+	if metadataError := store.writeMetadata(expired); metadataError != nil {
+		t.Fatalf("expired metadata: %v", metadataError)
+	}
+	deleted := upload()
+	if deleteError := store.delete(requestTenant, deleted.AssetID); deleteError != nil {
+		t.Fatalf("delete: %v", deleteError)
+	}
+	if directoryError := os.Mkdir(filepath.Join(root, "ignored-directory"), assetDirectoryMode); directoryError != nil {
+		t.Fatalf("directory: %v", directoryError)
+	}
+	if writeError := os.WriteFile(filepath.Join(root, "ignored.txt"), []byte("ignored"), assetFileMode); writeError != nil {
+		t.Fatalf("nonmetadata: %v", writeError)
+	}
+	if writeError := os.WriteFile(filepath.Join(root, "not-an-asset.json"), []byte("ignored"), assetFileMode); writeError != nil {
+		t.Fatalf("invalid metadata name: %v", writeError)
+	}
+
+	recoveredStore := newTenantAssetStore(root, 1024, 60)
+	recoveredStore.now = func() time.Time { return now.Add(2 * time.Minute) }
+	reader, resolveError := recoveredStore.resolve(requestTenant, available.AssetID, available.MIMEType, available.SHA256)
+	if resolveError != nil {
+		t.Fatalf("resolve available: %v", resolveError)
+	}
+	_ = reader.Close()
+	if _, statError := os.Stat(recoveredStore.dataPath(expired.AssetID)); !errors.Is(statError, os.ErrNotExist) {
+		t.Fatalf("expired data error=%v", statError)
+	}
+	if _, resolveError := recoveredStore.resolve(requestTenant, expired.AssetID, expired.MIMEType, expired.SHA256); !errors.Is(resolveError, errAssetExpired) {
+		t.Fatalf("expired resolve error=%v", resolveError)
+	}
+	if _, resolveError := recoveredStore.resolve(requestTenant, deleted.AssetID, deleted.MIMEType, deleted.SHA256); !errors.Is(resolveError, errAssetDeleted) {
+		t.Fatalf("deleted resolve error=%v", resolveError)
+	}
+}
+
+func TestTenantAssetExpirationMaintenanceFailureContracts(t *testing.T) {
+	originalCreateTemp := assetCreateTemp
+	originalOpen := assetOpen
+	originalRemove := assetRemove
+	originalAfterFunc := assetAfterFunc
+	timers := make([]*time.Timer, 0)
+	reset := func() {
+		assetCreateTemp = originalCreateTemp
+		assetOpen = originalOpen
+		assetRemove = originalRemove
+		assetAfterFunc = originalAfterFunc
+	}
+	t.Cleanup(func() {
+		reset()
+		for _, timer := range timers {
+			timer.Stop()
+		}
+	})
+
+	requestTenant, tenantError := newTenant(TenantConfiguration{ID: "asset-maintenance", Secret: "secret"})
+	if tenantError != nil {
+		t.Fatalf("new tenant: %v", tenantError)
+	}
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	assetBytes := []byte("asset-maintenance")
+	digestBytes := sha256.Sum256(assetBytes)
+	digest := hex.EncodeToString(digestBytes[:])
+	newStore := func(root string) *tenantAssetStore {
+		store := newTenantAssetStore(root, 1024, 3600)
+		store.now = func() time.Time { return now }
+		return store
+	}
+
+	store := newStore(t.TempDir())
+	metadata, uploadError := store.upload(requestTenant, "image/png", digest, bytes.NewReader(assetBytes))
+	if uploadError != nil {
+		t.Fatalf("upload: %v", uploadError)
+	}
+	assetAfterFunc = func(delay time.Duration, callback func()) *time.Timer {
+		if delay != 0 || callback == nil {
+			t.Fatalf("past expiration schedule delay=%s callback_nil=%t", delay, callback == nil)
+		}
+		timer := time.NewTimer(time.Hour)
+		timers = append(timers, timer)
+		return timer
+	}
+	pastMetadata := metadata
+	pastMetadata.ExpiresAt = now.Add(-time.Second)
+	store.scheduleExpirationLocked(pastMetadata)
+	assetAfterFunc = originalAfterFunc
+
+	failedStore := newStore(t.TempDir())
+	failedStore.cleanupError = errAssetEdge
+	failedStore.expireAsset(metadata.AssetID, metadata.ExpiresAt)
+	if _, resolveError := failedStore.resolve(requestTenant, metadata.AssetID, "image/png", digest); !errors.Is(resolveError, errAssetEdge) {
+		t.Fatalf("cleanup resolve error=%v", resolveError)
+	}
+	if deleteError := failedStore.delete(requestTenant, metadata.AssetID); !errors.Is(deleteError, errAssetEdge) {
+		t.Fatalf("cleanup delete error=%v", deleteError)
+	}
+
+	missingStore := newStore(t.TempDir())
+	missingStore.expireAsset("ast_00000000000000000000000000000000", now)
+
+	assetOpen = func(string) (*os.File, error) { return nil, errAssetEdge }
+	metadataFailureStore := newStore(t.TempDir())
+	metadataFailureStore.expireAsset(metadata.AssetID, metadata.ExpiresAt)
+	if !errors.Is(metadataFailureStore.cleanupError, errAssetStore) {
+		t.Fatalf("expiration metadata error=%v", metadataFailureStore.cleanupError)
+	}
+	assetOpen = originalOpen
+
+	store.expireAsset(metadata.AssetID, metadata.ExpiresAt.Add(time.Second))
+	store.now = func() time.Time { return metadata.ExpiresAt.Add(time.Second) }
+	assetRemove = func(string) error { return errAssetEdge }
+	store.expireAsset(metadata.AssetID, metadata.ExpiresAt)
+	if !errors.Is(store.cleanupError, errAssetStore) {
+		t.Fatalf("expiration remove error=%v", store.cleanupError)
+	}
+	reset()
+
+	uploadStore := newStore(t.TempDir())
+	assetCreateTemp = func(directory string, pattern string) (*os.File, error) {
+		uploadStore.cleanupError = errAssetEdge
+		return originalCreateTemp(directory, pattern)
+	}
+	if _, uploadError := uploadStore.upload(requestTenant, "image/png", digest, bytes.NewReader(assetBytes)); !errors.Is(uploadError, errAssetEdge) {
+		t.Fatalf("concurrent cleanup upload error=%v", uploadError)
+	}
+	reset()
+
+	malformedRoot := t.TempDir()
+	malformedID := "ast_11111111111111111111111111111111"
+	if writeError := os.WriteFile(filepath.Join(malformedRoot, malformedID+".json"), []byte("{"), assetFileMode); writeError != nil {
+		t.Fatalf("malformed metadata: %v", writeError)
+	}
+	malformedStore := newStore(malformedRoot)
+	if initializationError := malformedStore.initializeLocked(); !errors.Is(initializationError, errAssetStore) {
+		t.Fatalf("malformed initialization error=%v", initializationError)
+	}
+
+	reclaimRoot := t.TempDir()
+	reclaimStore := newStore(reclaimRoot)
+	reclaimMetadata, reclaimUploadError := reclaimStore.upload(requestTenant, "image/png", digest, bytes.NewReader(assetBytes))
+	if reclaimUploadError != nil {
+		t.Fatalf("reclaim upload: %v", reclaimUploadError)
+	}
+	recoveredStore := newStore(reclaimRoot)
+	recoveredStore.now = func() time.Time { return reclaimMetadata.ExpiresAt.Add(time.Second) }
+	assetRemove = func(string) error { return errAssetEdge }
+	if initializationError := recoveredStore.initializeLocked(); !errors.Is(initializationError, errAssetStore) {
+		t.Fatalf("reclaim initialization error=%v", initializationError)
+	}
+	reset()
+
+	handlerStore := newStore(t.TempDir())
+	request := httptest.NewRequest(http.MethodPost, "/assets", strings.NewReader("x"))
+	request.Header.Set("Content-Type", "image/png")
+	requestContext, cancelRequest := context.WithCancel(request.Context())
+	cancelRequest()
+	request = request.WithContext(requestContext)
+	response := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(response)
+	ginContext.Request = request
+	ginContext.Set(contextKeyTenant, requestTenant)
+	ginContext.Set(contextKeyRequestTimeoutState, &requestTimeoutState{})
+	tenantAssetUploadHandler(handlerStore)(ginContext)
+	if ginContext.Writer.Status() != statusClientClosedRequest {
+		t.Fatalf("cancelled upload status=%d", ginContext.Writer.Status())
+	}
+}
 
 func TestTenantAssetStoreFailureContracts(t *testing.T) {
 	originalMkdirAll := assetMkdirAll
@@ -27,6 +287,7 @@ func TestTenantAssetStoreFailureContracts(t *testing.T) {
 	originalRename := assetRename
 	originalRemove := assetRemove
 	originalOpen := assetOpen
+	originalReadDir := assetReadDir
 	originalStat := assetStat
 	originalSeek := assetSeek
 	originalWrite := assetWrite
@@ -39,6 +300,7 @@ func TestTenantAssetStoreFailureContracts(t *testing.T) {
 		assetRename = originalRename
 		assetRemove = originalRemove
 		assetOpen = originalOpen
+		assetReadDir = originalReadDir
 		assetStat = originalStat
 		assetSeek = originalSeek
 		assetWrite = originalWrite
@@ -74,6 +336,11 @@ func TestTenantAssetStoreFailureContracts(t *testing.T) {
 
 	store = newStore()
 	assetChmod = func(string, os.FileMode) error { return errAssetEdge }
+	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
+	reset()
+
+	store = newStore()
+	assetReadDir = func(string) ([]os.DirEntry, error) { return nil, errAssetEdge }
 	requireUploadError(store, bytes.NewReader(assetBytes), "image/png", digest, errAssetStore)
 	reset()
 
@@ -417,7 +684,11 @@ func TestTenantAssetDeletionAndHTTPErrorContracts(t *testing.T) {
 		ginContext.Set(contextKeyTenant, requestTenant)
 		ginContext.Next()
 	})
-	router.POST("/assets", tenantAssetUploadHandler(handlerStore))
+	timeoutPolicy, timeoutPolicyError := newRequestTimeoutPolicy(5, 5)
+	if timeoutPolicyError != nil {
+		t.Fatalf("timeout policy: %v", timeoutPolicyError)
+	}
+	router.POST("/assets", requestTimeoutHandler(timeoutPolicy, nil, tenantAssetUploadHandler(handlerStore)))
 	router.DELETE("/assets/:asset_id", tenantAssetDeleteHandler(handlerStore))
 	tooLargeRequest := httptest.NewRequest(http.MethodPost, "/assets", strings.NewReader("12345"))
 	tooLargeRequest.Header.Set("Content-Type", "image/png")
@@ -441,6 +712,11 @@ func TestTenantAssetDeletionAndHTTPErrorContracts(t *testing.T) {
 }
 
 func TestMediaLimitAndMessageMediaEdgeContracts(t *testing.T) {
+	maximumValue := int64(math.MaxInt64)
+	overflowCatalog := ModelCatalog{Offerings: []ProviderOffering{{MediaLimits: []CatalogMediaLimit{{ID: CatalogMediaLimitIDInlineRequestBytes, Status: CatalogMediaLimitStatusBounded, Value: &maximumValue}}}}}
+	if maximumV2RequestBytes(1, overflowCatalog) != math.MaxInt64 || maximumV2RequestBytes(7, ModelCatalog{}) != 7 {
+		t.Fatal("v2 request bound mismatch")
+	}
 	if _, configError := validateConfig(Configuration{AssetStorePath: "relative"}); configError == nil {
 		t.Fatal("relative asset store path accepted")
 	}

--- a/internal/proxy/media_assets_routing_test.go
+++ b/internal/proxy/media_assets_routing_test.go
@@ -6,10 +6,12 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -77,6 +79,24 @@ func TestV2LargeInlineMediaBypassesCompatibilityPromptLimit(t *testing.T) {
 	response := postV2MediaRequest(t, router, "secret-a", requestBody)
 	if response.Code != http.StatusOK || !bytes.Equal(receivedMedia, mediaBytes) {
 		t.Fatalf("status=%d received=%d want=%d", response.Code, len(receivedMedia), len(mediaBytes))
+	}
+}
+
+func TestV2RejectsJSONAboveCatalogDerivedIngressBound(t *testing.T) {
+	catalog := testfixtures.ModelCatalog(t)
+	for offeringIndex := range catalog.Offerings {
+		for limitIndex := range catalog.Offerings[offeringIndex].MediaLimits {
+			limit := &catalog.Offerings[offeringIndex].MediaLimits[limitIndex]
+			if limit.ID == proxy.CatalogMediaLimitIDInlineRequestBytes && limit.Status == proxy.CatalogMediaLimitStatusBounded {
+				value := int64(64)
+				limit.Value = &value
+			}
+		}
+	}
+	router := mediaAssetRouterWithMaxPrompt(t, "https://provider.invalid", t.TempDir(), catalog, 60, 32)
+	response := postV2MediaRequest(t, router, "secret-a", bytes.Repeat([]byte("x"), 97))
+	if response.Code != http.StatusRequestEntityTooLarge || !strings.Contains(response.Body.String(), "prompt payload too large") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }
 
@@ -275,6 +295,45 @@ func TestGeminiFileTransportPreservesAssetBytesAndCleansUp(t *testing.T) {
 	}
 }
 
+func TestGeminiFileCleanupFailureFailsTheRequest(t *testing.T) {
+	for _, interactionStatus := range []string{"completed", "incomplete"} {
+		t.Run(interactionStatus, func(subTest *testing.T) {
+			mediaBytes := []byte("cleanup-failure")
+			digest := sha256.Sum256(mediaBytes)
+			interactionCalls := 0
+			var upstream *httptest.Server
+			upstream = httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+				switch {
+				case request.Method == http.MethodPost && request.URL.Path == "/upload/v1beta/files":
+					responseWriter.Header().Set("X-Goog-Upload-URL", upstream.URL+"/upload-session")
+					responseWriter.WriteHeader(http.StatusOK)
+				case request.Method == http.MethodPost && request.URL.Path == "/upload-session":
+					_, _ = fmt.Fprintf(responseWriter, `{"file":{"name":"files/cleanup-failure","mimeType":"image/png","sizeBytes":"%d","sha256Hash":"%s","uri":"%s/files/cleanup-failure","state":"ACTIVE"}}`, len(mediaBytes), base64.StdEncoding.EncodeToString(digest[:]), upstream.URL)
+				case request.Method == http.MethodPost && request.URL.Path == "/interactions":
+					interactionCalls++
+					responseWriter.Header().Set("Content-Type", "application/json")
+					_, _ = fmt.Fprintf(responseWriter, `{"status":%q,"steps":[{"type":"model_output","content":[{"type":"text","text":"accepted"}]}]}`, interactionStatus)
+				case request.Method == http.MethodDelete && request.URL.Path == "/files/cleanup-failure":
+					responseWriter.WriteHeader(http.StatusInternalServerError)
+				default:
+					http.NotFound(responseWriter, request)
+				}
+			}))
+			defer upstream.Close()
+			catalog := testfixtures.ModelCatalog(subTest)
+			setGeminiMediaLimit(subTest, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDInlineRequestBytes, 1)
+			setGeminiMediaLimit(subTest, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDImageFileBytes, int64(len(mediaBytes)))
+			router := mediaAssetRouter(subTest, upstream.URL, subTest.TempDir(), catalog, 60)
+			response := postV2MediaRequest(subTest, router, "secret-a", []byte(mediaV2RequestBody(subTest, proxy.ModelNameGemini25Flash, "inspect", []map[string]any{
+				messageMediaPayload("image", "image/png", mediaBytes),
+			})))
+			if response.Code != http.StatusBadGateway || !strings.Contains(response.Body.String(), llmproxycontract.ErrorCodeProviderError) || interactionCalls != 1 {
+				subTest.Fatalf("status=%d body=%s interaction_calls=%d", response.Code, response.Body.String(), interactionCalls)
+			}
+		})
+	}
+}
+
 func TestDeletingAssetAfterAdmissionKeepsTheOpenRequestStable(t *testing.T) {
 	mediaBytes := bytes.Repeat([]byte("admitted-media"), 100)
 	digest := sha256.Sum256(mediaBytes)
@@ -330,9 +389,21 @@ func TestExpiredAssetAndProviderMediaLimitsFailWithStableCodes(t *testing.T) {
 			subTest.Error("expired asset reached provider")
 		}))
 		defer upstream.Close()
-		router := mediaAssetRouter(subTest, upstream.URL, subTest.TempDir(), testfixtures.ModelCatalog(subTest), 1)
+		assetRoot := subTest.TempDir()
+		router := mediaAssetRouter(subTest, upstream.URL, assetRoot, testfixtures.ModelCatalog(subTest), 1)
 		asset := uploadTestAsset(subTest, router, "secret-a", "image/png", []byte("expires"))
-		time.Sleep(1100 * time.Millisecond)
+		dataPath := fmt.Sprintf("%s/%s.data", assetRoot, asset.AssetID)
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			_, statError := os.Stat(dataPath)
+			if errors.Is(statError, os.ErrNotExist) {
+				break
+			}
+			if statError != nil || time.Now().After(deadline) {
+				subTest.Fatalf("expired asset cleanup path=%s error=%v", dataPath, statError)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 		response := postV2MediaRequest(subTest, router, "secret-a", v2AssetReferencePayload(asset.AssetID, asset.MIMEType, asset.SHA256))
 		if response.Code != http.StatusGone || !strings.Contains(response.Body.String(), "asset_expired") {
 			subTest.Fatalf("status=%d body=%s", response.Code, response.Body.String())
@@ -375,7 +446,25 @@ func TestExpiredAssetAndProviderMediaLimitsFailWithStableCodes(t *testing.T) {
 	})
 }
 
+func TestTenantAssetUploadUsesTheAuthenticatedRequestBudget(t *testing.T) {
+	router := mediaAssetRouter(t, "https://provider.invalid", t.TempDir(), testfixtures.ModelCatalog(t), 60)
+	request := httptest.NewRequest(http.MethodPost, llmproxycontract.AssetPath+"?key=secret-a", strings.NewReader("asset"))
+	request.Header.Set("Content-Type", "image/png")
+	request.Header.Set(llmproxycontract.HeaderAssetSHA256, strings.Repeat("0", 64))
+	request.Header.Set(llmproxycontract.HeaderRequestTimeoutSeconds, "3601")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), llmproxycontract.ErrorCodeInvalidRequestTimeout) {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
 func mediaAssetRouter(t *testing.T, geminiBaseURL string, assetRoot string, catalog proxy.ModelCatalog, retentionSeconds int) http.Handler {
+	t.Helper()
+	return mediaAssetRouterWithMaxPrompt(t, geminiBaseURL, assetRoot, catalog, retentionSeconds, proxy.DefaultMaxPromptBytes)
+}
+
+func mediaAssetRouterWithMaxPrompt(t *testing.T, geminiBaseURL string, assetRoot string, catalog proxy.ModelCatalog, retentionSeconds int, maxPromptBytes int64) http.Handler {
 	t.Helper()
 	configuration := proxy.Configuration{
 		Tenants: []proxy.TenantConfiguration{
@@ -383,7 +472,7 @@ func mediaAssetRouter(t *testing.T, geminiBaseURL string, assetRoot string, cata
 			{ID: "tenant-b", Secret: "secret-b", Defaults: proxy.TenantDefaults{Provider: proxy.ProviderNameGemini, Model: proxy.ModelNameGemini25Flash, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}},
 		},
 		OpenAIKey: "openai-key", GeminiKey: "gemini-key", GeminiBaseURL: geminiBaseURL,
-		WorkerCount: 2, QueueSize: 4, RequestTimeoutSeconds: 10, MaxPromptBytes: proxy.DefaultMaxPromptBytes,
+		WorkerCount: 2, QueueSize: 4, RequestTimeoutSeconds: 10, MaxPromptBytes: maxPromptBytes,
 		MaxAssetBytes: 10 * 1024 * 1024, AssetRetentionSeconds: retentionSeconds, AssetStorePath: assetRoot,
 		ModelCatalog: catalog,
 	}

--- a/internal/proxy/media_assets_routing_test.go
+++ b/internal/proxy/media_assets_routing_test.go
@@ -1,0 +1,478 @@
+package proxy_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tyemirov/llm-proxy/internal/proxy"
+	"github.com/tyemirov/llm-proxy/internal/testfixtures"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
+	"go.uber.org/zap"
+)
+
+type mediaAssetResponse struct {
+	AssetID   string `json:"asset_id"`
+	MIMEType  string `json:"mime_type"`
+	SizeBytes int64  `json:"size_bytes"`
+	SHA256    string `json:"sha256"`
+	State     string `json:"state"`
+}
+
+func TestV2LargeInlineMediaBypassesCompatibilityPromptLimit(t *testing.T) {
+	mediaBytes := bytes.Repeat([]byte{0x89, 0x50, 0x4e, 0x47}, 831681)
+	digest := sha256.Sum256(mediaBytes)
+	var receivedMedia []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/interactions" {
+			http.NotFound(responseWriter, request)
+			return
+		}
+		var payload struct {
+			Input []struct {
+				Content []struct {
+					Type string `json:"type"`
+					Data string `json:"data"`
+				} `json:"content"`
+			} `json:"input"`
+		}
+		if decodeError := json.NewDecoder(request.Body).Decode(&payload); decodeError != nil {
+			t.Errorf("decode interaction: %v", decodeError)
+			return
+		}
+		for _, step := range payload.Input {
+			for _, content := range step.Content {
+				if content.Type == "image" {
+					receivedMedia, _ = base64.StdEncoding.DecodeString(content.Data)
+				}
+			}
+		}
+		writeGeminiCompletedResponse(responseWriter)
+	}))
+	defer upstream.Close()
+	router := mediaAssetRouter(t, upstream.URL, t.TempDir(), testfixtures.ModelCatalog(t), 60)
+	payload := map[string]any{
+		"messages": []any{map[string]any{
+			"role": "user", "content": "inspect exact image bytes",
+			"attachments": []any{map[string]any{
+				"type": "image", "mime_type": "image/png",
+				"data": base64.StdEncoding.EncodeToString(mediaBytes), "sha256": hex.EncodeToString(digest[:]),
+			}},
+		}},
+	}
+	requestBody, _ := json.Marshal(payload)
+	if len(requestBody) <= proxy.DefaultMaxPromptBytes {
+		t.Fatalf("fixture body=%d want greater than %d", len(requestBody), proxy.DefaultMaxPromptBytes)
+	}
+	response := postV2MediaRequest(t, router, "secret-a", requestBody)
+	if response.Code != http.StatusOK || !bytes.Equal(receivedMedia, mediaBytes) {
+		t.Fatalf("status=%d received=%d want=%d", response.Code, len(receivedMedia), len(mediaBytes))
+	}
+}
+
+func TestGeminiImageCountLimitAdmitsBoundaryAndRejectsOneAbove(t *testing.T) {
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		upstreamCalls++
+		_, _ = io.Copy(io.Discard, request.Body)
+		writeGeminiCompletedResponse(responseWriter)
+	}))
+	defer upstream.Close()
+	router := mediaAssetRouter(t, upstream.URL, t.TempDir(), testfixtures.ModelCatalog(t), 60)
+	attachment := messageMediaPayload("image", "image/png", []byte("x"))
+	attachments := make([]map[string]any, 3_600)
+	for attachmentIndex := range attachments {
+		attachments[attachmentIndex] = attachment
+	}
+	boundaryBody := mediaV2RequestBody(t, proxy.ModelNameGemini25Flash, "inspect", attachments)
+	boundaryResponse := postV2MediaRequest(t, router, "secret-a", []byte(boundaryBody))
+	if boundaryResponse.Code != http.StatusOK || upstreamCalls != 1 {
+		t.Fatalf("boundary status=%d calls=%d body=%s", boundaryResponse.Code, upstreamCalls, boundaryResponse.Body.String())
+	}
+	aboveBody := mediaV2RequestBody(t, proxy.ModelNameGemini25Flash, "inspect", append(attachments, attachment))
+	aboveResponse := postV2MediaRequest(t, router, "secret-a", []byte(aboveBody))
+	if aboveResponse.Code != http.StatusRequestEntityTooLarge || upstreamCalls != 1 || !strings.Contains(aboveResponse.Body.String(), llmproxycontract.ErrorCodeProviderMediaLimitExceeded) {
+		t.Fatalf("above status=%d calls=%d body=%s", aboveResponse.Code, upstreamCalls, aboveResponse.Body.String())
+	}
+}
+
+func TestGeminiInlineRequestLimitSelectsInlineAtBoundaryAndFilesOneAbove(t *testing.T) {
+	mediaBytes := []byte("inline-boundary-image")
+	digest := sha256.Sum256(mediaBytes)
+	var upstream *httptest.Server
+	inlineRequestSizes := []int{}
+	fileInteractions := 0
+	uploadCount := 0
+	upstream = httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/upload/v1beta/files":
+			responseWriter.Header().Set("X-Goog-Upload-URL", upstream.URL+"/upload-session")
+			responseWriter.WriteHeader(http.StatusOK)
+		case request.Method == http.MethodPost && request.URL.Path == "/upload-session":
+			uploadedBytes, _ := io.ReadAll(request.Body)
+			if !bytes.Equal(uploadedBytes, mediaBytes) {
+				t.Errorf("uploaded bytes=%q", uploadedBytes)
+			}
+			uploadCount++
+			_, _ = fmt.Fprintf(responseWriter, `{"file":{"name":"files/inline-boundary","mimeType":"image/png","sizeBytes":"%d","sha256Hash":"%s","uri":"%s/files/inline-boundary","state":"ACTIVE"}}`, len(mediaBytes), base64.StdEncoding.EncodeToString(digest[:]), upstream.URL)
+		case request.Method == http.MethodPost && request.URL.Path == "/interactions":
+			body, _ := io.ReadAll(request.Body)
+			if bytes.Contains(body, []byte(`"data"`)) {
+				inlineRequestSizes = append(inlineRequestSizes, len(body))
+			}
+			if bytes.Contains(body, []byte(`"uri"`)) {
+				fileInteractions++
+			}
+			writeGeminiCompletedResponse(responseWriter)
+		case request.Method == http.MethodDelete && request.URL.Path == "/files/inline-boundary":
+			responseWriter.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(responseWriter, request)
+		}
+	}))
+	defer upstream.Close()
+	requestBody := []byte(mediaV2RequestBody(t, proxy.ModelNameGemini25Flash, "inspect", []map[string]any{
+		messageMediaPayload("image", "image/png", mediaBytes),
+	}))
+	executeCatalog := func(catalog proxy.ModelCatalog) *httptest.ResponseRecorder {
+		return postV2MediaRequest(t, mediaAssetRouter(t, upstream.URL, t.TempDir(), catalog, 60), "secret-a", requestBody)
+	}
+	executeBounded := func(inlineLimit int64) *httptest.ResponseRecorder {
+		catalog := testfixtures.ModelCatalog(t)
+		setGeminiMediaLimit(t, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDInlineRequestBytes, inlineLimit)
+		setGeminiMediaLimit(t, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDImageFileBytes, int64(len(mediaBytes)))
+		return executeCatalog(catalog)
+	}
+	initialResponse := executeBounded(20_000_000)
+	if initialResponse.Code != http.StatusOK || len(inlineRequestSizes) != 1 {
+		t.Fatalf("initial status=%d inline sizes=%v body=%s", initialResponse.Code, inlineRequestSizes, initialResponse.Body.String())
+	}
+	inlineBoundary := int64(inlineRequestSizes[0])
+	boundaryResponse := executeBounded(inlineBoundary)
+	aboveResponse := executeBounded(inlineBoundary - 1)
+	if boundaryResponse.Code != http.StatusOK || aboveResponse.Code != http.StatusOK || len(inlineRequestSizes) != 2 || int64(inlineRequestSizes[1]) != inlineBoundary || uploadCount != 1 || fileInteractions != 1 {
+		t.Fatalf("boundary=%d statuses=%d,%d inline=%v uploads=%d file_interactions=%d", inlineBoundary, boundaryResponse.Code, aboveResponse.Code, inlineRequestSizes, uploadCount, fileInteractions)
+	}
+	for _, status := range []string{proxy.CatalogMediaLimitStatusUnbounded, proxy.CatalogMediaLimitStatusUnknown} {
+		catalog := testfixtures.ModelCatalog(t)
+		setGeminiMediaLimitStatus(t, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDInlineRequestBytes, status)
+		response := executeCatalog(catalog)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status=%s response=%d body=%s", status, response.Code, response.Body.String())
+		}
+	}
+	if len(inlineRequestSizes) != 4 || uploadCount != 1 || fileInteractions != 1 {
+		t.Fatalf("non-bounded inline=%v uploads=%d file_interactions=%d", inlineRequestSizes, uploadCount, fileInteractions)
+	}
+}
+
+func TestTenantAssetReferenceValidationAndExactRouting(t *testing.T) {
+	mediaBytes := []byte("tenant-owned-image-bytes")
+	var receivedMedia []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		var payload map[string]any
+		_ = json.NewDecoder(request.Body).Decode(&payload)
+		encoded := payload["input"].([]any)[0].(map[string]any)["content"].([]any)[1].(map[string]any)["data"].(string)
+		receivedMedia, _ = base64.StdEncoding.DecodeString(encoded)
+		writeGeminiCompletedResponse(responseWriter)
+	}))
+	defer upstream.Close()
+	assetRoot := t.TempDir()
+	router := mediaAssetRouter(t, upstream.URL, assetRoot, testfixtures.ModelCatalog(t), 60)
+	asset := uploadTestAsset(t, router, "secret-a", "image/png", mediaBytes)
+
+	assetPayload := v2AssetReferencePayload(asset.AssetID, asset.MIMEType, asset.SHA256)
+	response := postV2MediaRequest(t, router, "secret-a", assetPayload)
+	if response.Code != http.StatusOK || !bytes.Equal(receivedMedia, mediaBytes) {
+		t.Fatalf("status=%d body=%s received=%q", response.Code, response.Body.String(), receivedMedia)
+	}
+
+	for _, testCase := range []struct {
+		name       string
+		secret     string
+		payload    []byte
+		wantStatus int
+	}{
+		{name: "foreign tenant", secret: "secret-b", payload: assetPayload, wantStatus: http.StatusNotFound},
+		{name: "missing asset", secret: "secret-a", payload: v2AssetReferencePayload("ast_00000000000000000000000000000000", asset.MIMEType, asset.SHA256), wantStatus: http.StatusNotFound},
+		{name: "wrong MIME", secret: "secret-a", payload: v2AssetReferencePayload(asset.AssetID, "image/jpeg", asset.SHA256), wantStatus: http.StatusBadRequest},
+		{name: "wrong digest", secret: "secret-a", payload: v2AssetReferencePayload(asset.AssetID, asset.MIMEType, strings.Repeat("0", 64)), wantStatus: http.StatusBadRequest},
+		{name: "both union variants", secret: "secret-a", payload: v2ConflictingAttachmentPayload(asset, mediaBytes), wantStatus: http.StatusBadRequest},
+	} {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			validationResponse := postV2MediaRequest(subTest, router, testCase.secret, testCase.payload)
+			if validationResponse.Code != testCase.wantStatus {
+				subTest.Fatalf("status=%d body=%s", validationResponse.Code, validationResponse.Body.String())
+			}
+		})
+	}
+
+	deleteRequest := httptest.NewRequest(http.MethodDelete, llmproxycontract.AssetPath+"/"+asset.AssetID+"?key=secret-a", nil)
+	deleteResponse := httptest.NewRecorder()
+	router.ServeHTTP(deleteResponse, deleteRequest)
+	if deleteResponse.Code != http.StatusNoContent {
+		t.Fatalf("delete status=%d body=%s", deleteResponse.Code, deleteResponse.Body.String())
+	}
+	deletedResponse := postV2MediaRequest(t, router, "secret-a", assetPayload)
+	if deletedResponse.Code != http.StatusGone || !strings.Contains(deletedResponse.Body.String(), "asset_deleted") {
+		t.Fatalf("deleted status=%d body=%s", deletedResponse.Code, deletedResponse.Body.String())
+	}
+}
+
+func TestGeminiFileTransportPreservesAssetBytesAndCleansUp(t *testing.T) {
+	mediaBytes := bytes.Repeat([]byte("media"), 300)
+	digest := sha256.Sum256(mediaBytes)
+	var upstream *httptest.Server
+	var mutex sync.Mutex
+	uploadedBytes := []byte(nil)
+	interactionURI := ""
+	cleanupCount := 0
+	upstream = httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/upload/v1beta/files":
+			responseWriter.Header().Set("X-Goog-Upload-URL", upstream.URL+"/upload-session")
+			responseWriter.WriteHeader(http.StatusOK)
+		case request.Method == http.MethodPost && request.URL.Path == "/upload-session":
+			body, _ := io.ReadAll(request.Body)
+			mutex.Lock()
+			uploadedBytes = body
+			mutex.Unlock()
+			responseWriter.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(responseWriter, `{"file":{"name":"files/media-1","mimeType":"image/png","sizeBytes":"%d","sha256Hash":"%s","uri":"%s/files/media-1","state":"ACTIVE"}}`, len(mediaBytes), base64.StdEncoding.EncodeToString(digest[:]), upstream.URL)
+		case request.Method == http.MethodPost && request.URL.Path == "/interactions":
+			var payload map[string]any
+			_ = json.NewDecoder(request.Body).Decode(&payload)
+			interactionURI = payload["input"].([]any)[0].(map[string]any)["content"].([]any)[1].(map[string]any)["uri"].(string)
+			writeGeminiCompletedResponse(responseWriter)
+		case request.Method == http.MethodDelete && request.URL.Path == "/files/media-1":
+			cleanupCount++
+			responseWriter.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(responseWriter, request)
+		}
+	}))
+	defer upstream.Close()
+	catalog := testfixtures.ModelCatalog(t)
+	setGeminiMediaLimit(t, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDInlineRequestBytes, 256)
+	setGeminiMediaLimit(t, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDImageFileBytes, int64(len(mediaBytes)))
+	router := mediaAssetRouter(t, upstream.URL, t.TempDir(), catalog, 60)
+	asset := uploadTestAsset(t, router, "secret-a", "image/png", mediaBytes)
+	response := postV2MediaRequest(t, router, "secret-a", v2AssetReferencePayload(asset.AssetID, asset.MIMEType, asset.SHA256))
+	mutex.Lock()
+	defer mutex.Unlock()
+	if response.Code != http.StatusOK || !bytes.Equal(uploadedBytes, mediaBytes) || interactionURI != upstream.URL+"/files/media-1" || cleanupCount != 1 {
+		t.Fatalf("status=%d upload=%d uri=%q cleanup=%d body=%s", response.Code, len(uploadedBytes), interactionURI, cleanupCount, response.Body.String())
+	}
+}
+
+func TestDeletingAssetAfterAdmissionKeepsTheOpenRequestStable(t *testing.T) {
+	mediaBytes := bytes.Repeat([]byte("admitted-media"), 100)
+	digest := sha256.Sum256(mediaBytes)
+	startReached := make(chan struct{})
+	releaseStart := make(chan struct{})
+	var upstream *httptest.Server
+	var uploadedBytes []byte
+	upstream = httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/upload/v1beta/files":
+			close(startReached)
+			<-releaseStart
+			responseWriter.Header().Set("X-Goog-Upload-URL", upstream.URL+"/upload-session")
+			responseWriter.WriteHeader(http.StatusOK)
+		case request.Method == http.MethodPost && request.URL.Path == "/upload-session":
+			uploadedBytes, _ = io.ReadAll(request.Body)
+			_, _ = fmt.Fprintf(responseWriter, `{"file":{"name":"files/admitted","mimeType":"image/png","sizeBytes":"%d","sha256Hash":"%s","uri":"%s/files/admitted","state":"ACTIVE"}}`, len(mediaBytes), base64.StdEncoding.EncodeToString(digest[:]), upstream.URL)
+		case request.Method == http.MethodPost && request.URL.Path == "/interactions":
+			writeGeminiCompletedResponse(responseWriter)
+		case request.Method == http.MethodDelete && request.URL.Path == "/files/admitted":
+			responseWriter.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(responseWriter, request)
+		}
+	}))
+	defer upstream.Close()
+	catalog := testfixtures.ModelCatalog(t)
+	setGeminiMediaLimit(t, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDInlineRequestBytes, 1)
+	router := mediaAssetRouter(t, upstream.URL, t.TempDir(), catalog, 60)
+	asset := uploadTestAsset(t, router, "secret-a", "image/png", mediaBytes)
+	requestComplete := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		requestComplete <- postV2MediaRequest(t, router, "secret-a", v2AssetReferencePayload(asset.AssetID, asset.MIMEType, asset.SHA256))
+	}()
+	select {
+	case <-startReached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider file admission did not start")
+	}
+	deleteRequest := httptest.NewRequest(http.MethodDelete, llmproxycontract.AssetPath+"/"+asset.AssetID+"?key=secret-a", nil)
+	deleteResponse := httptest.NewRecorder()
+	router.ServeHTTP(deleteResponse, deleteRequest)
+	close(releaseStart)
+	response := <-requestComplete
+	if deleteResponse.Code != http.StatusNoContent || response.Code != http.StatusOK || !bytes.Equal(uploadedBytes, mediaBytes) {
+		t.Fatalf("delete=%d request=%d uploaded=%d body=%s", deleteResponse.Code, response.Code, len(uploadedBytes), response.Body.String())
+	}
+}
+
+func TestExpiredAssetAndProviderMediaLimitsFailWithStableCodes(t *testing.T) {
+	t.Run("expired asset", func(subTest *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			subTest.Error("expired asset reached provider")
+		}))
+		defer upstream.Close()
+		router := mediaAssetRouter(subTest, upstream.URL, subTest.TempDir(), testfixtures.ModelCatalog(subTest), 1)
+		asset := uploadTestAsset(subTest, router, "secret-a", "image/png", []byte("expires"))
+		time.Sleep(1100 * time.Millisecond)
+		response := postV2MediaRequest(subTest, router, "secret-a", v2AssetReferencePayload(asset.AssetID, asset.MIMEType, asset.SHA256))
+		if response.Code != http.StatusGone || !strings.Contains(response.Body.String(), "asset_expired") {
+			subTest.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	})
+
+	t.Run("configured file limit", func(subTest *testing.T) {
+		upstreamCalls := 0
+		upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			upstreamCalls++
+		}))
+		defer upstream.Close()
+		catalog := testfixtures.ModelCatalog(subTest)
+		setGeminiMediaLimit(subTest, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDInlineRequestBytes, 1)
+		setGeminiMediaLimit(subTest, &catalog, proxy.ModelNameGemini25Flash, proxy.CatalogMediaLimitIDImageFileBytes, int64(len("above-limit")-1))
+		router := mediaAssetRouter(subTest, upstream.URL, subTest.TempDir(), catalog, 60)
+		asset := uploadTestAsset(subTest, router, "secret-a", "image/png", []byte("above-limit"))
+		response := postV2MediaRequest(subTest, router, "secret-a", v2AssetReferencePayload(asset.AssetID, asset.MIMEType, asset.SHA256))
+		if response.Code != http.StatusRequestEntityTooLarge || !strings.Contains(response.Body.String(), llmproxycontract.ErrorCodeProviderMediaLimitExceeded) || upstreamCalls != 0 {
+			subTest.Fatalf("status=%d calls=%d body=%s", response.Code, upstreamCalls, response.Body.String())
+		}
+	})
+
+	t.Run("upstream media limit", func(subTest *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+			responseWriter.WriteHeader(http.StatusRequestEntityTooLarge)
+		}))
+		defer upstream.Close()
+		router := mediaAssetRouter(subTest, upstream.URL, subTest.TempDir(), testfixtures.ModelCatalog(subTest), 60)
+		mediaBytes := []byte("inline-media")
+		digest := sha256.Sum256(mediaBytes)
+		requestBody, _ := json.Marshal(map[string]any{"messages": []any{map[string]any{
+			"role": "user", "content": "inspect",
+			"attachments": []any{map[string]any{"type": "image", "mime_type": "image/png", "data": base64.StdEncoding.EncodeToString(mediaBytes), "sha256": hex.EncodeToString(digest[:])}},
+		}}})
+		response := postV2MediaRequest(subTest, router, "secret-a", requestBody)
+		if response.Code != http.StatusRequestEntityTooLarge || !strings.Contains(response.Body.String(), llmproxycontract.ErrorCodeProviderMediaLimitExceeded) {
+			subTest.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	})
+}
+
+func mediaAssetRouter(t *testing.T, geminiBaseURL string, assetRoot string, catalog proxy.ModelCatalog, retentionSeconds int) http.Handler {
+	t.Helper()
+	configuration := proxy.Configuration{
+		Tenants: []proxy.TenantConfiguration{
+			{ID: "tenant-a", Secret: "secret-a", Defaults: proxy.TenantDefaults{Provider: proxy.ProviderNameGemini, Model: proxy.ModelNameGemini25Flash, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}},
+			{ID: "tenant-b", Secret: "secret-b", Defaults: proxy.TenantDefaults{Provider: proxy.ProviderNameGemini, Model: proxy.ModelNameGemini25Flash, DictationProvider: proxy.ProviderNameOpenAI, DictationModel: proxy.DefaultDictationModel}},
+		},
+		OpenAIKey: "openai-key", GeminiKey: "gemini-key", GeminiBaseURL: geminiBaseURL,
+		WorkerCount: 2, QueueSize: 4, RequestTimeoutSeconds: 10, MaxPromptBytes: proxy.DefaultMaxPromptBytes,
+		MaxAssetBytes: 10 * 1024 * 1024, AssetRetentionSeconds: retentionSeconds, AssetStorePath: assetRoot,
+		ModelCatalog: catalog,
+	}
+	router, buildError := proxy.BuildRouter(configuration, zap.NewNop().Sugar())
+	if buildError != nil {
+		t.Fatalf("BuildRouter error: %v", buildError)
+	}
+	return router
+}
+
+func uploadTestAsset(t *testing.T, router http.Handler, secret string, mimeType string, data []byte) mediaAssetResponse {
+	t.Helper()
+	digest := sha256.Sum256(data)
+	request := httptest.NewRequest(http.MethodPost, llmproxycontract.AssetPath+"?key="+secret, bytes.NewReader(data))
+	request.Header.Set("Content-Type", mimeType)
+	request.Header.Set(llmproxycontract.HeaderAssetSHA256, hex.EncodeToString(digest[:]))
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("upload status=%d body=%s", response.Code, response.Body.String())
+	}
+	var asset mediaAssetResponse
+	if decodeError := json.Unmarshal(response.Body.Bytes(), &asset); decodeError != nil {
+		t.Fatalf("decode asset: %v", decodeError)
+	}
+	return asset
+}
+
+func postV2MediaRequest(t *testing.T, router http.Handler, secret string, payload []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/v2?key="+secret+"&format=text/plain", bytes.NewReader(payload))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	return response
+}
+
+func v2AssetReferencePayload(assetID string, mimeType string, digest string) []byte {
+	payload, _ := json.Marshal(map[string]any{"messages": []any{map[string]any{
+		"role": "user", "content": "inspect asset",
+		"attachments": []any{map[string]any{"type": "image", "asset_id": assetID, "mime_type": mimeType, "sha256": digest}},
+	}}})
+	return payload
+}
+
+func v2ConflictingAttachmentPayload(asset mediaAssetResponse, data []byte) []byte {
+	payload, _ := json.Marshal(map[string]any{"messages": []any{map[string]any{
+		"role": "user", "content": "inspect asset",
+		"attachments": []any{map[string]any{"type": "image", "asset_id": asset.AssetID, "data": base64.StdEncoding.EncodeToString(data), "mime_type": asset.MIMEType, "sha256": asset.SHA256}},
+	}}})
+	return payload
+}
+
+func setGeminiMediaLimit(t *testing.T, catalog *proxy.ModelCatalog, model string, limitID string, value int64) {
+	t.Helper()
+	for offeringIndex := range catalog.Offerings {
+		offering := &catalog.Offerings[offeringIndex]
+		if offering.Provider != proxy.ProviderNameGemini || offering.Model != model {
+			continue
+		}
+		for limitIndex := range offering.MediaLimits {
+			if offering.MediaLimits[limitIndex].ID == limitID {
+				offering.MediaLimits[limitIndex].Value = &value
+				return
+			}
+		}
+	}
+	t.Fatalf("missing Gemini media limit=%s", limitID)
+}
+
+func setGeminiMediaLimitStatus(t *testing.T, catalog *proxy.ModelCatalog, model string, limitID string, status string) {
+	t.Helper()
+	for offeringIndex := range catalog.Offerings {
+		offering := &catalog.Offerings[offeringIndex]
+		if offering.Provider != proxy.ProviderNameGemini || offering.Model != model {
+			continue
+		}
+		for limitIndex := range offering.MediaLimits {
+			if offering.MediaLimits[limitIndex].ID == limitID {
+				offering.MediaLimits[limitIndex].Status = status
+				offering.MediaLimits[limitIndex].Value = nil
+				return
+			}
+		}
+	}
+	t.Fatalf("missing Gemini media limit=%s", limitID)
+}
+
+func writeGeminiCompletedResponse(responseWriter http.ResponseWriter) {
+	responseWriter.Header().Set("Content-Type", "application/json")
+	_, _ = responseWriter.Write([]byte(`{"status":"completed","steps":[{"type":"model_output","content":[{"type":"text","text":"accepted"}]}]}`))
+}

--- a/internal/proxy/media_limits.go
+++ b/internal/proxy/media_limits.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"math"
 	"net/url"
 	"strings"
 	"time"
@@ -157,4 +158,19 @@ func catalogMediaLimit(limits []CatalogMediaLimit, identifier string, mediaType 
 		return limit, true
 	}
 	return CatalogMediaLimit{}, false
+}
+
+func maximumV2RequestBytes(maxPromptBytes int64, catalog ModelCatalog) int64 {
+	maximumInlineBytes := int64(0)
+	for _, offering := range catalog.Offerings {
+		for _, limit := range offering.MediaLimits {
+			if limit.ID == CatalogMediaLimitIDInlineRequestBytes && limit.Status == CatalogMediaLimitStatusBounded && limit.Value != nil && *limit.Value > maximumInlineBytes {
+				maximumInlineBytes = *limit.Value
+			}
+		}
+	}
+	if maximumInlineBytes > math.MaxInt64-maxPromptBytes {
+		return math.MaxInt64
+	}
+	return maxPromptBytes + maximumInlineBytes
 }

--- a/internal/proxy/media_limits.go
+++ b/internal/proxy/media_limits.go
@@ -1,0 +1,160 @@
+package proxy
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	CatalogMediaLimitStatusBounded   = "bounded"
+	CatalogMediaLimitStatusUnbounded = "unbounded"
+	CatalogMediaLimitStatusUnknown   = "unknown"
+
+	CatalogMediaTransportAny    = "any"
+	CatalogMediaTransportFile   = "file"
+	CatalogMediaTransportInline = "inline"
+
+	CatalogMediaLimitUnitBytes = "bytes"
+	CatalogMediaLimitUnitFiles = "files"
+
+	CatalogMediaLimitScopeAttachment          = "attachment"
+	CatalogMediaLimitScopeRequest             = "request"
+	CatalogMediaLimitScopeRequestEncodedBytes = "request_encoded_bytes"
+
+	CatalogMediaLimitTypeAll = "all"
+
+	CatalogMediaLimitIDInlineRequestBytes = "inline_request_bytes"
+	CatalogMediaLimitIDImageCount         = "image_count"
+	CatalogMediaLimitIDAudioCount         = "audio_count"
+	CatalogMediaLimitIDImageFileBytes     = "image_file_bytes"
+	CatalogMediaLimitIDAudioFileBytes     = "audio_file_bytes"
+)
+
+// CatalogMediaLimit declares one provider-offering media admission rule.
+type CatalogMediaLimit struct {
+	ID           string `json:"id" mapstructure:"id"`
+	MediaType    string `json:"media_type" mapstructure:"media_type"`
+	Transport    string `json:"transport" mapstructure:"transport"`
+	Status       string `json:"status" mapstructure:"status"`
+	Value        *int64 `json:"value" mapstructure:"value"`
+	Unit         string `json:"unit" mapstructure:"unit"`
+	Scope        string `json:"scope" mapstructure:"scope"`
+	Source       string `json:"source" mapstructure:"source"`
+	LastVerified string `json:"last_verified" mapstructure:"last_verified"`
+}
+
+func cloneCatalogMediaLimits(limits []CatalogMediaLimit) []CatalogMediaLimit {
+	cloned := make([]CatalogMediaLimit, len(limits))
+	for limitIndex, limit := range limits {
+		cloned[limitIndex] = limit
+		if limit.Value != nil {
+			value := *limit.Value
+			cloned[limitIndex].Value = &value
+		}
+	}
+	return cloned
+}
+
+func validateCatalogMediaLimits(limits []CatalogMediaLimit, mediaInputs []string, field string) error {
+	if len(mediaInputs) == 0 {
+		if len(limits) != 0 {
+			return fmt.Errorf("%w: field=%s reason=media_limits_without_media_inputs", ErrInvalidModelCatalog, field)
+		}
+		return nil
+	}
+	if len(limits) == 0 {
+		return fmt.Errorf("%w: field=%s reason=media_limits_missing", ErrInvalidModelCatalog, field)
+	}
+	mediaInputSet := configuredMediaInputSet(mediaInputs)
+	seen := map[string]struct{}{}
+	configured := map[string]CatalogMediaLimit{}
+	for limitIndex, limit := range limits {
+		limitField := fmt.Sprintf("%s[%d]", field, limitIndex)
+		identifier, identifierError := canonicalCatalogIdentifier(limit.ID, limitField+".id")
+		if identifierError != nil {
+			return identifierError
+		}
+		if _, duplicate := seen[identifier]; duplicate {
+			return fmt.Errorf("%w: field=%s.id duplicate_identifier=%s", ErrInvalidModelCatalog, limitField, identifier)
+		}
+		seen[identifier] = struct{}{}
+		configured[identifier] = limit
+		if limit.MediaType != CatalogMediaLimitTypeAll {
+			if _, supported := mediaInputSet[messageMediaType(limit.MediaType)]; !supported {
+				return fmt.Errorf("%w: field=%s.media_type media_type=%s", ErrInvalidModelCatalog, limitField, limit.MediaType)
+			}
+		}
+		if limit.Transport != CatalogMediaTransportAny && limit.Transport != CatalogMediaTransportInline && limit.Transport != CatalogMediaTransportFile {
+			return fmt.Errorf("%w: field=%s.transport transport=%s", ErrInvalidModelCatalog, limitField, limit.Transport)
+		}
+		if limit.Unit != CatalogMediaLimitUnitBytes && limit.Unit != CatalogMediaLimitUnitFiles {
+			return fmt.Errorf("%w: field=%s.unit unit=%s", ErrInvalidModelCatalog, limitField, limit.Unit)
+		}
+		if limit.Scope != CatalogMediaLimitScopeAttachment && limit.Scope != CatalogMediaLimitScopeRequest && limit.Scope != CatalogMediaLimitScopeRequestEncodedBytes {
+			return fmt.Errorf("%w: field=%s.scope scope=%s", ErrInvalidModelCatalog, limitField, limit.Scope)
+		}
+		switch limit.Status {
+		case CatalogMediaLimitStatusBounded:
+			if limit.Value == nil || *limit.Value <= 0 {
+				return fmt.Errorf("%w: field=%s.value", ErrInvalidModelCatalog, limitField)
+			}
+		case CatalogMediaLimitStatusUnbounded, CatalogMediaLimitStatusUnknown:
+			if limit.Value != nil {
+				return fmt.Errorf("%w: field=%s.value status=%s", ErrInvalidModelCatalog, limitField, limit.Status)
+			}
+		default:
+			return fmt.Errorf("%w: field=%s.status status=%s", ErrInvalidModelCatalog, limitField, limit.Status)
+		}
+		parsedSource, sourceError := url.ParseRequestURI(strings.TrimSpace(limit.Source))
+		if sourceError != nil || parsedSource.Scheme != "https" || parsedSource.Host == "" || limit.Source != strings.TrimSpace(limit.Source) {
+			return fmt.Errorf("%w: field=%s.source", ErrInvalidModelCatalog, limitField)
+		}
+		if _, dateError := time.Parse(time.DateOnly, limit.LastVerified); dateError != nil {
+			return fmt.Errorf("%w: field=%s.last_verified", ErrInvalidModelCatalog, limitField)
+		}
+	}
+	requiredLimits := []CatalogMediaLimit{
+		{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Transport: CatalogMediaTransportInline, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeRequestEncodedBytes},
+	}
+	for _, mediaInput := range mediaInputs {
+		switch messageMediaType(mediaInput) {
+		case messageMediaTypeImage:
+			requiredLimits = append(requiredLimits,
+				CatalogMediaLimit{ID: CatalogMediaLimitIDImageCount, MediaType: mediaInput, Transport: CatalogMediaTransportAny, Unit: CatalogMediaLimitUnitFiles, Scope: CatalogMediaLimitScopeRequest},
+				CatalogMediaLimit{ID: CatalogMediaLimitIDImageFileBytes, MediaType: mediaInput, Transport: CatalogMediaTransportFile, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment},
+			)
+		case messageMediaTypeAudio:
+			requiredLimits = append(requiredLimits,
+				CatalogMediaLimit{ID: CatalogMediaLimitIDAudioCount, MediaType: mediaInput, Transport: CatalogMediaTransportAny, Unit: CatalogMediaLimitUnitFiles, Scope: CatalogMediaLimitScopeRequest},
+				CatalogMediaLimit{ID: CatalogMediaLimitIDAudioFileBytes, MediaType: mediaInput, Transport: CatalogMediaTransportFile, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment},
+			)
+		}
+	}
+	for _, requiredLimit := range requiredLimits {
+		limit, exists := configured[requiredLimit.ID]
+		if !exists || limit.MediaType != requiredLimit.MediaType || limit.Transport != requiredLimit.Transport || limit.Unit != requiredLimit.Unit || limit.Scope != requiredLimit.Scope {
+			return fmt.Errorf("%w: field=%s required_limit=%s", ErrInvalidModelCatalog, field, requiredLimit.ID)
+		}
+	}
+	return nil
+}
+
+func boundedCatalogMediaLimit(limits []CatalogMediaLimit, identifier string, mediaType messageMediaType) (int64, bool) {
+	limit, found := catalogMediaLimit(limits, identifier, mediaType)
+	if !found || limit.Status != CatalogMediaLimitStatusBounded {
+		return 0, false
+	}
+	return *limit.Value, true
+}
+
+func catalogMediaLimit(limits []CatalogMediaLimit, identifier string, mediaType messageMediaType) (CatalogMediaLimit, bool) {
+	for _, limit := range limits {
+		if limit.ID != identifier || (limit.MediaType != CatalogMediaLimitTypeAll && limit.MediaType != string(mediaType)) {
+			continue
+		}
+		return limit, true
+	}
+	return CatalogMediaLimit{}, false
+}

--- a/internal/proxy/message_media.go
+++ b/internal/proxy/message_media.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/tyemirov/llm-proxy/internal/constants"
@@ -28,16 +29,20 @@ const (
 type messageMediaType string
 
 type chatMessageAttachmentPayload struct {
-	Type     string `json:"type"`
-	MIMEType string `json:"mime_type"`
-	Data     string `json:"data"`
-	SHA256   string `json:"sha256"`
+	Type     string  `json:"type"`
+	MIMEType string  `json:"mime_type"`
+	Data     *string `json:"data,omitempty"`
+	AssetID  *string `json:"asset_id,omitempty"`
+	SHA256   string  `json:"sha256"`
 }
 
 type messageMedia struct {
 	mediaType messageMediaType
 	mimeType  string
+	sha256    string
+	sizeBytes int64
 	data      []byte
+	asset     *tenantAssetReader
 }
 
 var providerMessageMediaInputs = map[string]map[messageMediaType]struct{}{
@@ -47,29 +52,88 @@ var providerMessageMediaInputs = map[string]map[messageMediaType]struct{}{
 	},
 }
 
-func newMessageMedia(payload chatMessageAttachmentPayload) (messageMedia, error) {
+func newMessageMedia(payload chatMessageAttachmentPayload, requestTenant tenant, assetStore *tenantAssetStore) (messageMedia, error) {
 	mediaType := messageMediaType(payload.Type)
+	if !supportedMessageMediaTypeMIME(mediaType, payload.MIMEType) {
+		if mediaType != messageMediaTypeImage && mediaType != messageMediaTypeAudio {
+			return messageMedia{}, fmt.Errorf("%w: unsupported attachment type=%q", ErrInvalidChatMessages, payload.Type)
+		}
+		return messageMedia{}, fmt.Errorf("%w: unsupported %s MIME type=%q", ErrInvalidChatMessages, mediaType, payload.MIMEType)
+	}
+	if (payload.Data == nil) == (payload.AssetID == nil) {
+		return messageMedia{}, fmt.Errorf("%w: attachment requires exactly one of data or asset_id", ErrInvalidChatMessages)
+	}
+	if payload.Data != nil {
+		data, dataError := decodeHashBoundMessageMedia(*payload.Data, payload.SHA256)
+		if dataError != nil {
+			return messageMedia{}, dataError
+		}
+		return messageMedia{mediaType: mediaType, mimeType: payload.MIMEType, sha256: payload.SHA256, sizeBytes: int64(len(data)), data: data}, nil
+	}
+	assetID := strings.TrimSpace(*payload.AssetID)
+	if assetID != *payload.AssetID {
+		return messageMedia{}, fmt.Errorf("%w: asset_id is not canonical", ErrInvalidChatMessages)
+	}
+	asset, assetError := assetStore.resolve(requestTenant, assetID, payload.MIMEType, payload.SHA256)
+	if assetError != nil {
+		return messageMedia{}, assetError
+	}
+	return messageMedia{mediaType: mediaType, mimeType: payload.MIMEType, sha256: payload.SHA256, sizeBytes: asset.metadata.SizeBytes, asset: asset}, nil
+}
+
+func supportedMessageMediaTypeMIME(mediaType messageMediaType, mimeType string) bool {
 	switch mediaType {
 	case messageMediaTypeImage:
-		switch payload.MIMEType {
-		case messageImageMIMEJPEG, messageImageMIMEPNG, messageImageMIMEWebP:
-		default:
-			return messageMedia{}, fmt.Errorf("%w: unsupported image MIME type=%q", ErrInvalidChatMessages, payload.MIMEType)
-		}
+		return mimeType == messageImageMIMEJPEG || mimeType == messageImageMIMEPNG || mimeType == messageImageMIMEWebP
 	case messageMediaTypeAudio:
-		switch payload.MIMEType {
-		case messageAudioMIMEM4A, messageAudioMIMEMPEG, messageAudioMIMEWAV:
-		default:
-			return messageMedia{}, fmt.Errorf("%w: unsupported audio MIME type=%q", ErrInvalidChatMessages, payload.MIMEType)
-		}
+		return mimeType == messageAudioMIMEM4A || mimeType == messageAudioMIMEMPEG || mimeType == messageAudioMIMEWAV
 	default:
-		return messageMedia{}, fmt.Errorf("%w: unsupported attachment type=%q", ErrInvalidChatMessages, payload.Type)
+		return false
 	}
-	data, dataError := decodeHashBoundMessageMedia(payload.Data, payload.SHA256)
-	if dataError != nil {
-		return messageMedia{}, dataError
+}
+
+func supportedMessageMediaMIME(mimeType string) bool {
+	return supportedMessageMediaTypeMIME(messageMediaTypeImage, mimeType) || supportedMessageMediaTypeMIME(messageMediaTypeAudio, mimeType)
+}
+
+func (media *messageMedia) reader() (io.Reader, error) {
+	if media.asset == nil {
+		return bytes.NewReader(media.data), nil
 	}
-	return messageMedia{mediaType: mediaType, mimeType: payload.MIMEType, data: data}, nil
+	if _, seekError := media.asset.file.Seek(0, io.SeekStart); seekError != nil {
+		return nil, fmt.Errorf("%w: open attachment", errAssetStore)
+	}
+	return media.asset.file, nil
+}
+
+func (media *messageMedia) close() error {
+	if media.asset == nil {
+		return nil
+	}
+	return media.asset.Close()
+}
+
+func (messages chatMessages) closeMedia() {
+	for messageIndex := range messages {
+		for attachmentIndex := range messages[messageIndex].attachments {
+			_ = messages[messageIndex].attachments[attachmentIndex].close()
+		}
+	}
+}
+
+func (media *messageMedia) bytes() ([]byte, error) {
+	if media.asset == nil {
+		return media.data, nil
+	}
+	reader, readerError := media.reader()
+	if readerError != nil {
+		return nil, readerError
+	}
+	data, readError := io.ReadAll(io.LimitReader(reader, media.sizeBytes+1))
+	if readError != nil || int64(len(data)) != media.sizeBytes {
+		return nil, fmt.Errorf("%w: read attachment", errAssetStore)
+	}
+	return data, nil
 }
 
 func decodeHashBoundMessageMedia(rawData string, rawDigest string) ([]byte, error) {

--- a/internal/proxy/message_media_routing_test.go
+++ b/internal/proxy/message_media_routing_test.go
@@ -186,7 +186,7 @@ func TestV2RejectsInvalidOrUnsupportedMediaBeforeUpstreamWork(testingInstance *t
 	}
 }
 
-func TestCompatibilityMessagesRejectMediaAndV2BoundsEncodedMediaBody(testingInstance *testing.T) {
+func TestCompatibilityMessagesRejectMediaAndV2IgnoresCompatibilityBodyLimit(testingInstance *testing.T) {
 	upstreamCalls := 0
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
 		upstreamCalls++
@@ -229,11 +229,11 @@ func TestCompatibilityMessagesRejectMediaAndV2BoundsEncodedMediaBody(testingInst
 	oversizedRequest.Header.Set("Content-Type", "application/json")
 	oversizedResponse := httptest.NewRecorder()
 	router.ServeHTTP(oversizedResponse, oversizedRequest)
-	if oversizedResponse.Code != http.StatusRequestEntityTooLarge {
+	if oversizedResponse.Code != http.StatusBadGateway {
 		testingInstance.Fatalf("oversized status=%d body=%s", oversizedResponse.Code, oversizedResponse.Body.String())
 	}
-	if upstreamCalls != 0 {
-		testingInstance.Fatalf("upstream calls=%d want=0", upstreamCalls)
+	if upstreamCalls != 1 {
+		testingInstance.Fatalf("upstream calls=%d want=1", upstreamCalls)
 	}
 }
 

--- a/internal/proxy/model_catalog.go
+++ b/internal/proxy/model_catalog.go
@@ -92,6 +92,7 @@ type ProviderOffering struct {
 	OutputTokenLimit   int                        `mapstructure:"output_token_limit"`
 	ReasoningEffort    *ReasoningEffortCapability `mapstructure:"reasoning_effort"`
 	MediaInputs        []string                   `mapstructure:"media_inputs"`
+	MediaLimits        []CatalogMediaLimit        `mapstructure:"media_limits"`
 	Controls           []CatalogControl           `mapstructure:"controls"`
 	Limits             []CatalogLimit             `mapstructure:"limits"`
 }
@@ -383,6 +384,9 @@ func validateProviderOfferings(offerings []ProviderOffering, catalog validatedMo
 				return fmt.Errorf("%w: field=%s.media_inputs media_input=%s reason=unsupported_by_model", ErrInvalidModelCatalog, fieldPrefix, mediaInput)
 			}
 		}
+		if mediaLimitError := validateCatalogMediaLimits(offering.MediaLimits, offering.MediaInputs, fieldPrefix+".media_limits"); mediaLimitError != nil {
+			return mediaLimitError
+		}
 		catalog.offerings[offeringIdentifier] = offering
 	}
 	for provider, operations := range providerOperations {
@@ -407,7 +411,7 @@ func validateDictationOffering(offering ProviderOffering, fieldPrefix string) er
 	if offering.WireContract != CatalogWireContractMultipartTranscription || offering.ExecutionLifecycle != string(textExecutionLifecycleSynchronousCompletion) {
 		return fmt.Errorf("%w: field=%s reason=unsupported_dictation_route", ErrInvalidModelCatalog, fieldPrefix)
 	}
-	if offering.RequestProfile != constants.EmptyString || offering.WebSearch || offering.OutputTokenLimit != 0 || offering.ReasoningEffort != nil || len(offering.MediaInputs) != 0 || len(offering.Controls) != 0 || len(offering.Limits) != 0 {
+	if offering.RequestProfile != constants.EmptyString || offering.WebSearch || offering.OutputTokenLimit != 0 || offering.ReasoningEffort != nil || len(offering.MediaInputs) != 0 || len(offering.MediaLimits) != 0 || len(offering.Controls) != 0 || len(offering.Limits) != 0 {
 		return fmt.Errorf("%w: field=%s reason=text_capabilities_on_dictation_route", ErrInvalidModelCatalog, fieldPrefix)
 	}
 	return nil

--- a/internal/proxy/openapi_contract_test.go
+++ b/internal/proxy/openapi_contract_test.go
@@ -2,6 +2,8 @@ package proxy_test
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -97,7 +99,7 @@ func TestOpenAPIContractDocumentsActualAuthenticationBoundaries(t *testing.T) {
 	for _, operation := range operations {
 		expectedSecurity := [][]string{{"TAuthSession"}}
 		switch operation.Path {
-		case "/", "/v2", "/dictate":
+		case "/", "/v2", "/dictate", "/model/v1/assets", "/model/v1/assets/{asset_id}":
 			expectedSecurity = [][]string{{"TenantClientKey"}}
 		case proxy.ManagementConfigUIPath, proxy.PublicCapabilitiesPath:
 			expectedSecurity = [][]string{}
@@ -163,6 +165,16 @@ func TestOpenAPIContractEnforcesV2MediaRelationships(t *testing.T) {
 			wantValid: true,
 		},
 		{
+			name:      "user image asset attachment",
+			body:      `{"messages":[{"role":"user","content":"Describe the image.","attachments":[{"type":"image","mime_type":"image/png","asset_id":"ast_0123456789abcdef0123456789abcdef","sha256":"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"}]}]}`,
+			wantValid: true,
+		},
+		{
+			name:      "user audio asset attachment",
+			body:      `{"messages":[{"role":"user","content":"Transcribe the audio.","attachments":[{"type":"audio","mime_type":"audio/wav","asset_id":"ast_0123456789abcdef0123456789abcdef","sha256":"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"}]}]}`,
+			wantValid: true,
+		},
+		{
 			name:      "assistant text",
 			body:      `{"messages":[{"role":"assistant","content":"Text only."}]}`,
 			wantValid: true,
@@ -174,6 +186,10 @@ func TestOpenAPIContractEnforcesV2MediaRelationships(t *testing.T) {
 		{
 			name: "system attachment",
 			body: `{"messages":[{"role":"system","content":"Reject attached system media.","attachments":[{"type":"image","mime_type":"image/png","data":"YQ==","sha256":"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"}]}]}`,
+		},
+		{
+			name: "attachment with data and asset id",
+			body: `{"messages":[{"role":"user","content":"Reject conflicting media.","attachments":[{"type":"image","mime_type":"image/png","data":"YQ==","asset_id":"ast_0123456789abcdef0123456789abcdef","sha256":"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"}]}]}`,
 		},
 	}
 
@@ -191,6 +207,42 @@ func TestOpenAPIContractEnforcesV2MediaRelationships(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOpenAPIContractValidatesTenantAssetUploadAndDeleteExchanges(t *testing.T) {
+	contract, loadError := openapitest.Load(filepath.Join("..", "..", openapitest.CanonicalDocumentPath))
+	if loadError != nil {
+		t.Fatalf("load canonical OpenAPI contract: %v", loadError)
+	}
+	router, buildError := buildRouterWithCatalogs(t, proxy.Configuration{
+		Tenants:        proxy.SingleTenantConfigurations("asset-contract", TestSecret),
+		OpenAIKey:      TestAPIKey,
+		AssetStorePath: t.TempDir(),
+	}, nil)
+	if buildError != nil {
+		t.Fatalf("BuildRouter error: %v", buildError)
+	}
+	assetBytes := []byte("openapi-asset")
+	digest := sha256.Sum256(assetBytes)
+	uploadRequest := httptest.NewRequest(http.MethodPost, "/model/v1/assets?key="+TestSecret, bytes.NewReader(assetBytes))
+	uploadRequest.Header.Set("Content-Type", "image/png")
+	uploadRequest.Header.Set("X-LLM-Proxy-Asset-SHA256", hex.EncodeToString(digest[:]))
+	assertOpenAPIRequest(t, contract, "/model/v1/assets", uploadRequest, assetBytes)
+	uploadResponse := httptest.NewRecorder()
+	router.ServeHTTP(uploadResponse, uploadRequest)
+	assertOpenAPIResponse(t, contract, "/model/v1/assets", http.MethodPost, uploadResponse)
+	var asset struct {
+		AssetID string `json:"asset_id"`
+	}
+	if decodeError := json.Unmarshal(uploadResponse.Body.Bytes(), &asset); decodeError != nil || asset.AssetID == "" {
+		t.Fatalf("asset response=%s error=%v", uploadResponse.Body.String(), decodeError)
+	}
+	deletePath := "/model/v1/assets/" + asset.AssetID
+	deleteRequest := httptest.NewRequest(http.MethodDelete, deletePath+"?key="+TestSecret, nil)
+	assertOpenAPIRequest(t, contract, "/model/v1/assets/{asset_id}", deleteRequest, nil)
+	deleteResponse := httptest.NewRecorder()
+	router.ServeHTTP(deleteResponse, deleteRequest)
+	assertOpenAPIResponse(t, contract, "/model/v1/assets/{asset_id}", http.MethodDelete, deleteResponse)
 }
 
 func TestOpenAPIContractValidatesRepresentativeRealHTTPExchanges(t *testing.T) {

--- a/internal/proxy/provider_error_response.go
+++ b/internal/proxy/provider_error_response.go
@@ -33,6 +33,8 @@ func writeProviderErrorResponse(ginContext *gin.Context, providerIdentifier stri
 	errorCode := llmproxycontract.ErrorCodeProviderError
 	if errors.Is(requestError, ErrProviderRateLimited) {
 		errorCode = llmproxycontract.ErrorCodeProviderRateLimited
+	} else if errors.Is(requestError, ErrProviderMediaLimit) {
+		errorCode = llmproxycontract.ErrorCodeProviderMediaLimitExceeded
 	}
 
 	upstreamStatus, retryAfterValue, retryable, hasUpstreamStatus := providerHTTPMetadata(requestError)

--- a/internal/proxy/provider_errors.go
+++ b/internal/proxy/provider_errors.go
@@ -22,6 +22,8 @@ var (
 	ErrProviderRateLimited = errors.New(errorProviderRateLimited)
 	// ErrProviderAPI is returned when an upstream provider returns an unsuccessful response.
 	ErrProviderAPI = errors.New(errorProviderAPI)
+	// ErrProviderMediaLimit is returned when media exceeds the selected provider offering limit.
+	ErrProviderMediaLimit = errors.New("provider media limit exceeded")
 	// ErrInvalidChatMessages is returned when a JSON request body contains invalid chat messages.
 	ErrInvalidChatMessages = errors.New(errorInvalidChatMessages)
 	// ErrInvalidModelCatalog is returned when configured provider model catalogs are incomplete or inconsistent.
@@ -45,6 +47,15 @@ func newProviderHTTPError(statusCode int, responseHeader http.Header) error {
 		statusCode:    statusCode,
 		retryAfter:    sanitizedRetryAfter(responseHeader.Get("Retry-After")),
 		retryableHint: retryableProviderStatus(statusCode),
+	}
+}
+
+func newProviderMediaLimitHTTPError(statusCode int, responseHeader http.Header) error {
+	return &providerHTTPError{
+		error:         ErrProviderMediaLimit,
+		statusCode:    statusCode,
+		retryAfter:    sanitizedRetryAfter(responseHeader.Get("Retry-After")),
+		retryableHint: false,
 	}
 }
 

--- a/internal/proxy/provider_registry.go
+++ b/internal/proxy/provider_registry.go
@@ -57,6 +57,7 @@ func newProviderRegistry(configuration Configuration) *providerRegistry {
 				hasOutputTokenLimit: offering.OutputTokenLimit > 0,
 				reasoningEffort:     configuredReasoningEffortCapability(offering.ReasoningEffort),
 				mediaInputs:         configuredMediaInputSet(offering.MediaInputs),
+				mediaLimits:         cloneCatalogMediaLimits(offering.MediaLimits),
 			}
 			if offeringDefaultsOperation(offering, ModelOperationText) {
 				definition.defaultTextModel = modelID(offering.Model)

--- a/internal/proxy/provider_types.go
+++ b/internal/proxy/provider_types.go
@@ -267,6 +267,7 @@ type textModelDefinition struct {
 	hasOutputTokenLimit bool
 	reasoningEffort     *reasoningEffortCapability
 	mediaInputs         map[messageMediaType]struct{}
+	mediaLimits         []CatalogMediaLimit
 }
 
 func (definition textModelDefinition) string() string {

--- a/internal/proxy/public_capabilities.go
+++ b/internal/proxy/public_capabilities.go
@@ -73,16 +73,17 @@ type PublicExactModelCapability struct {
 
 // PublicProviderOffering describes one selectable provider and exact-model route.
 type PublicProviderOffering struct {
-	Identifier         string           `json:"identifier"`
-	Provider           string           `json:"provider"`
-	Model              string           `json:"model"`
-	Capabilities       []string         `json:"capabilities"`
-	WireContract       string           `json:"wire_contract"`
-	ExecutionLifecycle string           `json:"execution_lifecycle"`
-	OutputTokenLimit   int              `json:"output_token_limit"`
-	ReasoningEfforts   []string         `json:"reasoning_efforts"`
-	Controls           []CatalogControl `json:"controls"`
-	Limits             []CatalogLimit   `json:"limits"`
+	Identifier         string              `json:"identifier"`
+	Provider           string              `json:"provider"`
+	Model              string              `json:"model"`
+	Capabilities       []string            `json:"capabilities"`
+	WireContract       string              `json:"wire_contract"`
+	ExecutionLifecycle string              `json:"execution_lifecycle"`
+	OutputTokenLimit   int                 `json:"output_token_limit"`
+	ReasoningEfforts   []string            `json:"reasoning_efforts"`
+	Controls           []CatalogControl    `json:"controls"`
+	Limits             []CatalogLimit      `json:"limits"`
+	MediaLimits        []CatalogMediaLimit `json:"media_limits"`
 }
 
 // Public model capability identifiers are the stable filter vocabulary for the
@@ -229,6 +230,7 @@ func publicProviderOffering(offering ProviderOffering) PublicProviderOffering {
 		ReasoningEfforts:   reasoningEfforts,
 		Controls:           publicCatalogControls(offering.Controls),
 		Limits:             publicCatalogLimits(offering.Limits),
+		MediaLimits:        cloneCatalogMediaLimits(offering.MediaLimits),
 	}
 }
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/tyemirov/llm-proxy/internal/constants"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
 	"go.uber.org/zap"
 )
 
@@ -124,6 +125,7 @@ func buildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 		runtimeStaticTenants = tenantRegistry{}
 	}
 	tenantAuthenticator := newTenantAuthenticator(runtimeStaticTenants, managedTenants)
+	assetStore := newTenantAssetStore(configuration.AssetStorePath, configuration.MaxAssetBytes, configuration.AssetRetentionSeconds)
 
 	router.Use(gin.Recovery())
 	registerPublicCapabilityRoutes(router, capabilityCatalog)
@@ -138,7 +140,9 @@ func buildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	}
 	router.GET(rootPath, rootProxyHandler)
 	router.POST(rootPath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatJSONHandler(upstreamProviders, providers, configuration.MaxPromptBytes, managedTenants, structuredLogger))))
-	router.POST(v2Path, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatV2JSONHandler(upstreamProviders, providers, configuration.MaxPromptBytes, managedTenants, structuredLogger))))
+	router.POST(v2Path, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatV2JSONHandler(upstreamProviders, providers, assetStore, managedTenants, structuredLogger))))
+	router.POST(llmproxycontract.AssetPath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, tenantAssetUploadHandler(assetStore)))
+	router.DELETE(llmproxycontract.AssetPath+"/:asset_id", tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, tenantAssetDeleteHandler(assetStore)))
 	router.POST(dictatePath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, dictateHandler(upstreamProviders, providers, configuration.MaxInputAudioBytes, managedTenants, structuredLogger))))
 	return router, nil
 }
@@ -211,7 +215,7 @@ func chatJSONHandler(upstreamProviders *providerRouter, providers *providerRegis
 	}
 }
 
-func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, maxPromptBytes int64, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, assetStore *tenantAssetStore, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
 		requestStart := time.Now()
 		requestTenant := authenticatedTenantFromContext(ginContext)
@@ -219,7 +223,6 @@ func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerReg
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
 			return
 		}
-		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxPromptBytes)
 		bodyBytes, readBodyOK := readJSONProxyBody(ginContext)
 		if !readBodyOK {
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
@@ -240,11 +243,12 @@ func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerReg
 
 		validator := newModelValidator(providers.forTenant(requestTenant))
 		textDefaults := textRequestDefaultsForProvider(ginContext.Query(queryParameterProvider), requestTenant, providers)
-		chatRequest, ok := chatRequestFromV2Payload(ginContext, payload, textDefaults, validator)
+		chatRequest, ok := chatRequestFromV2Payload(ginContext, payload, textDefaults, validator, requestTenant, assetStore)
 		if !ok {
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, payload.Model, requestTenant.defaults), requestStart)
 			return
 		}
+		defer chatRequest.messages.closeMedia()
 		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointV2, managedTenants, structuredLogger)
 	}
 }
@@ -419,7 +423,7 @@ func chatRequestFromPayload(ginContext *gin.Context, payload chatRequestPayload,
 	}, true
 }
 
-func chatRequestFromV2Payload(ginContext *gin.Context, payload chatV2RequestPayload, defaults textRequestDefaults, validator *modelValidator) (chatRequestParameters, bool) {
+func chatRequestFromV2Payload(ginContext *gin.Context, payload chatV2RequestPayload, defaults textRequestDefaults, validator *modelValidator, requestTenant tenant, assetStore *tenantAssetStore) (chatRequestParameters, bool) {
 	if payload.Prompt != nil {
 		ginContext.String(http.StatusBadRequest, errorUnsupportedPromptParameter)
 		return chatRequestParameters{}, false
@@ -463,9 +467,13 @@ func chatRequestFromV2Payload(ginContext *gin.Context, payload chatV2RequestPayl
 		ginContext.String(http.StatusBadRequest, errorInvalidReasoningEffort)
 		return chatRequestParameters{}, false
 	}
-	messages, messageError := newV2PayloadChatMessages(*payload.Messages, defaults.systemPrompt)
+	messages, messageError := newV2PayloadChatMessages(*payload.Messages, defaults.systemPrompt, requestTenant, assetStore)
 	if messageError != nil {
-		ginContext.String(statusCodeForError(messageError), responseMessageForError(messageError))
+		if isTenantAssetError(messageError) {
+			writeTenantAssetError(ginContext, messageError)
+		} else {
+			ginContext.String(statusCodeForError(messageError), responseMessageForError(messageError))
+		}
 		return chatRequestParameters{}, false
 	}
 	if mediaCapabilityError := validateMessageMediaForResolvedTextRoute(providerDefinition, resolvedModel, messages); mediaCapabilityError != nil {
@@ -788,8 +796,14 @@ func validateTextMaxTokens(providerDefinition providerDefinition, modelIdentifie
 
 func statusCodeForError(requestError error) int {
 	switch {
-	case errors.Is(requestError, ErrUnknownProvider), errors.Is(requestError, ErrUnknownModel), errors.Is(requestError, ErrUnsupportedCapability), errors.Is(requestError, ErrUnsupportedEndpoint), errors.Is(requestError, ErrConflictingModelParameters), errors.Is(requestError, ErrInvalidChatMessages):
+	case errors.Is(requestError, ErrUnknownProvider), errors.Is(requestError, ErrUnknownModel), errors.Is(requestError, ErrUnsupportedCapability), errors.Is(requestError, ErrUnsupportedEndpoint), errors.Is(requestError, ErrConflictingModelParameters), errors.Is(requestError, ErrInvalidChatMessages), errors.Is(requestError, errAssetInvalid), errors.Is(requestError, errAssetMIMEMismatch), errors.Is(requestError, errAssetDigestMismatch):
 		return http.StatusBadRequest
+	case errors.Is(requestError, errAssetNotFound):
+		return http.StatusNotFound
+	case errors.Is(requestError, errAssetExpired), errors.Is(requestError, errAssetDeleted):
+		return http.StatusGone
+	case errors.Is(requestError, errAssetTooLarge), errors.Is(requestError, ErrProviderMediaLimit):
+		return http.StatusRequestEntityTooLarge
 	case errors.Is(requestError, ErrProviderNotConfigured), errors.Is(requestError, errQueueFull):
 		return http.StatusServiceUnavailable
 	case errors.Is(requestError, ErrProviderRateLimited):

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -140,8 +140,8 @@ func buildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	}
 	router.GET(rootPath, rootProxyHandler)
 	router.POST(rootPath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatJSONHandler(upstreamProviders, providers, configuration.MaxPromptBytes, managedTenants, structuredLogger))))
-	router.POST(v2Path, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatV2JSONHandler(upstreamProviders, providers, assetStore, managedTenants, structuredLogger))))
-	router.POST(llmproxycontract.AssetPath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, tenantAssetUploadHandler(assetStore)))
+	router.POST(v2Path, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, chatV2JSONHandler(upstreamProviders, providers, maximumV2RequestBytes(configuration.MaxPromptBytes, configuration.ModelCatalog), assetStore, managedTenants, structuredLogger))))
+	router.POST(llmproxycontract.AssetPath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, tenantAssetUploadHandler(assetStore))))
 	router.DELETE(llmproxycontract.AssetPath+"/:asset_id", tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, tenantAssetDeleteHandler(assetStore)))
 	router.POST(dictatePath, tenantAuthenticatedHandler(tenantAuthenticator, structuredLogger, requestTimeoutHandler(configuration.requestTimeoutPolicy, structuredLogger, dictateHandler(upstreamProviders, providers, configuration.MaxInputAudioBytes, managedTenants, structuredLogger))))
 	return router, nil
@@ -215,7 +215,7 @@ func chatJSONHandler(upstreamProviders *providerRouter, providers *providerRegis
 	}
 }
 
-func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, assetStore *tenantAssetStore, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
+func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerRegistry, maxRequestBytes int64, assetStore *tenantAssetStore, managedTenants *managedTenantStore, structuredLogger *zap.SugaredLogger) gin.HandlerFunc {
 	return func(ginContext *gin.Context) {
 		requestStart := time.Now()
 		requestTenant := authenticatedTenantFromContext(ginContext)
@@ -223,6 +223,7 @@ func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerReg
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
 			return
 		}
+		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxRequestBytes)
 		bodyBytes, readBodyOK := readJSONProxyBody(ginContext)
 		if !readBodyOK {
 			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)

--- a/pkg/llmproxyclient/assets.go
+++ b/pkg/llmproxyclient/assets.go
@@ -1,0 +1,120 @@
+package llmproxyclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
+)
+
+// AssetUploadInput is the exact media content supplied to UploadAsset.
+type AssetUploadInput struct {
+	MIMEType string
+	Data     []byte
+}
+
+// Asset is a hash-bound tenant asset returned by llm-proxy.
+type Asset struct {
+	AssetID   string    `json:"asset_id"`
+	MIMEType  string    `json:"mime_type"`
+	SizeBytes int64     `json:"size_bytes"`
+	SHA256    string    `json:"sha256"`
+	State     string    `json:"state"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// AssetUploadURL builds the authenticated tenant asset upload URL for this config.
+func (config Config) AssetUploadURL() string {
+	requestURL := config.assetUploadURL()
+	return requestURL.String()
+}
+
+func (config Config) assetUploadURL() url.URL {
+	requestURL := *config.baseURL
+	requestURL.Path = assetEndpointPath(requestURL.Path)
+	queryValues := requestURL.Query()
+	for queryKeyName := range postBodyQueryKeys {
+		queryValues.Del(queryKeyName)
+	}
+	queryValues.Del(queryFormat)
+	queryValues.Del(queryProvider)
+	queryValues.Set(queryKey, config.secret)
+	requestURL.RawQuery = queryValues.Encode()
+	return requestURL
+}
+
+func assetEndpointPath(basePath string) string {
+	trimmedPath := strings.TrimRight(strings.TrimSpace(basePath), "/")
+	trimmedPath = strings.TrimSuffix(trimmedPath, "/v2")
+	if trimmedPath == "" {
+		return llmproxycontract.AssetPath
+	}
+	return trimmedPath + llmproxycontract.AssetPath
+}
+
+// UploadAsset stores exact media bytes for later hash-bound attachment references.
+func (client Client) UploadAsset(contextValue context.Context, input AssetUploadInput) (Asset, error) {
+	mimeType := strings.ToLower(strings.TrimSpace(input.MIMEType))
+	if !supportedClientMediaMIME(mimeType) {
+		return Asset{}, fmt.Errorf("%w: unsupported asset MIME type=%q", ErrInvalidClientRequest, input.MIMEType)
+	}
+	if len(input.Data) == 0 {
+		return Asset{}, fmt.Errorf("%w: asset data is empty", ErrInvalidClientRequest)
+	}
+	digest := sha256.Sum256(input.Data)
+	digestText := hex.EncodeToString(digest[:])
+	requestURL := client.config.assetUploadURL()
+	request := (&http.Request{
+		Method:        http.MethodPost,
+		URL:           &requestURL,
+		Header:        http.Header{},
+		Body:          io.NopCloser(bytes.NewReader(input.Data)),
+		ContentLength: int64(len(input.Data)),
+	}).WithContext(contextValue)
+	request.Header.Set(headerContentType, mimeType)
+	request.Header.Set(llmproxycontract.HeaderAssetSHA256, digestText)
+	response, requestError := client.httpClient.Do(request)
+	if requestError != nil {
+		return Asset{}, fmt.Errorf("%w: upload asset", ErrClientHTTPFailure)
+	}
+	defer response.Body.Close()
+	responseBody, readError := io.ReadAll(io.LimitReader(response.Body, 64*1024+1))
+	if readError != nil || len(responseBody) > 64*1024 {
+		return Asset{}, fmt.Errorf("%w: read asset response", ErrClientHTTPFailure)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return Asset{}, newHTTPFailure(response.StatusCode, responseBody)
+	}
+	var asset Asset
+	decoder := json.NewDecoder(bytes.NewReader(responseBody))
+	decoder.DisallowUnknownFields()
+	if decodeError := decoder.Decode(&asset); decodeError != nil {
+		return Asset{}, fmt.Errorf("%w: decode asset response", ErrClientHTTPFailure)
+	}
+	if trailingError := decoder.Decode(&struct{}{}); trailingError != io.EOF {
+		return Asset{}, fmt.Errorf("%w: decode asset response", ErrClientHTTPFailure)
+	}
+	if !assetIdentifierPattern.MatchString(asset.AssetID) || asset.MIMEType != mimeType || asset.SizeBytes != int64(len(input.Data)) || asset.SHA256 != digestText || asset.State != "available" || asset.CreatedAt.IsZero() || !asset.ExpiresAt.After(asset.CreatedAt) {
+		return Asset{}, fmt.Errorf("%w: invalid asset response", ErrClientHTTPFailure)
+	}
+	return asset, nil
+}
+
+func supportedClientMediaMIME(mimeType string) bool {
+	switch mimeType {
+	case audioMIMEM4A, audioMIMEMPEG, audioMIMEWAV, imageMIMEJPEG, imageMIMEPNG, imageMIMEWebP:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/llmproxyclient/http_failure.go
+++ b/pkg/llmproxyclient/http_failure.go
@@ -63,6 +63,7 @@ func recognizedProxyErrorCode(responseBody []byte) string {
 	switch envelope.Error.Code {
 	case llmproxycontract.ErrorCodeInvalidRequestTimeout,
 		llmproxycontract.ErrorCodeProviderError,
+		llmproxycontract.ErrorCodeProviderMediaLimitExceeded,
 		llmproxycontract.ErrorCodeProviderRateLimited,
 		llmproxycontract.ErrorCodeRequestTimeout:
 		return envelope.Error.Code

--- a/pkg/llmproxyclient/media.go
+++ b/pkg/llmproxyclient/media.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -31,14 +32,18 @@ type messageAttachment struct {
 	attachmentType string
 	mimeType       string
 	data           []byte
+	assetID        string
 	sha256         string
 }
+
+var assetIdentifierPattern = regexp.MustCompile(`^ast_[0-9a-f]{32}$`)
 
 func (attachment messageAttachment) clientMessageAttachment() messageAttachment {
 	return messageAttachment{
 		attachmentType: attachment.attachmentType,
 		mimeType:       attachment.mimeType,
 		data:           append([]byte(nil), attachment.data...),
+		assetID:        attachment.assetID,
 		sha256:         attachment.sha256,
 	}
 }
@@ -53,6 +58,20 @@ type ImageAttachmentInput struct {
 type AudioAttachmentInput struct {
 	MIMEType string
 	Data     []byte
+}
+
+// ImageAssetAttachmentInput is an existing tenant image asset supplied to NewImageAssetAttachment.
+type ImageAssetAttachmentInput struct {
+	AssetID  string
+	MIMEType string
+	SHA256   string
+}
+
+// AudioAssetAttachmentInput is an existing tenant audio asset supplied to NewAudioAssetAttachment.
+type AudioAssetAttachmentInput struct {
+	AssetID  string
+	MIMEType string
+	SHA256   string
 }
 
 // NewImageAttachment validates and hash-binds exact image bytes.
@@ -77,6 +96,39 @@ func NewAudioAttachment(input AudioAttachmentInput) (MessageAttachment, error) {
 	return newMessageAttachment(messageAttachmentTypeAudio, mimeType, input.Data)
 }
 
+// NewImageAssetAttachment validates a hash-bound tenant image asset reference.
+func NewImageAssetAttachment(input ImageAssetAttachmentInput) (MessageAttachment, error) {
+	mimeType := strings.ToLower(strings.TrimSpace(input.MIMEType))
+	switch mimeType {
+	case imageMIMEJPEG, imageMIMEPNG, imageMIMEWebP:
+	default:
+		return nil, fmt.Errorf("%w: unsupported image MIME type=%q", ErrInvalidClientRequest, input.MIMEType)
+	}
+	return newAssetMessageAttachment(messageAttachmentTypeImage, mimeType, input.AssetID, input.SHA256)
+}
+
+// NewAudioAssetAttachment validates a hash-bound tenant audio asset reference.
+func NewAudioAssetAttachment(input AudioAssetAttachmentInput) (MessageAttachment, error) {
+	mimeType := strings.ToLower(strings.TrimSpace(input.MIMEType))
+	switch mimeType {
+	case audioMIMEM4A, audioMIMEMPEG, audioMIMEWAV:
+	default:
+		return nil, fmt.Errorf("%w: unsupported audio MIME type=%q", ErrInvalidClientRequest, input.MIMEType)
+	}
+	return newAssetMessageAttachment(messageAttachmentTypeAudio, mimeType, input.AssetID, input.SHA256)
+}
+
+func newAssetMessageAttachment(attachmentType string, mimeType string, assetID string, digest string) (MessageAttachment, error) {
+	if !assetIdentifierPattern.MatchString(assetID) {
+		return nil, fmt.Errorf("%w: invalid asset_id", ErrInvalidClientRequest)
+	}
+	decodedDigest, digestError := hex.DecodeString(digest)
+	if digestError != nil || len(decodedDigest) != sha256.Size || strings.ToLower(digest) != digest {
+		return nil, fmt.Errorf("%w: invalid asset sha256", ErrInvalidClientRequest)
+	}
+	return messageAttachment{attachmentType: attachmentType, mimeType: mimeType, assetID: assetID, sha256: digest}, nil
+}
+
 func newMessageAttachment(attachmentType string, mimeType string, data []byte) (MessageAttachment, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("%w: %s attachment data is empty", ErrInvalidClientRequest, attachmentType)
@@ -94,12 +146,17 @@ func newMessageAttachment(attachmentType string, mimeType string, data []byte) (
 func messageAttachmentPayload(attachments []messageAttachment) []map[string]string {
 	payload := make([]map[string]string, 0, len(attachments))
 	for _, attachment := range attachments {
-		payload = append(payload, map[string]string{
+		payloadAttachment := map[string]string{
 			"type":      attachment.attachmentType,
 			"mime_type": attachment.mimeType,
-			"data":      base64.StdEncoding.EncodeToString(attachment.data),
 			"sha256":    attachment.sha256,
-		})
+		}
+		if attachment.assetID == "" {
+			payloadAttachment["data"] = base64.StdEncoding.EncodeToString(attachment.data)
+		} else {
+			payloadAttachment["asset_id"] = attachment.assetID
+		}
+		payload = append(payload, payloadAttachment)
 	}
 	return payload
 }

--- a/pkg/llmproxyclient/media_test.go
+++ b/pkg/llmproxyclient/media_test.go
@@ -1,17 +1,22 @@
 package llmproxyclient_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/tyemirov/llm-proxy/pkg/llmproxyclient"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
 )
 
 func TestClientPostMessagesSerializesImmutableOrderedMediaAttachments(testingInstance *testing.T) {
@@ -113,6 +118,139 @@ func TestClientPostMessagesSerializesImmutableOrderedMediaAttachments(testingIns
 	}
 }
 
+func TestClientUploadsAssetAndSerializesImageAndAudioAssetReferences(testingInstance *testing.T) {
+	imageBytes := []byte("uploaded-image")
+	imageDigest := sha256.Sum256(imageBytes)
+	digestText := hex.EncodeToString(imageDigest[:])
+	assetID := "ast_0123456789abcdef0123456789abcdef"
+	var capturedAttachment map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case llmproxycontract.AssetPath:
+			body, _ := io.ReadAll(request.Body)
+			if !bytes.Equal(body, imageBytes) || request.Header.Get("Content-Type") != "image/png" || request.Header.Get(llmproxycontract.HeaderAssetSHA256) != digestText {
+				testingInstance.Errorf("asset upload body=%q content-type=%q digest=%q", body, request.Header.Get("Content-Type"), request.Header.Get(llmproxycontract.HeaderAssetSHA256))
+			}
+			responseWriter.Header().Set("Content-Type", "application/json")
+			responseWriter.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprintf(responseWriter, `{"asset_id":"%s","mime_type":"image/png","size_bytes":%d,"sha256":"%s","state":"available","created_at":"2026-08-11T10:00:00Z","expires_at":"2026-08-13T10:00:00Z"}`, assetID, len(imageBytes), digestText)
+		case "/v2":
+			var payload map[string]any
+			_ = json.NewDecoder(request.Body).Decode(&payload)
+			capturedAttachment = payload["messages"].([]any)[0].(map[string]any)["attachments"].([]any)[0].(map[string]any)
+			_, _ = responseWriter.Write([]byte("asset ok"))
+		default:
+			http.NotFound(responseWriter, request)
+		}
+	}))
+	defer server.Close()
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{BaseURL: server.URL, Secret: "sekret", Provider: "gemini"})
+	if configError != nil {
+		testingInstance.Fatalf("config: %v", configError)
+	}
+	if assetURL := config.AssetUploadURL(); !strings.Contains(assetURL, llmproxycontract.AssetPath+"?key=sekret") {
+		testingInstance.Fatalf("asset URL=%q", assetURL)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		testingInstance.Fatalf("client: %v", clientError)
+	}
+	asset, uploadError := client.UploadAsset(context.Background(), llmproxyclient.AssetUploadInput{MIMEType: " IMAGE/PNG ", Data: imageBytes})
+	if uploadError != nil || asset.AssetID != assetID || asset.CreatedAt != time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC) {
+		testingInstance.Fatalf("asset=%+v error=%v", asset, uploadError)
+	}
+	imageAttachment, imageError := llmproxyclient.NewImageAssetAttachment(llmproxyclient.ImageAssetAttachmentInput{AssetID: asset.AssetID, MIMEType: asset.MIMEType, SHA256: asset.SHA256})
+	if imageError != nil {
+		testingInstance.Fatalf("image asset attachment: %v", imageError)
+	}
+	if _, audioError := llmproxyclient.NewAudioAssetAttachment(llmproxyclient.AudioAssetAttachmentInput{AssetID: asset.AssetID, MIMEType: "audio/wav", SHA256: asset.SHA256}); audioError != nil {
+		testingInstance.Fatalf("audio asset attachment: %v", audioError)
+	}
+	request, requestError := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{Messages: []llmproxyclient.MessageInput{{Role: "user", Content: "inspect", Attachments: []llmproxyclient.MessageAttachment{imageAttachment}}}})
+	if requestError != nil {
+		testingInstance.Fatalf("request: %v", requestError)
+	}
+	response, postError := client.PostMessages(context.Background(), request)
+	if postError != nil || response != "asset ok" || capturedAttachment["asset_id"] != assetID || capturedAttachment["data"] != nil || capturedAttachment["sha256"] != digestText {
+		testingInstance.Fatalf("response=%q error=%v attachment=%v", response, postError, capturedAttachment)
+	}
+}
+
+type assetRoundTripper func(*http.Request) (*http.Response, error)
+
+func (roundTripper assetRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTripper(request)
+}
+
+type assetErrorReader struct{}
+
+func (assetErrorReader) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("asset response read failure")
+}
+
+func TestClientAssetUploadRejectsInvalidInputsAndResponses(testingInstance *testing.T) {
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{BaseURL: "https://proxy.example/review/v2", Secret: "sekret"})
+	if configError != nil {
+		testingInstance.Fatalf("config: %v", configError)
+	}
+	if assetURL := config.AssetUploadURL(); !strings.Contains(assetURL, "/review"+llmproxycontract.AssetPath+"?key=sekret") {
+		testingInstance.Fatalf("asset URL=%q", assetURL)
+	}
+	clientFor := func(roundTripper assetRoundTripper) llmproxyclient.Client {
+		testingInstance.Helper()
+		client, clientError := llmproxyclient.NewClient(config, &http.Client{Transport: roundTripper})
+		if clientError != nil {
+			testingInstance.Fatalf("client: %v", clientError)
+		}
+		return client
+	}
+	if _, uploadError := clientFor(func(*http.Request) (*http.Response, error) {
+		testingInstance.Fatal("invalid input reached transport")
+		return nil, nil
+	}).UploadAsset(context.Background(), llmproxyclient.AssetUploadInput{MIMEType: "text/plain", Data: []byte("x")}); uploadError == nil {
+		testingInstance.Fatal("unsupported MIME accepted")
+	}
+	if _, uploadError := clientFor(func(*http.Request) (*http.Response, error) {
+		testingInstance.Fatal("empty input reached transport")
+		return nil, nil
+	}).UploadAsset(context.Background(), llmproxyclient.AssetUploadInput{MIMEType: "image/png"}); uploadError == nil {
+		testingInstance.Fatal("empty asset accepted")
+	}
+
+	validInput := llmproxyclient.AssetUploadInput{MIMEType: "image/png", Data: []byte("x")}
+	testCases := []struct {
+		name string
+		do   assetRoundTripper
+	}{
+		{name: "transport failure", do: func(*http.Request) (*http.Response, error) { return nil, fmt.Errorf("transport failure") }},
+		{name: "read failure", do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(assetErrorReader{}), Header: http.Header{}}, nil
+		}},
+		{name: "oversized response", do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(strings.Repeat("x", 64*1024+1))), Header: http.Header{}}, nil
+		}},
+		{name: "HTTP failure", do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(strings.NewReader(`{"error":{"code":"asset_invalid"}}`)), Header: http.Header{}}, nil
+		}},
+		{name: "malformed response", do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader("{")), Header: http.Header{}}, nil
+		}},
+		{name: "trailing response", do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(`{} {}`)), Header: http.Header{}}, nil
+		}},
+		{name: "invalid response", do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(`{"asset_id":"bad"}`)), Header: http.Header{}}, nil
+		}},
+	}
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			if _, uploadError := clientFor(testCase.do).UploadAsset(context.Background(), validInput); uploadError == nil {
+				subTest.Fatal("invalid asset exchange accepted")
+			}
+		})
+	}
+}
+
 func TestMessageAttachmentConstructorsEnforceCanonicalMediaContract(testingInstance *testing.T) {
 	for _, testCase := range []struct {
 		name      string
@@ -168,6 +306,34 @@ func TestMessageAttachmentConstructorsEnforceCanonicalMediaContract(testingInsta
 			name: "empty audio",
 			construct: func() (llmproxyclient.MessageAttachment, error) {
 				return llmproxyclient.NewAudioAttachment(llmproxyclient.AudioAttachmentInput{MIMEType: "audio/wav"})
+			},
+			wantError: true,
+		},
+		{
+			name: "unsupported image asset MIME",
+			construct: func() (llmproxyclient.MessageAttachment, error) {
+				return llmproxyclient.NewImageAssetAttachment(llmproxyclient.ImageAssetAttachmentInput{MIMEType: "image/gif"})
+			},
+			wantError: true,
+		},
+		{
+			name: "unsupported audio asset MIME",
+			construct: func() (llmproxyclient.MessageAttachment, error) {
+				return llmproxyclient.NewAudioAssetAttachment(llmproxyclient.AudioAssetAttachmentInput{MIMEType: "audio/ogg"})
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid asset identifier",
+			construct: func() (llmproxyclient.MessageAttachment, error) {
+				return llmproxyclient.NewImageAssetAttachment(llmproxyclient.ImageAssetAttachmentInput{AssetID: "bad", MIMEType: "image/png", SHA256: strings.Repeat("0", 64)})
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid asset digest",
+			construct: func() (llmproxyclient.MessageAttachment, error) {
+				return llmproxyclient.NewAudioAssetAttachment(llmproxyclient.AudioAssetAttachmentInput{AssetID: "ast_0123456789abcdef0123456789abcdef", MIMEType: "audio/wav", SHA256: "bad"})
 			},
 			wantError: true,
 		},

--- a/pkg/llmproxycontract/contract.go
+++ b/pkg/llmproxycontract/contract.go
@@ -2,6 +2,10 @@
 package llmproxycontract
 
 const (
+	// AssetPath is the authenticated tenant asset upload endpoint.
+	AssetPath = "/model/v1/assets"
+	// HeaderAssetSHA256 carries the canonical lowercase hexadecimal digest for an asset upload.
+	HeaderAssetSHA256 = "X-LLM-Proxy-Asset-SHA256"
 	// HeaderRequestID carries the proxy-owned identifier used to correlate one public request with structured logs.
 	HeaderRequestID = "X-LLM-Proxy-Request-ID"
 	// HeaderRequestTimeoutSeconds carries the accepted proxy work budget for one upstream request.
@@ -12,6 +16,8 @@ const (
 	ErrorCodeProviderError = "provider_error"
 	// ErrorCodeProviderRateLimited identifies a sanitized upstream provider rate-limit response.
 	ErrorCodeProviderRateLimited = "provider_rate_limited"
+	// ErrorCodeProviderMediaLimitExceeded identifies media that exceeds the selected provider offering limit.
+	ErrorCodeProviderMediaLimitExceeded = "provider_media_limit_exceeded"
 	// ErrorCodeRequestTimeout identifies expiration of the accepted proxy work budget.
 	ErrorCodeRequestTimeout = "request_timeout"
 )

--- a/python/llm_proxy_client/__init__.py
+++ b/python/llm_proxy_client/__init__.py
@@ -2,22 +2,34 @@
 
 from .client import (
     Client,
+    ClientAsset,
+    ClientAttachment,
     ClientConfig,
-    ClientMessagesRequest,
     ClientMessage,
+    ClientMessagesRequest,
     LLMProxyClientError,
     LLMProxyHTTPError,
     LLMProxyModelProfileError,
     LLMProxyTransportError,
+    audio_asset_attachment,
+    audio_attachment,
+    image_asset_attachment,
+    image_attachment,
 )
 
 __all__ = [
     "Client",
+    "ClientAsset",
+    "ClientAttachment",
     "ClientConfig",
-    "ClientMessagesRequest",
     "ClientMessage",
+    "ClientMessagesRequest",
     "LLMProxyClientError",
     "LLMProxyHTTPError",
     "LLMProxyModelProfileError",
     "LLMProxyTransportError",
+    "audio_asset_attachment",
+    "audio_attachment",
+    "image_asset_attachment",
+    "image_attachment",
 ]

--- a/python/llm_proxy_client/client.py
+++ b/python/llm_proxy_client/client.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Protocol, Sequence, cast
 
 ACCEPT_HEADER = "Accept"
@@ -16,6 +20,8 @@ FORMAT_QUERY_VALUE_TEXT_PLAIN = "text/plain"
 JSON_CONTENT_TYPE = "application/json; charset=utf-8"
 KEY_QUERY_KEY = "key"
 REQUEST_TIMEOUT_HEADER = "X-LLM-Proxy-Request-Timeout-Seconds"
+ASSET_SHA256_HEADER = "X-LLM-Proxy-Asset-SHA256"
+ASSET_ENDPOINT_PATH = "/model/v1/assets"
 PROVIDER_QUERY_KEY = "provider"
 MODEL_PROFILE_MODEL_KEY = "model"
 MODEL_PROFILE_SUBJECT = "model_profile"
@@ -34,6 +40,11 @@ POST_BODY_QUERY_KEYS = frozenset(
     }
 )
 MESSAGE_ROLES = frozenset({"system", "user", "assistant"})
+IMAGE_MIME_TYPES = frozenset({"image/jpeg", "image/png", "image/webp"})
+AUDIO_MIME_TYPES = frozenset({"audio/m4a", "audio/mpeg", "audio/wav"})
+MEDIA_MIME_TYPES = IMAGE_MIME_TYPES | AUDIO_MIME_TYPES
+ASSET_ID_PATTERN = re.compile(r"^ast_[0-9a-f]{32}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
 class LLMProxyClientError(ValueError):
@@ -140,6 +151,28 @@ class ClientConfig:
         if self.model_profile_path.strip():
             provider = self._current_model_profile().provider
         return self._messages_post_url_for_provider(provider)
+
+    def asset_upload_url(self) -> str:
+        """Return the authenticated tenant asset upload URL for this config."""
+
+        parsed_url = urllib.parse.urlparse(self.base_url.strip())
+        query_items = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+        stripped_query_keys = set(POST_BODY_QUERY_KEYS)
+        stripped_query_keys.update({KEY_QUERY_KEY, FORMAT_QUERY_KEY, PROVIDER_QUERY_KEY})
+        preserved_items = [
+            (query_key, query_value) for query_key, query_value in query_items if query_key not in stripped_query_keys
+        ]
+        preserved_items.append((KEY_QUERY_KEY, self.secret.strip()))
+        return urllib.parse.urlunparse(
+            (
+                parsed_url.scheme,
+                parsed_url.netloc,
+                asset_endpoint_path(parsed_url.path or "/"),
+                parsed_url.params,
+                urllib.parse.urlencode(preserved_items),
+                "",
+            )
+        )
 
     def _current_model_profile(self) -> _ModelProfile:
         """Read and validate the current model-profile document."""
@@ -272,6 +305,114 @@ def v2_endpoint_path(base_path: str) -> str:
     return f"{trimmed_path}/v2"
 
 
+def asset_endpoint_path(base_path: str) -> str:
+    """Return the tenant asset endpoint for an optional base path prefix."""
+
+    trimmed_path = base_path.strip().rstrip("/")
+    if trimmed_path.endswith("/v2"):
+        trimmed_path = trimmed_path[: -len("/v2")]
+    if not trimmed_path:
+        return ASSET_ENDPOINT_PATH
+    return f"{trimmed_path}{ASSET_ENDPOINT_PATH}"
+
+
+@dataclass(frozen=True)
+class ClientAttachment:
+    """One exact inline or hash-bound tenant media attachment."""
+
+    attachment_type: str
+    mime_type: str
+    sha256: str
+    data: bytes | None = None
+    asset_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.attachment_type not in {"image", "audio"}:
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: unsupported attachment type")
+        supported_mime_types = IMAGE_MIME_TYPES if self.attachment_type == "image" else AUDIO_MIME_TYPES
+        if self.mime_type not in supported_mime_types:
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: unsupported attachment MIME type")
+        if (self.data is None) == (self.asset_id is None):
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: attachment requires data or asset_id")
+        if not SHA256_PATTERN.fullmatch(self.sha256):
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: invalid attachment sha256")
+        if self.data is not None:
+            if not isinstance(self.data, bytes) or not self.data:
+                raise LLMProxyClientError("llm_proxy_client_invalid_request: attachment data is empty")
+            if hashlib.sha256(self.data).hexdigest() != self.sha256:
+                raise LLMProxyClientError("llm_proxy_client_invalid_request: attachment sha256 mismatch")
+        if self.asset_id is not None and not ASSET_ID_PATTERN.fullmatch(self.asset_id):
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: invalid attachment asset_id")
+
+    def body(self) -> dict[str, str]:
+        """Return this attachment as one JSON-ready union variant."""
+
+        payload = {"type": self.attachment_type, "mime_type": self.mime_type, "sha256": self.sha256}
+        if self.data is not None:
+            payload["data"] = base64.b64encode(self.data).decode("ascii")
+        else:
+            payload["asset_id"] = cast(str, self.asset_id)
+        return payload
+
+
+def image_attachment(data: bytes, mime_type: str) -> ClientAttachment:
+    """Construct one exact inline image attachment."""
+
+    return _inline_attachment("image", data, mime_type, IMAGE_MIME_TYPES)
+
+
+def audio_attachment(data: bytes, mime_type: str) -> ClientAttachment:
+    """Construct one exact inline audio attachment."""
+
+    return _inline_attachment("audio", data, mime_type, AUDIO_MIME_TYPES)
+
+
+def image_asset_attachment(asset_id: str, mime_type: str, sha256: str) -> ClientAttachment:
+    """Construct one hash-bound tenant image asset attachment."""
+
+    return _asset_attachment("image", asset_id, mime_type, sha256, IMAGE_MIME_TYPES)
+
+
+def audio_asset_attachment(asset_id: str, mime_type: str, sha256: str) -> ClientAttachment:
+    """Construct one hash-bound tenant audio asset attachment."""
+
+    return _asset_attachment("audio", asset_id, mime_type, sha256, AUDIO_MIME_TYPES)
+
+
+def _inline_attachment(
+    attachment_type: str, data: bytes, mime_type: str, supported_mime_types: frozenset[str]
+) -> ClientAttachment:
+    normalized_mime_type = mime_type.strip().lower()
+    if normalized_mime_type not in supported_mime_types:
+        raise LLMProxyClientError("llm_proxy_client_invalid_request: unsupported attachment MIME type")
+    if not isinstance(data, bytes) or not data:
+        raise LLMProxyClientError("llm_proxy_client_invalid_request: attachment data is empty")
+    return ClientAttachment(
+        attachment_type=attachment_type,
+        mime_type=normalized_mime_type,
+        sha256=hashlib.sha256(data).hexdigest(),
+        data=data,
+    )
+
+
+def _asset_attachment(
+    attachment_type: str,
+    asset_id: str,
+    mime_type: str,
+    sha256: str,
+    supported_mime_types: frozenset[str],
+) -> ClientAttachment:
+    normalized_mime_type = mime_type.strip().lower()
+    if normalized_mime_type not in supported_mime_types:
+        raise LLMProxyClientError("llm_proxy_client_invalid_request: unsupported attachment MIME type")
+    return ClientAttachment(
+        attachment_type=attachment_type,
+        mime_type=normalized_mime_type,
+        sha256=sha256,
+        asset_id=asset_id,
+    )
+
+
 @dataclass(frozen=True)
 class ClientMessage:
     """Validated chat message; order is optional but all-or-none within one request."""
@@ -279,6 +420,7 @@ class ClientMessage:
     role: str
     content: str
     order: int | None = None
+    attachments: Sequence[ClientAttachment] = ()
 
     def __post_init__(self) -> None:
         if self.role.strip().lower() not in MESSAGE_ROLES:
@@ -287,13 +429,19 @@ class ClientMessage:
             raise LLMProxyClientError("llm_proxy_client_invalid_request: empty message content")
         if self.order is not None and self.order < 0:
             raise LLMProxyClientError("llm_proxy_client_invalid_request: message order must be non-negative")
+        if self.attachments and self.role.strip().lower() != "user":
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: attachments require user role")
+        if any(not isinstance(attachment, ClientAttachment) for attachment in self.attachments):
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: invalid attachment")
 
-    def body(self) -> dict[str, str | int]:
+    def body(self) -> dict[str, Any]:
         """Return this message as a JSON-ready body item."""
 
-        payload: dict[str, str | int] = {"role": self.role.strip().lower(), "content": self.content}
+        payload: dict[str, Any] = {"role": self.role.strip().lower(), "content": self.content}
         if self.order is not None:
             payload["order"] = self.order
+        if self.attachments:
+            payload["attachments"] = [attachment.body() for attachment in self.attachments]
         return payload
 
 
@@ -370,6 +518,19 @@ def ordered_messages(messages: Sequence[ClientMessage]) -> Sequence[ClientMessag
 
 
 @dataclass(frozen=True)
+class ClientAsset:
+    """One hash-bound tenant asset returned by llm-proxy."""
+
+    asset_id: str
+    mime_type: str
+    size_bytes: int
+    sha256: str
+    state: str
+    created_at: str
+    expires_at: str
+
+
+@dataclass(frozen=True)
 class Client:
     """HTTP client for llm-proxy v2 JSON POST text requests."""
 
@@ -392,6 +553,70 @@ class Client:
                 request.request_timeout_seconds,
             )
         return self._post_json(request.body(), self.config.messages_post_url(), request.request_timeout_seconds)
+
+    def upload_asset(self, data: bytes, mime_type: str) -> ClientAsset:
+        """Upload exact tenant media bytes and return their hash-bound asset record."""
+
+        normalized_mime_type = mime_type.strip().lower()
+        if normalized_mime_type not in MEDIA_MIME_TYPES:
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: unsupported asset MIME type")
+        if not isinstance(data, bytes) or not data:
+            raise LLMProxyClientError("llm_proxy_client_invalid_request: asset data is empty")
+        digest = hashlib.sha256(data).hexdigest()
+        prepared_request = urllib.request.Request(
+            self.config.asset_upload_url(),
+            data=data,
+            headers={CONTENT_TYPE_HEADER: normalized_mime_type, ASSET_SHA256_HEADER: digest},
+            method="POST",
+        )
+        opener = self.opener or default_response_opener
+        try:
+            response_text = opener(prepared_request)
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            raise LLMProxyHTTPError(error.code, body, str(error.reason), "operation=asset_upload") from error
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            raise LLMProxyTransportError("llm_proxy_client_transport_failure: operation=asset_upload") from error
+        if not isinstance(response_text, str) or len(response_text.encode("utf-8")) > 64 * 1024:
+            raise LLMProxyTransportError("llm_proxy_client_transport_failure: invalid asset response")
+        try:
+            response = json.loads(response_text)
+        except (json.JSONDecodeError, TypeError) as error:
+            raise LLMProxyTransportError("llm_proxy_client_transport_failure: invalid asset response") from error
+        required_fields = {
+            "asset_id",
+            "mime_type",
+            "size_bytes",
+            "sha256",
+            "state",
+            "created_at",
+            "expires_at",
+        }
+        if not isinstance(response, dict) or set(response) != required_fields:
+            raise LLMProxyTransportError("llm_proxy_client_transport_failure: invalid asset response")
+        if (
+            not isinstance(response["asset_id"], str)
+            or not ASSET_ID_PATTERN.fullmatch(response["asset_id"])
+            or response["mime_type"] != normalized_mime_type
+            or isinstance(response["size_bytes"], bool)
+            or response["size_bytes"] != len(data)
+            or response["sha256"] != digest
+            or response["state"] != "available"
+        ):
+            raise LLMProxyTransportError("llm_proxy_client_transport_failure: invalid asset response")
+        created_at = _asset_timestamp(response["created_at"])
+        expires_at = _asset_timestamp(response["expires_at"])
+        if expires_at <= created_at:
+            raise LLMProxyTransportError("llm_proxy_client_transport_failure: invalid asset response")
+        return ClientAsset(
+            asset_id=response["asset_id"],
+            mime_type=response["mime_type"],
+            size_bytes=response["size_bytes"],
+            sha256=response["sha256"],
+            state=response["state"],
+            created_at=response["created_at"],
+            expires_at=response["expires_at"],
+        )
 
     def _post_json(
         self, request_payload: dict[str, Any], request_url: str, request_timeout_seconds: int | None
@@ -430,6 +655,20 @@ class Client:
             raise LLMProxyTransportError(
                 f"llm_proxy_client_transport_failure: {failure_context} reason={error}"
             ) from error
+
+
+def _asset_timestamp(value: Any) -> datetime:
+    """Parse one timezone-aware RFC 3339 asset timestamp."""
+
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise LLMProxyTransportError("llm_proxy_client_transport_failure: invalid asset response")
+    try:
+        timestamp = datetime.fromisoformat(value.removesuffix("Z") + "+00:00")
+    except ValueError as error:
+        raise LLMProxyTransportError("llm_proxy_client_transport_failure: invalid asset response") from error
+    if timestamp.tzinfo is None or timestamp.utcoffset() != timezone.utc.utcoffset(timestamp):
+        raise LLMProxyTransportError("llm_proxy_client_transport_failure: invalid asset response")
+    return timestamp
 
 
 def request_failure_context(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import threading
@@ -20,16 +21,77 @@ import yaml
 from llm_proxy_client import (
     Client,
     ClientConfig,
-    ClientMessagesRequest,
     ClientMessage,
+    ClientMessagesRequest,
     LLMProxyClientError,
     LLMProxyHTTPError,
     LLMProxyModelProfileError,
     LLMProxyTransportError,
+    audio_asset_attachment,
+    image_asset_attachment,
+    image_attachment,
 )
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 CANONICAL_OPENAPI_PATH = REPOSITORY_ROOT / "docs" / "openapi.yaml"
+
+
+def test_media_attachment_constructors_serialize_inline_and_asset_union_variants() -> None:
+    """Image and audio constructors emit exactly one attachment union variant."""
+
+    inline_data = b"inline-image"
+    inline = image_attachment(inline_data, " IMAGE/PNG ")
+    asset_digest = hashlib.sha256(b"asset-audio").hexdigest()
+    asset = audio_asset_attachment(
+        "ast_0123456789abcdef0123456789abcdef",
+        "audio/wav",
+        asset_digest,
+    )
+    message = ClientMessage(role="user", content="inspect", attachments=(inline, asset))
+    body = message.body()
+    assert body["attachments"][0] == {
+        "type": "image",
+        "mime_type": "image/png",
+        "sha256": hashlib.sha256(inline_data).hexdigest(),
+        "data": "aW5saW5lLWltYWdl",
+    }
+    assert body["attachments"][1] == {
+        "type": "audio",
+        "mime_type": "audio/wav",
+        "sha256": asset_digest,
+        "asset_id": "ast_0123456789abcdef0123456789abcdef",
+    }
+    with pytest.raises(LLMProxyClientError, match="attachments require user role"):
+        ClientMessage(role="assistant", content="invalid", attachments=(inline,))
+
+
+def test_client_upload_asset_validates_exact_response_without_exposing_bytes() -> None:
+    """The asset client sends exact bytes and validates the hash-bound record."""
+
+    data = b"asset-image"
+    digest = hashlib.sha256(data).hexdigest()
+
+    def opener(request: urllib.request.Request) -> str:
+        assert request.full_url.endswith("/model/v1/assets?key=sekret")
+        assert request.data == data
+        assert request.headers["Content-type"] == "image/png"
+        assert request.headers["X-llm-proxy-asset-sha256"] == digest
+        return json.dumps(
+            {
+                "asset_id": "ast_0123456789abcdef0123456789abcdef",
+                "mime_type": "image/png",
+                "size_bytes": len(data),
+                "sha256": digest,
+                "state": "available",
+                "created_at": "2026-08-11T10:00:00Z",
+                "expires_at": "2026-08-13T10:00:00Z",
+            }
+        )
+
+    client = Client(ClientConfig(base_url="https://proxy.example/v2", secret="sekret"), opener=opener)
+    asset = client.upload_asset(data, " IMAGE/PNG ")
+    assert asset.asset_id == "ast_0123456789abcdef0123456789abcdef"
+    assert image_asset_attachment(asset.asset_id, asset.mime_type, asset.sha256).body()["asset_id"] == asset.asset_id
 
 
 @dataclass

--- a/scripts/render_public_site.mjs
+++ b/scripts/render_public_site.mjs
@@ -64,10 +64,12 @@ await renderPublicSite(options);
  *   reasoning_efforts: string[],
  *   controls: PublicCatalogControl[],
  *   limits: PublicCatalogLimit[],
+ *   media_limits: PublicCatalogMediaLimit[],
  * }} PublicProviderOffering
  */
 /** @typedef {{id: string, kind: string, values: string[], minimum: number | null, maximum: number | null, account_dependent: boolean}} PublicCatalogControl */
 /** @typedef {{id: string, value: number | null, unit: string, account_dependent: boolean}} PublicCatalogLimit */
+/** @typedef {{id: string, media_type: string, transport: string, status: string, value: number | null, unit: string, scope: string, source: string, last_verified: string}} PublicCatalogMediaLimit */
 /** @typedef {{resolution: string, generated_audio: string, input_media: string, output_media: string, duration: string, quantity: string, quality: string, mode: string, api_version: string, avatar_type: string, billing_mode: string, billing_outcome: string}} PublicPriceConditions */
 /** @typedef {{component: string, currency: string, rate: number, unit: string, conditions: PublicPriceConditions}} PublicPriceRate */
 /** @typedef {{currency: string, amount: number, unit: string}} PublicMinimumCharge */
@@ -290,7 +292,7 @@ function parseCapabilityCatalog(rawCatalog) {
     const offering = requiredRecord(rawOffering, field);
     requireExactKeys(offering, [
       "identifier", "provider", "model", "capabilities", "wire_contract", "execution_lifecycle",
-      "output_token_limit", "reasoning_efforts", "controls", "limits",
+      "output_token_limit", "reasoning_efforts", "controls", "limits", "media_limits",
     ], field);
     return {
       identifier: requiredString(offering.identifier, `${field}.identifier`),
@@ -303,6 +305,7 @@ function parseCapabilityCatalog(rawCatalog) {
       reasoning_efforts: requiredStringArray(offering.reasoning_efforts, `${field}.reasoning_efforts`),
       controls: requiredArray(offering.controls, `${field}.controls`).map((control, controlIndex) => parseCatalogControl(control, `${field}.controls[${controlIndex}]`)),
       limits: requiredArray(offering.limits, `${field}.limits`).map((limit, limitIndex) => parseCatalogLimit(limit, `${field}.limits[${limitIndex}]`)),
+      media_limits: requiredArray(offering.media_limits, `${field}.media_limits`).map((limit, limitIndex) => parseCatalogMediaLimit(limit, `${field}.media_limits[${limitIndex}]`)),
     };
   });
 
@@ -475,6 +478,55 @@ function parseCatalogLimit(rawLimit, field) {
     value: nullableNonnegativeInteger(limit.value, `${field}.value`),
     unit: requiredString(limit.unit, `${field}.unit`),
     account_dependent: requiredBoolean(limit.account_dependent, `${field}.account_dependent`),
+  };
+}
+
+/**
+ * @param {unknown} rawLimit
+ * @param {string} field
+ * @returns {PublicCatalogMediaLimit}
+ */
+function parseCatalogMediaLimit(rawLimit, field) {
+  const limit = requiredRecord(rawLimit, field);
+  requireExactKeys(limit, [
+    "id", "media_type", "transport", "status", "value", "unit", "scope", "source", "last_verified",
+  ], field);
+  const mediaType = requiredString(limit.media_type, `${field}.media_type`);
+  const transport = requiredString(limit.transport, `${field}.transport`);
+  const status = requiredString(limit.status, `${field}.status`);
+  const unit = requiredString(limit.unit, `${field}.unit`);
+  const scope = requiredString(limit.scope, `${field}.scope`);
+  const value = nullableNonnegativeInteger(limit.value, `${field}.value`);
+  if (!new Set(["all", "image", "audio"]).has(mediaType)
+      || !new Set(["any", "inline", "file"]).has(transport)
+      || !new Set(["bounded", "unbounded", "unknown"]).has(status)
+      || !new Set(["bytes", "files"]).has(unit)
+      || !new Set(["attachment", "request", "request_encoded_bytes"]).has(scope)
+      || (status === "bounded" ? value === null || value === 0 : value !== null)) {
+    throw new Error(`public_capabilities_invalid: ${field} media limit`);
+  }
+  const source = requiredString(limit.source, `${field}.source`);
+  try {
+    if (new URL(source).protocol !== "https:") {
+      throw new Error("source protocol");
+    }
+  } catch {
+    throw new Error(`public_capabilities_invalid: ${field}.source`);
+  }
+  const lastVerified = requiredString(limit.last_verified, `${field}.last_verified`);
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(lastVerified)) {
+    throw new Error(`public_capabilities_invalid: ${field}.last_verified`);
+  }
+  return {
+    id: requiredString(limit.id, `${field}.id`),
+    media_type: mediaType,
+    transport,
+    status,
+    value,
+    unit,
+    scope,
+    source,
+    last_verified: lastVerified,
   };
 }
 

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="00ba030da153f6d37e18a87601af1cff1f4ebb8a2bd52af3d4dac495dca2b7a0">
+    <meta name="openapi-source-sha256" content="e4f8d83fa082967e1018f428e6e4a404908b47f4581085b788aca47dd67b8052">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.css">
     <link rel="stylesheet" href="/assets/llm-proxy/public-shell.css">
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="00ba030da153f6d37e18a87601af1cff1f4ebb8a2bd52af3d4dac495dca2b7a0">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="e4f8d83fa082967e1018f428e6e4a404908b47f4581085b788aca47dd67b8052">
     <mpr-header
       class="public-site-header"
       data-config-url="/config-ui.yaml"
@@ -49,7 +49,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>00ba030da153f6d37e18a87601af1cff1f4ebb8a2bd52af3d4dac495dca2b7a0</code></span>
+          <span>Source SHA-256 <code>e4f8d83fa082967e1018f428e6e4a404908b47f4581085b788aca47dd67b8052</code></span>
         </div>
         <div class="resource-actions" aria-label="OpenAPI schema actions">
           <a class="resource-button" href="#openapi-yaml">View YAML</a>
@@ -233,6 +233,7 @@ paths:
       parameters:
         - $ref: &#39;#/components/parameters/TenantClientKey&#39;
         - $ref: &#39;#/components/parameters/AssetSHA256&#39;
+        - $ref: &#39;#/components/parameters/RequestTimeout&#39;
       requestBody:
         $ref: &#39;#/components/requestBodies/AssetUpload&#39;
       responses:
@@ -244,6 +245,10 @@ paths:
           $ref: &#39;#/components/responses/ProxyForbidden&#39;
         &#39;413&#39;:
           $ref: &#39;#/components/responses/AssetFailure&#39;
+        &#39;499&#39;:
+          $ref: &#39;#/components/responses/CallerClosed&#39;
+        &#39;504&#39;:
+          $ref: &#39;#/components/responses/ProxyTimeout&#39;
         &#39;500&#39;:
           $ref: &#39;#/components/responses/AssetFailure&#39;
   /model/v1/assets/{asset_id}:
@@ -1069,12 +1074,18 @@ components:
               - $ref: &#39;#/components/schemas/AssetErrorEnvelope&#39;
     AssetCreated:
       description: The asset is available to its authenticated tenant.
+      headers:
+        X-LLM-Proxy-Request-Timeout-Seconds:
+          $ref: &#39;#/components/headers/ResolvedRequestTimeout&#39;
       content:
         application/json:
           schema:
             $ref: &#39;#/components/schemas/TenantAsset&#39;
     AssetFailure:
       description: The asset operation failed with a stable safe code.
+      headers:
+        X-LLM-Proxy-Request-Timeout-Seconds:
+          $ref: &#39;#/components/headers/OptionalResolvedRequestTimeout&#39;
       content:
         application/json:
           schema:
@@ -3844,6 +3855,7 @@ components:
               <tbody>
                 <tr><td><code>key</code></td><td>query</td><td>Yes</td><td>string</td><td>Tenant client secret.</td></tr>
 <tr><td><code>X-LLM-Proxy-Asset-SHA256</code></td><td>header</td><td>Yes</td><td>string</td><td>Lowercase hexadecimal SHA-256 of the exact request body.</td></tr>
+<tr><td><code>X-LLM-Proxy-Request-Timeout-Seconds</code></td><td>header</td><td>No</td><td>integer</td><td>A positive whole-second request budget no greater than the server maximum. Omission selects the configured default.</td></tr>
               </tbody>
             </table>
           </div>
@@ -3855,11 +3867,13 @@ components:
             <table>
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
-                <tr><td><code>201</code></td><td>application/json</td><td>none</td><td>The asset is available to its authenticated tenant.</td></tr>
-<tr><td><code>400</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+                <tr><td><code>201</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset is available to its authenticated tenant.</td></tr>
+<tr><td><code>400</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
-<tr><td><code>413</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
-<tr><td><code>500</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>413</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
+<tr><td><code>500</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>
               </tbody>
             </table>
           </div>
@@ -3894,9 +3908,9 @@ components:
               <tbody>
                 <tr><td><code>204</code></td><td>none</td><td>none</td><td>The asset is deleted.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
-<tr><td><code>404</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
-<tr><td><code>410</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
-<tr><td><code>500</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>404</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>410</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>500</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
               </tbody>
             </table>
           </div>
@@ -3950,12 +3964,12 @@ components:
                 <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The selected model has one validated wire contract and one execution lifecycle; no lifecycle is inferred from an endpoint or upstream id. The proxy internally observes queued and in_progress states for OpenAI Responses and background-capable Gemini Interactions while keeping every public operation blocking; synchronous Gemini Interactions must return an immediate terminal state. Separately, it continues exact output-budget stops through new provider calls: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini Interactions incomplete, and Anthropic max_tokens. HTTP 200 is returned only after the adapter reports its complete signal: OpenAI or Gemini completed, Chat stop, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The canonical message input or referenced asset is invalid.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
-<tr><td><code>404</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
-<tr><td><code>410</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>404</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>410</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
 <tr><td><code>413</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The compatibility JSON request limit, dictation audio limit, tenant asset limit, or selected provider media limit was exceeded.</td></tr>
 <tr><td><code>429</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider returned HTTP 429. The proxy preserves 429 at its public boundary and returns only sanitized provider metadata; it never exposes the raw provider body or message.</td></tr>
 <tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
-<tr><td><code>500</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>500</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The asset operation failed with a stable safe code.</td></tr>
 <tr><td><code>502</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider failed, returned a non-429 unsuccessful HTTP status, or returned an unusable success payload. Output-budget stops are continued internally and do not create this response. The response contains only sanitized provider metadata and never exposes partial generated text, token-count headers, a raw provider body, or a provider error message; provider-reported usage can still be retained in managed failure accounting.</td></tr>
 <tr><td><code>503</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected provider is not configured or the bounded request queue is full.</td></tr>
 <tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="10884193feb1e24d84a8334498a3f3f4be0e05bc7362ab1c64b9fb10216f7145">
+    <meta name="openapi-source-sha256" content="00ba030da153f6d37e18a87601af1cff1f4ebb8a2bd52af3d4dac495dca2b7a0">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.css">
     <link rel="stylesheet" href="/assets/llm-proxy/public-shell.css">
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="10884193feb1e24d84a8334498a3f3f4be0e05bc7362ab1c64b9fb10216f7145">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="00ba030da153f6d37e18a87601af1cff1f4ebb8a2bd52af3d4dac495dca2b7a0">
     <mpr-header
       class="public-site-header"
       data-config-url="/config-ui.yaml"
@@ -49,7 +49,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>10884193feb1e24d84a8334498a3f3f4be0e05bc7362ab1c64b9fb10216f7145</code></span>
+          <span>Source SHA-256 <code>00ba030da153f6d37e18a87601af1cff1f4ebb8a2bd52af3d4dac495dca2b7a0</code></span>
         </div>
         <div class="resource-actions" aria-label="OpenAPI schema actions">
           <a class="resource-button" href="#openapi-yaml">View YAML</a>
@@ -172,7 +172,15 @@ paths:
     post:
       operationId: postV2Messages
       summary: Generate text from canonical messages
-      description: The current messages-only operation. `messages` is required. User messages may include provider-neutral ordered image or audio attachments with canonical base64 bytes and matching SHA-256 digests. `model`, `web_search`, `max_tokens`, and `reasoning_effort` are optional. Omitting `reasoning_effort` selects the tenant or route default; an explicitly supplied value must be non-blank and supported by the resolved provider/model route. Unsupported media or route capabilities return the canonical plain-text 400 error response before an upstream call.
+      description: &gt;-
+        The current messages-only operation. `messages` is required. User
+        messages may include ordered inline or tenant-asset-backed image and
+        audio attachments. `model`, `web_search`, `max_tokens`, and
+        `reasoning_effort` are optional. Omitting `reasoning_effort` selects
+        the tenant or route default. A supplied value must be non-blank and
+        supported by the resolved route. The selected provider offering owns
+        media admission and transport limits. Unsupported media or route
+        capabilities return HTTP 400 before an upstream call.
       tags:
         - Proxy
       security:
@@ -190,9 +198,13 @@ paths:
         &#39;200&#39;:
           $ref: &#39;#/components/responses/TextSuccess&#39;
         &#39;400&#39;:
-          $ref: &#39;#/components/responses/ProxyBadRequest&#39;
+          $ref: &#39;#/components/responses/V2BadRequest&#39;
         &#39;403&#39;:
           $ref: &#39;#/components/responses/ProxyForbidden&#39;
+        &#39;404&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
+        &#39;410&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
         &#39;413&#39;:
           $ref: &#39;#/components/responses/ProxyPayloadTooLarge&#39;
         &#39;429&#39;:
@@ -205,6 +217,57 @@ paths:
           $ref: &#39;#/components/responses/ProxyUnavailable&#39;
         &#39;504&#39;:
           $ref: &#39;#/components/responses/ProxyTimeout&#39;
+        &#39;500&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
+  /model/v1/assets:
+    post:
+      operationId: uploadTenantAsset
+      summary: Upload exact tenant media bytes
+      description: &gt;-
+        Stores one hash-bound image or audio asset for the configured retention
+        period. The authenticated tenant owns the returned opaque asset id.
+      tags:
+        - Proxy
+      security:
+        - TenantClientKey: []
+      parameters:
+        - $ref: &#39;#/components/parameters/TenantClientKey&#39;
+        - $ref: &#39;#/components/parameters/AssetSHA256&#39;
+      requestBody:
+        $ref: &#39;#/components/requestBodies/AssetUpload&#39;
+      responses:
+        &#39;201&#39;:
+          $ref: &#39;#/components/responses/AssetCreated&#39;
+        &#39;400&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
+        &#39;403&#39;:
+          $ref: &#39;#/components/responses/ProxyForbidden&#39;
+        &#39;413&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
+        &#39;500&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
+  /model/v1/assets/{asset_id}:
+    delete:
+      operationId: deleteTenantAsset
+      summary: Delete one tenant asset
+      tags:
+        - Proxy
+      security:
+        - TenantClientKey: []
+      parameters:
+        - $ref: &#39;#/components/parameters/TenantClientKey&#39;
+        - $ref: &#39;#/components/parameters/AssetID&#39;
+      responses:
+        &#39;204&#39;:
+          description: The asset is deleted.
+        &#39;403&#39;:
+          $ref: &#39;#/components/responses/ProxyForbidden&#39;
+        &#39;404&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
+        &#39;410&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
+        &#39;500&#39;:
+          $ref: &#39;#/components/responses/AssetFailure&#39;
   /dictate:
     post:
       operationId: postDictation
@@ -775,6 +838,22 @@ components:
       schema:
         type: integer
         minimum: 1
+    AssetSHA256:
+      name: X-LLM-Proxy-Asset-SHA256
+      in: header
+      required: true
+      description: Lowercase hexadecimal SHA-256 of the exact request body.
+      schema:
+        type: string
+        pattern: ^[0-9a-f]{64}$
+    AssetID:
+      name: asset_id
+      in: path
+      required: true
+      description: Opaque tenant asset identifier.
+      schema:
+        type: string
+        pattern: ^ast_[0-9a-f]{32}$
     TenantID:
       name: tenant_id
       in: path
@@ -858,6 +937,33 @@ components:
           encoding:
             audio:
               contentType: audio/*,application/octet-stream
+    AssetUpload:
+      required: true
+      content:
+        image/jpeg:
+          schema:
+            type: string
+            format: binary
+        image/png:
+          schema:
+            type: string
+            format: binary
+        image/webp:
+          schema:
+            type: string
+            format: binary
+        audio/m4a:
+          schema:
+            type: string
+            format: binary
+        audio/mpeg:
+          schema:
+            type: string
+            format: binary
+        audio/wav:
+          schema:
+            type: string
+            format: binary
     TenantNameRequest:
       required: true
       content:
@@ -936,7 +1042,7 @@ components:
             type: string
             const: unknown client key
     ProxyPayloadTooLarge:
-      description: The configured JSON request or dictation audio payload limit was exceeded.
+      description: The compatibility JSON request limit, dictation audio limit, tenant asset limit, or selected provider media limit was exceeded.
       headers:
         X-LLM-Proxy-Request-Timeout-Seconds:
           $ref: &#39;#/components/headers/ResolvedRequestTimeout&#39;
@@ -944,6 +1050,35 @@ components:
         text/plain:
           schema:
             type: string
+        application/json:
+          schema:
+            $ref: &#39;#/components/schemas/ProviderErrorEnvelope&#39;
+    V2BadRequest:
+      description: The canonical message input or referenced asset is invalid.
+      headers:
+        X-LLM-Proxy-Request-Timeout-Seconds:
+          $ref: &#39;#/components/headers/OptionalResolvedRequestTimeout&#39;
+      content:
+        text/plain:
+          schema:
+            type: string
+        application/json:
+          schema:
+            oneOf:
+              - $ref: &#39;#/components/schemas/ProxyErrorEnvelope&#39;
+              - $ref: &#39;#/components/schemas/AssetErrorEnvelope&#39;
+    AssetCreated:
+      description: The asset is available to its authenticated tenant.
+      content:
+        application/json:
+          schema:
+            $ref: &#39;#/components/schemas/TenantAsset&#39;
+    AssetFailure:
+      description: The asset operation failed with a stable safe code.
+      content:
+        application/json:
+          schema:
+            $ref: &#39;#/components/schemas/AssetErrorEnvelope&#39;
     ProxyRateLimited:
       description: The selected upstream provider returned HTTP 429. The proxy preserves 429 at its public boundary and returns only sanitized provider metadata; it never exposes the raw provider body or message.
       headers:
@@ -1395,6 +1530,7 @@ components:
         - reasoning_efforts
         - controls
         - limits
+        - media_limits
       properties:
         identifier:
           type: string
@@ -1444,6 +1580,10 @@ components:
           type: array
           items:
             $ref: &#39;#/components/schemas/PublicCatalogLimit&#39;
+        media_limits:
+          type: array
+          items:
+            $ref: &#39;#/components/schemas/PublicCatalogMediaLimit&#39;
     PublicCatalogControl:
       type: object
       additionalProperties: false
@@ -1504,6 +1644,64 @@ components:
           minLength: 1
         account_dependent:
           type: boolean
+    PublicCatalogMediaLimit:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - media_type
+        - transport
+        - status
+        - value
+        - unit
+        - scope
+        - source
+        - last_verified
+      properties:
+        id:
+          type: string
+          minLength: 1
+        media_type:
+          type: string
+          enum:
+            - all
+            - image
+            - audio
+        transport:
+          type: string
+          enum:
+            - any
+            - inline
+            - file
+        status:
+          type: string
+          enum:
+            - bounded
+            - unbounded
+            - unknown
+        value:
+          oneOf:
+            - type: integer
+              minimum: 1
+            - type: &#39;null&#39;
+        unit:
+          type: string
+          enum:
+            - bytes
+            - files
+        scope:
+          type: string
+          enum:
+            - attachment
+            - request
+            - request_encoded_bytes
+        source:
+          type: string
+          format: uri
+          pattern: &#39;^https://&#39;
+        last_verified:
+          type: string
+          format: date
     PublicPriceDescriptor:
       type: object
       additionalProperties: false
@@ -1668,6 +1866,8 @@ components:
       oneOf:
         - $ref: &#39;#/components/schemas/ImageMessageAttachment&#39;
         - $ref: &#39;#/components/schemas/AudioMessageAttachment&#39;
+        - $ref: &#39;#/components/schemas/ImageAssetMessageAttachment&#39;
+        - $ref: &#39;#/components/schemas/AudioAssetMessageAttachment&#39;
     ImageMessageAttachment:
       type: object
       additionalProperties: false
@@ -1720,6 +1920,117 @@ components:
           type: string
           pattern: ^[0-9a-f]{64}$
           description: Lowercase hexadecimal SHA-256 of the decoded media bytes.
+    ImageAssetMessageAttachment:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - mime_type
+        - asset_id
+        - sha256
+      properties:
+        type:
+          type: string
+          const: image
+        mime_type:
+          type: string
+          enum:
+            - image/jpeg
+            - image/png
+            - image/webp
+        asset_id:
+          type: string
+          pattern: ^ast_[0-9a-f]{32}$
+        sha256:
+          type: string
+          pattern: ^[0-9a-f]{64}$
+    AudioAssetMessageAttachment:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - mime_type
+        - asset_id
+        - sha256
+      properties:
+        type:
+          type: string
+          const: audio
+        mime_type:
+          type: string
+          enum:
+            - audio/m4a
+            - audio/mpeg
+            - audio/wav
+        asset_id:
+          type: string
+          pattern: ^ast_[0-9a-f]{32}$
+        sha256:
+          type: string
+          pattern: ^[0-9a-f]{64}$
+    TenantAsset:
+      type: object
+      additionalProperties: false
+      required:
+        - asset_id
+        - mime_type
+        - size_bytes
+        - sha256
+        - state
+        - created_at
+        - expires_at
+      properties:
+        asset_id:
+          type: string
+          pattern: ^ast_[0-9a-f]{32}$
+        mime_type:
+          type: string
+          enum:
+            - image/jpeg
+            - image/png
+            - image/webp
+            - audio/m4a
+            - audio/mpeg
+            - audio/wav
+        size_bytes:
+          type: integer
+          format: int64
+          minimum: 1
+        sha256:
+          type: string
+          pattern: ^[0-9a-f]{64}$
+        state:
+          type: string
+          const: available
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+    AssetErrorEnvelope:
+      type: object
+      additionalProperties: false
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          additionalProperties: false
+          required:
+            - code
+          properties:
+            code:
+              type: string
+              enum:
+                - asset_invalid
+                - asset_not_found
+                - asset_expired
+                - asset_deleted
+                - asset_mime_mismatch
+                - asset_digest_mismatch
+                - asset_too_large
+                - asset_store_error
     V2ChatMessage:
       description: A user message that may carry attachments, or a text-only system or assistant message.
       oneOf:
@@ -1962,6 +2273,7 @@ components:
               type: string
               enum:
                 - provider_error
+                - provider_media_limit_exceeded
                 - provider_rate_limited
             provider:
               type: string
@@ -2655,6 +2967,8 @@ components:
 <a href="#operation-getPublicCapabilities"><span class="api-method api-method-get">GET</span><code>/api/public/capabilities</code><span>Read the public normalized model capability catalog</span></a>
 <a href="#operation-getBrowserConfiguration"><span class="api-method api-method-get">GET</span><code>/config-ui.yaml</code><span>Read the browser runtime configuration</span></a>
 <a href="#operation-postDictation"><span class="api-method api-method-post">POST</span><code>/dictate</code><span>Transcribe an audio upload</span></a>
+<a href="#operation-uploadTenantAsset"><span class="api-method api-method-post">POST</span><code>/model/v1/assets</code><span>Upload exact tenant media bytes</span></a>
+<a href="#operation-deleteTenantAsset"><span class="api-method api-method-delete">DELETE</span><code>/model/v1/assets/{asset_id}</code><span>Delete one tenant asset</span></a>
 <a href="#operation-postV2Messages"><span class="api-method api-method-post">POST</span><code>/v2</code><span>Generate text from canonical messages</span></a>
         </div>
       </section>
@@ -2757,7 +3071,7 @@ components:
                 <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The selected model has one validated wire contract and one execution lifecycle; no lifecycle is inferred from an endpoint or upstream id. The proxy internally observes queued and in_progress states for OpenAI Responses and background-capable Gemini Interactions while keeping every public operation blocking; synchronous Gemini Interactions must return an immediate terminal state. Separately, it continues exact output-budget stops through new provider calls: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini Interactions incomplete, and Anthropic max_tokens. HTTP 200 is returned only after the adapter reports its complete signal: OpenAI or Gemini completed, Chat stop, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
-<tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured JSON request or dictation audio payload limit was exceeded.</td></tr>
+<tr><td><code>413</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The compatibility JSON request limit, dictation audio limit, tenant asset limit, or selected provider media limit was exceeded.</td></tr>
 <tr><td><code>429</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider returned HTTP 429. The proxy preserves 429 at its public boundary and returns only sanitized provider metadata; it never exposes the raw provider body or message.</td></tr>
 <tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
 <tr><td><code>502</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider failed, returned a non-429 unsuccessful HTTP status, or returned an unusable success payload. Output-budget stops are continued internally and do not create this response. The response contains only sanitized provider metadata and never exposes partial generated text, token-count headers, a raw provider body, or a provider error message; provider-reported usage can still be retained in managed failure accounting.</td></tr>
@@ -3502,12 +3816,87 @@ components:
                 <tr><td><code>200</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>Transcription result.</td></tr>
 <tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
-<tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured JSON request or dictation audio payload limit was exceeded.</td></tr>
+<tr><td><code>413</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The compatibility JSON request limit, dictation audio limit, tenant asset limit, or selected provider media limit was exceeded.</td></tr>
 <tr><td><code>429</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider returned HTTP 429. The proxy preserves 429 at its public boundary and returns only sanitized provider metadata; it never exposes the raw provider body or message.</td></tr>
 <tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
 <tr><td><code>502</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider failed, returned a non-429 unsuccessful HTTP status, or returned an unusable success payload. Output-budget stops are continued internally and do not create this response. The response contains only sanitized provider metadata and never exposes partial generated text, token-count headers, a raw provider body, or a provider error message; provider-reported usage can still be retained in managed failure accounting.</td></tr>
 <tr><td><code>503</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected provider is not configured or the bounded request queue is full.</td></tr>
 <tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+<section class="api-operation" id="operation-uploadTenantAsset">
+        <header class="api-operation-heading">
+          <span class="api-method api-method-post">POST</span>
+          <code>/model/v1/assets</code>
+          <span class="api-operation-id">uploadTenantAsset</span>
+        </header>
+        <h2>Upload exact tenant media bytes</h2>
+        <p>Stores one hash-bound image or audio asset for the configured retention period. The authenticated tenant owns the returned opaque asset id.</p>
+        <p class="api-security"><strong>Authentication:</strong> TenantClientKey (query key)</p>
+        <div class="api-contract-block">
+          <h3>Parameters</h3>
+          <div class="resource-table-wrap">
+            <table>
+              <thead><tr><th>Name</th><th>Location</th><th>Required</th><th>Type</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>key</code></td><td>query</td><td>Yes</td><td>string</td><td>Tenant client secret.</td></tr>
+<tr><td><code>X-LLM-Proxy-Asset-SHA256</code></td><td>header</td><td>Yes</td><td>string</td><td>Lowercase hexadecimal SHA-256 of the exact request body.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="api-contract-block"><h3>Request body</h3><p>None.</p></div>
+        <div class="api-contract-block">
+          <h3>Responses</h3>
+          <div class="resource-table-wrap">
+            <table>
+              <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>201</code></td><td>application/json</td><td>none</td><td>The asset is available to its authenticated tenant.</td></tr>
+<tr><td><code>400</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
+<tr><td><code>413</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>500</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+<section class="api-operation" id="operation-deleteTenantAsset">
+        <header class="api-operation-heading">
+          <span class="api-method api-method-delete">DELETE</span>
+          <code>/model/v1/assets/{asset_id}</code>
+          <span class="api-operation-id">deleteTenantAsset</span>
+        </header>
+        <h2>Delete one tenant asset</h2>
+        <p class="api-security"><strong>Authentication:</strong> TenantClientKey (query key)</p>
+        <div class="api-contract-block">
+          <h3>Parameters</h3>
+          <div class="resource-table-wrap">
+            <table>
+              <thead><tr><th>Name</th><th>Location</th><th>Required</th><th>Type</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>key</code></td><td>query</td><td>Yes</td><td>string</td><td>Tenant client secret.</td></tr>
+<tr><td><code>asset_id</code></td><td>path</td><td>Yes</td><td>string</td><td>Opaque tenant asset identifier.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="api-contract-block"><h3>Request body</h3><p>None.</p></div>
+        <div class="api-contract-block">
+          <h3>Responses</h3>
+          <div class="resource-table-wrap">
+            <table>
+              <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>204</code></td><td>none</td><td>none</td><td>The asset is deleted.</td></tr>
+<tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
+<tr><td><code>404</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>410</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>500</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
               </tbody>
             </table>
           </div>
@@ -3520,7 +3909,7 @@ components:
           <span class="api-operation-id">postV2Messages</span>
         </header>
         <h2>Generate text from canonical messages</h2>
-        <p>The current messages-only operation. `messages` is required. User messages may include provider-neutral ordered image or audio attachments with canonical base64 bytes and matching SHA-256 digests. `model`, `web_search`, `max_tokens`, and `reasoning_effort` are optional. Omitting `reasoning_effort` selects the tenant or route default; an explicitly supplied value must be non-blank and supported by the resolved provider/model route. Unsupported media or route capabilities return the canonical plain-text 400 error response before an upstream call.</p>
+        <p>The current messages-only operation. `messages` is required. User messages may include ordered inline or tenant-asset-backed image and audio attachments. `model`, `web_search`, `max_tokens`, and `reasoning_effort` are optional. Omitting `reasoning_effort` selects the tenant or route default. A supplied value must be non-blank and supported by the resolved route. The selected provider offering owns media admission and transport limits. Unsupported media or route capabilities return HTTP 400 before an upstream call.</p>
         <p class="api-security"><strong>Authentication:</strong> TenantClientKey (query key)</p>
         <div class="api-contract-block">
           <h3>Parameters</h3>
@@ -3559,11 +3948,14 @@ components:
               <thead><tr><th>Status</th><th>Content types</th><th>Headers</th><th>Description</th></tr></thead>
               <tbody>
                 <tr><td><code>200</code></td><td>text/plain, application/json, application/xml, text/csv</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-Tokens, X-LLM-Proxy-Response-Tokens, X-LLM-Proxy-Total-Tokens</td><td>Complete generated text in the selected representation. The selected model has one validated wire contract and one execution lifecycle; no lifecycle is inferred from an endpoint or upstream id. The proxy internally observes queued and in_progress states for OpenAI Responses and background-capable Gemini Interactions while keeping every public operation blocking; synchronous Gemini Interactions must return an immediate terminal state. Separately, it continues exact output-budget stops through new provider calls: OpenAI Responses incomplete/max_output_tokens, OpenAI-compatible Chat Completions length, Gemini Interactions incomplete, and Anthropic max_tokens. HTTP 200 is returned only after the adapter reports its complete signal: OpenAI or Gemini completed, Chat stop, or Anthropic end_turn|stop_sequence. Intermediate, safety, refusal, tool, malformed, missing, and unknown states never return text as success.</td></tr>
-<tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The request is malformed, names an invalid route/capability, or supplies an invalid timeout. Text validation failures use the canonical plain-text error. Timeout-header validation uses the canonical JSON error.</td></tr>
+<tr><td><code>400</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The canonical message input or referenced asset is invalid.</td></tr>
 <tr><td><code>403</code></td><td>text/plain</td><td>none</td><td>The tenant client key is absent or unknown.</td></tr>
-<tr><td><code>413</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The configured JSON request or dictation audio payload limit was exceeded.</td></tr>
+<tr><td><code>404</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>410</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
+<tr><td><code>413</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The compatibility JSON request limit, dictation audio limit, tenant asset limit, or selected provider media limit was exceeded.</td></tr>
 <tr><td><code>429</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider returned HTTP 429. The proxy preserves 429 at its public boundary and returns only sanitized provider metadata; it never exposes the raw provider body or message.</td></tr>
 <tr><td><code>499</code></td><td>none</td><td>none</td><td>The caller canceled or closed the request.</td></tr>
+<tr><td><code>500</code></td><td>application/json</td><td>none</td><td>The asset operation failed with a stable safe code.</td></tr>
 <tr><td><code>502</code></td><td>application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds, X-LLM-Proxy-Request-ID, Retry-After</td><td>The selected upstream provider failed, returned a non-429 unsuccessful HTTP status, or returned an unusable success payload. Output-budget stops are continued internally and do not create this response. The response contains only sanitized provider metadata and never exposes partial generated text, token-count headers, a raw provider body, or a provider error message; provider-reported usage can still be retained in managed failure accounting.</td></tr>
 <tr><td><code>503</code></td><td>text/plain</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The selected provider is not configured or the bounded request queue is full.</td></tr>
 <tr><td><code>504</code></td><td>text/plain, application/json</td><td>X-LLM-Proxy-Request-Timeout-Seconds</td><td>The proxy request budget or upstream operation timed out.</td></tr>

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -164,6 +164,81 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 	}
 }
 
+func TestPublicCapabilityCatalogPublishesExactGeminiMediaLimits(testingInstance *testing.T) {
+	catalog, catalogError := proxy.NewPublicCapabilityCatalog(proxy.Configuration{
+		ModelCatalog: testfixtures.ModelCatalog(testingInstance),
+	})
+	if catalogError != nil {
+		testingInstance.Fatalf("NewPublicCapabilityCatalog error: %v", catalogError)
+	}
+	expectedLimits := map[string]struct {
+		mediaType string
+		transport string
+		status    string
+		value     int64
+		unit      string
+		scope     string
+		source    string
+	}{
+		proxy.CatalogMediaLimitIDInlineRequestBytes: {
+			mediaType: proxy.CatalogMediaLimitTypeAll, transport: proxy.CatalogMediaTransportInline,
+			status: proxy.CatalogMediaLimitStatusBounded, value: 20_000_000,
+			unit: proxy.CatalogMediaLimitUnitBytes, scope: proxy.CatalogMediaLimitScopeRequestEncodedBytes,
+			source: "https://ai.google.dev/gemini-api/docs/file-input-methods",
+		},
+		proxy.CatalogMediaLimitIDImageCount: {
+			mediaType: "image", transport: proxy.CatalogMediaTransportAny,
+			status: proxy.CatalogMediaLimitStatusBounded, value: 3_600,
+			unit: proxy.CatalogMediaLimitUnitFiles, scope: proxy.CatalogMediaLimitScopeRequest,
+			source: "https://ai.google.dev/gemini-api/docs/image-understanding",
+		},
+		proxy.CatalogMediaLimitIDAudioCount: {
+			mediaType: "audio", transport: proxy.CatalogMediaTransportAny,
+			status: proxy.CatalogMediaLimitStatusUnknown,
+			unit:   proxy.CatalogMediaLimitUnitFiles, scope: proxy.CatalogMediaLimitScopeRequest,
+			source: "https://ai.google.dev/gemini-api/docs/audio",
+		},
+		proxy.CatalogMediaLimitIDImageFileBytes: {
+			mediaType: "image", transport: proxy.CatalogMediaTransportFile,
+			status: proxy.CatalogMediaLimitStatusBounded, value: 2_000_000_000,
+			unit: proxy.CatalogMediaLimitUnitBytes, scope: proxy.CatalogMediaLimitScopeAttachment,
+			source: "https://ai.google.dev/gemini-api/docs/files",
+		},
+		proxy.CatalogMediaLimitIDAudioFileBytes: {
+			mediaType: "audio", transport: proxy.CatalogMediaTransportFile,
+			status: proxy.CatalogMediaLimitStatusBounded, value: 2_000_000_000,
+			unit: proxy.CatalogMediaLimitUnitBytes, scope: proxy.CatalogMediaLimitScopeAttachment,
+			source: "https://ai.google.dev/gemini-api/docs/files",
+		},
+	}
+
+	mediaOfferingCount := 0
+	for _, offering := range catalog.Offerings {
+		if len(offering.MediaLimits) == 0 {
+			continue
+		}
+		mediaOfferingCount++
+		if offering.Provider != proxy.ProviderNameGemini || (offering.Model != proxy.ModelNameGemini35Flash && offering.Model != proxy.ModelNameGemini25Flash) || len(offering.MediaLimits) != len(expectedLimits) {
+			testingInstance.Fatalf("unexpected media offering=%+v", offering)
+		}
+		for _, limit := range offering.MediaLimits {
+			expected, exists := expectedLimits[limit.ID]
+			if !exists || limit.MediaType != expected.mediaType || limit.Transport != expected.transport || limit.Status != expected.status || limit.Unit != expected.unit || limit.Scope != expected.scope || limit.Source != expected.source || limit.LastVerified != "2026-08-11" {
+				testingInstance.Fatalf("media limit=%+v", limit)
+			}
+			if expected.status == proxy.CatalogMediaLimitStatusBounded && (limit.Value == nil || *limit.Value != expected.value) {
+				testingInstance.Fatalf("bounded media limit=%+v", limit)
+			}
+			if expected.status != proxy.CatalogMediaLimitStatusBounded && limit.Value != nil {
+				testingInstance.Fatalf("non-bounded media limit=%+v", limit)
+			}
+		}
+	}
+	if mediaOfferingCount != 2 {
+		testingInstance.Fatalf("media offerings=%d want=2", mediaOfferingCount)
+	}
+}
+
 func TestPublicCapabilityRESTResourceProjectsChangedCatalogWithoutPrivateConfig(testingInstance *testing.T) {
 	const (
 		changedModelID = "kimi-rest-contract"
@@ -274,6 +349,30 @@ func TestPublicCapabilityCatalogRejectsNoncanonicalRuntimeRegistries(testingInst
 				catalogs.Offerings[0].Model = "missing-model"
 			},
 			expectedError: "reason=dangling_reference",
+		},
+		{
+			name: "missing media limits",
+			mutate: func(catalogs *proxy.ModelCatalog) {
+				for offeringIndex := range catalogs.Offerings {
+					if catalogs.Offerings[offeringIndex].Provider == proxy.ProviderNameGemini && catalogs.Offerings[offeringIndex].Model == proxy.ModelNameGemini25Flash {
+						catalogs.Offerings[offeringIndex].MediaLimits = nil
+						return
+					}
+				}
+			},
+			expectedError: "reason=media_limits_missing",
+		},
+		{
+			name: "bounded media limit without value",
+			mutate: func(catalogs *proxy.ModelCatalog) {
+				for offeringIndex := range catalogs.Offerings {
+					if catalogs.Offerings[offeringIndex].Provider == proxy.ProviderNameGemini && catalogs.Offerings[offeringIndex].Model == proxy.ModelNameGemini25Flash {
+						catalogs.Offerings[offeringIndex].MediaLimits[0].Value = nil
+						return
+					}
+				}
+			},
+			expectedError: ".media_limits[0].value",
 		},
 	}
 

--- a/tests/e2e/management-ui.spec.js
+++ b/tests/e2e/management-ui.spec.js
@@ -1288,10 +1288,12 @@ test("site publishes the exact canonical OpenAPI artifact and its derived refere
     `<a class="resource-button" href="${openAPIPath}" download="${openAPIDownloadFilename}">Download YAML</a>`,
   );
   expect(documentationHTML).toContain('id="operation-postV2Messages"');
+  expect(documentationHTML).toContain('id="operation-uploadTenantAsset"');
+  expect(documentationHTML).toContain('id="operation-deleteTenantAsset"');
   expect(documentationHTML).not.toContain('id="operation-deleteManagementTenantSecret"');
   expect(documentationHTML).toContain("<code>reasoning_effort</code>");
   expect(documentationHTML).toContain(`href="${openAPIPath}"`);
-  expect(documentationHTML.match(/<section class="api-operation"/g) || []).toHaveLength(21);
+  expect(documentationHTML.match(/<section class="api-operation"/g) || []).toHaveLength(23);
 });
 
 test("OpenAPI reference views and downloads the exact canonical YAML", async ({ page }) => {

--- a/tests/e2e/public-site-renderer.spec.js
+++ b/tests/e2e/public-site-renderer.spec.js
@@ -88,6 +88,7 @@ function normalizedCapabilityFixture() {
       reasoning_efforts: [],
       controls: [],
       limits: [],
+      media_limits: [],
     }],
     prices: [{
       provider: "example-provider",


### PR DESCRIPTION
## Summary

Adds tenant-managed media assets and routes Gemini media requests through the appropriate transport based on published provider limits.

## Changes

- Introduces tenant asset upload and deletion endpoints with configurable storage path, retention period, and maximum asset size.
- Adds hash-bound image and audio asset references for canonical message attachments alongside inline media.
- Validates asset ownership, availability, expiry, MIME type, byte count, and SHA-256 before provider dispatch.
- Publishes offering-level media limits in the capability catalog and enforces them for canonical media requests.
- Routes Gemini media inline when the encoded request fits the inline limit; otherwise uploads media through Gemini Files API and cleans up provider files after use.
- Extends the Go and Python clients with asset upload and asset-backed attachment helpers.
- Documents the asset API, attachment contract, provider limits, error behavior, and configuration in OpenAPI, README, public capability content, and site documentation.
- Adds routing, validation, limit, failure-mode, client, API contract, and public-site coverage for the new media flows.