### PR TITLE
gix/restore-five-stage-model-routing-explorer

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1098,6 +1098,50 @@ retain satisfied historical dependencies.
 
 ## Features
 
+- [x] [F034] (P1) Filter the route explorer by weight access and capability.
+  Goal:
+  Reduce the model family fan with compact route filters in the diagram title.
+  Requirements:
+  - Add one explicit `weight_access` value to each model family.
+  - Accept only `proprietary` and `open_weights` values.
+  - Publish weight access through the public capability resource and OpenAPI.
+  - Reuse the canonical capability definitions and compact capability pills.
+  - Keep the title and filters in one header row.
+  - Keep filtered counts in that row when the available width permits it.
+  - Select one or more weight access values. Select `Proprietary` by default.
+  - Select exactly one capability. Select `Text generation` by default.
+  - Show a family when its weight access and one provider offering match the
+    active filters.
+  - Show only exact models and provider offerings that match the active
+    filters.
+  - Keep the current route when it remains valid. Otherwise, select the first
+    valid route in catalog order.
+  - Update the visible family, exact model, and provider offering counts.
+  - Show an explicit empty result when no route matches the active filters.
+  - Preserve complete semantic HTML without JavaScript.
+  - Preserve the five-stage route and responsive page containment.
+  Validation:
+  - Prove the default `Proprietary` and `Text generation` selections.
+  - Prove each access selection and each canonical capability selection.
+  - Prove that weight access keeps one or more selections.
+  - Prove that capability keeps exactly one selection.
+  - Prove the empty result for a valid filter combination without a route.
+  - Prove filtered connector endpoints and deterministic route selection.
+  - Inspect the single header row at 1280, 900, and 390 pixels.
+  - Run `make ci` after the last application change.
+  Resolution:
+  - The model catalog classifies each family as proprietary or open weights.
+  - The public capability resource and OpenAPI publish this classification.
+  - The title row contains a multi-choice weight access group. It also contains
+    a single-choice capability group.
+  - Weight access keeps at least one selection. Capability keeps exactly one
+    selection.
+  - `Proprietary` and `Text generation` are the default selections.
+  - The route fan, counts, empty result, selection, and connectors follow all
+    selected values.
+  - Visual checks passed at 1280, 900, and 390 pixels.
+  - `make ci` passed all 11 gates with 93 browser tests and 100.0% Go statement
+    coverage.
 - [x] [F033] (P0) {F022} Pass canonical message media to selected providers.
   Goal:
   Let `/v2` accept provider-neutral media without a smaller LLM Proxy media

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -58,6 +58,45 @@ retain satisfied historical dependencies.
     orchestration readiness checks.
   - `make ci` passed all 11 gates with 91 browser tests and 100.0% Go statement
     coverage.
+- [x] [B131] (P1) Restore the five-stage model route.
+  Goal:
+  Restore one continuous route graph from the product to the selected provider
+  offering. The graph uses model family and exact model stages.
+  Evidence:
+  - The current route explorer separates publisher and model selection from
+    the lower route graph.
+  - The lower graph combines publisher and exact model in one node.
+  - The model family appears only as a filter and model label.
+  Requirements:
+  - Render exactly five desktop stages: Product, LLM Proxy, Model Family,
+    Model, and Provider.
+  - Keep this stage order at each supported desktop width.
+  - Generate each model family, exact model, and provider offering from the
+    normalized public catalog.
+  - Select a model family before an exact model.
+  - Show only the selected family's exact models in the model stage.
+  - Show only the selected exact model's provider offerings in the provider
+    stage.
+  - Remove the publisher picker and route filters from the route explorer.
+  - Keep publisher data in the normalized catalog and capability table.
+  - Preserve complete semantic HTML without JavaScript.
+  - Preserve responsive containment and the selected provider/model route
+    output.
+  Validation:
+  - Prove the five-stage order and connector endpoints in a real browser.
+  - Prove family, model, and provider selection updates the explicit route.
+  - Prove all families, exact models, and provider offerings exist without
+    JavaScript.
+  - Run `make ci` after the last application change.
+  Resolution:
+  - Restored one continuous Product, LLM Proxy, Model Family, Model, and
+    Provider route graph.
+  - Removed publisher selection and route filters from the route explorer.
+    The capability matrix continues to show publisher data and its filters.
+  - Added browser proofs for the five-stage order, connector endpoints,
+    selection updates, complete semantic HTML, and responsive layouts.
+  - `make ci` passed all 11 gates with 92 browser tests and 100.0% Go statement
+    coverage.
 - [!] [B126] (P1) Activate the current v0.4.0 release on every public surface.
   Goal:
   Make the production API, container, and Pages site serve the immutable

--- a/.mprlab/TERMINOLOGY.md
+++ b/.mprlab/TERMINOLOGY.md
@@ -12,6 +12,7 @@ Give each term one meaning. Use the same term for the same concept in all docume
 - `exact model`: One canonical model version that a client can select.
 - `model family`: A group of exact models from one model publisher.
 - `model publisher`: An organization or community that creates or releases a model.
+- `weight access`: A model family classification of proprietary or open weights.
 - `provider offering`: One exact model that one provider makes available as a route.
 - `production acceptance`: Evidence that the production runtime satisfies the checks that an issue specifies.
 - `route explorer`: The public interface that selects an exact model and a provider offering.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ that input capability.
 
 The public [LLM Proxy landing page](https://llm-proxy.mprlab.com/) explains the
 current provider, model, dictation, web-search, request-limit, and integration
-surface. Its route explorer selects a model family, an exact model, and a
-provider offering. Its model matrix has one row for each exact model and shows
-all current provider offerings for that model. Both interfaces use the
+surface. Its route explorer filters model families by weight access and
+provider-offering capabilities. It then selects a model family, an exact model,
+and a provider offering. Its model matrix has one row for each exact model and
+shows all current provider offerings for that model. Both interfaces use the
 validated runtime catalog. A catalog change appears on the landing page without
 a second inventory. The authenticated
 management app opens at [`/app/`](https://llm-proxy.mprlab.com/app/) only after
@@ -572,8 +573,10 @@ replaces the public landing's capability marker with the returned model-centric
 catalog. It replaces the routing marker with a five-stage route from the
 product through LLM Proxy, model family, exact model, and provider offering.
 Every route item remains in semantic HTML without JavaScript. Browser
-enhancement supplies family, model, and provider selection and the final route
-display. The capability catalog also supplies
+enhancement supplies a multi-choice weight-access filter and a single-choice
+capability filter in the route title row. Proprietary and Text are the default
+filters. Browser enhancement also supplies family, model, and provider
+selection and the final route display. The capability catalog supplies
 one all-characteristics search surface, disclosed match-all capability filters,
 sortable table headers, a live result count, and reset. Node exists only in the
 Pages build stage; the published artifact is static and has no runtime renderer
@@ -1475,8 +1478,8 @@ removing only its old container. The retained
 The Pages declaration uses `docker/pages/Dockerfile`. A compiled Go backend
 serves the secret-free `/api/public/capabilities` resource during the build.
 The Node frontend renderer fetches that resource. It renders model families,
-exact models, and provider offerings in the route explorer. It keeps publishers
-in the capability matrix. It also renders
+exact models, provider offerings, and route filters in the route explorer. It
+keeps publishers in the capability matrix. It also renders
 request limits and injects the browser configuration URL into
 every generated auth-aware HTML page. The final Pages image contains only the
 static artifact. Application runtime code has no Caddy deployment knowledge, and

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ that input capability.
 
 The public [LLM Proxy landing page](https://llm-proxy.mprlab.com/) explains the
 current provider, model, dictation, web-search, request-limit, and integration
-surface. Its route explorer selects a model publisher, an exact model, and a
+surface. Its route explorer selects a model family, an exact model, and a
 provider offering. Its model matrix has one row for each exact model and shows
 all current provider offerings for that model. Both interfaces use the
 validated runtime catalog. A catalog change appears on the landing page without
@@ -569,10 +569,11 @@ backend's public-capabilities-only REST surface, then the frontend-owned Node
 renderer fetches `/api/public/capabilities`. The renderer writes
 `https://llm-proxy-api.mprlab.com/config-ui.yaml` into every auth-aware header,
 replaces the public landing's capability marker with the returned model-centric
-catalog. It replaces the routing marker with the publisher, exact model, and
-provider offering explorer. Every catalog item remains in semantic HTML without
-JavaScript. Browser enhancement supplies exact-model filters, route selection,
-and the final route display. It also supplies
+catalog. It replaces the routing marker with a five-stage route from the
+product through LLM Proxy, model family, exact model, and provider offering.
+Every route item remains in semantic HTML without JavaScript. Browser
+enhancement supplies family, model, and provider selection and the final route
+display. The capability catalog also supplies
 one all-characteristics search surface, disclosed match-all capability filters,
 sortable table headers, a live result count, and reset. Node exists only in the
 Pages build stage; the published artifact is static and has no runtime renderer
@@ -1472,9 +1473,10 @@ removing only its old container. The retained
 `mprlab-nginx-gateway_llm-proxy-data` volume is not removed.
 
 The Pages declaration uses `docker/pages/Dockerfile`. A compiled Go backend
-serves the secret-free `/api/public/capabilities` resource during the build;
-the Node frontend renderer fetches that resource, renders the provider/model
-catalog as publishers, exact models, and provider offerings. It also renders
+serves the secret-free `/api/public/capabilities` resource during the build.
+The Node frontend renderer fetches that resource. It renders model families,
+exact models, and provider offerings in the route explorer. It keeps publishers
+in the capability matrix. It also renders
 request limits and injects the browser configuration URL into
 every generated auth-aware HTML page. The final Pages image contains only the
 static artifact. Application runtime code has no Caddy deployment knowledge, and

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -1492,6 +1492,13 @@ providers:
 			expectedError: "field=catalog.families[0].label",
 		},
 		{
+			name: "unknown catalog family weight access",
+			providersYAML: mutateCatalogRecordYAML(completeLiteralProvidersYAML(), "families", "gpt-4", func(block string) string {
+				return strings.Replace(block, "    weight_access: proprietary", "    weight_access: unknown", 1)
+			}),
+			expectedError: "field=catalog.families[0].weight_access value=unknown",
+		},
+		{
 			name:          "empty exact models",
 			providersYAML: mutateCatalogSectionYAML(completeLiteralProvidersYAML(), "models", func(string) string { return "  models: []" }),
 			expectedError: "field=catalog.models",

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -154,75 +154,99 @@ catalog:
   - id: gpt-4
     publisher: openai
     label: GPT-4
+    weight_access: proprietary
   - id: gpt-5
     publisher: openai
     label: GPT-5
+    weight_access: proprietary
   - id: gpt-transcribe
     publisher: openai
     label: GPT Transcribe
+    weight_access: proprietary
   - id: deepseek-v4
     publisher: deepseek
     label: DeepSeek V4
+    weight_access: open_weights
   - id: deepseek-v3
     publisher: deepseek
     label: DeepSeek V3
+    weight_access: open_weights
   - id: deepseek-r1
     publisher: deepseek
     label: DeepSeek R1
+    weight_access: open_weights
   - id: qwen
     publisher: alibaba
     label: Qwen
+    weight_access: proprietary
   - id: kimi-k2
     publisher: moonshot
     label: Kimi K2
+    weight_access: open_weights
   - id: kimi-k3
     publisher: moonshot
     label: Kimi K3
+    weight_access: open_weights
   - id: minimax-m2
     publisher: minimax
     label: MiniMax M2
+    weight_access: open_weights
   - id: sensevoice
     publisher: funaudio
     label: SenseVoice
+    weight_access: open_weights
   - id: glm-5
     publisher: zhipu
     label: GLM-5
+    weight_access: open_weights
   - id: glm-asr
     publisher: zhipu
     label: GLM ASR
+    weight_access: open_weights
   - id: gemini
     publisher: google
     label: Gemini
+    weight_access: proprietary
   - id: claude-fable
     publisher: anthropic
     label: Claude Fable
+    weight_access: proprietary
   - id: claude-sonnet
     publisher: anthropic
     label: Claude Sonnet
+    weight_access: proprietary
   - id: claude-opus
     publisher: anthropic
     label: Claude Opus
+    weight_access: proprietary
   - id: claude-haiku
     publisher: anthropic
     label: Claude Haiku
+    weight_access: proprietary
   - id: muse-spark
     publisher: meta
     label: Muse Spark
+    weight_access: proprietary
   - id: grok
     publisher: xai
     label: Grok
+    weight_access: proprietary
   - id: grok-build
     publisher: xai
     label: Grok Build
+    weight_access: proprietary
   - id: grok-code
     publisher: xai
     label: Grok Code
+    weight_access: proprietary
   - id: grok-imagine
     publisher: xai
     label: Grok Imagine
+    weight_access: proprietary
   - id: xai-stt
     publisher: xai
     label: xAI STT
+    weight_access: proprietary
   models:
   - id: gpt-4o-mini
     publisher: openai

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1391,6 +1391,7 @@ components:
         - identifier
         - publisher
         - label
+        - weight_access
       properties:
         identifier:
           type: string
@@ -1401,6 +1402,11 @@ components:
         label:
           type: string
           minLength: 1
+        weight_access:
+          type: string
+          enum:
+            - proprietary
+            - open_weights
     PublicExactModelCapability:
       type: object
       additionalProperties: false

--- a/internal/proxy/catalog_service_internal_test.go
+++ b/internal/proxy/catalog_service_internal_test.go
@@ -162,7 +162,9 @@ func TestCatalogCapabilityValidationRejectsIncompleteContracts(t *testing.T) {
 	t.Run("catalog publisher without exact model", func(t *testing.T) {
 		catalog := internalTestModelCatalog(internalTestOffering(ProviderNameOpenAI, ModelNameGPT41, []string{ModelOperationText}, []string{ModelOperationText}))
 		catalog.Publishers = append(catalog.Publishers, ModelPublisher{ID: "unused", Label: "Unused"})
-		catalog.Families = append(catalog.Families, ModelFamily{ID: "unused", Publisher: "unused", Label: "Unused"})
+		catalog.Families = append(catalog.Families, ModelFamily{
+			ID: "unused", Publisher: "unused", Label: "Unused", WeightAccess: ModelWeightAccessProprietary,
+		})
 		_, validationError := NewCatalogService(catalog)
 		assertError(t, validationError, "publisher=unused reason=missing_exact_model")
 	})

--- a/internal/proxy/model_catalog.go
+++ b/internal/proxy/model_catalog.go
@@ -63,10 +63,18 @@ type ModelPublisher struct {
 
 // ModelFamily groups exact models from one publisher.
 type ModelFamily struct {
-	ID        string `mapstructure:"id"`
-	Publisher string `mapstructure:"publisher"`
-	Label     string `mapstructure:"label"`
+	ID           string `mapstructure:"id"`
+	Publisher    string `mapstructure:"publisher"`
+	Label        string `mapstructure:"label"`
+	WeightAccess string `mapstructure:"weight_access"`
 }
+
+const (
+	// ModelWeightAccessProprietary identifies families whose model weights are not published for independent deployment.
+	ModelWeightAccessProprietary = "proprietary"
+	// ModelWeightAccessOpenWeights identifies families with published weights for independent deployment.
+	ModelWeightAccessOpenWeights = "open_weights"
+)
 
 // ExactModel declares provider-independent identity and model capabilities.
 type ExactModel struct {
@@ -240,6 +248,9 @@ func validateModelFamilies(families []ModelFamily, publishers map[string]ModelPu
 		}
 		if strings.TrimSpace(family.Label) == constants.EmptyString || family.Label != strings.TrimSpace(family.Label) {
 			return fmt.Errorf("%w: field=catalog.families[%d].label", ErrInvalidModelCatalog, index)
+		}
+		if family.WeightAccess != ModelWeightAccessProprietary && family.WeightAccess != ModelWeightAccessOpenWeights {
+			return fmt.Errorf("%w: field=catalog.families[%d].weight_access value=%s", ErrInvalidModelCatalog, index, family.WeightAccess)
 		}
 		validated[identifier] = family
 	}

--- a/internal/proxy/model_catalog_internal_test.go
+++ b/internal/proxy/model_catalog_internal_test.go
@@ -66,10 +66,12 @@ func internalTestModelCatalog(offerings ...ProviderOffering) ModelCatalog {
 		},
 		Providers:  providers,
 		Publishers: []ModelPublisher{{ID: "test", Label: "Test"}},
-		Families:   []ModelFamily{{ID: "test", Publisher: "test", Label: "Test"}},
-		Models:     models,
-		Offerings:  offerings,
-		Prices:     prices,
+		Families: []ModelFamily{{
+			ID: "test", Publisher: "test", Label: "Test", WeightAccess: ModelWeightAccessProprietary,
+		}},
+		Models:    models,
+		Offerings: offerings,
+		Prices:    prices,
 	}
 }
 

--- a/internal/proxy/public_capabilities.go
+++ b/internal/proxy/public_capabilities.go
@@ -54,9 +54,10 @@ type PublicModelPublisher struct {
 
 // PublicModelFamily identifies one family within a model publisher.
 type PublicModelFamily struct {
-	Identifier string `json:"identifier"`
-	Publisher  string `json:"publisher"`
-	Label      string `json:"label"`
+	Identifier   string `json:"identifier"`
+	Publisher    string `json:"publisher"`
+	Label        string `json:"label"`
+	WeightAccess string `json:"weight_access"`
 }
 
 // PublicExactModelCapability describes one provider-independent exact model.
@@ -136,7 +137,9 @@ func newPublicCapabilityCatalog(configuration Configuration) PublicCapabilityCat
 
 	families := make([]PublicModelFamily, 0, len(configuration.ModelCatalog.Families))
 	for _, family := range configuration.ModelCatalog.Families {
-		families = append(families, PublicModelFamily{Identifier: family.ID, Publisher: family.Publisher, Label: family.Label})
+		families = append(families, PublicModelFamily{
+			Identifier: family.ID, Publisher: family.Publisher, Label: family.Label, WeightAccess: family.WeightAccess,
+		})
 	}
 	sort.Slice(families, func(first int, second int) bool { return families[first].Identifier < families[second].Identifier })
 

--- a/scripts/render_public_site.mjs
+++ b/scripts/render_public_site.mjs
@@ -12,16 +12,23 @@ const legacyRuntimeConfigFile = "llm-proxy-config.json";
 const binaryBytesPerMiB = 1024 * 1024;
 
 const capabilityDefinitions = Object.freeze([
-  { identifier: "text", label: "Text generation", className: "capability-badge--primary" },
-  { identifier: "dictation", label: "Dictation", className: "capability-badge--info" },
-  { identifier: "video_generation", label: "Video generation", className: "capability-badge--info" },
-  { identifier: "image_input", label: "Image input", className: "capability-badge--info" },
-  { identifier: "audio_input", label: "Audio message input", className: "capability-badge--info" },
-  { identifier: "web_search", label: "Web search", className: "capability-badge--success" },
-  { identifier: "reasoning", label: "Reasoning", className: "capability-badge--success" },
+  { identifier: "text", label: "Text generation", routeLabel: "Text", className: "capability-badge--primary" },
+  { identifier: "dictation", label: "Dictation", routeLabel: "Dictation", className: "capability-badge--info" },
+  { identifier: "video_generation", label: "Video generation", routeLabel: "Video", className: "capability-badge--info" },
+  { identifier: "image_input", label: "Image input", routeLabel: "Image", className: "capability-badge--info" },
+  { identifier: "audio_input", label: "Audio message input", routeLabel: "Audio", className: "capability-badge--info" },
+  { identifier: "web_search", label: "Web search", routeLabel: "Web search", className: "capability-badge--success" },
+  { identifier: "reasoning", label: "Reasoning", routeLabel: "Reasoning", className: "capability-badge--success" },
 ]);
 const capabilityDefinitionsByIdentifier = new Map(
   capabilityDefinitions.map((definition) => [definition.identifier, definition]),
+);
+const weightAccessDefinitions = Object.freeze([
+  { identifier: "proprietary", label: "Proprietary" },
+  { identifier: "open_weights", label: "Open weights" },
+]);
+const weightAccessDefinitionsByIdentifier = new Map(
+  weightAccessDefinitions.map((definition) => [definition.identifier, definition]),
 );
 
 const options = parseArguments(process.argv.slice(2));
@@ -39,7 +46,7 @@ await renderPublicSite(options);
 /** @typedef {{id: string, input_artifacts: string[], output_artifacts: string[]}} PublicModelOperation */
 /** @typedef {{identifier: string, label: string, credential_kinds: string[]}} PublicProviderCapability */
 /** @typedef {{identifier: string, label: string, model_count: number}} PublicModelPublisher */
-/** @typedef {{identifier: string, publisher: string, label: string}} PublicModelFamily */
+/** @typedef {{identifier: string, publisher: string, label: string, weight_access: string}} PublicModelFamily */
 /**
  * @typedef {{
  *   identifier: string,
@@ -101,7 +108,7 @@ await renderPublicSite(options);
  */
 
 /**
- * @typedef {{identifier: string, label: string, className: string}} CapabilityDefinition
+ * @typedef {{identifier: string, label: string, routeLabel: string, className: string}} CapabilityDefinition
  */
 
 /**
@@ -249,11 +256,16 @@ function parseCapabilityCatalog(rawCatalog) {
   const families = requiredNonemptyArray(catalog.families, "catalog.families").map((rawFamily, familyIndex) => {
     const field = `catalog.families[${familyIndex}]`;
     const family = requiredRecord(rawFamily, field);
-    requireExactKeys(family, ["identifier", "publisher", "label"], field);
+    requireExactKeys(family, ["identifier", "publisher", "label", "weight_access"], field);
+    const weightAccess = requiredString(family.weight_access, `${field}.weight_access`);
+    if (!weightAccessDefinitionsByIdentifier.has(weightAccess)) {
+      throw new Error(`public_capabilities_invalid: ${field}.weight_access value=${weightAccess}`);
+    }
     return {
       identifier: requiredString(family.identifier, `${field}.identifier`),
       publisher: requiredString(family.publisher, `${field}.publisher`),
       label: requiredString(family.label, `${field}.label`),
+      weight_access: weightAccess,
     };
   });
 
@@ -640,12 +652,31 @@ function renderRoutingTree(catalog) {
   for (const model of catalog.models) {
     modelsByFamily.get(model.family)?.push(model);
   }
-  const selectedFamily = catalog.families[0];
-  const selectedModel = modelsByFamily.get(selectedFamily.identifier)?.[0];
+  const defaultWeightAccess = "proprietary";
+  const defaultCapability = "text";
+  /** @type {Map<string, PublicProviderOffering[]>} */
+  const defaultOfferingsByModel = new Map(catalog.models.map((model) => [
+    model.identifier,
+    model.provider_offerings.map((offeringIdentifier) => requireReference(
+      offeringsByIdentifier,
+      offeringIdentifier,
+      `model=${model.identifier} offering`,
+    )).filter((offering) => offering.capabilities.includes(defaultCapability)),
+  ]));
+  const selectedFamily = catalog.families.find((family) => (
+    family.weight_access === defaultWeightAccess
+    && (modelsByFamily.get(family.identifier) ?? []).some((model) => (defaultOfferingsByModel.get(model.identifier)?.length ?? 0) > 0)
+  ));
+  if (!selectedFamily) {
+    throw new Error(`public_capabilities_invalid: weight_access=${defaultWeightAccess} capability=${defaultCapability} has no model family`);
+  }
+  const selectedModel = modelsByFamily.get(selectedFamily.identifier)?.find(
+    (model) => (defaultOfferingsByModel.get(model.identifier)?.length ?? 0) > 0,
+  );
   if (!selectedModel) {
     throw new Error(`public_capabilities_invalid: family=${selectedFamily.identifier} has no exact models`);
   }
-  const selectedOffering = offeringsByIdentifier.get(selectedModel.provider_offerings[0]);
+  const selectedOffering = defaultOfferingsByModel.get(selectedModel.identifier)?.[0];
   if (!selectedOffering) {
     throw new Error(`public_capabilities_invalid: model=${selectedModel.identifier} has no provider offering`);
   }
@@ -653,19 +684,30 @@ function renderRoutingTree(catalog) {
   if (!selectedProvider) {
     throw new Error(`public_capabilities_invalid: offering=${selectedOffering.identifier} provider`);
   }
-  const familyButtons = catalog.families.map((family, familyIndex) => {
+  const availableCapabilities = new Set(catalog.offerings.flatMap((offering) => offering.capabilities));
+  const accessButtons = weightAccessDefinitions.map((definition) => (
+    `<button type="button" class="routing-tree__filter" data-route-weight-access="${escapeAttribute(definition.identifier)}" aria-pressed="${definition.identifier === defaultWeightAccess ? "true" : "false"}" disabled>${escapeHTML(definition.label)}</button>`
+  )).join("");
+  const capabilityButtons = capabilityDefinitions.filter((definition) => availableCapabilities.has(definition.identifier)).map((definition) => (
+    `<button type="button" class="routing-tree__filter" data-route-capability="${escapeAttribute(definition.identifier)}" aria-label="${escapeAttribute(definition.label)}" title="${escapeAttribute(definition.label)}" aria-pressed="${definition.identifier === defaultCapability ? "true" : "false"}" disabled>${escapeHTML(definition.routeLabel)}</button>`
+  )).join("");
+  const familyButtons = catalog.families.map((family) => {
     const familyModels = modelsByFamily.get(family.identifier) ?? [];
-    return `        <button type="button" class="routing-tree__branch routing-tree__family" data-route-family="${escapeAttribute(family.identifier)}" aria-controls="routing-tree-models-${escapeAttribute(family.identifier)}" aria-pressed="${familyIndex === 0 ? "true" : "false"}" disabled>
-          <strong>${escapeHTML(family.label)}</strong><small>${countLabel(familyModels.length, "model")}</small>
+    const matchingModels = familyModels.filter((model) => (defaultOfferingsByModel.get(model.identifier)?.length ?? 0) > 0);
+    const visible = family.weight_access === defaultWeightAccess && matchingModels.length > 0;
+    return `        <button type="button" class="routing-tree__branch routing-tree__family" data-route-family="${escapeAttribute(family.identifier)}" data-route-family-weight-access="${escapeAttribute(family.weight_access)}" aria-controls="routing-tree-models-${escapeAttribute(family.identifier)}" aria-pressed="${family.identifier === selectedFamily.identifier ? "true" : "false"}"${visible ? "" : " hidden"} disabled>
+          <strong>${escapeHTML(family.label)}</strong><small data-route-family-model-count>${countLabel(matchingModels.length, "model")}</small>
         </button>`;
   }).join("");
-  const modelGroups = catalog.families.map((family, familyIndex) => {
+  const modelGroups = catalog.families.map((family) => {
     const familyModels = modelsByFamily.get(family.identifier) ?? [];
-    const modelButtons = familyModels.map((model, modelIndex) => {
-      return `<button type="button" class="routing-tree__branch routing-tree__model" data-route-model="${escapeAttribute(model.identifier)}" data-route-model-family="${escapeAttribute(model.family)}" aria-pressed="${familyIndex === 0 && modelIndex === 0 ? "true" : "false"}" disabled><code>${escapeHTML(model.identifier)}</code><small>${escapeHTML(model.operations.join(" + "))}</small></button>`;
+    const matchingModels = familyModels.filter((model) => (defaultOfferingsByModel.get(model.identifier)?.length ?? 0) > 0);
+    const modelButtons = familyModels.map((model) => {
+      const visible = family.weight_access === defaultWeightAccess && (defaultOfferingsByModel.get(model.identifier)?.length ?? 0) > 0;
+      return `<button type="button" class="routing-tree__branch routing-tree__model" data-route-model="${escapeAttribute(model.identifier)}" data-route-model-family="${escapeAttribute(model.family)}" aria-pressed="${model.identifier === selectedModel.identifier ? "true" : "false"}"${visible ? "" : " hidden"} disabled><code>${escapeHTML(model.identifier)}</code><small>${escapeHTML(model.operations.join(" + "))}</small></button>`;
     }).join("");
-    return `      <section id="routing-tree-models-${escapeAttribute(family.identifier)}" class="routing-tree__model-group" data-route-model-group="${escapeAttribute(family.identifier)}" aria-label="${escapeAttribute(family.label)} exact models"${familyIndex === 0 ? "" : " hidden"}>
-        <p><strong>${escapeHTML(family.label)}</strong><span>${countLabel(familyModels.length, "exact model")}</span></p>
+    return `      <section id="routing-tree-models-${escapeAttribute(family.identifier)}" class="routing-tree__model-group" data-route-model-group="${escapeAttribute(family.identifier)}" aria-label="${escapeAttribute(family.label)} exact models"${family.identifier === selectedFamily.identifier ? "" : " hidden"}>
+        <p><strong>${escapeHTML(family.label)}</strong><span data-route-model-count>${countLabel(matchingModels.length, "exact model")}</span></p>
         <div class="routing-tree__branches routing-tree__model-branches" role="group" aria-label="Choose an exact ${escapeAttribute(family.label)} model">
           ${modelButtons}
         </div>
@@ -677,21 +719,36 @@ function renderRoutingTree(catalog) {
       offeringIdentifier,
       `model=${model.identifier} offering`,
     ));
-    const providerButtons = modelOfferings.map((offering, offeringIndex) => {
+    const matchingOfferings = defaultOfferingsByModel.get(model.identifier) ?? [];
+    const providerButtons = modelOfferings.map((offering) => {
       const provider = providersByIdentifier.get(offering.provider);
-      return `<button type="button" class="routing-tree__branch routing-tree__provider" data-route-provider="${escapeAttribute(offering.provider)}" data-route-offering="${escapeAttribute(offering.identifier)}" aria-pressed="${model.identifier === selectedModel.identifier && offeringIndex === 0 ? "true" : "false"}" disabled><strong>${escapeHTML(provider?.label ?? offering.provider)}</strong><small>${escapeHTML(offering.capabilities.join(" · "))}</small></button>`;
+      const visible = offering.capabilities.includes(defaultCapability);
+      return `<button type="button" class="routing-tree__branch routing-tree__provider" data-route-provider="${escapeAttribute(offering.provider)}" data-route-offering="${escapeAttribute(offering.identifier)}" data-route-provider-capabilities="${escapeAttribute(offering.capabilities.join(" "))}" aria-pressed="${offering.identifier === selectedOffering.identifier ? "true" : "false"}"${visible ? "" : " hidden"} disabled><strong>${escapeHTML(provider?.label ?? offering.provider)}</strong><small>${escapeHTML(offering.capabilities.join(" · "))}</small></button>`;
     }).join("");
     return `      <section class="routing-tree__provider-group" data-route-provider-group="${escapeAttribute(model.identifier)}" aria-label="Providers offering ${escapeAttribute(model.identifier)}"${model.identifier === selectedModel.identifier ? "" : " hidden"}>
-        <p><strong>Provider offerings</strong><span>${modelOfferings.length} route${modelOfferings.length === 1 ? "" : "s"}</span></p>
+        <p><strong>Provider offerings</strong><span data-route-provider-count>${matchingOfferings.length} route${matchingOfferings.length === 1 ? "" : "s"}</span></p>
         <div class="routing-tree__branches routing-tree__provider-branches" role="group" aria-label="Choose a provider for ${escapeAttribute(model.identifier)}">
           ${providerButtons}
         </div>
       </section>`;
   }).join("");
+  const defaultFamilies = catalog.families.filter((family) => family.weight_access === defaultWeightAccess && (
+    modelsByFamily.get(family.identifier) ?? []
+  ).some((model) => (defaultOfferingsByModel.get(model.identifier)?.length ?? 0) > 0));
+  const defaultModels = catalog.models.filter((model) => (
+    catalog.families.find((family) => family.identifier === model.family)?.weight_access === defaultWeightAccess
+    && (defaultOfferingsByModel.get(model.identifier)?.length ?? 0) > 0
+  ));
+  const defaultOfferings = defaultModels.flatMap((model) => defaultOfferingsByModel.get(model.identifier) ?? []);
   return `<routing-tree class="routing-tree" data-enhanced="false" aria-label="Interactive LLM routing map">
   <header class="routing-tree__header">
     <h2>One integration. Choose the exact route.</h2>
-    <span>${countLabel(catalog.counts.model_families, "family", "families")} · ${countLabel(catalog.counts.exact_models, "exact model")} · ${countLabel(catalog.counts.provider_offerings, "offering")}</span>
+    <div class="routing-tree__filters" aria-label="Route filters">
+      <div class="routing-tree__filter-group" role="group" aria-label="Choose one or both weight access types">${accessButtons}</div>
+      <span class="routing-tree__filter-divider" aria-hidden="true"></span>
+      <div class="routing-tree__filter-group" role="group" aria-label="Choose one capability">${capabilityButtons}</div>
+    </div>
+    <output class="routing-tree__counts" aria-live="polite" data-route-counts>${countLabel(defaultFamilies.length, "family", "families")} · ${countLabel(defaultModels.length, "exact model")} · ${countLabel(defaultOfferings.length, "offering")}</output>
   </header>
   <div class="routing-tree__map" data-route-map>
     <canvas class="routing-tree__connectors" data-route-canvas aria-hidden="true"></canvas>
@@ -703,21 +760,22 @@ function renderRoutingTree(catalog) {
       <strong>LLM Proxy</strong>
       <span>Authenticate · validate · route</span>
     </article>
-    <section class="routing-tree__stage routing-tree__stage--families" aria-labelledby="routing-tree-family-title">
+    <section class="routing-tree__stage routing-tree__stage--families" data-route-stage aria-labelledby="routing-tree-family-title">
       <h3 id="routing-tree-family-title">Choose a model family</h3>
       <div class="routing-tree__branches routing-tree__family-branches" role="group" aria-label="Model families">
 ${familyButtons}
       </div>
     </section>
-    <section class="routing-tree__stage routing-tree__stage--models" aria-labelledby="routing-tree-model-title">
+    <section class="routing-tree__stage routing-tree__stage--models" data-route-stage aria-labelledby="routing-tree-model-title">
       <h3 id="routing-tree-model-title">Choose an exact model</h3>
 ${modelGroups}
     </section>
-    <section class="routing-tree__stage routing-tree__stage--providers" aria-labelledby="routing-tree-provider-title">
+    <section class="routing-tree__stage routing-tree__stage--providers" data-route-stage aria-labelledby="routing-tree-provider-title">
       <h3 id="routing-tree-provider-title">Choose a provider offering</h3>
 ${providerGroups}
     </section>
-    <footer class="routing-tree__selection">
+    <p class="routing-tree__empty" data-route-empty hidden>No routes match these filters.</p>
+    <footer class="routing-tree__selection" data-route-selection>
       <span>Selected route:</span>
       <output aria-live="polite"><code data-route-selected-provider>${escapeHTML(selectedProvider.identifier)}</code><i aria-hidden="true">/</i><code data-route-selected-model>${escapeHTML(selectedModel.identifier)}</code></output>
     </footer>

--- a/scripts/render_public_site.mjs
+++ b/scripts/render_public_site.mjs
@@ -634,18 +634,16 @@ async function renderLandingContent(outputDirectory, capabilityCatalog) {
  */
 function renderRoutingTree(catalog) {
   const providersByIdentifier = new Map(catalog.providers.map((provider) => [provider.identifier, provider]));
-  const publishersByIdentifier = new Map(catalog.publishers.map((publisher) => [publisher.identifier, publisher]));
-  const familiesByIdentifier = new Map(catalog.families.map((family) => [family.identifier, family]));
   const offeringsByIdentifier = new Map(catalog.offerings.map((offering) => [offering.identifier, offering]));
   /** @type {Map<string, PublicExactModelCapability[]>} */
-  const modelsByPublisher = new Map(catalog.publishers.map((publisher) => [publisher.identifier, []]));
+  const modelsByFamily = new Map(catalog.families.map((family) => [family.identifier, []]));
   for (const model of catalog.models) {
-    modelsByPublisher.get(model.publisher)?.push(model);
+    modelsByFamily.get(model.family)?.push(model);
   }
-  const selectedPublisher = catalog.publishers[0];
-  const selectedModel = modelsByPublisher.get(selectedPublisher.identifier)?.[0];
+  const selectedFamily = catalog.families[0];
+  const selectedModel = modelsByFamily.get(selectedFamily.identifier)?.[0];
   if (!selectedModel) {
-    throw new Error(`public_capabilities_invalid: publisher=${selectedPublisher.identifier} has no exact models`);
+    throw new Error(`public_capabilities_invalid: family=${selectedFamily.identifier} has no exact models`);
   }
   const selectedOffering = offeringsByIdentifier.get(selectedModel.provider_offerings[0]);
   if (!selectedOffering) {
@@ -655,19 +653,20 @@ function renderRoutingTree(catalog) {
   if (!selectedProvider) {
     throw new Error(`public_capabilities_invalid: offering=${selectedOffering.identifier} provider`);
   }
-  const publisherButtons = catalog.publishers.map((publisher, publisherIndex) => `        <button type="button" class="routing-tree__branch routing-tree__publisher" data-route-publisher="${escapeAttribute(publisher.identifier)}" aria-controls="routing-tree-models-${escapeAttribute(publisher.identifier)}" aria-pressed="${publisherIndex === 0 ? "true" : "false"}" disabled>
-          <strong>${escapeHTML(publisher.label)}</strong><small>${countLabel(publisher.model_count, "model")}</small>
-        </button>`).join("");
-  const modelGroups = catalog.publishers.map((publisher, publisherIndex) => {
-    const publisherModels = modelsByPublisher.get(publisher.identifier) ?? [];
-    const modelButtons = publisherModels.map((model, modelIndex) => {
-      const family = familiesByIdentifier.get(model.family);
-      const searchText = [publisher.identifier, publisher.label, model.identifier, model.version, model.family, family?.label ?? "", ...model.operations].join(" ");
-      return `<button type="button" class="routing-tree__branch routing-tree__model" data-route-model="${escapeAttribute(model.identifier)}" data-route-model-publisher="${escapeAttribute(model.publisher)}" data-route-family="${escapeAttribute(model.family)}" data-route-operations="${escapeAttribute(model.operations.join(" "))}" data-route-search-text="${escapeAttribute(searchText)}" aria-pressed="${publisherIndex === 0 && modelIndex === 0 ? "true" : "false"}" disabled><code>${escapeHTML(model.identifier)}</code><small>${escapeHTML(family?.label ?? model.family)} · ${escapeHTML(model.operations.join(" + "))}</small></button>`;
+  const familyButtons = catalog.families.map((family, familyIndex) => {
+    const familyModels = modelsByFamily.get(family.identifier) ?? [];
+    return `        <button type="button" class="routing-tree__branch routing-tree__family" data-route-family="${escapeAttribute(family.identifier)}" aria-controls="routing-tree-models-${escapeAttribute(family.identifier)}" aria-pressed="${familyIndex === 0 ? "true" : "false"}" disabled>
+          <strong>${escapeHTML(family.label)}</strong><small>${countLabel(familyModels.length, "model")}</small>
+        </button>`;
+  }).join("");
+  const modelGroups = catalog.families.map((family, familyIndex) => {
+    const familyModels = modelsByFamily.get(family.identifier) ?? [];
+    const modelButtons = familyModels.map((model, modelIndex) => {
+      return `<button type="button" class="routing-tree__branch routing-tree__model" data-route-model="${escapeAttribute(model.identifier)}" data-route-model-family="${escapeAttribute(model.family)}" aria-pressed="${familyIndex === 0 && modelIndex === 0 ? "true" : "false"}" disabled><code>${escapeHTML(model.identifier)}</code><small>${escapeHTML(model.operations.join(" + "))}</small></button>`;
     }).join("");
-    return `      <section id="routing-tree-models-${escapeAttribute(publisher.identifier)}" class="routing-tree__model-group" data-route-model-group="${escapeAttribute(publisher.identifier)}" aria-label="${escapeAttribute(publisher.label)} exact models"${publisherIndex === 0 ? "" : " hidden"}>
-        <p><strong>${escapeHTML(publisher.label)}</strong><span>${countLabel(publisherModels.length, "exact model")}</span></p>
-        <div class="routing-tree__branches routing-tree__model-branches" role="group" aria-label="Choose an exact ${escapeAttribute(publisher.label)} model">
+    return `      <section id="routing-tree-models-${escapeAttribute(family.identifier)}" class="routing-tree__model-group" data-route-model-group="${escapeAttribute(family.identifier)}" aria-label="${escapeAttribute(family.label)} exact models"${familyIndex === 0 ? "" : " hidden"}>
+        <p><strong>${escapeHTML(family.label)}</strong><span>${countLabel(familyModels.length, "exact model")}</span></p>
+        <div class="routing-tree__branches routing-tree__model-branches" role="group" aria-label="Choose an exact ${escapeAttribute(family.label)} model">
           ${modelButtons}
         </div>
       </section>`;
@@ -689,55 +688,38 @@ function renderRoutingTree(catalog) {
         </div>
       </section>`;
   }).join("");
-  const familyOptions = catalog.families.map((family) => `<option value="${escapeAttribute(family.identifier)}">${escapeHTML(family.label)}</option>`).join("");
   return `<routing-tree class="routing-tree" data-enhanced="false" aria-label="Interactive LLM routing map">
   <header class="routing-tree__header">
     <h2>One integration. Choose the exact route.</h2>
-    <span>${countLabel(catalog.counts.model_publishers, "publisher")} · ${countLabel(catalog.counts.exact_models, "exact model")} · ${countLabel(catalog.counts.provider_offerings, "offering")}</span>
+    <span>${countLabel(catalog.counts.model_families, "family", "families")} · ${countLabel(catalog.counts.exact_models, "exact model")} · ${countLabel(catalog.counts.provider_offerings, "offering")}</span>
   </header>
-  <form class="routing-tree__filters" data-route-picker role="search" aria-label="Find an exact model">
-    <input type="search" aria-label="Search exact models" placeholder="Search publisher, family, or model" autocomplete="off" data-route-search disabled>
-    <select aria-label="Filter model family" data-route-family-filter disabled><option value="">All families</option>${familyOptions}</select>
-    <select aria-label="Filter model operation" data-route-operation-filter disabled><option value="">All operations</option><option value="text">Text</option><option value="dictation">Dictation</option><option value="video_generation">Video generation</option></select>
-    <button type="reset" data-route-reset disabled>Reset</button>
-  </form>
-  <div class="routing-tree__catalog">
-    <section class="routing-tree__stage routing-tree__stage--publishers" aria-labelledby="routing-tree-publisher-title">
-      <h3 id="routing-tree-publisher-title">Choose a publisher</h3>
-      <div class="routing-tree__branches routing-tree__publisher-branches" role="group" aria-label="Model publishers">
-${publisherButtons}
+  <div class="routing-tree__map" data-route-map>
+    <canvas class="routing-tree__connectors" data-route-canvas aria-hidden="true"></canvas>
+    <article class="routing-tree__node routing-tree__node--product" data-route-product>
+      <strong>Your product</strong>
+      <span>HTTP · Go · Python · CLI</span>
+    </article>
+    <article class="routing-tree__node routing-tree__node--proxy" data-route-proxy>
+      <strong>LLM Proxy</strong>
+      <span>Authenticate · validate · route</span>
+    </article>
+    <section class="routing-tree__stage routing-tree__stage--families" aria-labelledby="routing-tree-family-title">
+      <h3 id="routing-tree-family-title">Choose a model family</h3>
+      <div class="routing-tree__branches routing-tree__family-branches" role="group" aria-label="Model families">
+${familyButtons}
       </div>
     </section>
     <section class="routing-tree__stage routing-tree__stage--models" aria-labelledby="routing-tree-model-title">
       <h3 id="routing-tree-model-title">Choose an exact model</h3>
 ${modelGroups}
-      <p class="routing-tree__empty" data-route-empty hidden>No exact models match these filters.</p>
     </section>
-  </div>
-  <div class="routing-tree__map" data-route-map>
-    <canvas class="routing-tree__connectors" data-route-canvas aria-hidden="true"></canvas>
-    <div class="routing-tree__ingress" aria-label="One connection into LLM Proxy">
-      <article class="routing-tree__node routing-tree__node--product" data-route-product>
-        <strong>Your product</strong>
-        <span>HTTP · Go · Python · CLI</span>
-      </article>
-      <article class="routing-tree__node routing-tree__node--proxy" data-route-proxy>
-        <strong>LLM Proxy</strong>
-        <span>Authenticate · validate · route</span>
-      </article>
-    </div>
-    <article class="routing-tree__node routing-tree__node--selection" data-route-selection-node>
-      <span data-route-selected-publisher>${escapeHTML(selectedPublisher.label)}</span>
-      <strong><code data-route-selected-model>${escapeHTML(selectedModel.identifier)}</code></strong>
-      <small>${escapeHTML(selectedModel.operations.join(" + "))}</small>
-    </article>
     <section class="routing-tree__stage routing-tree__stage--providers" aria-labelledby="routing-tree-provider-title">
       <h3 id="routing-tree-provider-title">Choose a provider offering</h3>
 ${providerGroups}
     </section>
     <footer class="routing-tree__selection">
       <span>Selected route:</span>
-      <output aria-live="polite"><code data-route-selected-provider>${escapeHTML(selectedProvider.identifier)}</code><i aria-hidden="true">/</i><code data-route-selected-route-model>${escapeHTML(selectedModel.identifier)}</code></output>
+      <output aria-live="polite"><code data-route-selected-provider>${escapeHTML(selectedProvider.identifier)}</code><i aria-hidden="true">/</i><code data-route-selected-model>${escapeHTML(selectedModel.identifier)}</code></output>
     </footer>
   </div>
 </routing-tree>`;
@@ -1131,9 +1113,10 @@ function requireCount(declared, actual, field) {
 /**
  * @param {number} count
  * @param {string} singular
+ * @param {string} [plural]
  */
-function countLabel(count, singular) {
-  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+function countLabel(count, singular, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
 }
 
 /**

--- a/site/assets/llm-proxy/js/ui/routingTree.js
+++ b/site/assets/llm-proxy/js/ui/routingTree.js
@@ -12,16 +12,25 @@ const ACTIVE_LINE_OPACITY = 1;
 
 const SELECTORS = Object.freeze({
   CANVAS: "[data-route-canvas]",
+  CAPABILITY: "[data-route-capability]",
+  COUNTS: "[data-route-counts]",
+  EMPTY: "[data-route-empty]",
   FAMILY: "[data-route-family]",
+  FAMILY_MODEL_COUNT: "[data-route-family-model-count]",
   MAP: "[data-route-map]",
   MODEL: "[data-route-model]",
+  MODEL_COUNT: "[data-route-model-count]",
   MODEL_GROUP: "[data-route-model-group]",
   PRODUCT: "[data-route-product]",
   PROVIDER: "[data-route-provider]",
+  PROVIDER_COUNT: "[data-route-provider-count]",
   PROVIDER_GROUP: "[data-route-provider-group]",
   PROXY: "[data-route-proxy]",
+  SELECTION: "[data-route-selection]",
   SELECTED_MODEL: "[data-route-selected-model]",
   SELECTED_PROVIDER: "[data-route-selected-provider]",
+  STAGE: "[data-route-stage]",
+  WEIGHT_ACCESS: "[data-route-weight-access]",
 });
 
 class RoutingTreeElement extends HTMLElement {
@@ -30,7 +39,13 @@ class RoutingTreeElement extends HTMLElement {
     /** @type {HTMLButtonElement[]} */
     this.familyButtons = [];
     /** @type {HTMLButtonElement[]} */
+    this.weightAccessButtons = [];
+    /** @type {HTMLButtonElement[]} */
+    this.capabilityButtons = [];
+    /** @type {HTMLButtonElement[]} */
     this.modelButtons = [];
+    /** @type {HTMLButtonElement[]} */
+    this.providerButtons = [];
     /** @type {Map<string, HTMLElement>} */
     this.modelGroups = new Map();
     /** @type {Map<string, HTMLElement>} */
@@ -43,6 +58,14 @@ class RoutingTreeElement extends HTMLElement {
     this.selectedModelOutput = null;
     /** @type {HTMLElement | null} */
     this.selectedProviderOutput = null;
+    /** @type {HTMLOutputElement | null} */
+    this.countsOutput = null;
+    /** @type {HTMLElement | null} */
+    this.emptyMessage = null;
+    /** @type {HTMLElement | null} */
+    this.selectionFooter = null;
+    /** @type {HTMLElement[]} */
+    this.downstreamStages = [];
     /** @type {HTMLElement | null} */
     this.routeMap = null;
     /** @type {HTMLCanvasElement | null} */
@@ -60,12 +83,19 @@ class RoutingTreeElement extends HTMLElement {
     if (this.dataset.enhanced === SELECTED_ATTRIBUTE_VALUE) {
       return;
     }
+    this.weightAccessButtons = requiredButtons(this, SELECTORS.WEIGHT_ACCESS);
+    this.capabilityButtons = requiredButtons(this, SELECTORS.CAPABILITY);
     this.familyButtons = requiredButtons(this, SELECTORS.FAMILY);
     this.modelButtons = requiredButtons(this, SELECTORS.MODEL);
+    this.providerButtons = requiredButtons(this, SELECTORS.PROVIDER);
     this.modelGroups = routingGroups(this, SELECTORS.MODEL_GROUP, "routeModelGroup");
     this.providerGroups = routingGroups(this, SELECTORS.PROVIDER_GROUP, "routeProviderGroup");
     this.selectedModelOutput = requiredElement(this, SELECTORS.SELECTED_MODEL, HTMLElement);
     this.selectedProviderOutput = requiredElement(this, SELECTORS.SELECTED_PROVIDER, HTMLElement);
+    this.countsOutput = requiredElement(this, SELECTORS.COUNTS, HTMLOutputElement);
+    this.emptyMessage = requiredElement(this, SELECTORS.EMPTY, HTMLElement);
+    this.selectionFooter = requiredElement(this, SELECTORS.SELECTION, HTMLElement);
+    this.downstreamStages = requiredElements(this, SELECTORS.STAGE, HTMLElement);
     this.routeMap = requiredElement(this, SELECTORS.MAP, HTMLElement);
     this.routeCanvas = requiredElement(this, SELECTORS.CANVAS, HTMLCanvasElement);
     this.productNode = requiredElement(this, SELECTORS.PRODUCT, HTMLElement);
@@ -76,8 +106,19 @@ class RoutingTreeElement extends HTMLElement {
     }
     const selectedFamilies = this.familyButtons.filter((button) => isSelected(button));
     const selectedModels = this.modelButtons.filter((button) => isSelected(button));
-    if (selectedFamilies.length !== 1 || selectedModels.length !== 1) {
-      throw new Error(`routing_tree_selection_invalid: families=${selectedFamilies.length} models=${selectedModels.length}`);
+    const selectedWeightAccess = this.weightAccessButtons.filter((button) => isSelected(button));
+    const selectedCapabilities = this.capabilityButtons.filter((button) => isSelected(button));
+    if (selectedFamilies.length !== 1 || selectedModels.length !== 1 || selectedWeightAccess.length === 0 || selectedCapabilities.length !== 1) {
+      throw new Error(`routing_tree_selection_invalid: weight_access=${selectedWeightAccess.length} capabilities=${selectedCapabilities.length} families=${selectedFamilies.length} models=${selectedModels.length}`);
+    }
+
+    for (const weightAccessButton of this.weightAccessButtons) {
+      weightAccessButton.disabled = false;
+      weightAccessButton.addEventListener("click", () => this.toggleWeightAccess(weightAccessButton));
+    }
+    for (const capabilityButton of this.capabilityButtons) {
+      capabilityButton.disabled = false;
+      capabilityButton.addEventListener("click", () => this.selectCapability(capabilityButton));
     }
 
     for (const familyButton of this.familyButtons) {
@@ -88,14 +129,124 @@ class RoutingTreeElement extends HTMLElement {
       modelButton.disabled = false;
       modelButton.addEventListener("click", () => this.selectModel(modelButton));
     }
-    for (const providerButton of requiredButtons(this, SELECTORS.PROVIDER)) {
+    for (const providerButton of this.providerButtons) {
       providerButton.disabled = false;
       providerButton.addEventListener("click", () => this.selectProvider(providerButton));
     }
     this.resizeObserver = new ResizeObserver(() => this.scheduleRouteDraw());
     this.resizeObserver.observe(this.routeMap);
     this.dataset.enhanced = SELECTED_ATTRIBUTE_VALUE;
-    this.selectFamily(selectedFamilies[0]);
+    this.applyFilters();
+  }
+
+  /** @param {HTMLButtonElement} weightAccessButton */
+  toggleWeightAccess(weightAccessButton) {
+    const selectedWeightAccessButtons = this.weightAccessButtons.filter((button) => isSelected(button));
+    if (isSelected(weightAccessButton) && selectedWeightAccessButtons.length === 1) {
+      return;
+    }
+    weightAccessButton.setAttribute("aria-pressed", String(!isSelected(weightAccessButton)));
+    this.applyFilters();
+  }
+
+  /** @param {HTMLButtonElement} capabilityButton */
+  selectCapability(capabilityButton) {
+    for (const candidateButton of this.capabilityButtons) {
+      candidateButton.setAttribute("aria-pressed", String(candidateButton === capabilityButton));
+    }
+    this.applyFilters();
+  }
+
+  applyFilters() {
+    const selectedWeightAccessButtons = this.weightAccessButtons.filter((button) => isSelected(button));
+    if (selectedWeightAccessButtons.length === 0) {
+      throw new Error(`routing_tree_weight_access_selection_invalid: selected=${selectedWeightAccessButtons.length}`);
+    }
+    const selectedCapabilityButtons = this.capabilityButtons.filter((button) => isSelected(button));
+    if (selectedCapabilityButtons.length !== 1) {
+      throw new Error(`routing_tree_capability_selection_invalid: selected=${selectedCapabilityButtons.length}`);
+    }
+    const selectedWeightAccessValues = new Set(selectedWeightAccessButtons.map(
+      (button) => requiredDatasetValue(button, "routeWeightAccess"),
+    ));
+    const selectedCapability = requiredDatasetValue(selectedCapabilityButtons[0], "routeCapability");
+
+    for (const providerButton of this.providerButtons) {
+      const capabilities = new Set(requiredDatasetValue(providerButton, "routeProviderCapabilities").split(" "));
+      providerButton.hidden = !capabilities.has(selectedCapability);
+    }
+
+    let exactModelCount = 0;
+    let offeringCount = 0;
+    for (const modelButton of this.modelButtons) {
+      const modelIdentifier = requiredDatasetValue(modelButton, "routeModel");
+      const providerGroup = this.providerGroups.get(modelIdentifier);
+      if (!providerGroup) {
+        throw new Error(`routing_tree_provider_group_missing: model=${modelIdentifier}`);
+      }
+      const matchingProviders = requiredButtons(providerGroup, SELECTORS.PROVIDER).filter((button) => !button.hidden);
+      modelButton.hidden = matchingProviders.length === 0;
+      const providerCount = requiredElement(providerGroup, SELECTORS.PROVIDER_COUNT, HTMLElement);
+      providerCount.textContent = countLabel(matchingProviders.length, "route");
+    }
+
+    /** @type {HTMLButtonElement[]} */
+    const visibleFamilies = [];
+    for (const familyButton of this.familyButtons) {
+      const familyIdentifier = requiredDatasetValue(familyButton, "routeFamily");
+      const familyWeightAccess = requiredDatasetValue(familyButton, "routeFamilyWeightAccess");
+      const modelGroup = this.modelGroups.get(familyIdentifier);
+      if (!modelGroup) {
+        throw new Error(`routing_tree_model_group_missing: family=${familyIdentifier}`);
+      }
+      const matchingModels = requiredButtons(modelGroup, SELECTORS.MODEL).filter((button) => !button.hidden);
+      const matchesWeightAccess = selectedWeightAccessValues.has(familyWeightAccess);
+      familyButton.hidden = !matchesWeightAccess || matchingModels.length === 0;
+      const familyModelCount = requiredElement(familyButton, SELECTORS.FAMILY_MODEL_COUNT, HTMLElement);
+      const groupModelCount = requiredElement(modelGroup, SELECTORS.MODEL_COUNT, HTMLElement);
+      familyModelCount.textContent = countLabel(matchingModels.length, "model");
+      groupModelCount.textContent = countLabel(matchingModels.length, "exact model");
+      if (!familyButton.hidden) {
+        visibleFamilies.push(familyButton);
+        exactModelCount += matchingModels.length;
+        for (const matchingModel of matchingModels) {
+          const providerGroup = this.providerGroups.get(requiredDatasetValue(matchingModel, "routeModel"));
+          if (!providerGroup) {
+            throw new Error("routing_tree_visible_model_provider_group_missing");
+          }
+          offeringCount += requiredButtons(providerGroup, SELECTORS.PROVIDER).filter((button) => !button.hidden).length;
+        }
+      }
+    }
+
+    if (!this.countsOutput || !this.emptyMessage || !this.selectionFooter) {
+      throw new Error("routing_tree_filter_surface_missing");
+    }
+    this.countsOutput.textContent = `${countLabel(visibleFamilies.length, "family", "families")} · ${countLabel(exactModelCount, "exact model")} · ${countLabel(offeringCount, "offering")}`;
+    const isEmpty = visibleFamilies.length === 0;
+    this.emptyMessage.hidden = !isEmpty;
+    this.selectionFooter.hidden = isEmpty;
+    for (const stage of this.downstreamStages) {
+      stage.hidden = isEmpty;
+    }
+    if (isEmpty) {
+      for (const branchButton of [...this.familyButtons, ...this.modelButtons, ...this.providerButtons]) {
+        branchButton.setAttribute("aria-pressed", "false");
+      }
+      for (const modelGroup of this.modelGroups.values()) {
+        modelGroup.hidden = true;
+      }
+      for (const providerGroup of this.providerGroups.values()) {
+        providerGroup.hidden = true;
+      }
+      this.activeModelGroup = null;
+      this.activeProviderGroup = null;
+      this.scheduleRouteDraw();
+      return;
+    }
+
+    const selectedFamily = visibleFamilies.find((button) => isSelected(button)) ?? visibleFamilies[0];
+    this.selectFamily(selectedFamily);
   }
 
   disconnectedCallback() {
@@ -120,7 +271,10 @@ class RoutingTreeElement extends HTMLElement {
       candidateModelGroup.hidden = candidateModelGroup !== modelGroup;
     }
     this.activeModelGroup = modelGroup;
-    const familyModels = requiredButtons(modelGroup, SELECTORS.MODEL);
+    const familyModels = requiredButtons(modelGroup, SELECTORS.MODEL).filter((button) => !button.hidden);
+    if (familyModels.length === 0) {
+      throw new Error(`routing_tree_family_models_missing: family=${familyIdentifier}`);
+    }
     const selectedModel = familyModels.find((button) => isSelected(button)) ?? familyModels[0];
     this.selectModel(selectedModel);
   }
@@ -146,7 +300,10 @@ class RoutingTreeElement extends HTMLElement {
       throw new Error("routing_tree_selected_model_output_missing");
     }
     this.selectedModelOutput.textContent = modelIdentifier;
-    const providerButtons = requiredButtons(providerGroup, SELECTORS.PROVIDER);
+    const providerButtons = requiredButtons(providerGroup, SELECTORS.PROVIDER).filter((button) => !button.hidden);
+    if (providerButtons.length === 0) {
+      throw new Error(`routing_tree_provider_buttons_missing: model=${modelIdentifier}`);
+    }
     this.selectProvider(providerButtons.find((button) => isSelected(button)) ?? providerButtons[0]);
   }
 
@@ -156,7 +313,7 @@ class RoutingTreeElement extends HTMLElement {
       throw new Error("routing_tree_provider_outside_active_model");
     }
     const providerIdentifier = requiredDatasetValue(providerButton, "routeProvider");
-    for (const candidateProvider of requiredButtons(this, SELECTORS.PROVIDER)) {
+    for (const candidateProvider of this.providerButtons) {
       candidateProvider.setAttribute("aria-pressed", String(candidateProvider === providerButton));
     }
     if (!this.selectedProviderOutput) {
@@ -177,7 +334,7 @@ class RoutingTreeElement extends HTMLElement {
   }
 
   drawRoutes() {
-    if (!this.routeMap || !this.routeCanvas || !this.productNode || !this.proxyNode || !this.activeModelGroup || !this.activeProviderGroup) {
+    if (!this.routeMap || !this.routeCanvas || !this.productNode || !this.proxyNode) {
       throw new Error("routing_tree_drawing_surface_missing");
     }
     const mapBounds = this.routeMap.getBoundingClientRect();
@@ -205,7 +362,12 @@ class RoutingTreeElement extends HTMLElement {
     const proxyPoint = relativeElementPoint(this.proxyNode, mapBounds);
     drawHorizontalCurve(drawingContext, productPoint, proxyPoint, accentColor, ACTIVE_LINE_WIDTH, ACTIVE_LINE_OPACITY);
 
-    const familyConnections = this.familyButtons.map((familyButton) => ({
+    if (!this.activeModelGroup || !this.activeProviderGroup) {
+      this.dataset.routeLinesRendered = SELECTED_ATTRIBUTE_VALUE;
+      return;
+    }
+
+    const familyConnections = this.familyButtons.filter((familyButton) => !familyButton.hidden).map((familyButton) => ({
       active: isSelected(familyButton),
       point: relativeElementPoint(familyButton, mapBounds),
     }));
@@ -224,7 +386,7 @@ class RoutingTreeElement extends HTMLElement {
       throw new Error("routing_tree_selected_family_missing");
     }
     const selectedFamilyPoint = relativeElementPoint(selectedFamily, mapBounds);
-    const modelConnections = requiredButtons(this.activeModelGroup, SELECTORS.MODEL).map((modelButton) => ({
+    const modelConnections = requiredButtons(this.activeModelGroup, SELECTORS.MODEL).filter((modelButton) => !modelButton.hidden).map((modelButton) => ({
       active: isSelected(modelButton),
       point: relativeElementPoint(modelButton, mapBounds),
     }));
@@ -243,7 +405,7 @@ class RoutingTreeElement extends HTMLElement {
       throw new Error("routing_tree_selected_model_missing");
     }
     const selectedModelPoint = relativeElementPoint(selectedModel, mapBounds);
-    const providerConnections = requiredButtons(this.activeProviderGroup, SELECTORS.PROVIDER).map((providerButton) => ({
+    const providerConnections = requiredButtons(this.activeProviderGroup, SELECTORS.PROVIDER).filter((providerButton) => !providerButton.hidden).map((providerButton) => ({
       active: isSelected(providerButton),
       point: relativeElementPoint(providerButton, mapBounds),
     }));
@@ -357,6 +519,35 @@ function requiredButtons(root, selector) {
     throw new Error(`routing_tree_buttons_missing: selector=${selector}`);
   }
   return buttons;
+}
+
+/**
+ * @template {Element} ElementType
+ * @param {ParentNode} root
+ * @param {string} selector
+ * @param {{new(): ElementType}} expectedType
+ * @returns {ElementType[]}
+ */
+function requiredElements(root, selector, expectedType) {
+  const elements = [...root.querySelectorAll(selector)].map((element) => {
+    if (!(element instanceof expectedType)) {
+      throw new Error(`routing_tree_element_invalid: selector=${selector}`);
+    }
+    return element;
+  });
+  if (elements.length === 0) {
+    throw new Error(`routing_tree_elements_missing: selector=${selector}`);
+  }
+  return elements;
+}
+
+/**
+ * @param {number} count
+ * @param {string} singular
+ * @param {string} [plural]
+ */
+function countLabel(count, singular, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
 }
 
 /**

--- a/site/assets/llm-proxy/js/ui/routingTree.js
+++ b/site/assets/llm-proxy/js/ui/routingTree.js
@@ -12,32 +12,23 @@ const ACTIVE_LINE_OPACITY = 1;
 
 const SELECTORS = Object.freeze({
   CANVAS: "[data-route-canvas]",
-  EMPTY: "[data-route-empty]",
-  FAMILY_FILTER: "[data-route-family-filter]",
+  FAMILY: "[data-route-family]",
   MAP: "[data-route-map]",
   MODEL: "[data-route-model]",
   MODEL_GROUP: "[data-route-model-group]",
-  OPERATION_FILTER: "[data-route-operation-filter]",
-  PICKER: "[data-route-picker]",
   PRODUCT: "[data-route-product]",
   PROVIDER: "[data-route-provider]",
   PROVIDER_GROUP: "[data-route-provider-group]",
   PROXY: "[data-route-proxy]",
-  PUBLISHER: "[data-route-publisher]",
-  RESET: "[data-route-reset]",
-  SEARCH: "[data-route-search]",
   SELECTED_MODEL: "[data-route-selected-model]",
   SELECTED_PROVIDER: "[data-route-selected-provider]",
-  SELECTED_PUBLISHER: "[data-route-selected-publisher]",
-  SELECTED_ROUTE_MODEL: "[data-route-selected-route-model]",
-  SELECTION_NODE: "[data-route-selection-node]",
 });
 
 class RoutingTreeElement extends HTMLElement {
   constructor() {
     super();
     /** @type {HTMLButtonElement[]} */
-    this.publisherButtons = [];
+    this.familyButtons = [];
     /** @type {HTMLButtonElement[]} */
     this.modelButtons = [];
     /** @type {Map<string, HTMLElement>} */
@@ -48,22 +39,8 @@ class RoutingTreeElement extends HTMLElement {
     this.activeModelGroup = null;
     /** @type {HTMLElement | null} */
     this.activeProviderGroup = null;
-    /** @type {HTMLFormElement | null} */
-    this.picker = null;
-    /** @type {HTMLInputElement | null} */
-    this.searchInput = null;
-    /** @type {HTMLSelectElement | null} */
-    this.familyFilter = null;
-    /** @type {HTMLSelectElement | null} */
-    this.operationFilter = null;
-    /** @type {HTMLElement | null} */
-    this.emptyState = null;
-    /** @type {HTMLElement | null} */
-    this.selectedPublisherOutput = null;
     /** @type {HTMLElement | null} */
     this.selectedModelOutput = null;
-    /** @type {HTMLElement | null} */
-    this.selectedRouteModelOutput = null;
     /** @type {HTMLElement | null} */
     this.selectedProviderOutput = null;
     /** @type {HTMLElement | null} */
@@ -74,8 +51,6 @@ class RoutingTreeElement extends HTMLElement {
     this.productNode = null;
     /** @type {HTMLElement | null} */
     this.proxyNode = null;
-    /** @type {HTMLElement | null} */
-    this.selectionNode = null;
     /** @type {ResizeObserver | null} */
     this.resizeObserver = null;
     this.drawFrameRequest = 0;
@@ -85,42 +60,29 @@ class RoutingTreeElement extends HTMLElement {
     if (this.dataset.enhanced === SELECTED_ATTRIBUTE_VALUE) {
       return;
     }
-    this.publisherButtons = requiredButtons(this, SELECTORS.PUBLISHER);
+    this.familyButtons = requiredButtons(this, SELECTORS.FAMILY);
     this.modelButtons = requiredButtons(this, SELECTORS.MODEL);
     this.modelGroups = routingGroups(this, SELECTORS.MODEL_GROUP, "routeModelGroup");
     this.providerGroups = routingGroups(this, SELECTORS.PROVIDER_GROUP, "routeProviderGroup");
-    this.picker = requiredElement(this, SELECTORS.PICKER, HTMLFormElement);
-    this.searchInput = requiredElement(this, SELECTORS.SEARCH, HTMLInputElement);
-    this.familyFilter = requiredElement(this, SELECTORS.FAMILY_FILTER, HTMLSelectElement);
-    this.operationFilter = requiredElement(this, SELECTORS.OPERATION_FILTER, HTMLSelectElement);
-    this.emptyState = requiredElement(this, SELECTORS.EMPTY, HTMLElement);
-    this.selectedPublisherOutput = requiredElement(this, SELECTORS.SELECTED_PUBLISHER, HTMLElement);
     this.selectedModelOutput = requiredElement(this, SELECTORS.SELECTED_MODEL, HTMLElement);
-    this.selectedRouteModelOutput = requiredElement(this, SELECTORS.SELECTED_ROUTE_MODEL, HTMLElement);
     this.selectedProviderOutput = requiredElement(this, SELECTORS.SELECTED_PROVIDER, HTMLElement);
     this.routeMap = requiredElement(this, SELECTORS.MAP, HTMLElement);
     this.routeCanvas = requiredElement(this, SELECTORS.CANVAS, HTMLCanvasElement);
     this.productNode = requiredElement(this, SELECTORS.PRODUCT, HTMLElement);
     this.proxyNode = requiredElement(this, SELECTORS.PROXY, HTMLElement);
-    this.selectionNode = requiredElement(this, SELECTORS.SELECTION_NODE, HTMLElement);
 
-    if (this.publisherButtons.length !== this.modelGroups.size || this.modelButtons.length !== this.providerGroups.size) {
-      throw new Error(`routing_tree_normalized_group_count_invalid: publishers=${this.publisherButtons.length} model_groups=${this.modelGroups.size} models=${this.modelButtons.length} provider_groups=${this.providerGroups.size}`);
+    if (this.familyButtons.length !== this.modelGroups.size || this.modelButtons.length !== this.providerGroups.size) {
+      throw new Error(`routing_tree_normalized_group_count_invalid: families=${this.familyButtons.length} model_groups=${this.modelGroups.size} models=${this.modelButtons.length} provider_groups=${this.providerGroups.size}`);
     }
-    const selectedPublishers = this.publisherButtons.filter((button) => isSelected(button));
+    const selectedFamilies = this.familyButtons.filter((button) => isSelected(button));
     const selectedModels = this.modelButtons.filter((button) => isSelected(button));
-    if (selectedPublishers.length !== 1 || selectedModels.length !== 1) {
-      throw new Error(`routing_tree_selection_invalid: publishers=${selectedPublishers.length} models=${selectedModels.length}`);
+    if (selectedFamilies.length !== 1 || selectedModels.length !== 1) {
+      throw new Error(`routing_tree_selection_invalid: families=${selectedFamilies.length} models=${selectedModels.length}`);
     }
 
-    for (const control of this.picker.elements) {
-      if (control instanceof HTMLInputElement || control instanceof HTMLSelectElement || control instanceof HTMLButtonElement) {
-        control.disabled = false;
-      }
-    }
-    for (const publisherButton of this.publisherButtons) {
-      publisherButton.disabled = false;
-      publisherButton.addEventListener("click", () => this.selectPublisher(publisherButton));
+    for (const familyButton of this.familyButtons) {
+      familyButton.disabled = false;
+      familyButton.addEventListener("click", () => this.selectFamily(familyButton));
     }
     for (const modelButton of this.modelButtons) {
       modelButton.disabled = false;
@@ -130,13 +92,10 @@ class RoutingTreeElement extends HTMLElement {
       providerButton.disabled = false;
       providerButton.addEventListener("click", () => this.selectProvider(providerButton));
     }
-    this.picker.addEventListener("input", () => this.applyFilters());
-    this.picker.addEventListener("change", () => this.applyFilters());
-    this.picker.addEventListener("reset", () => requestAnimationFrame(() => this.applyFilters()));
     this.resizeObserver = new ResizeObserver(() => this.scheduleRouteDraw());
     this.resizeObserver.observe(this.routeMap);
     this.dataset.enhanced = SELECTED_ATTRIBUTE_VALUE;
-    this.applyFilters();
+    this.selectFamily(selectedFamilies[0]);
   }
 
   disconnectedCallback() {
@@ -147,86 +106,29 @@ class RoutingTreeElement extends HTMLElement {
     }
   }
 
-  applyFilters() {
-    if (!this.searchInput || !this.familyFilter || !this.operationFilter || !this.emptyState) {
-      throw new Error("routing_tree_picker_not_connected");
-    }
-    const searchTerms = normalizedSearchTerms(this.searchInput.value);
-    const selectedFamily = this.familyFilter.value;
-    const selectedOperation = this.operationFilter.value;
-    for (const modelButton of this.modelButtons) {
-      const family = requiredDatasetValue(modelButton, "routeFamily");
-      const operations = requiredDatasetValue(modelButton, "routeOperations").split(" ");
-      const searchText = requiredDatasetValue(modelButton, "routeSearchText").toLocaleLowerCase();
-      modelButton.hidden = !searchTerms.every((term) => searchText.includes(term)) ||
-        (selectedFamily !== "" && family !== selectedFamily) ||
-        (selectedOperation !== "" && !operations.includes(selectedOperation));
-    }
-    for (const publisherButton of this.publisherButtons) {
-      const publisherIdentifier = requiredDatasetValue(publisherButton, "routePublisher");
-      const modelGroup = this.modelGroups.get(publisherIdentifier);
-      if (!modelGroup) {
-        throw new Error(`routing_tree_model_group_missing: publisher=${publisherIdentifier}`);
-      }
-      publisherButton.hidden = visibleButtons(modelGroup, SELECTORS.MODEL).length === 0;
-    }
-    const visiblePublishers = this.publisherButtons.filter((button) => !button.hidden);
-    this.emptyState.hidden = visiblePublishers.length !== 0;
-    if (visiblePublishers.length === 0) {
-      for (const modelGroup of this.modelGroups.values()) {
-        modelGroup.hidden = true;
-      }
-      this.scheduleRouteDraw();
-      return;
-    }
-    const selectedPublisher = this.publisherButtons.find((button) => isSelected(button));
-    if (!selectedPublisher || selectedPublisher.hidden) {
-      this.selectPublisher(visiblePublishers[0]);
-      return;
-    }
-    const publisherIdentifier = requiredDatasetValue(selectedPublisher, "routePublisher");
-    const selectedModelGroup = this.modelGroups.get(publisherIdentifier);
-    if (!selectedModelGroup) {
-      throw new Error(`routing_tree_model_group_missing: publisher=${publisherIdentifier}`);
-    }
-    if (this.activeModelGroup !== selectedModelGroup) {
-      this.selectPublisher(selectedPublisher);
-      return;
-    }
-    const selectedModel = this.modelButtons.find((button) => isSelected(button));
-    if (!selectedModel || selectedModel.hidden || requiredDatasetValue(selectedModel, "routeModelPublisher") !== publisherIdentifier) {
-      this.selectPublisher(selectedPublisher);
-      return;
-    }
-    this.selectModel(selectedModel);
-  }
-
-  /** @param {HTMLButtonElement} publisherButton */
-  selectPublisher(publisherButton) {
-    const publisherIdentifier = requiredDatasetValue(publisherButton, "routePublisher");
-    const modelGroup = this.modelGroups.get(publisherIdentifier);
+  /** @param {HTMLButtonElement} familyButton */
+  selectFamily(familyButton) {
+    const familyIdentifier = requiredDatasetValue(familyButton, "routeFamily");
+    const modelGroup = this.modelGroups.get(familyIdentifier);
     if (!modelGroup) {
-      throw new Error(`routing_tree_model_group_missing: publisher=${publisherIdentifier}`);
+      throw new Error(`routing_tree_model_group_missing: family=${familyIdentifier}`);
     }
-    const selectableModels = visibleButtons(modelGroup, SELECTORS.MODEL);
-    if (selectableModels.length === 0) {
-      throw new Error(`routing_tree_publisher_without_visible_models: publisher=${publisherIdentifier}`);
-    }
-    for (const candidatePublisher of this.publisherButtons) {
-      candidatePublisher.setAttribute("aria-pressed", String(candidatePublisher === publisherButton));
+    for (const candidateFamily of this.familyButtons) {
+      candidateFamily.setAttribute("aria-pressed", String(candidateFamily === familyButton));
     }
     for (const candidateModelGroup of this.modelGroups.values()) {
       candidateModelGroup.hidden = candidateModelGroup !== modelGroup;
     }
     this.activeModelGroup = modelGroup;
-    const selectedModel = selectableModels.find((button) => isSelected(button)) ?? selectableModels[0];
+    const familyModels = requiredButtons(modelGroup, SELECTORS.MODEL);
+    const selectedModel = familyModels.find((button) => isSelected(button)) ?? familyModels[0];
     this.selectModel(selectedModel);
   }
 
   /** @param {HTMLButtonElement} modelButton */
   selectModel(modelButton) {
-    if (!this.activeModelGroup || !this.activeModelGroup.contains(modelButton) || modelButton.hidden) {
-      throw new Error("routing_tree_model_outside_active_publisher");
+    if (!this.activeModelGroup || !this.activeModelGroup.contains(modelButton)) {
+      throw new Error("routing_tree_model_outside_active_family");
     }
     const modelIdentifier = requiredDatasetValue(modelButton, "routeModel");
     const providerGroup = this.providerGroups.get(modelIdentifier);
@@ -240,13 +142,10 @@ class RoutingTreeElement extends HTMLElement {
       candidateProviderGroup.hidden = candidateProviderGroup !== providerGroup;
     }
     this.activeProviderGroup = providerGroup;
-    const selectedPublisher = this.publisherButtons.find((button) => isSelected(button));
-    if (!selectedPublisher || !this.selectedPublisherOutput || !this.selectedModelOutput || !this.selectedRouteModelOutput) {
+    if (!this.selectedModelOutput) {
       throw new Error("routing_tree_selected_model_output_missing");
     }
-    this.selectedPublisherOutput.textContent = requiredButtonLabel(selectedPublisher);
     this.selectedModelOutput.textContent = modelIdentifier;
-    this.selectedRouteModelOutput.textContent = modelIdentifier;
     const providerButtons = requiredButtons(providerGroup, SELECTORS.PROVIDER);
     this.selectProvider(providerButtons.find((button) => isSelected(button)) ?? providerButtons[0]);
   }
@@ -278,7 +177,7 @@ class RoutingTreeElement extends HTMLElement {
   }
 
   drawRoutes() {
-    if (!this.routeMap || !this.routeCanvas || !this.productNode || !this.proxyNode || !this.selectionNode || !this.activeProviderGroup) {
+    if (!this.routeMap || !this.routeCanvas || !this.productNode || !this.proxyNode || !this.activeModelGroup || !this.activeProviderGroup) {
       throw new Error("routing_tree_drawing_surface_missing");
     }
     const mapBounds = this.routeMap.getBoundingClientRect();
@@ -304,9 +203,46 @@ class RoutingTreeElement extends HTMLElement {
     const accentColor = requiredCSSProperty(treeStyles, "--routing-tree-accent");
     const productPoint = relativeElementPoint(this.productNode, mapBounds);
     const proxyPoint = relativeElementPoint(this.proxyNode, mapBounds);
-    const selectionPoint = relativeElementPoint(this.selectionNode, mapBounds);
     drawHorizontalCurve(drawingContext, productPoint, proxyPoint, accentColor, ACTIVE_LINE_WIDTH, ACTIVE_LINE_OPACITY);
-    drawHorizontalCurve(drawingContext, proxyPoint, selectionPoint, accentColor, ACTIVE_LINE_WIDTH, ACTIVE_LINE_OPACITY);
+
+    const familyConnections = this.familyButtons.map((familyButton) => ({
+      active: isSelected(familyButton),
+      point: relativeElementPoint(familyButton, mapBounds),
+    }));
+    for (const connection of familyConnections.sort((first, second) => Number(first.active) - Number(second.active))) {
+      drawHorizontalCurve(
+        drawingContext,
+        proxyPoint,
+        connection.point,
+        connection.active ? accentColor : lineColor,
+        connection.active ? ACTIVE_LINE_WIDTH : INACTIVE_LINE_WIDTH,
+        connection.active ? ACTIVE_LINE_OPACITY : INACTIVE_LINE_OPACITY,
+      );
+    }
+    const selectedFamily = this.familyButtons.find((familyButton) => isSelected(familyButton));
+    if (!selectedFamily) {
+      throw new Error("routing_tree_selected_family_missing");
+    }
+    const selectedFamilyPoint = relativeElementPoint(selectedFamily, mapBounds);
+    const modelConnections = requiredButtons(this.activeModelGroup, SELECTORS.MODEL).map((modelButton) => ({
+      active: isSelected(modelButton),
+      point: relativeElementPoint(modelButton, mapBounds),
+    }));
+    for (const connection of modelConnections.sort((first, second) => Number(first.active) - Number(second.active))) {
+      drawHorizontalCurve(
+        drawingContext,
+        selectedFamilyPoint,
+        connection.point,
+        connection.active ? accentColor : lineColor,
+        connection.active ? ACTIVE_LINE_WIDTH : INACTIVE_LINE_WIDTH,
+        connection.active ? ACTIVE_LINE_OPACITY : INACTIVE_LINE_OPACITY,
+      );
+    }
+    const selectedModel = requiredButtons(this.activeModelGroup, SELECTORS.MODEL).find((modelButton) => isSelected(modelButton));
+    if (!selectedModel) {
+      throw new Error("routing_tree_selected_model_missing");
+    }
+    const selectedModelPoint = relativeElementPoint(selectedModel, mapBounds);
     const providerConnections = requiredButtons(this.activeProviderGroup, SELECTORS.PROVIDER).map((providerButton) => ({
       active: isSelected(providerButton),
       point: relativeElementPoint(providerButton, mapBounds),
@@ -314,7 +250,7 @@ class RoutingTreeElement extends HTMLElement {
     for (const connection of providerConnections.sort((first, second) => Number(first.active) - Number(second.active))) {
       drawHorizontalCurve(
         drawingContext,
-        selectionPoint,
+        selectedModelPoint,
         connection.point,
         connection.active ? accentColor : lineColor,
         connection.active ? ACTIVE_LINE_WIDTH : INACTIVE_LINE_WIDTH,
@@ -370,28 +306,6 @@ function relativeElementPoint(element, bounds) {
 /** @param {HTMLButtonElement} button */
 function isSelected(button) {
   return button.getAttribute("aria-pressed") === SELECTED_ATTRIBUTE_VALUE;
-}
-
-/**
- * @param {ParentNode} root
- * @param {string} selector
- */
-function visibleButtons(root, selector) {
-  return requiredButtons(root, selector).filter((button) => !button.hidden);
-}
-
-/** @param {string} rawSearch */
-function normalizedSearchTerms(rawSearch) {
-  return rawSearch.trim().toLocaleLowerCase().split(/\s+/u).filter(Boolean);
-}
-
-/** @param {HTMLButtonElement} button */
-function requiredButtonLabel(button) {
-  const label = button.querySelector("strong")?.textContent?.trim();
-  if (!label) {
-    throw new Error("routing_tree_button_label_missing");
-  }
-  return label;
 }
 
 /**

--- a/site/assets/llm-proxy/landing.css
+++ b/site/assets/llm-proxy/landing.css
@@ -231,12 +231,12 @@ routing-tree {
 }
 
 .routing-tree__header {
-  display: flex;
+  display: grid;
   min-height: 58px;
-  padding: 1.15rem 1.25rem 0.65rem;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  grid-template-columns: max-content minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 0.85rem;
 }
 
 .routing-tree__header h2,
@@ -248,10 +248,83 @@ routing-tree {
 }
 
 .routing-tree__header h2 {
+  overflow: hidden;
   font-size: 1.02rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.routing-tree__header > span {
+.routing-tree__filters,
+.routing-tree__filter-group {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.routing-tree__filters {
+  overflow-x: auto;
+  gap: 0.42rem;
+  scrollbar-width: none;
+}
+
+.routing-tree__filters::-webkit-scrollbar {
+  display: none;
+}
+
+.routing-tree__filter-group {
+  flex: 0 0 auto;
+  gap: 0.22rem;
+}
+
+.routing-tree__filter-divider {
+  width: 1px;
+  height: 18px;
+  flex: 0 0 auto;
+  background: var(--border-strong);
+}
+
+.routing-tree__filter {
+  min-height: 24px;
+  padding: 0.26rem 0.46rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  appearance: none;
+  background: #171a1f;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 0.48rem;
+  font-weight: 600;
+  letter-spacing: 0.045em;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition: border-color 130ms ease, background 130ms ease, color 130ms ease;
+}
+
+.routing-tree__filter:hover,
+.routing-tree__filter:focus-visible {
+  border-color: var(--routing-tree-accent);
+  color: var(--text-support);
+}
+
+.routing-tree__filter:focus-visible {
+  outline: 2px solid rgba(74, 211, 181, 0.2);
+  outline-offset: 1px;
+}
+
+.routing-tree__filter[aria-pressed="true"] {
+  border-color: var(--routing-tree-accent);
+  background: var(--routing-tree-accent-soft);
+  color: var(--text);
+}
+
+.routing-tree__filter:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
+.routing-tree__counts {
   color: var(--text-muted);
   font-family: var(--mono);
   font-size: 0.53rem;
@@ -326,8 +399,11 @@ routing-tree {
 }
 
 .routing-tree__branch[hidden],
+.routing-tree__stage[hidden],
 .routing-tree__model-group[hidden],
-.routing-tree__provider-group[hidden] {
+.routing-tree__provider-group[hidden],
+.routing-tree__empty[hidden],
+.routing-tree__selection[hidden] {
   display: none;
 }
 
@@ -529,6 +605,18 @@ routing-tree {
 .routing-tree__selection output i {
   color: var(--text-muted);
   font-style: normal;
+}
+
+.routing-tree__empty {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  grid-column: 3 / -1;
+  grid-row: 1;
+  align-self: center;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  text-align: center;
 }
 .section.route-overview {
   --content: 1180px;
@@ -1388,6 +1476,20 @@ capability-catalog[data-enhanced="false"] .catalog-toolbar {
     width: min(100%, 720px);
   }
 
+  .routing-tree__counts {
+    display: none;
+  }
+
+  .routing-tree__header {
+    padding-inline: 1rem;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 0.65rem;
+  }
+
+  .routing-tree__header h2 {
+    font-size: 0.86rem;
+  }
+
   .routing-tree__map {
     min-height: 620px;
     grid-template-columns:
@@ -1460,14 +1562,20 @@ capability-catalog[data-enhanced="false"] .catalog-toolbar {
   }
 
   .routing-tree__header {
-    align-items: flex-start;
-    flex-direction: column;
-    flex-wrap: wrap;
-    gap: 0.35rem;
+    min-height: 50px;
+    padding: 0.6rem 0.7rem;
+    grid-template-columns: minmax(6rem, 7.5rem) minmax(0, 1fr);
+    gap: 0.5rem;
   }
 
-  .routing-tree__header > span {
-    white-space: normal;
+  .routing-tree__header h2 {
+    font-size: 0.78rem;
+  }
+
+  .routing-tree__filter {
+    min-height: 22px;
+    padding-inline: 0.4rem;
+    font-size: 0.45rem;
   }
 
   .routing-tree__map {
@@ -1504,6 +1612,13 @@ capability-catalog[data-enhanced="false"] .catalog-toolbar {
 
   .routing-tree__selection {
     flex-wrap: wrap;
+  }
+
+  .routing-tree__empty {
+    grid-column: 1;
+    grid-row: 3;
+    min-height: 82px;
+    align-content: center;
   }
 
   .value-strip__grid,

--- a/site/assets/llm-proxy/landing.css
+++ b/site/assets/llm-proxy/landing.css
@@ -258,49 +258,15 @@ routing-tree {
   white-space: nowrap;
 }
 
-.routing-tree__filters {
-  display: grid;
-  padding: 0 1.25rem 0.85rem;
-  grid-template-columns: minmax(220px, 1fr) minmax(150px, 0.35fr) minmax(145px, 0.3fr) auto;
-  gap: 0.45rem;
-}
-
-.routing-tree__filters input,
-.routing-tree__filters select,
-.routing-tree__filters button {
-  min-width: 0;
-  min-height: 34px;
-  padding: 0.42rem 0.58rem;
-  border: 1px solid var(--border-strong);
-  border-radius: 6px;
-  background: #181b20;
-  color: var(--text-support);
-  font: inherit;
-  font-size: 0.62rem;
-}
-
-.routing-tree__filters button {
-  cursor: pointer;
-}
-
-.routing-tree__filters :focus-visible,
 .routing-tree__branch:focus-visible {
   border-color: var(--routing-tree-accent);
   outline: 2px solid rgba(74, 211, 181, 0.2);
   outline-offset: 1px;
 }
 
-.routing-tree__catalog {
-  display: grid;
-  min-height: 300px;
-  padding: 0.9rem 1.25rem;
-  border-block: 1px solid var(--border);
-  grid-template-columns: minmax(170px, 220px) minmax(0, 1fr);
-  gap: 1rem;
-  background: #14171c;
-}
-
 .routing-tree__stage {
+  position: relative;
+  z-index: 1;
   min-width: 0;
 }
 
@@ -315,10 +281,8 @@ routing-tree {
   gap: 0.35rem;
 }
 
-.routing-tree__publisher-branches {
-  max-height: 254px;
-  padding-right: 0.25rem;
-  overflow-y: auto;
+.routing-tree__family-branches {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .routing-tree__branch {
@@ -363,12 +327,11 @@ routing-tree {
 
 .routing-tree__branch[hidden],
 .routing-tree__model-group[hidden],
-.routing-tree__provider-group[hidden],
-.routing-tree__empty[hidden] {
+.routing-tree__provider-group[hidden] {
   display: none;
 }
 
-.routing-tree__publisher strong,
+.routing-tree__family strong,
 .routing-tree__provider strong {
   min-width: 0;
   font-size: 0.65rem;
@@ -408,10 +371,7 @@ routing-tree {
 }
 
 .routing-tree__model-branches {
-  max-height: 230px;
-  padding-right: 0.25rem;
-  overflow-y: auto;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 0.42rem;
 }
 
@@ -428,24 +388,24 @@ routing-tree {
   overflow-wrap: anywhere;
 }
 
-.routing-tree__empty {
-  margin: 1rem 0;
-  color: var(--text-muted);
-  font-size: 0.62rem;
-}
-
 .routing-tree__map {
   position: relative;
   display: grid;
-  min-height: 230px;
-  padding: 1rem 1.25rem 0.8rem;
-  grid-template-columns: minmax(360px, 1fr) minmax(180px, 220px) minmax(200px, 1fr);
+  min-height: 570px;
+  padding: 1.2rem 1.25rem 0.8rem;
+  border-top: 1px solid var(--border);
+  grid-template-columns:
+    minmax(110px, 0.7fr)
+    minmax(145px, 0.85fr)
+    minmax(245px, 1.4fr)
+    minmax(175px, 1fr)
+    minmax(155px, 0.9fr);
   grid-template-areas:
-    "ingress selected providers"
-    "route route route";
+    "product proxy families models providers"
+    "route route route route route";
   grid-template-rows: 1fr auto;
   align-items: center;
-  gap: 0.8rem 4rem;
+  gap: 0.8rem 1.55rem;
 }
 
 .routing-tree__connectors {
@@ -457,17 +417,9 @@ routing-tree {
   pointer-events: none;
 }
 
-.routing-tree__ingress {
+.routing-tree__node {
   position: relative;
   z-index: 1;
-  display: grid;
-  grid-area: ingress;
-  grid-template-columns: repeat(2, minmax(160px, 1fr));
-  align-items: center;
-  gap: 4rem;
-}
-
-.routing-tree__node {
   display: flex;
   width: 100%;
   min-height: 86px;
@@ -496,8 +448,13 @@ routing-tree {
 }
 
 .routing-tree__node--proxy {
+  grid-area: proxy;
   border-color: var(--routing-tree-accent);
   background: #142622;
+}
+
+.routing-tree__node--product {
+  grid-area: product;
 }
 
 .routing-tree__node--proxy::before {
@@ -510,32 +467,32 @@ routing-tree {
   content: "";
 }
 
-.routing-tree__node--selection {
-  position: relative;
-  z-index: 1;
-  grid-area: selected;
-  border-color: rgba(74, 211, 181, 0.55);
-  background: #171f1e;
+.routing-tree__stage--families {
+  grid-area: families;
 }
 
-.routing-tree__node--selection code {
-  color: inherit;
-  font-size: 0.66rem;
-  overflow-wrap: anywhere;
+.routing-tree__stage--models {
+  grid-area: models;
 }
 
 .routing-tree__stage--providers {
-  position: relative;
-  z-index: 1;
   grid-area: providers;
 }
 
 .routing-tree__provider-branches {
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: 1fr;
 }
 
 .routing-tree__provider {
   min-height: 42px;
+}
+
+.routing-tree__provider small {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .routing-tree__selection {
@@ -1431,24 +1388,29 @@ capability-catalog[data-enhanced="false"] .catalog-toolbar {
     width: min(100%, 720px);
   }
 
-  .routing-tree__filters {
-    grid-template-columns: 1fr 1fr;
-  }
-
   .routing-tree__map {
-    grid-template-columns: minmax(0, 1fr) minmax(180px, 220px);
+    min-height: 620px;
+    grid-template-columns:
+      minmax(80px, 0.65fr)
+      minmax(95px, 0.75fr)
+      minmax(170px, 1.35fr)
+      minmax(130px, 1fr)
+      minmax(115px, 0.9fr);
     grid-template-areas:
-      "ingress ingress"
-      "selected providers"
-      "route route";
-    grid-template-rows: auto auto auto;
-    align-items: stretch;
-    gap: 1rem 2rem;
+      "product proxy families models providers"
+      "route route route route route";
+    grid-template-rows: 1fr auto;
+    align-items: center;
+    gap: 0.8rem 0.55rem;
   }
 
-  .routing-tree__ingress {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 2rem;
+  .routing-tree__node {
+    min-height: 76px;
+    padding-inline: 0.4rem;
+  }
+
+  .routing-tree__provider small {
+    display: none;
   }
 
   .catalog-summary {
@@ -1508,34 +1470,15 @@ capability-catalog[data-enhanced="false"] .catalog-toolbar {
     white-space: normal;
   }
 
-  .routing-tree__filters {
-    padding-inline: 0.85rem;
-    grid-template-columns: 1fr;
-  }
-
-  .routing-tree__catalog {
-    min-height: 0;
-    padding-inline: 0.85rem;
-    grid-template-columns: 1fr;
-  }
-
-  .routing-tree__publisher-branches {
-    max-height: none;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .routing-tree__model-branches {
-    max-height: 260px;
-    grid-template-columns: 1fr;
-  }
-
   .routing-tree__map {
     min-height: 0;
     padding-inline: 0.85rem;
     grid-template-columns: 1fr;
     grid-template-areas:
-      "ingress"
-      "selected"
+      "product"
+      "proxy"
+      "families"
+      "models"
       "providers"
       "route";
     grid-template-rows: auto;
@@ -1546,12 +1489,6 @@ capability-catalog[data-enhanced="false"] .catalog-toolbar {
     display: none;
   }
 
-  .routing-tree__ingress {
-    min-height: 0;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.65rem;
-  }
-
   .routing-tree__node {
     min-height: 82px;
     padding-inline: 0.45rem;
@@ -1559,6 +1496,10 @@ capability-catalog[data-enhanced="false"] .catalog-toolbar {
 
   .routing-tree__provider-branches {
     grid-template-columns: 1fr;
+  }
+
+  .routing-tree__provider small {
+    display: inline;
   }
 
   .routing-tree__selection {

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="e4f8d83fa082967e1018f428e6e4a404908b47f4581085b788aca47dd67b8052">
+    <meta name="openapi-source-sha256" content="9f75f00a49eefffc9d8c53ce99fc48a8c52cf95ab3975b07fbaaf693841338ef">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.css">
     <link rel="stylesheet" href="/assets/llm-proxy/public-shell.css">
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="e4f8d83fa082967e1018f428e6e4a404908b47f4581085b788aca47dd67b8052">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="9f75f00a49eefffc9d8c53ce99fc48a8c52cf95ab3975b07fbaaf693841338ef">
     <mpr-header
       class="public-site-header"
       data-config-url="/config-ui.yaml"
@@ -49,7 +49,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>e4f8d83fa082967e1018f428e6e4a404908b47f4581085b788aca47dd67b8052</code></span>
+          <span>Source SHA-256 <code>9f75f00a49eefffc9d8c53ce99fc48a8c52cf95ab3975b07fbaaf693841338ef</code></span>
         </div>
         <div class="resource-actions" aria-label="OpenAPI schema actions">
           <a class="resource-button" href="#openapi-yaml">View YAML</a>
@@ -1453,6 +1453,7 @@ components:
         - identifier
         - publisher
         - label
+        - weight_access
       properties:
         identifier:
           type: string
@@ -1463,6 +1464,11 @@ components:
         label:
           type: string
           minLength: 1
+        weight_access:
+          type: string
+          enum:
+            - proprietary
+            - open_weights
     PublicExactModelCapability:
       type: object
       additionalProperties: false

--- a/site/index.html
+++ b/site/index.html
@@ -46,7 +46,7 @@
       data-mpr-ui-bundle-src="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.js"
     ></script>
     <script defer src="/assets/llm-proxy/js/googleAnalytics.js"></script>
-    <script type="module" src="/assets/llm-proxy/js/ui/routingTree.js?v=20260808i215b"></script>
+    <script type="module" src="/assets/llm-proxy/js/ui/routingTree.js?v=20260811b131"></script>
     <script type="module" src="/assets/llm-proxy/js/ui/capabilityCatalog.js?v=20260806i209"></script>
     <script defer src="https://loopaware.mprlab.com/pixel.js?site_id=839f018b-97a9-4955-a489-4ad5cb626f4f"></script>
   </head>

--- a/site/index.html
+++ b/site/index.html
@@ -46,7 +46,7 @@
       data-mpr-ui-bundle-src="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.js"
     ></script>
     <script defer src="/assets/llm-proxy/js/googleAnalytics.js"></script>
-    <script type="module" src="/assets/llm-proxy/js/ui/routingTree.js?v=20260811b131"></script>
+    <script type="module" src="/assets/llm-proxy/js/ui/routingTree.js?v=20260811f034b"></script>
     <script type="module" src="/assets/llm-proxy/js/ui/capabilityCatalog.js?v=20260806i209"></script>
     <script defer src="https://loopaware.mprlab.com/pixel.js?site_id=839f018b-97a9-4955-a489-4ad5cb626f4f"></script>
   </head>

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -127,8 +127,18 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 	if catalogError != nil {
 		testingInstance.Fatalf("NewPublicCapabilityCatalog error: %v", catalogError)
 	}
-	if catalog.Revision == "" || len(catalog.Operations) != 3 || len(catalog.Prices) != len(catalog.Offerings) || catalog.Counts.Providers != 11 || catalog.Counts.ModelPublishers != 11 || catalog.Counts.ExactModels != len(catalog.Models) || catalog.Counts.ProviderOfferings != len(catalog.Offerings) || catalog.MaxPromptBytes != proxy.DefaultMaxPromptBytes || catalog.MaxInputAudioBytes != proxy.DefaultMaxInputAudioBytes {
+	if catalog.Revision == "" || len(catalog.Operations) != 3 || len(catalog.Prices) != len(catalog.Offerings) || catalog.Counts.Providers != 11 || catalog.Counts.ModelPublishers != 11 || catalog.Counts.ModelFamilies != len(catalog.Families) || catalog.Counts.ExactModels != len(catalog.Models) || catalog.Counts.ProviderOfferings != len(catalog.Offerings) || catalog.MaxPromptBytes != proxy.DefaultMaxPromptBytes || catalog.MaxInputAudioBytes != proxy.DefaultMaxInputAudioBytes {
 		testingInstance.Fatalf("catalog summary=%+v", catalog)
+	}
+	weightAccessFound := map[string]bool{}
+	for _, family := range catalog.Families {
+		if family.WeightAccess != proxy.ModelWeightAccessProprietary && family.WeightAccess != proxy.ModelWeightAccessOpenWeights {
+			testingInstance.Fatalf("family=%s weight_access=%q", family.Identifier, family.WeightAccess)
+		}
+		weightAccessFound[family.WeightAccess] = true
+	}
+	if !weightAccessFound[proxy.ModelWeightAccessProprietary] || !weightAccessFound[proxy.ModelWeightAccessOpenWeights] {
+		testingInstance.Fatalf("public weight access classifications=%v", weightAccessFound)
 	}
 	geminiCapabilityFound := false
 	openAIDictationCapabilityFound := false

--- a/tests/e2e/management-ui.spec.js
+++ b/tests/e2e/management-ui.spec.js
@@ -92,7 +92,7 @@ const mprUIBundleURL = "https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@
 const forbiddenTAuthBrowserClientURL = "https://tauth.mprlab.com/tauth.js";
 const catalogColumnCount = 3;
 const b020ScreenshotDirectory = path.join(repoRoot, "output/playwright");
-const b131ScreenshotDirectory = path.join(repoRoot, "output/playwright");
+const f034ScreenshotDirectory = path.join(repoRoot, "output/playwright");
 const httpOK = 200;
 const httpNotFound = 404;
 const httpInternalServerError = 500;
@@ -188,6 +188,39 @@ async function expectFiveStageRouteOrder(routingTree) {
   for (let stageIndex = 1; stageIndex < stageOrder.length; stageIndex += 1) {
     expect(stageOrder[stageIndex - 1].right).toBeLessThan(stageOrder[stageIndex].left);
   }
+}
+
+/**
+ * @param {import("@playwright/test").Locator} routingTree
+ */
+async function expectRoutingHeaderSingleRow(routingTree) {
+  const geometry = await routingTree.evaluate((tree) => {
+    const header = tree.querySelector(".routing-tree__header");
+    const title = header?.querySelector("h2");
+    const filters = header?.querySelector(".routing-tree__filters");
+    const counts = header?.querySelector("[data-route-counts]");
+    if (!(header instanceof HTMLElement) || !(title instanceof HTMLElement) || !(filters instanceof HTMLElement) || !(counts instanceof HTMLElement)) {
+      throw new Error("routing_tree_header_surface_missing");
+    }
+    const visibleItems = [title, filters, counts].filter((item) => getComputedStyle(item).display !== "none");
+    const itemCenters = visibleItems.map((item) => {
+      const bounds = item.getBoundingClientRect();
+      return bounds.top + bounds.height / 2;
+    });
+    const filterButtons = [...filters.querySelectorAll("button")];
+    return {
+      filterButtonTopRange: Math.max(...filterButtons.map((button) => button.getBoundingClientRect().top))
+        - Math.min(...filterButtons.map((button) => button.getBoundingClientRect().top)),
+      filterClientHeight: filters.clientHeight,
+      filterScrollHeight: filters.scrollHeight,
+      headerHeight: header.getBoundingClientRect().height,
+      itemCenterRange: Math.max(...itemCenters) - Math.min(...itemCenters),
+    };
+  });
+  expect(geometry.headerHeight).toBeLessThanOrEqual(60);
+  expect(geometry.itemCenterRange).toBeLessThanOrEqual(1);
+  expect(geometry.filterButtonTopRange).toBeLessThanOrEqual(1);
+  expect(geometry.filterScrollHeight).toBeLessThanOrEqual(geometry.filterClientHeight + 1);
 }
 
 /**
@@ -407,7 +440,7 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).toContain('<routing-tree class="routing-tree" data-enhanced="false" aria-label="Interactive LLM routing map">');
   expect(html).toContain("One integration. Choose the exact route.");
   expect(html).toContain('<canvas class="routing-tree__connectors" data-route-canvas aria-hidden="true"></canvas>');
-  expect(html).toContain('<span>24 families · 57 exact models · 58 offerings</span>');
+  expect(html).toContain('<output class="routing-tree__counts" aria-live="polite" data-route-counts>12 families · 40 exact models · 40 offerings</output>');
   expect(html).toContain('data-route-family="deepseek-r1"');
   expect(html).toContain('data-route-family="muse-spark"');
   expect(html).toContain('data-route-family="qwen"');
@@ -799,6 +832,15 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(routingTree.locator("[data-route-family]")).toHaveCount(24);
   await expect(routingTree.locator("[data-route-provider]")).toHaveCount(58);
   await expect(routingTree.locator("[data-route-model]")).toHaveCount(57);
+  await expect(routingTree.locator("[data-route-weight-access]")).toHaveCount(2);
+  await expect(routingTree.locator("[data-route-capability]")).toHaveCount(7);
+  await expect(routingTree.locator('[data-route-weight-access="proprietary"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-weight-access="open_weights"]')).toHaveAttribute("aria-pressed", "false");
+  await expect(routingTree.locator('[data-route-capability="text"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
+  await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+  await expect(routingTree.locator('[data-route-family]:visible')).toHaveCount(12);
+  await expect(routingTree.locator("[data-route-counts]")).toHaveText("12 families · 40 exact models · 40 offerings");
   await expect(routingTree.locator('[data-route-family="claude-fable"]')).toHaveAttribute("aria-pressed", "true");
   await expect(routingTree.locator('[data-route-model-group="claude-fable"]')).toBeVisible();
   await expect(routingTree.locator('[data-route-model-group="grok"]')).toBeHidden();
@@ -827,7 +869,7 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await browserContext.close();
 });
 
-test("visitors can choose a model family, exact model, and provider offering", async ({ page }) => {
+test("visitors can filter and choose a model family, exact model, and provider offering", async ({ page }) => {
   await installAssetRoutes(page, { initialAuthStatus: "unauthenticated" });
   await page.setViewportSize({ width: 1280, height: 800 });
   await page.goto(baseURL);
@@ -835,15 +877,30 @@ test("visitors can choose a model family, exact model, and provider offering", a
   const routingTree = page.locator("routing-tree");
   const selectedProvider = routingTree.locator("[data-route-selected-provider]");
   const selectedModel = routingTree.locator("[data-route-selected-model]");
+  const counts = routingTree.locator("[data-route-counts]");
+  const proprietaryFilter = routingTree.locator('[data-route-weight-access="proprietary"]');
+  const openWeightsFilter = routingTree.locator('[data-route-weight-access="open_weights"]');
+  const textFilter = routingTree.locator('[data-route-capability="text"]');
+  const webSearchFilter = routingTree.locator('[data-route-capability="web_search"]');
   await expect(routingTree).toHaveAttribute("data-enhanced", "true");
   await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "true");
   await expect(routingTree.locator("[data-route-family]")).toHaveCount(24);
   await expect(routingTree.locator("[data-route-model]")).toHaveCount(57);
   await expect(routingTree.locator("[data-route-provider]")).toHaveCount(58);
+  await expect(routingTree.locator("[data-route-weight-access]")).toHaveCount(2);
+  await expect(routingTree.locator("[data-route-capability]")).toHaveCount(7);
+  await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "false");
+  await expect(textFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
+  await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+  await expect(counts).toHaveText("12 families · 40 exact models · 40 offerings");
+  await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(12);
   await expect(routingTree.locator("[data-route-model]:visible")).toHaveCount(1);
   await expect(routingTree.locator("[data-route-provider]:visible")).toHaveCount(1);
   await expect(selectedModel).toHaveText("claude-fable-5");
   await expect(selectedProvider).toHaveText("anthropic");
+  await expectRoutingHeaderSingleRow(routingTree);
 
   const routeCanvasDimensions = await routingTree.locator("[data-route-canvas]").evaluate((canvas) => ({
     height: canvas.height,
@@ -854,21 +911,100 @@ test("visitors can choose a model family, exact model, and provider offering", a
   await expectFiveStageRouteOrder(routingTree);
   await expectSelectedRoutingFanEndpoints(routingTree);
 
-  await routingTree.locator('[data-route-family="deepseek-r1"]').click();
+  await openWeightsFilter.click();
+  await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(2);
+  await expect(counts).toHaveText("19 families · 51 exact models · 52 offerings");
+  await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(19);
+  await expect(selectedModel).toHaveText("claude-fable-5");
+  await expect(selectedProvider).toHaveText("anthropic");
+
+  await proprietaryFilter.click();
+  await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "false");
+  await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
+  await expect(counts).toHaveText("7 families · 11 exact models · 12 offerings");
+  await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(7);
+  await expect(routingTree.locator('[data-route-family="deepseek-r1"]')).toHaveAttribute("aria-pressed", "true");
   const deepSeekModels = routingTree.locator('[data-route-model-group="deepseek-r1"]');
   await expect(deepSeekModels).toBeVisible();
   await expect(deepSeekModels.locator("[data-route-model]")).toHaveCount(1);
-  await deepSeekModels.locator('[data-route-model="deepseek-reasoner"]').click();
+  await expect(deepSeekModels.locator('[data-route-model="deepseek-reasoner"]')).toHaveAttribute("aria-pressed", "true");
   const reasonerProviders = routingTree.locator('[data-route-provider-group="deepseek-reasoner"]');
   await expect(reasonerProviders).toBeVisible();
-  await expect(reasonerProviders.locator("[data-route-provider]")).toHaveCount(2);
+  await expect(reasonerProviders.locator("[data-route-provider]:visible")).toHaveCount(2);
   await expect(selectedModel).toHaveText("deepseek-reasoner");
   await expect(selectedProvider).toHaveText("deepseek");
   await reasonerProviders.locator('[data-route-provider="siliconflow"]').click();
   await expect(selectedProvider).toHaveText("siliconflow");
+  await openWeightsFilter.click();
+  await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
+  await expect(counts).toHaveText("7 families · 11 exact models · 12 offerings");
   await expectFiveStageRouteOrder(routingTree);
   await expectSelectedRoutingFanEndpoints(routingTree);
 
+  await webSearchFilter.click();
+  await expect(webSearchFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(textFilter).toHaveAttribute("aria-pressed", "false");
+  await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+  await expect(counts).toHaveText("0 families · 0 exact models · 0 offerings");
+  await expect(routingTree.locator("[data-route-empty]")).toBeVisible();
+  await expect(routingTree.locator("[data-route-stage]:visible")).toHaveCount(0);
+  await expect(routingTree.locator("[data-route-selection]")).toBeHidden();
+  await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "true");
+  await webSearchFilter.click();
+  await expect(webSearchFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(counts).toHaveText("0 families · 0 exact models · 0 offerings");
+  await textFilter.click();
+  await expect(textFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(webSearchFilter).toHaveAttribute("aria-pressed", "false");
+  await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+  await expect(counts).toHaveText("7 families · 11 exact models · 12 offerings");
+  await expect(routingTree.locator("[data-route-empty]")).toBeHidden();
+  await expect(selectedModel).toHaveText("deepseek-reasoner");
+  await expect(selectedProvider).toHaveText("deepseek");
+
+  await proprietaryFilter.click();
+  await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(2);
+  await expect(counts).toHaveText("19 families · 51 exact models · 52 offerings");
+  await openWeightsFilter.click();
+  await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "false");
+  await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
+  await expect(counts).toHaveText("12 families · 40 exact models · 40 offerings");
+  await webSearchFilter.click();
+  await expect(webSearchFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(textFilter).toHaveAttribute("aria-pressed", "false");
+  await expect(counts).toHaveText("2 families · 9 exact models · 9 offerings");
+  await expect(selectedModel).toHaveText("gpt-4.1");
+  await webSearchFilter.click();
+  await expect(webSearchFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+  await expect(selectedModel).toHaveText("gpt-4.1");
+
+  const canonicalCapabilities = [
+    "text",
+    "dictation",
+    "video_generation",
+    "image_input",
+    "audio_input",
+    "web_search",
+    "reasoning",
+  ];
+  for (const capability of canonicalCapabilities) {
+    const capabilityFilter = routingTree.locator(`[data-route-capability="${capability}"]`);
+    await capabilityFilter.click();
+    await expect(capabilityFilter).toHaveAttribute("aria-pressed", "true");
+    await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+    await expect(counts).not.toHaveText(/^0 families/u);
+    expect(await routingTree.locator("[data-route-family]:visible").count()).toBeGreaterThan(0);
+  }
+
+  await textFilter.click();
   await routingTree.locator('[data-route-family="gpt-5"]').click();
   const gptModels = routingTree.locator('[data-route-model-group="gpt-5"]');
   await expect(gptModels).toBeVisible();
@@ -878,26 +1014,50 @@ test("visitors can choose a model family, exact model, and provider offering", a
   await expect(selectedProvider).toHaveText("openai");
   await expectFiveStageRouteOrder(routingTree);
   await expectSelectedRoutingFanEndpoints(routingTree);
+  await routingTree.locator('[data-route-capability="reasoning"]').click();
+  await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+  await expect(selectedModel).toHaveText("gpt-5.6-terra");
+  await expect(selectedProvider).toHaveText("openai");
+  await textFilter.click();
+  await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+  await expect(selectedModel).toHaveText("gpt-5.6-terra");
+  await expect(selectedProvider).toHaveText("openai");
+  await textFilter.click();
+  await expect(textFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
+  await expect(selectedModel).toHaveText("gpt-5.6-terra");
+  await expect(selectedProvider).toHaveText("openai");
 
   await page.setViewportSize({ width: 900, height: 900 });
   await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "true");
+  await expectRoutingHeaderSingleRow(routingTree);
   await expectFiveStageRouteOrder(routingTree);
   await expectSelectedRoutingFanEndpoints(routingTree);
 
-  if (process.env.B131_SCREENSHOTS === "1") {
-    await mkdir(b131ScreenshotDirectory, { recursive: true });
+  if (process.env.F034_SCREENSHOTS === "1") {
+    await mkdir(f034ScreenshotDirectory, { recursive: true });
+    await openWeightsFilter.click();
+    await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(2);
     for (const viewport of routingTreeViewports) {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await expect(routingTree).toHaveAttribute(
         "data-route-lines-rendered",
         viewport.width > 680 ? "true" : "false",
       );
-      await routingTree.screenshot({ path: path.join(b131ScreenshotDirectory, `B131-routing-${viewport.name}.png`) });
+      await expectRoutingHeaderSingleRow(routingTree);
+      await routingTree.screenshot({ path: path.join(f034ScreenshotDirectory, `F034-routing-${viewport.name}.png`) });
+      const routingHeader = routingTree.locator(".routing-tree__header");
+      await routingHeader.scrollIntoViewIfNeeded();
+      await page.evaluate(() => window.scrollBy(0, -80));
+      await routingHeader.screenshot({ path: path.join(f034ScreenshotDirectory, `F034-header-${viewport.name}.png`) });
     }
+    await openWeightsFilter.click();
+    await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
   }
 
   await page.setViewportSize({ width: 390, height: 780 });
   await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "false");
+  await expectRoutingHeaderSingleRow(routingTree);
   await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
   const routingTreeGeometry = await routingTree.evaluate((element) => ({
     left: element.getBoundingClientRect().left,

--- a/tests/e2e/management-ui.spec.js
+++ b/tests/e2e/management-ui.spec.js
@@ -92,7 +92,7 @@ const mprUIBundleURL = "https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@
 const forbiddenTAuthBrowserClientURL = "https://tauth.mprlab.com/tauth.js";
 const catalogColumnCount = 3;
 const b020ScreenshotDirectory = path.join(repoRoot, "output/playwright");
-const i220ScreenshotDirectory = path.join(repoRoot, "output/playwright");
+const b131ScreenshotDirectory = path.join(repoRoot, "output/playwright");
 const httpOK = 200;
 const httpNotFound = 404;
 const httpInternalServerError = 500;
@@ -106,9 +106,19 @@ const capabilityShutdownProbeTimeoutMilliseconds = 1_000;
 async function expectSelectedRoutingFanEndpoints(routingTree) {
   const endpointEvidence = await routingTree.evaluate((tree, endpointRadius) => {
     const canvas = tree.querySelector("[data-route-canvas]");
+    const product = tree.querySelector("[data-route-product]");
+    const proxy = tree.querySelector("[data-route-proxy]");
+    const selectedFamily = tree.querySelector('[data-route-family][aria-pressed="true"]');
+    const selectedModel = tree.querySelector('[data-route-model-group]:not([hidden]) [data-route-model][aria-pressed="true"]');
     const selectedProvider = tree.querySelector('[data-route-provider-group]:not([hidden]) [data-route-provider][aria-pressed="true"]');
-    const selectedModel = tree.querySelector("[data-route-selection-node]");
-    if (!(canvas instanceof HTMLCanvasElement) || !(selectedProvider instanceof HTMLElement) || !(selectedModel instanceof HTMLElement)) {
+    if (
+      !(canvas instanceof HTMLCanvasElement)
+      || !(product instanceof HTMLElement)
+      || !(proxy instanceof HTMLElement)
+      || !(selectedFamily instanceof HTMLElement)
+      || !(selectedModel instanceof HTMLElement)
+      || !(selectedProvider instanceof HTMLElement)
+    ) {
       throw new Error("routing_tree_selected_connector_endpoint_missing");
     }
     const drawingContext = canvas.getContext("2d", { willReadFrequently: true });
@@ -116,6 +126,9 @@ async function expectSelectedRoutingFanEndpoints(routingTree) {
       throw new Error("routing_tree_canvas_context_missing");
     }
     const canvasBounds = canvas.getBoundingClientRect();
+    const productBounds = product.getBoundingClientRect();
+    const proxyBounds = proxy.getBoundingClientRect();
+    const familyBounds = selectedFamily.getBoundingClientRect();
     const providerBounds = selectedProvider.getBoundingClientRect();
     const modelBounds = selectedModel.getBoundingClientRect();
     const canvasScaleHorizontal = canvas.width / canvasBounds.width;
@@ -142,12 +155,39 @@ async function expectSelectedRoutingFanEndpoints(routingTree) {
       return false;
     };
     return {
-      modelEndpoint: hasPaintedPixel(modelBounds.right, modelBounds.top + modelBounds.height / 2),
+      productOutgoingEndpoint: hasPaintedPixel(productBounds.right, productBounds.top + productBounds.height / 2),
+      proxyIncomingEndpoint: hasPaintedPixel(proxyBounds.left, proxyBounds.top + proxyBounds.height / 2),
+      proxyOutgoingEndpoint: hasPaintedPixel(proxyBounds.right, proxyBounds.top + proxyBounds.height / 2),
+      familyIncomingEndpoint: hasPaintedPixel(familyBounds.left, familyBounds.top + familyBounds.height / 2),
+      familyOutgoingEndpoint: hasPaintedPixel(familyBounds.right, familyBounds.top + familyBounds.height / 2),
+      modelIncomingEndpoint: hasPaintedPixel(modelBounds.left, modelBounds.top + modelBounds.height / 2),
+      modelOutgoingEndpoint: hasPaintedPixel(modelBounds.right, modelBounds.top + modelBounds.height / 2),
       providerIncomingEndpoint: hasPaintedPixel(providerBounds.left, providerBounds.top + providerBounds.height / 2),
     };
   }, routingConnectorEndpointRadius);
-  expect(endpointEvidence.providerIncomingEndpoint).toBe(true);
-  expect(endpointEvidence.modelEndpoint).toBe(true);
+  expect(Object.values(endpointEvidence).every(Boolean)).toBe(true);
+}
+
+/**
+ * @param {import("@playwright/test").Locator} routingTree
+ */
+async function expectFiveStageRouteOrder(routingTree) {
+  const stageOrder = await routingTree.evaluate((tree) => {
+    const stages = [
+      tree.querySelector("[data-route-product]"),
+      tree.querySelector("[data-route-proxy]"),
+      tree.querySelector('[data-route-family][aria-pressed="true"]'),
+      tree.querySelector('[data-route-model-group]:not([hidden]) [data-route-model][aria-pressed="true"]'),
+      tree.querySelector('[data-route-provider-group]:not([hidden]) [data-route-provider][aria-pressed="true"]'),
+    ];
+    if (!stages.every((stage) => stage instanceof HTMLElement)) {
+      throw new Error("routing_tree_five_stage_route_missing");
+    }
+    return stages.map((stage) => stage.getBoundingClientRect());
+  });
+  for (let stageIndex = 1; stageIndex < stageOrder.length; stageIndex += 1) {
+    expect(stageOrder[stageIndex - 1].right).toBeLessThan(stageOrder[stageIndex].left);
+  }
 }
 
 /**
@@ -367,13 +407,14 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).toContain('<routing-tree class="routing-tree" data-enhanced="false" aria-label="Interactive LLM routing map">');
   expect(html).toContain("One integration. Choose the exact route.");
   expect(html).toContain('<canvas class="routing-tree__connectors" data-route-canvas aria-hidden="true"></canvas>');
-  expect(html).toContain('<span>11 publishers · 57 exact models · 58 offerings</span>');
-  expect(html).toContain('data-route-publisher="deepseek"');
-  expect(html).toContain('data-route-publisher="alibaba"');
-  expect(html).toContain('data-route-publisher="moonshot"');
-  expect(html).toContain('data-route-model="kimi-k2.6" data-route-model-publisher="moonshot"');
-  expect(html).toContain('data-route-model="qwen-plus" data-route-model-publisher="alibaba"');
+  expect(html).toContain('<span>24 families · 57 exact models · 58 offerings</span>');
+  expect(html).toContain('data-route-family="deepseek-r1"');
+  expect(html).toContain('data-route-family="muse-spark"');
+  expect(html).toContain('data-route-family="qwen"');
+  expect(html).toContain('data-route-model="kimi-k2.6" data-route-model-family="kimi-k2"');
+  expect(html).toContain('data-route-model="qwen-plus" data-route-model-family="qwen"');
   expect(html).toContain('data-route-offering="siliconflow:deepseek-reasoner"');
+  expect(html).not.toContain("data-route-publisher");
   expect(html).not.toContain("llm-proxy-routing-tree");
   expect(html).toContain('<table class="catalog-table">');
   expect(html).toContain('<strong>11</strong><span>Providers</span>');
@@ -399,13 +440,12 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).not.toContain('data-catalog-capability-action="background"');
   expect(html).not.toContain('data-catalog-capability-action="synchronous"');
   expect(html).not.toContain("data-catalog-provider");
-  expect(html).toContain('<select aria-label="Filter model family"');
+  expect(html).not.toContain("data-route-picker");
   expect(html).toContain("gpt-4o-mini-transcribe");
   expect(html).toContain("gemini-2.5-flash");
   expect(html).toContain("claude-sonnet-4-6");
   expect(html).toContain("grok-4.3");
   expect(html).toContain("grok-imagine-video-1.5");
-  expect(html).toContain('<option value="video_generation">Video generation</option>');
   expect(html).not.toContain("api_key");
   expect(html).not.toContain("base_url");
   expect(html).not.toContain("provider_model");
@@ -756,16 +796,15 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(page.locator("#routing-overview routing-tree")).toHaveCount(1);
   await expect(page.locator("#models > routing-tree")).toHaveCount(0);
   await expect(routingTree).toHaveAttribute("data-enhanced", "false");
-  await expect(routingTree.locator("[data-route-publisher]")).toHaveCount(11);
+  await expect(routingTree.locator("[data-route-family]")).toHaveCount(24);
   await expect(routingTree.locator("[data-route-provider]")).toHaveCount(58);
   await expect(routingTree.locator("[data-route-model]")).toHaveCount(57);
-  await expect(routingTree.locator('[data-route-publisher="alibaba"]')).toHaveAttribute("aria-pressed", "true");
-  await expect(routingTree.locator('[data-route-model-group="alibaba"]')).toBeVisible();
-  await expect(routingTree.locator('[data-route-model-group="moonshot"]')).toBeHidden();
-  await expect(routingTree.locator('[data-route-provider="dashscope"]')).toHaveAttribute("aria-pressed", "true");
-  await expect(routingTree.locator('[data-route-selected-publisher]')).toHaveText("Alibaba");
-  await expect(routingTree.locator('[data-route-selected-provider]')).toHaveText("dashscope");
-  await expect(routingTree.locator('[data-route-selected-model]')).toHaveText("qwen-plus");
+  await expect(routingTree.locator('[data-route-family="claude-fable"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-model-group="claude-fable"]')).toBeVisible();
+  await expect(routingTree.locator('[data-route-model-group="grok"]')).toBeHidden();
+  await expect(routingTree.locator('[data-route-provider-group="claude-fable-5"] [data-route-provider="anthropic"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-selected-provider]')).toHaveText("anthropic");
+  await expect(routingTree.locator('[data-route-selected-model]')).toHaveText("claude-fable-5");
   await expect(routingTree.locator("button:enabled")).toHaveCount(0);
 
   const catalog = page.locator("capability-catalog");
@@ -788,27 +827,23 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await browserContext.close();
 });
 
-test("visitors can choose a publisher, exact model, and provider offering", async ({ page }) => {
+test("visitors can choose a model family, exact model, and provider offering", async ({ page }) => {
   await installAssetRoutes(page, { initialAuthStatus: "unauthenticated" });
   await page.setViewportSize({ width: 1280, height: 800 });
   await page.goto(baseURL);
 
   const routingTree = page.locator("routing-tree");
-  const selectedPublisher = routingTree.locator("[data-route-selected-publisher]");
   const selectedProvider = routingTree.locator("[data-route-selected-provider]");
   const selectedModel = routingTree.locator("[data-route-selected-model]");
-  const searchInput = routingTree.getByLabel("Search exact models");
-  const familyFilter = routingTree.getByLabel("Filter model family");
-  const operationFilter = routingTree.getByLabel("Filter model operation");
   await expect(routingTree).toHaveAttribute("data-enhanced", "true");
   await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "true");
-  await expect(routingTree.locator("[data-route-publisher]")).toHaveCount(11);
+  await expect(routingTree.locator("[data-route-family]")).toHaveCount(24);
   await expect(routingTree.locator("[data-route-model]")).toHaveCount(57);
   await expect(routingTree.locator("[data-route-provider]")).toHaveCount(58);
+  await expect(routingTree.locator("[data-route-model]:visible")).toHaveCount(1);
   await expect(routingTree.locator("[data-route-provider]:visible")).toHaveCount(1);
-  await expect(selectedPublisher).toHaveText("Alibaba");
-  await expect(selectedModel).toHaveText("qwen-plus");
-  await expect(selectedProvider).toHaveText("dashscope");
+  await expect(selectedModel).toHaveText("claude-fable-5");
+  await expect(selectedProvider).toHaveText("anthropic");
 
   const routeCanvasDimensions = await routingTree.locator("[data-route-canvas]").evaluate((canvas) => ({
     height: canvas.height,
@@ -816,38 +851,13 @@ test("visitors can choose a publisher, exact model, and provider offering", asyn
   }));
   expect(routeCanvasDimensions.height).toBeGreaterThan(0);
   expect(routeCanvasDimensions.width).toBeGreaterThan(0);
-  const desktopSequence = await routingTree.evaluate((tree) => {
-    const product = tree.querySelector("[data-route-product]");
-    const proxy = tree.querySelector("[data-route-proxy]");
-    const selection = tree.querySelector("[data-route-selection-node]");
-    const provider = tree.querySelector('[data-route-provider][aria-pressed="true"]');
-    if (
-      !(product instanceof HTMLElement)
-      || !(proxy instanceof HTMLElement)
-      || !(selection instanceof HTMLElement)
-      || !(provider instanceof HTMLElement)
-    ) {
-      throw new Error("routing_tree_desktop_sequence_missing");
-    }
-    return [
-      product.getBoundingClientRect().right,
-      proxy.getBoundingClientRect().left,
-      proxy.getBoundingClientRect().right,
-      selection.getBoundingClientRect().left,
-      selection.getBoundingClientRect().right,
-      provider.getBoundingClientRect().left,
-    ];
-  });
-  expect(desktopSequence[0]).toBeLessThan(desktopSequence[1]);
-  expect(desktopSequence[2]).toBeLessThan(desktopSequence[3]);
-  expect(desktopSequence[4]).toBeLessThan(desktopSequence[5]);
+  await expectFiveStageRouteOrder(routingTree);
   await expectSelectedRoutingFanEndpoints(routingTree);
 
-  await routingTree.locator('[data-route-publisher="deepseek"]').click();
-  const deepSeekModels = routingTree.locator('[data-route-model-group="deepseek"]');
+  await routingTree.locator('[data-route-family="deepseek-r1"]').click();
+  const deepSeekModels = routingTree.locator('[data-route-model-group="deepseek-r1"]');
   await expect(deepSeekModels).toBeVisible();
-  await expect(deepSeekModels.locator("[data-route-model]")).toHaveCount(4);
-  await expect(selectedPublisher).toHaveText("DeepSeek");
+  await expect(deepSeekModels.locator("[data-route-model]")).toHaveCount(1);
   await deepSeekModels.locator('[data-route-model="deepseek-reasoner"]').click();
   const reasonerProviders = routingTree.locator('[data-route-provider-group="deepseek-reasoner"]');
   await expect(reasonerProviders).toBeVisible();
@@ -856,37 +866,33 @@ test("visitors can choose a publisher, exact model, and provider offering", asyn
   await expect(selectedProvider).toHaveText("deepseek");
   await reasonerProviders.locator('[data-route-provider="siliconflow"]').click();
   await expect(selectedProvider).toHaveText("siliconflow");
+  await expectFiveStageRouteOrder(routingTree);
   await expectSelectedRoutingFanEndpoints(routingTree);
 
-  await searchInput.fill("deepseek reasoner");
-  await expect(routingTree.locator("[data-route-publisher]:visible")).toHaveCount(1);
-  await expect(routingTree.locator("[data-route-model]:visible")).toHaveCount(1);
-  await expect(reasonerProviders.locator("[data-route-provider]:visible")).toHaveCount(2);
-  await searchInput.fill("no-such-model");
-  await expect(routingTree.locator("[data-route-empty]")).toBeVisible();
-  await routingTree.getByRole("button", { name: "Reset" }).click();
-  await expect(routingTree.locator("[data-route-publisher]:visible")).toHaveCount(11);
+  await routingTree.locator('[data-route-family="gpt-5"]').click();
+  const gptModels = routingTree.locator('[data-route-model-group="gpt-5"]');
+  await expect(gptModels).toBeVisible();
+  await expect(gptModels.locator("[data-route-model]")).toHaveCount(8);
+  await gptModels.locator('[data-route-model="gpt-5.6-terra"]').click();
+  await expect(selectedModel).toHaveText("gpt-5.6-terra");
+  await expect(selectedProvider).toHaveText("openai");
+  await expectFiveStageRouteOrder(routingTree);
+  await expectSelectedRoutingFanEndpoints(routingTree);
 
-  await familyFilter.selectOption("gpt-transcribe");
-  await expect(routingTree.locator("[data-route-publisher]:visible")).toHaveCount(1);
-  await expect(routingTree.locator("[data-route-model]:visible")).toHaveCount(2);
-  await familyFilter.selectOption("");
-  await operationFilter.selectOption("dictation");
-  await expect(routingTree.locator("[data-route-publisher]:visible")).toHaveCount(4);
-  await expect(routingTree.locator("[data-route-model]:not([hidden])")).toHaveCount(5);
-  await operationFilter.selectOption("video_generation");
-  await expect(routingTree.locator("[data-route-publisher]:visible")).toHaveCount(1);
-  await expect(routingTree.locator("[data-route-model]:not([hidden])")).toHaveCount(1);
+  await page.setViewportSize({ width: 900, height: 900 });
+  await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "true");
+  await expectFiveStageRouteOrder(routingTree);
+  await expectSelectedRoutingFanEndpoints(routingTree);
 
-  if (process.env.I220_SCREENSHOTS === "1") {
-    await mkdir(i220ScreenshotDirectory, { recursive: true });
+  if (process.env.B131_SCREENSHOTS === "1") {
+    await mkdir(b131ScreenshotDirectory, { recursive: true });
     for (const viewport of routingTreeViewports) {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await expect(routingTree).toHaveAttribute(
         "data-route-lines-rendered",
         viewport.width > 680 ? "true" : "false",
       );
-      await routingTree.screenshot({ path: path.join(i220ScreenshotDirectory, `I221-routing-${viewport.name}.png`) });
+      await routingTree.screenshot({ path: path.join(b131ScreenshotDirectory, `B131-routing-${viewport.name}.png`) });
     }
   }
 

--- a/tests/e2e/public-site-renderer.spec.js
+++ b/tests/e2e/public-site-renderer.spec.js
@@ -43,10 +43,11 @@ test("public site rendering writes the normalized exact model catalog", async ()
     try {
       await renderFixture(fixture, capabilitiesURL);
       const renderedLanding = await readFile(path.join(fixture.output, "index.html"), "utf8");
-      expect(renderedLanding).toContain("1 publisher · 1 exact model · 1 offering");
-      expect(renderedLanding).toContain('data-route-publisher="example-publisher"');
-      expect(renderedLanding).toContain('data-route-model="example-model"');
+      expect(renderedLanding).toContain("1 family · 1 exact model · 1 offering");
+      expect(renderedLanding).toContain('data-route-family="example-family"');
+      expect(renderedLanding).toContain('data-route-model="example-model" data-route-model-family="example-family"');
       expect(renderedLanding).toContain('data-route-provider="example-provider"');
+      expect(renderedLanding).not.toContain("data-route-publisher");
       expect(renderedLanding).toContain('<strong>1</strong><span>Exact models</span>');
       expect(renderedLanding).not.toContain("provider_model");
       expect(renderedLanding).not.toContain("default_operations");

--- a/tests/e2e/public-site-renderer.spec.js
+++ b/tests/e2e/public-site-renderer.spec.js
@@ -37,6 +37,19 @@ test("public site rendering rejects an invalid capability REST representation", 
   });
 });
 
+test("public site rendering rejects an invalid model family weight access", async () => {
+  const capabilities = normalizedCapabilityFixture();
+  capabilities.families[0].weight_access = "restricted";
+  await withCapabilityServer(200, capabilities, async (capabilitiesURL) => {
+    const fixture = await siteFixture();
+    try {
+      await expect(renderFixture(fixture, capabilitiesURL)).rejects.toThrow(/catalog\.families\[0\]\.weight_access value=restricted/u);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+});
+
 test("public site rendering writes the normalized exact model catalog", async () => {
   await withCapabilityServer(200, normalizedCapabilityFixture(), async (capabilitiesURL) => {
     const fixture = await siteFixture();
@@ -44,6 +57,13 @@ test("public site rendering writes the normalized exact model catalog", async ()
       await renderFixture(fixture, capabilitiesURL);
       const renderedLanding = await readFile(path.join(fixture.output, "index.html"), "utf8");
       expect(renderedLanding).toContain("1 family · 1 exact model · 1 offering");
+      expect(renderedLanding).toContain('data-route-weight-access="proprietary" aria-pressed="true"');
+      expect(renderedLanding).toContain('data-route-weight-access="open_weights" aria-pressed="false"');
+      expect(renderedLanding).toContain('role="group" aria-label="Choose one or both weight access types"');
+      expect(renderedLanding).toContain('role="group" aria-label="Choose one capability"');
+      expect(renderedLanding).toContain('data-route-capability="text" aria-label="Text generation" title="Text generation" aria-pressed="true"');
+      expect(renderedLanding).toContain('data-route-family-weight-access="proprietary"');
+      expect(renderedLanding).toContain('data-route-provider-capabilities="text"');
       expect(renderedLanding).toContain('data-route-family="example-family"');
       expect(renderedLanding).toContain('data-route-model="example-model" data-route-model-family="example-family"');
       expect(renderedLanding).toContain('data-route-provider="example-provider"');
@@ -67,7 +87,12 @@ function normalizedCapabilityFixture() {
     ],
     providers: [{ identifier: "example-provider", label: "Example Provider", credential_kinds: ["api_key"] }],
     publishers: [{ identifier: "example-publisher", label: "Example Publisher", model_count: 1 }],
-    families: [{ identifier: "example-family", publisher: "example-publisher", label: "Example Family" }],
+    families: [{
+      identifier: "example-family",
+      publisher: "example-publisher",
+      label: "Example Family",
+      weight_access: "proprietary",
+    }],
     models: [{
       identifier: "example-model",
       publisher: "example-publisher",


### PR DESCRIPTION
## Summary

- Restores the routing explorer as a continuous five-stage flow: Product → LLM Proxy → Model Family → Exact Model → Provider Offering.
- Replaces publisher-based routing and route filters with family-first selection, so exact models are scoped to the selected family and offerings are scoped to the selected model.
- Keeps publisher information in the capability matrix while preserving complete semantic route content without JavaScript.
- Updates routing-tree presentation, connector behavior, responsive layout, and documentation to match the restored flow.

## Validation

- Expands browser coverage for five-stage ordering, connector endpoints, family/model/provider selection updates, no-JavaScript route content, and responsive layouts.
- Updates public-site rendering coverage for the family-based route explorer.