### PR TITLE
gix/add-provider-image-routing-and-live-media-matrix

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -97,6 +97,86 @@ retain satisfied historical dependencies.
     selection updates, complete semantic HTML, and responsive layouts.
   - `make ci` passed all 11 gates with 92 browser tests and 100.0% Go statement
     coverage.
+- [x] [B132] (P1) Route xAI Responses verification to xAI.
+  Goal:
+  Verify an xAI Responses model through the selected xAI provider endpoint.
+  Requirements:
+  - Use the exact protocol adapter and execution lifecycle for verification.
+  - Send synchronous Responses verification to the selected provider base URL.
+  - Keep OpenAI Responses verification on the configured OpenAI endpoint.
+  Validation:
+  - Prove management saves a verified `grok-4.5` key after an xAI request.
+  Resolution:
+  - Keyed verification request builders by wire contract and execution
+    lifecycle.
+  - Added management proof that `grok-4.5` verification calls xAI and saves
+    the key.
+- [x] [B133] (P1) Reject large media before provider serialization.
+  Goal:
+  Reject media that exceeds a provider limit before the proxy reads an asset.
+  Requirements:
+  - Check media counts and attachment sizes from validated metadata.
+  - Check a bounded encoded request minimum before media serialization.
+  - Preserve the exact serialized request-size check.
+  Validation:
+  - Prove each inline-only adapter rejects an oversized closed asset.
+  - Require a media limit error for each rejection.
+  Resolution:
+  - Split metadata admission from the exact serialized request-size check.
+  - Proved OpenAI, xAI, and Anthropic reject an oversized closed asset before
+    an asset read.
+- [x] [B134] (P1) Bound buffered canonical request bodies.
+  Goal:
+  Keep each buffered `POST /v2` body within a safe service limit.
+  Requirements:
+  - Apply one service body limit below large provider request limits.
+  - Keep tenant assets as the transport for larger media.
+  - Return HTTP `413` before JSON decoding for a body above the limit.
+  Validation:
+  - Prove the service limit overrides a larger provider catalog limit.
+  Resolution:
+  - Limited buffered `/v2` bodies to 8 MiB or the smaller catalog-derived
+    value.
+  - Removed the JSON body string copy and added public HTTP `413` proof.
+- [x] [B135] (P2) Bind media declarations to exact protocol adapters.
+  Goal:
+  Accept a media declaration only when the exact route adapter serializes it.
+  Requirements:
+  - Validate media input against the wire contract and execution lifecycle.
+  - Reject media on every Chat Completions route during startup.
+  Validation:
+  - Prove an xAI Chat Completions media declaration stops catalog startup.
+  Resolution:
+  - Keyed media support by wire contract and execution lifecycle.
+  - Proved an xAI Chat Completions media declaration stops catalog startup.
+- [x] [B136] (P2) Require each adapter media transport limit.
+  Goal:
+  Require the media limit for the transport that each exact adapter uses.
+  Requirements:
+  - Require inline attachment limits for inline-only adapters.
+  - Require file attachment limits for Gemini Interactions adapters.
+  - Reject limits that declare only an unused transport.
+  Validation:
+  - Prove startup rejects file-only limits for an inline adapter.
+  - Prove startup rejects a Gemini adapter without file limits.
+  Resolution:
+  - Required inline attachment limits for inline adapters and file attachment
+    limits for Gemini adapters.
+  - Added startup rejection proofs for each wrong transport declaration.
+- [x] [B137] (P2) Close assets after route media rejection.
+  Goal:
+  Close each resolved asset when exact route media validation rejects a request.
+  Requirements:
+  - Close all constructed message media before the handler returns an error.
+  - Preserve the provider-specific MIME rejection response.
+  Validation:
+  - Prove xAI WebP asset rejection closes the opened asset reader.
+  Resolution:
+  - Closed constructed message media before an exact route MIME rejection
+    returns.
+  - Proved xAI WebP asset rejection closes the asset reader.
+  - `make ci` passed all 11 gates with 93 browser tests and 100.0% Go statement
+    coverage.
 - [!] [B126] (P1) Activate the current v0.4.0 release on every public surface.
   Goal:
   Make the production API, container, and Pages site serve the immutable

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -245,6 +245,39 @@ retain satisfied historical dependencies.
     `timeout -k 350s -s SIGKILL 350s make ci` pair.
 ## Improvements
 
+- [x] [I224] (P0) {F035} Add a paid live matrix for provider image routes.
+  Goal:
+  Add one repository command that proves each current provider image route
+  accepts a canonical image request through LLM Proxy.
+  Requirements:
+  - Add an explicit image mode to the disposable live-provider harness.
+  - Run the image matrix for OpenAI, Anthropic, Gemini, and xAI by default.
+  - Verify each provider key before its image request.
+  - Select each image model from the validated public provider catalog.
+  - Use the configured provider default when that model supports image input.
+  - Otherwise, require one exact image model for that provider.
+  - Send one deterministic inline PNG through canonical `POST /v2`.
+  - Require HTTP `200` and the exact expected response marker.
+  - Keep provider keys, tenant secrets, image data, and response bodies private.
+  - Keep paid provider requests outside `make ci`.
+  Deliverables:
+  - Add a Make target for the four-provider image matrix.
+  - Add fake-boundary coverage for model selection, request order, and payload.
+  - Document the paid command and its environment requirements.
+  Validation:
+  - Run the focused live-harness contract tests.
+  - Run the non-paid live-provider harness preflight.
+  - Run `make ci` after the last application change.
+  Resolution:
+  - Added one catalog-selected image mode and its Make target.
+  - Added exact payload, request order, redaction, and rejection tests.
+  - On 2026-08-11, the paid OpenAI, Anthropic, and Gemini image cases returned
+    HTTP `200`.
+  - The xAI credential was found in the private MediaOps environment, but xAI
+    rejected `grok-4.5` verification with HTTP `422`. No image request ran.
+  - `make ci` passed all 11 gates with 93 browser tests and 100.0% Go statement
+    coverage.
+
 - [ ] [I223] (P0) {I216,I221} Load all supported providers and models from one catalog file.
   Goal:
   Make `configs/providers.yml` the only source that defines supported providers,
@@ -1212,7 +1245,7 @@ retain satisfied historical dependencies.
 
 ## Features
 
-- [ ] [F035] (P0) {F033} Add verified provider image routes.
+- [x] [F035] (P0) {F033} Add verified provider image routes.
   Goal:
   LLM Proxy routes canonical image and audio attachments only through Gemini.
   As a result, the Image input filter shows only the Gemini family. Provider
@@ -1252,6 +1285,16 @@ retain satisfied historical dependencies.
   - Prove the Image input and Audio input route filters in a browser.
   - Prove complete semantic route content without JavaScript.
   - Run `make ci` after the last application change.
+  Resolution:
+  - Added image transport for all verified OpenAI and Anthropic text models.
+  - Added synchronous xAI Responses image transport for `grok-4.5`.
+  - Declared image and conversational audio input for all seven Gemini text models.
+  - Added provider MIME checks and offering-owned request, count, and attachment limits.
+  - The Image input filter now shows 8 proprietary families and 29 exact models.
+  - The Audio message input filter now shows 1 family and 7 exact models.
+  - Public `POST /v2`, capability, browser, and no-JavaScript tests passed.
+  - `make ci` passed all 11 gates with 93 browser tests and 100.0% Go statement
+    coverage.
 - [x] [F034] (P1) Filter the route explorer by weight access and capability.
   Goal:
   Reduce the model family fan with compact route filters in the diagram title.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export PLAYWRIGHT_BROWSERS_PATH
 
 GO_SOURCES := $(shell find . -name '*.go' -not -path './vendor/*')
 
-.PHONY: fmt check-format lint go-lint python-lint frontend-dependencies frontend-lint test go-test python-test python-package-install-test frontend-test test-frontend-dependency-contract test-openapi-pages-artifact test-management-auth-blackbox test-live-provider-harness test-live-providers test-live-gemini live-test build clean ci up down
+.PHONY: fmt check-format lint go-lint python-lint frontend-dependencies frontend-lint test go-test python-test python-package-install-test frontend-test test-frontend-dependency-contract test-openapi-pages-artifact test-management-auth-blackbox test-live-provider-harness test-live-providers test-live-provider-media test-live-gemini live-test build clean ci up down
 
 fmt:
 	$(GOFMT) -w $(GO_SOURCES)
@@ -76,6 +76,9 @@ test-live-provider-harness:
 
 test-live-providers:
 	@GO="$(GO)" ./scripts/test_live_providers.sh
+
+test-live-provider-media:
+	@GO="$(GO)" ./scripts/test_live_providers.sh --media
 
 test-live-gemini:
 	@GO="$(GO)" ./scripts/test_live_gemini.sh

--- a/README.md
+++ b/README.md
@@ -328,19 +328,19 @@ adapters before they are available through `/dictate`.
 | `zhipu` | `glm` | `openai_chat_completions` | `synchronous_completion` | `glm-5.1` | `providers.zhipu.api_key` | `https://open.bigmodel.cn/api/paas/v4` | Yes: `glm-asr-2512` | No |
 | `gemini` | none | `gemini_interactions` | Model-specific: Gemini 3.x `pollable_resource`; Gemini 2.5 `synchronous_completion` | `gemini-2.5-flash` | `providers.gemini.api_key` | `https://generativelanguage.googleapis.com/v1beta` | No | No |
 | `anthropic` | `claude` | `anthropic_messages` | `synchronous_completion` | `claude-sonnet-4-6` | `providers.anthropic.api_key` | `https://api.anthropic.com` | No | No |
-| `xai` | none | `openai_chat_completions` | `synchronous_completion` | `grok-4.3` | `providers.xai.api_key` | `https://api.x.ai/v1` | Yes: `xai-stt` | No |
+| `xai` | none | Model-specific: `grok-4.5` uses `openai_responses`, and other text models use `openai_chat_completions` | `synchronous_completion` | `grok-4.3` | `providers.xai.api_key` | `https://api.x.ai/v1` | Yes: `xai-stt` | No |
 
 All upstream provider credentials are server-side only. Client requests must
 never send OpenAI, Meta, Anthropic, xAI, Gemini, or other upstream API keys.
-Media input is independently model-scoped: the checked-in catalog currently
-declares `image` and `audio` only for `gemini-3.5-flash` and
-`gemini-2.5-flash`. Every other configured model remains text-only on
-`POST /v2`, regardless of capabilities its upstream provider may expose.
+Media input is model-scoped. The checked-in catalog declares media input only
+when the provider offering has a code-owned transport.
 
-| Model | Provider | Standard-message media inputs |
-|-------|----------|-------------------------------|
-| `gemini-3.5-flash` | Gemini | `image`, `audio` |
-| `gemini-2.5-flash` | Gemini | `image`, `audio` |
+| Exact model set | Provider | Standard-message media inputs |
+|-----------------|----------|-------------------------------|
+| All 11 OpenAI text models in the GPT-4 and GPT-5 families | OpenAI | `image` |
+| All 10 Claude text models in the Fable, Sonnet, Opus, and Haiku families | Anthropic | `image` |
+| All 7 Gemini text models | Gemini | `image`, `audio` |
+| `grok-4.5` | xAI | `image` |
 | Every other configured model | Its configured provider | None |
 
 ### Model catalog schema
@@ -440,11 +440,12 @@ treats an arbitrary upstream identifier as pollable state.
 
 Provider-specific details:
 
-* OpenAI is the only provider currently exposed with `web_search` support, and
-  only for OpenAI model catalog entries with `web_search: true`. OpenAI
-  dictation uses the same `providers.openai.api_key` value. OpenAI Responses
-  and Models endpoint URLs are derived from `providers.openai.base_url`;
-  dictation uses `providers.openai.transcriptions_url`.
+* OpenAI is the only provider currently exposed with `web_search` support.
+  This support applies only to catalog entries with `web_search: true`.
+  OpenAI derives Responses and Models endpoint URLs from `providers.openai.base_url`.
+  Dictation uses `providers.openai.transcriptions_url` and the same API key.
+  Each catalog model with image input sends ordered Data URLs through OpenAI Responses.
+  The adapter uses `detail: auto` for each image.
 * OpenAI-compatible text providers send chat completion requests with
   `Authorization: Bearer <api_key>` and the selected provider base URL. The
   shared adapter normalizes `finish_reason=length` into the common
@@ -501,20 +502,21 @@ Provider-specific details:
   [background execution guide](https://ai.google.dev/gemini-api/docs/background-execution),
   and [Interactions API reference](https://ai.google.dev/api/interactions-api).
 * Anthropic text requests use `POST /v1/messages` with `x-api-key` and
-  `anthropic-version: 2023-06-01`. System messages are translated to
-  Anthropic's top-level `system` field. Anthropic requires `max_tokens`, so
-  when the client omits it the proxy sends the selected Claude model's
-  configured output limit. `stop_reason=max_tokens` enters the common
-  missing-suffix loop; `end_turn` or `stop_sequence` completes the assembled
-  answer. Tool use, paused turns, refusals, and unknown reasons remain upstream
-  failures because this adapter exposes no tool loop.
+  `anthropic-version: 2023-06-01`. The proxy maps system messages to Anthropic's
+  top-level `system` field. Anthropic requires `max_tokens`.
+  When the client omits it, the proxy sends the selected model output limit.
+  `stop_reason=max_tokens` starts the common missing-suffix loop.
+  `end_turn` or `stop_sequence` completes the assembled answer.
+  Tool use, paused turns, refusals, and unknown reasons remain upstream failures.
+  Each catalog model with image input sends ordered base64 image blocks before the message text.
 * Zhipu dictation uses Z.AI GLM-ASR through
   `providers.zhipu.transcriptions_url` with the selected configured dictation
   model.
-* xAI text requests use xAI's OpenAI-compatible `/chat/completions` API at
-  `https://api.x.ai/v1`. Grok/xAI dictation uses xAI STT through
-  `providers.xai.transcriptions_url`. The upstream STT endpoint does not
-  receive a `model` multipart field.
+* Most xAI text models use xAI's OpenAI-compatible `/chat/completions` API at
+  `https://api.x.ai/v1`. The `grok-4.5` route uses synchronous `/responses`
+  with `store: false`. Its image blocks use `detail: high`. Grok/xAI dictation
+  uses xAI STT through `providers.xai.transcriptions_url`. The upstream STT
+  endpoint does not receive a `model` multipart field.
 
 When management is disabled, provider API keys are optional until a configured
 static tenant uses that provider as a default. If a non-default provider key is
@@ -1333,6 +1335,7 @@ This repository exposes the standard local targets used by MPR app repos:
 | `make ci` | Prepare pinned frontend dependencies, then run format checks, Go lint (`go vet`, `staticcheck`, `ineffassign`), Python strict mypy, frontend syntax checks, the 100% coverage-gated Go test suite, Python pytest, Playwright browser tests, the app lifecycle contract test, and the non-paid live-harness preflight. A successful run ends with a per-gate table, current-run coverage, and an explicit `CI PASSED` receipt. |
 | `make test-live-provider-harness` | Generate the temporary static-mode live-test config and verify authenticated routing without an upstream call. |
 | `make test-live-providers` | Start a disposable managed tenant, verify every available provider key through the canonical management operation, and run that provider's live text smoke only after verification succeeds; use `LIVE_ENV_FILE=/path/to/env` to load key values. |
+| `make test-live-provider-media` | Verify OpenAI, Anthropic, Gemini, and xAI keys, then send one paid canonical image request through each provider. |
 | `make test-live-gemini` | Compatibility wrapper for `make test-live-providers` with `LLM_PROXY_LIVE_PROVIDERS=gemini`. |
 | `make live-test` | Send paid production `POST /v2` requests through the Default tenant using only `LLM_PROXY_SECRET`: echo checks for OpenAI, Anthropic, Meta, Gemini, and Moonshot, plus large completion cases for OpenAI, Anthropic, Meta, and Gemini. |
 | `make release` | Delegate this clean checkout and its schema-v4 resource declaration to the exact sibling `../mprlab-gateway` release transaction. |
@@ -1389,6 +1392,31 @@ directory. It submits each candidate once to
 safe `200` keyed-profile result, and only then sends that provider's smoke
 request. Candidate payloads, session material, provider responses, and proxy
 responses are never printed, and the temporary state is removed at exit.
+
+The paid image matrix uses OpenAI, Anthropic, Gemini, and xAI by default. It
+requires all four provider keys. Set `LLM_PROXY_LIVE_PROVIDERS` to run a
+selected subset. The harness selects each image model from the validated public
+provider catalog. It uses the configured default when that model supports image
+input. Otherwise, it requires one exact image model for that provider. The key
+verification uses the selected image model.
+
+Each image case creates the same deterministic 256 by 256 red PNG. The request
+sends canonical padded base64 data and its matching SHA-256 through `POST /v2`.
+The case requires HTTP `200`, an exact `RED` response, and a valid proxy request
+identifier. The harness does not print the image, response body, or credentials.
+
+Run the complete paid image matrix:
+
+```shell
+make test-live-provider-media LIVE_ENV_FILE=configs/.env
+```
+
+Run a selected paid image subset:
+
+```shell
+LLM_PROXY_LIVE_PROVIDERS=openai,gemini \
+  make test-live-provider-media LIVE_ENV_FILE=configs/.env
+```
 
 The non-paid `--preflight` and `--write-config` modes retain the isolated
 static-mode contract with management disabled, a temporary tenant, and

--- a/README.md
+++ b/README.md
@@ -2032,9 +2032,10 @@ canonical padded base64 `data`, and the matching lowercase hexadecimal
 matching lowercase hexadecimal `sha256`. The proxy validates tenant ownership,
 asset state, expiry, MIME type, byte count, and digest before provider dispatch.
 `server.max_prompt_bytes` applies to compatibility `POST /`. Canonical
-`POST /v2` bounds its encoded JSON envelope with the configured text allowance
-plus the largest bounded inline request in the provider catalog. It applies
-the selected provider offering's published media limits and transport rules.
+`POST /v2` accepts an encoded JSON envelope of 8 MiB or less. A smaller
+catalog-derived limit applies when its configured text and inline media limits
+have a smaller sum. The proxy applies the selected provider offering's
+published media limits and transport rules.
 Upload larger media through `POST /model/v1/assets` and send its asset
 reference through `/v2`.
 
@@ -2302,10 +2303,10 @@ and [latest-model guide](https://developers.openai.com/api/docs/guides/latest-mo
 * `400 Bad Request` - missing/invalid parameters, invalid request timeout, invalid multipart audio form, unknown provider/model, or unsupported provider capability. Invalid timeout headers return `{"error":{"code":"invalid_request_timeout","max_request_timeout_seconds":M}}`.
 * `403 Forbidden` - missing or invalid `key`
 * `413 Payload Too Large` - compatibility JSON exceeds `max_prompt_bytes`, a
-  `/v2` JSON envelope exceeds its catalog-derived ingress bound, dictation
-  audio exceeds `max_input_audio_bytes`, an asset upload exceeds
-  `max_asset_bytes`, or media exceeds every transport limit for the selected
-  provider offering. Provider media failures use
+  `/v2` JSON envelope exceeds its service or catalog-derived ingress limit,
+  dictation audio exceeds `max_input_audio_bytes`, an asset upload exceeds
+  `max_asset_bytes`, or media exceeds the selected provider offering's
+  transport limit. Provider media failures use
   `provider_media_limit_exceeded`.
 * `429 Too Many Requests` - upstream provider rate limit; returns the sanitized `provider_rate_limited` JSON contract
 * `503 Service Unavailable` - selected provider credential is unavailable because that non-default provider is disabled or missing its API key

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -1587,8 +1587,8 @@ providers:
 		},
 		{
 			name: "offering media unsupported by exact model",
-			providersYAML: mutateCatalogOfferingYAML(completeLiteralProvidersYAML(), proxy.ProviderNameGemini, "gemini-3.1-pro-preview", func(block string) string {
-				return strings.Replace(block, "    operations:", "    media_inputs:\n    - image\n    operations:", 1)
+			providersYAML: mutateExactModelYAML(completeLiteralProvidersYAML(), proxy.ModelNameGemini35Flash, func(block string) string {
+				return strings.Replace(block, "    - image\n", "", 1)
 			}),
 			expectedError: "media_input=image reason=unsupported_by_model",
 		},

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -254,66 +254,88 @@ catalog:
     version: gpt-4o-mini
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-4o
     publisher: openai
     family: gpt-4
     version: gpt-4o
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-4.1
     publisher: openai
     family: gpt-4
     version: gpt-4.1
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-5-mini
     publisher: openai
     family: gpt-5
     version: gpt-5-mini
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-5
     publisher: openai
     family: gpt-5
     version: gpt-5
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-5.5
     publisher: openai
     family: gpt-5
     version: gpt-5.5
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-5.5-pro
     publisher: openai
     family: gpt-5
     version: gpt-5.5-pro
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-5.6
     publisher: openai
     family: gpt-5
     version: gpt-5.6
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-5.6-sol
     publisher: openai
     family: gpt-5
     version: gpt-5.6-sol
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-5.6-terra
     publisher: openai
     family: gpt-5
     version: gpt-5.6-terra
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-5.6-luna
     publisher: openai
     family: gpt-5
     version: gpt-5.6-luna
     operations:
     - text
+    media_inputs:
+    - image
   - id: gpt-4o-mini-transcribe
     publisher: openai
     family: gpt-transcribe
@@ -425,18 +447,27 @@ catalog:
     version: gemini-3.1-pro-preview
     operations:
     - text
+    media_inputs:
+    - image
+    - audio
   - id: gemini-3-flash-preview
     publisher: google
     family: gemini
     version: gemini-3-flash-preview
     operations:
     - text
+    media_inputs:
+    - image
+    - audio
   - id: gemini-3.1-flash-lite
     publisher: google
     family: gemini
     version: gemini-3.1-flash-lite
     operations:
     - text
+    media_inputs:
+    - image
+    - audio
   - id: gemini-2.5-flash
     publisher: google
     family: gemini
@@ -452,72 +483,98 @@ catalog:
     version: gemini-2.5-flash-lite
     operations:
     - text
+    media_inputs:
+    - image
+    - audio
   - id: gemini-2.5-pro
     publisher: google
     family: gemini
     version: gemini-2.5-pro
     operations:
     - text
+    media_inputs:
+    - image
+    - audio
   - id: claude-fable-5
     publisher: anthropic
     family: claude-fable
     version: claude-fable-5
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-sonnet-5
     publisher: anthropic
     family: claude-sonnet
     version: claude-sonnet-5
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-opus-4-8
     publisher: anthropic
     family: claude-opus
     version: claude-opus-4-8
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-sonnet-4-6
     publisher: anthropic
     family: claude-sonnet
     version: claude-sonnet-4-6
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-haiku-4-5-20251001
     publisher: anthropic
     family: claude-haiku
     version: claude-haiku-4-5-20251001
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-haiku-4-5
     publisher: anthropic
     family: claude-haiku
     version: claude-haiku-4-5
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-sonnet-4-5-20250929
     publisher: anthropic
     family: claude-sonnet
     version: claude-sonnet-4-5-20250929
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-sonnet-4-5
     publisher: anthropic
     family: claude-sonnet
     version: claude-sonnet-4-5
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-opus-4-1-20250805
     publisher: anthropic
     family: claude-opus
     version: claude-opus-4-1-20250805
     operations:
     - text
+    media_inputs:
+    - image
   - id: claude-opus-4-1
     publisher: anthropic
     family: claude-opus
     version: claude-opus-4-1
     operations:
     - text
+    media_inputs:
+    - image
   - id: muse-spark-1.1
     publisher: meta
     family: muse-spark
@@ -542,6 +599,8 @@ catalog:
     version: grok-4.5
     operations:
     - text
+    media_inputs:
+    - image
   - id: grok-4.20-0309-reasoning
     publisher: xai
     family: grok
@@ -604,6 +663,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_temperature
   - provider: openai
     model: gpt-4o
@@ -612,6 +700,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_temperature_tools
     web_search: true
   - provider: openai
@@ -623,6 +740,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_temperature_tools
     web_search: true
   - provider: openai
@@ -632,6 +778,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_reasoning_tools
     reasoning_effort:
       adapter: openai_responses
@@ -647,6 +822,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_reasoning_tools
     web_search: true
     reasoning_effort:
@@ -663,6 +867,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_reasoning_tools
     web_search: true
     reasoning_effort:
@@ -680,6 +913,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_reasoning_tools
     web_search: true
     reasoning_effort:
@@ -695,6 +957,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_reasoning_tools
     web_search: true
     reasoning_effort:
@@ -713,6 +1004,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_reasoning_tools
     web_search: true
     reasoning_effort:
@@ -731,6 +1051,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_reasoning_tools
     web_search: true
     reasoning_effort:
@@ -749,6 +1098,35 @@ catalog:
     - text
     wire_contract: openai_responses
     execution_lifecycle: pollable_resource
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 512000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 1500
+      unit: files
+      scope: request
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://developers.openai.com/api/docs/guides/images-vision
+      last_verified: "2026-08-11"
     request_profile: openai_responses_reasoning_tools
     web_search: true
     reasoning_effort:
@@ -963,6 +1341,54 @@ catalog:
     wire_contract: gemini_interactions
     execution_lifecycle: pollable_resource
     output_token_limit: 65536
+    media_inputs:
+    - image
+    - audio
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 20000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://ai.google.dev/gemini-api/docs/file-input-methods
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 3600
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/image-understanding
+      last_verified: "2026-08-11"
+    - id: audio_count
+      media_type: audio
+      transport: any
+      status: unknown
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/audio
+      last_verified: "2026-08-11"
+    - id: image_file_bytes
+      media_type: image
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
+    - id: audio_file_bytes
+      media_type: audio
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
   - provider: gemini
     model: gemini-3-flash-preview
     provider_model: gemini-3-flash-preview
@@ -971,6 +1397,54 @@ catalog:
     wire_contract: gemini_interactions
     execution_lifecycle: pollable_resource
     output_token_limit: 65536
+    media_inputs:
+    - image
+    - audio
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 20000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://ai.google.dev/gemini-api/docs/file-input-methods
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 3600
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/image-understanding
+      last_verified: "2026-08-11"
+    - id: audio_count
+      media_type: audio
+      transport: any
+      status: unknown
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/audio
+      last_verified: "2026-08-11"
+    - id: image_file_bytes
+      media_type: image
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
+    - id: audio_file_bytes
+      media_type: audio
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
   - provider: gemini
     model: gemini-3.1-flash-lite
     provider_model: gemini-3.1-flash-lite
@@ -979,6 +1453,54 @@ catalog:
     wire_contract: gemini_interactions
     execution_lifecycle: pollable_resource
     output_token_limit: 65536
+    media_inputs:
+    - image
+    - audio
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 20000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://ai.google.dev/gemini-api/docs/file-input-methods
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 3600
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/image-understanding
+      last_verified: "2026-08-11"
+    - id: audio_count
+      media_type: audio
+      transport: any
+      status: unknown
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/audio
+      last_verified: "2026-08-11"
+    - id: image_file_bytes
+      media_type: image
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
+    - id: audio_file_bytes
+      media_type: audio
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
   - provider: gemini
     model: gemini-2.5-flash
     provider_model: gemini-2.5-flash
@@ -1045,6 +1567,54 @@ catalog:
     wire_contract: gemini_interactions
     execution_lifecycle: synchronous_completion
     output_token_limit: 65536
+    media_inputs:
+    - image
+    - audio
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 20000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://ai.google.dev/gemini-api/docs/file-input-methods
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 3600
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/image-understanding
+      last_verified: "2026-08-11"
+    - id: audio_count
+      media_type: audio
+      transport: any
+      status: unknown
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/audio
+      last_verified: "2026-08-11"
+    - id: image_file_bytes
+      media_type: image
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
+    - id: audio_file_bytes
+      media_type: audio
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
   - provider: gemini
     model: gemini-2.5-pro
     provider_model: gemini-2.5-pro
@@ -1053,6 +1623,54 @@ catalog:
     wire_contract: gemini_interactions
     execution_lifecycle: synchronous_completion
     output_token_limit: 65536
+    media_inputs:
+    - image
+    - audio
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 20000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://ai.google.dev/gemini-api/docs/file-input-methods
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 3600
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/image-understanding
+      last_verified: "2026-08-11"
+    - id: audio_count
+      media_type: audio
+      transport: any
+      status: unknown
+      unit: files
+      scope: request
+      source: https://ai.google.dev/gemini-api/docs/audio
+      last_verified: "2026-08-11"
+    - id: image_file_bytes
+      media_type: image
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
+    - id: audio_file_bytes
+      media_type: audio
+      transport: file
+      status: bounded
+      value: 2000000000
+      unit: bytes
+      scope: attachment
+      source: https://ai.google.dev/gemini-api/docs/files
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-fable-5
     provider_model: claude-fable-5
@@ -1061,6 +1679,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 128000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 600
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-sonnet-5
     provider_model: claude-sonnet-5
@@ -1069,6 +1717,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 128000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 600
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-opus-4-8
     provider_model: claude-opus-4-8
@@ -1077,6 +1755,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 128000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 600
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-sonnet-4-6
     provider_model: claude-sonnet-4-6
@@ -1087,6 +1795,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 64000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 600
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-haiku-4-5-20251001
     provider_model: claude-haiku-4-5-20251001
@@ -1095,6 +1833,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 64000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 100
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-haiku-4-5
     provider_model: claude-haiku-4-5
@@ -1103,6 +1871,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 64000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 100
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-sonnet-4-5-20250929
     provider_model: claude-sonnet-4-5-20250929
@@ -1111,6 +1909,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 64000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 100
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-sonnet-4-5
     provider_model: claude-sonnet-4-5
@@ -1119,6 +1947,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 64000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 100
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-opus-4-1-20250805
     provider_model: claude-opus-4-1-20250805
@@ -1127,6 +1985,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 32000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 100
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: anthropic
     model: claude-opus-4-1
     provider_model: claude-opus-4-1
@@ -1135,6 +2023,36 @@ catalog:
     wire_contract: anthropic_messages
     execution_lifecycle: synchronous_completion
     output_token_limit: 32000
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 32000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: bounded
+      value: 100
+      unit: files
+      scope: request
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 10000000
+      unit: bytes
+      scope: attachment_encoded_bytes
+      source: https://platform.claude.com/docs/en/build-with-claude/vision
+      last_verified: "2026-08-11"
   - provider: meta
     model: muse-spark-1.1
     provider_model: muse-spark-1.1
@@ -1165,8 +2083,36 @@ catalog:
     provider_model: grok-4.5
     operations:
     - text
-    wire_contract: openai_chat_completions
+    wire_contract: openai_responses
     execution_lifecycle: synchronous_completion
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://docs.x.ai/developers/model-capabilities/images/understanding
+      last_verified: "2026-08-11"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: unbounded
+      unit: files
+      scope: request
+      source: https://docs.x.ai/developers/model-capabilities/images/understanding
+      last_verified: "2026-08-11"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: bounded
+      value: 20971520
+      unit: bytes
+      scope: attachment
+      source: https://docs.x.ai/developers/model-capabilities/images/understanding
+      last_verified: "2026-08-11"
   - provider: xai
     model: grok-4.20-0309-reasoning
     provider_model: grok-4.20-0309-reasoning

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -38,12 +38,12 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
   hash-bound metadata. `DELETE /model/v1/assets/{asset_id}` marks the asset as
   deleted and removes its stored bytes.
 - `server.max_prompt_bytes` limits compatibility `POST /`. Canonical
-  `POST /v2` bounds the encoded JSON envelope with the configured text
-  allowance plus the largest bounded inline request in the provider catalog.
-  Larger media uses the asset endpoint and an asset reference. The proxy uses
-  the resolved provider offering's media limits and validates asset ownership,
-  state, expiry, MIME type, size, and SHA-256 before it dispatches provider
-  work.
+  `POST /v2` accepts an encoded JSON envelope of 8 MiB or less. A smaller
+  catalog-derived limit applies when its text and inline media limits have a
+  smaller sum. Larger media uses the asset endpoint and an asset reference.
+  The proxy uses the resolved provider offering's media limits. It validates
+  asset ownership, state, expiry, MIME type, size, and SHA-256 before provider
+  dispatch.
 - `messages[].order` is optional. When any submitted message includes `order`, every submitted message must include a unique non-negative integer `order`; the proxy sorts submitted messages by ascending `order` before adding a request or tenant system prompt and before routing upstream.
 - With `messages[]` on `POST /`, body `system_prompt` is prepended as a system message only when the transcript does not already contain a `system` message. A body containing both `system_prompt` and a system message is invalid. With `POST /v2`, callers send system instructions as `system` role messages.
 - `max_tokens` is an optional positive integer on `GET /` query strings and JSON `POST /` bodies. It is the initial per-attempt output budget and is reused for missing-suffix attempts.
@@ -400,9 +400,11 @@ non-user-content inference through the provider's canonical text transport:
 
 - OpenAI Responses uses one synchronous, non-stored `POST /responses` with
   `background: false`, `store: false`, and a 16-token output limit.
-- DeepSeek, DashScope, Moonshot, MiniMax, SiliconFlow, Zhipu, Meta,
-  and Grok use one authenticated OpenAI-compatible `POST /chat/completions`
-  with the provider's declared token-limit parameter.
+- xAI synchronous Responses uses one `POST /responses` at the selected xAI
+  base URL. It sends `store: false` and a 16-token output limit.
+- DeepSeek, DashScope, Moonshot, MiniMax, SiliconFlow, Zhipu, Meta, and xAI
+  Chat Completions models use one authenticated `POST /chat/completions`.
+  The request uses the provider's declared token-limit parameter.
 - Gemini uses one synchronous, non-stored `POST /interactions` request with
   `x-goog-api-key`, `Api-Revision: 2026-05-20`, `background: false`,
   `store: false`, and `generation_config.max_output_tokens: 16`.

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -91,7 +91,7 @@ Extend `llm-proxy` from an OpenAI-only proxy into an explicit multi-provider pro
 | `zhipu` | `glm` | `openai_chat_completions` | `synchronous_completion` | Z.AI GLM-ASR transcription | Not supported |
 | `gemini` | none | `gemini_interactions` | Model-specific: Gemini 3.x `pollable_resource`; Gemini 2.5 `synchronous_completion` | Not supported | Not supported |
 | `anthropic` | `claude` | `anthropic_messages` | `synchronous_completion` | Not supported | Not supported |
-| `xai` | none | `openai_chat_completions` | `synchronous_completion` | xAI STT | Not supported |
+| `xai` | none | Model-specific: `grok-4.5` uses `openai_responses`, and other text models use `openai_chat_completions` | `synchronous_completion` | xAI STT | Not supported |
 
 This matrix describes capabilities wired through `llm-proxy`. Upstream products
 can expose speech APIs that are not yet proxy adapters; do not mark them
@@ -301,6 +301,12 @@ provider file when the interaction ends. The catalog records Google's
 [audio input](https://ai.google.dev/gemini-api/docs/audio), and
 [Files API](https://ai.google.dev/gemini-api/docs/files) guides as the verified
 sources.
+
+OpenAI, Anthropic, and xAI image limits are also part of the validated catalog.
+The OpenAI Responses adapter sends image Data URLs with `detail: auto`.
+The Anthropic Messages adapter sends base64 image blocks before the message text.
+The xAI `grok-4.5` adapter sends image Data URLs with `detail: high` and `store: false`.
+Each adapter applies its provider offering limits before provider dispatch.
 
 OpenAI background Responses are stored upstream. llm-proxy keeps their ids only
 in memory for the active request and never returns or persists them, but the
@@ -538,6 +544,16 @@ port unless `LLM_PROXY_LIVE_PORT` explicitly provides one, and cleanup
 terminates only the proxy child started by the harness rather than a process
 discovered through a shared port.
 
+The explicit `--media` mode selects OpenAI, Anthropic, Gemini, and xAI by
+default. It verifies all four provider keys before it sends image requests.
+Each case selects its exact image model from the validated public provider
+catalog. It uses the verified model when that route supports image input.
+Otherwise, it requires one exact provider image route. Key verification uses
+the selected image model. Each request sends the same deterministic inline PNG
+through canonical `POST /v2`. The case requires HTTP `200`, the exact response
+marker, and one valid proxy request identifier. The paid media mode remains
+outside `make ci`.
+
 `make live-test` is deliberately a different boundary: it calls only the
 production API origin with `LLM_PROXY_SECRET`, the Default tenant client
 secret. It never loads a dotenv file or local provider credential. The command
@@ -666,7 +682,8 @@ that response or structured provider-failure logs.
 - OpenAI keeps the existing Responses API adapter and derives Responses and Models URLs from `providers.openai.base_url`; audio transcription uses `providers.openai.transcriptions_url`. The adapter polls documented pending states, normalizes only `incomplete/max_output_tokens` for shared continuation, and rejects failed, cancelled, other incomplete, missing, or unknown states.
 - Non-OpenAI compatible text providers use a shared Chat Completions adapter. It normalizes `finish_reason=length` for shared continuation and requires `finish_reason=stop` to complete content or reasoning text.
 - Meta uses the shared OpenAI-compatible Chat Completions adapter against `providers.meta.base_url`; its proxy contract is text-only and has no Responses fallback.
-- Anthropic uses a native Messages adapter, translating proxy `system` messages to the top-level Anthropic `system` parameter and `user`/`assistant` messages to Anthropic `messages[]`; `max_tokens` continues through the shared coordinator, while `end_turn` and `stop_sequence` are complete text stops.
+- Anthropic uses a native Messages adapter. It maps `system` messages to the top-level `system` parameter. It maps other messages to `messages[]`.
+- Anthropic sends declared image inputs as ordered base64 content blocks. `max_tokens` continues through the shared coordinator.
 - Gemini uses a native Interactions adapter against
   `providers.gemini.base_url`; `incomplete` continues through the shared
   coordinator as a new interaction, while `completed` with visible model text
@@ -675,13 +692,13 @@ that response or structured provider-failure logs.
   capability, ordered image and audio attachments become typed interaction
   content after the message text. The adapter selects inline `data` or Files
   API `uri` content from the exact provider offering limits.
-- xAI uses the shared OpenAI-compatible Chat Completions adapter against `providers.xai.base_url`.
+- xAI uses the shared Chat Completions adapter for text-only models. The `grok-4.5` image route uses synchronous Responses.
 - OpenAI-compatible chat providers receive validated and sorted `messages[]` as provider-supported `role` and `content` items.
 - OpenAI Responses payload shape comes from the selected configured model's stable `request_profile`; model-specific web-search support comes from the selected model catalog entry. OpenAI Responses text calls run in background mode with stored responses so long provider work can be polled by llm-proxy while the caller waits on one REST request.
 - Gemini receives user messages as `user_input` steps, assistant messages as
-  `model_output` steps, and system messages as `system_instruction`. Other
-  adapters remain text-only and reject model media declarations at startup.
-- OpenAI Responses receives single-prompt requests unchanged and multi-message requests as a deterministic role-labelled transcript.
+  `model_output` steps, and system messages as `system_instruction`.
+- OpenAI-compatible Chat Completions adapters remain text-only and reject media declarations at startup.
+- OpenAI Responses receives text-only single prompts unchanged. Requests with images use role-preserving typed content blocks.
 - Dictation routing reuses the multipart transcription adapter with provider-specific URLs. OpenAI, SiliconFlow, and Zhipu send a multipart `model` field. xAI STT omits the multipart `model` field. Only providers that support `/dictate` expose transcription URL config fields.
 - Response formatting keeps existing text/XML/CSV bodies and existing JSON `request`, `response`, and normalized `usage` fields. JSON responses also include OpenRouter-style `object`, `model`, and `choices[].message.content` metadata, plus caller-visible request `messages` with provided `order` values. Server-injected tenant default system prompts are sent upstream but not echoed in response metadata.
 
@@ -698,8 +715,9 @@ Black-box router tests cover:
 - Every configured provider through its public text route, proving the same
   shared continuation transcript, completion order, suffix assembly, and usage
   aggregation for Chat Completions, Gemini, Anthropic, and OpenAI.
-- Ordered images and audio through canonical `POST /v2` and Gemini native
-  inline `data` or Files API `uri`, with no media echo in response metadata.
+- Ordered images through OpenAI Responses, Anthropic Messages, xAI Responses,
+  and Gemini Interactions through canonical `POST /v2`.
+- Ordered Gemini audio through inline `data` or Files API `uri`, with no media echo in response metadata.
 - Inline and asset-backed media admission, exact-limit and one-unit-above
   provider boundaries, tenant isolation, asset expiry and deletion, and
   provider file cleanup.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -118,7 +118,9 @@ paths:
         the tenant or route default. A supplied value must be non-blank and
         supported by the resolved route. The selected provider offering owns
         media admission and transport limits. Unsupported media or route
-        capabilities return HTTP 400 before an upstream call.
+        capabilities return HTTP 400 before an upstream call. The service
+        rejects an encoded request body above 8 MiB before JSON decoding. A
+        smaller catalog-derived body limit applies when configured.
       tags:
         - Proxy
       security:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1648,6 +1648,7 @@ components:
           type: string
           enum:
             - attachment
+            - attachment_encoded_bytes
             - request
             - request_encoded_bytes
         source:

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,7 +36,19 @@ type anthropicMessagesRequest struct {
 
 type anthropicMessage struct {
 	Role    string `json:"role"`
-	Content string `json:"content"`
+	Content any    `json:"content"`
+}
+
+type anthropicInputContentBlock struct {
+	Type   string                `json:"type"`
+	Text   string                `json:"text,omitempty"`
+	Source *anthropicImageSource `json:"source,omitempty"`
+}
+
+type anthropicImageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
 }
 
 type anthropicMessagesResponse struct {
@@ -56,7 +69,10 @@ func newAnthropicMessagesClient(httpClient HTTPDoer) *anthropicMessagesClient {
 }
 
 func (client *anthropicMessagesClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier textModelDefinition, messages chatMessages, maxTokens *int, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
-	providerMessages, systemPrompt := messages.anthropicMessages()
+	providerMessages, systemPrompt, messagesError := messages.anthropicMessages()
+	if messagesError != nil {
+		return textGenerationResult{}, messagesError
+	}
 	payload := anthropicMessagesRequest{
 		Model:     modelIdentifier.providerString(),
 		MaxTokens: anthropicMaxTokens(modelIdentifier, maxTokens),
@@ -64,6 +80,9 @@ func (client *anthropicMessagesClient) generateText(parentContext context.Contex
 		Messages:  providerMessages,
 	}
 	payloadBytes, _ := json.Marshal(payload)
+	if mediaLimitError := validateInlineMessageMediaLimits(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
+		return textGenerationResult{}, mediaLimitError
+	}
 
 	requestURL := strings.TrimRight(baseURL, "/") + "/v1/messages"
 	httpRequest, buildError := http.NewRequestWithContext(parentContext, http.MethodPost, requestURL, bytes.NewReader(payloadBytes))
@@ -86,17 +105,39 @@ func (client *anthropicMessagesClient) generateText(parentContext context.Contex
 	return generation, nil
 }
 
-func (messages chatMessages) anthropicMessages() ([]anthropicMessage, string) {
+func (messages chatMessages) anthropicMessages() ([]anthropicMessage, string, error) {
 	providerMessages := make([]anthropicMessage, 0, len(messages))
 	systemPrompts := []string{}
-	for _, message := range messages {
+	for messageIndex := range messages {
+		message := &messages[messageIndex]
 		if message.role == chatRoleSystem {
 			systemPrompts = append(systemPrompts, message.content)
 			continue
 		}
-		providerMessages = append(providerMessages, anthropicMessage{Role: string(message.role), Content: message.content})
+		if len(message.attachments) == 0 {
+			providerMessages = append(providerMessages, anthropicMessage{Role: string(message.role), Content: message.content})
+			continue
+		}
+		content := make([]anthropicInputContentBlock, 0, len(message.attachments)+1)
+		for attachmentIndex := range message.attachments {
+			attachment := &message.attachments[attachmentIndex]
+			data, dataError := attachment.bytes()
+			if dataError != nil {
+				return nil, constants.EmptyString, dataError
+			}
+			content = append(content, anthropicInputContentBlock{
+				Type: "image",
+				Source: &anthropicImageSource{
+					Type:      "base64",
+					MediaType: attachment.mimeType,
+					Data:      base64.StdEncoding.EncodeToString(data),
+				},
+			})
+		}
+		content = append(content, anthropicInputContentBlock{Type: "text", Text: message.content})
+		providerMessages = append(providerMessages, anthropicMessage{Role: string(message.role), Content: content})
 	}
-	return providerMessages, strings.Join(systemPrompts, "\n\n")
+	return providerMessages, strings.Join(systemPrompts, "\n\n"), nil
 }
 
 func anthropicMaxTokens(modelIdentifier textModelDefinition, maxTokens *int) int {

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -69,6 +69,9 @@ func newAnthropicMessagesClient(httpClient HTTPDoer) *anthropicMessagesClient {
 }
 
 func (client *anthropicMessagesClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier textModelDefinition, messages chatMessages, maxTokens *int, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	if mediaLimitError := validateInlineMessageMediaBeforeSerialization(modelIdentifier, messages); mediaLimitError != nil {
+		return textGenerationResult{}, mediaLimitError
+	}
 	providerMessages, systemPrompt, messagesError := messages.anthropicMessages()
 	if messagesError != nil {
 		return textGenerationResult{}, messagesError
@@ -80,7 +83,7 @@ func (client *anthropicMessagesClient) generateText(parentContext context.Contex
 		Messages:  providerMessages,
 	}
 	payloadBytes, _ := json.Marshal(payload)
-	if mediaLimitError := validateInlineMessageMediaLimits(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
+	if mediaLimitError := validateInlineMessageMediaRequestLimit(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
 		return textGenerationResult{}, mediaLimitError
 	}
 

--- a/internal/proxy/chat_messages.go
+++ b/internal/proxy/chat_messages.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -235,7 +236,7 @@ func newChatRole(rawRole string) (chatRole, error) {
 	}
 }
 
-func (messages chatMessages) openAIResponsesInput() string {
+func (messages chatMessages) openAIResponsesTextInput() string {
 	if len(messages) == 1 && messages[0].role == chatRoleUser {
 		return messages[0].content
 	}
@@ -254,8 +255,38 @@ func (messages chatMessages) openAIResponsesInput() string {
 	return transcriptBuilder.String()
 }
 
+func (messages chatMessages) openAIResponsesInput(imageDetail string, preserveRoles bool) (any, error) {
+	if messages.mediaCount() == 0 && !preserveRoles {
+		return messages.openAIResponsesTextInput(), nil
+	}
+	providerMessages := make([]map[string]any, 0, len(messages))
+	for messageIndex := range messages {
+		message := &messages[messageIndex]
+		if len(message.attachments) == 0 {
+			providerMessages = append(providerMessages, map[string]any{"role": string(message.role), "content": message.content})
+			continue
+		}
+		content := make([]map[string]any, 0, len(message.attachments)+1)
+		for attachmentIndex := range message.attachments {
+			attachment := &message.attachments[attachmentIndex]
+			data, dataError := attachment.bytes()
+			if dataError != nil {
+				return nil, dataError
+			}
+			content = append(content, map[string]any{
+				"type":      "input_image",
+				"image_url": "data:" + attachment.mimeType + ";base64," + base64.StdEncoding.EncodeToString(data),
+				"detail":    imageDetail,
+			})
+		}
+		content = append(content, map[string]any{"type": "input_text", "text": message.content})
+		providerMessages = append(providerMessages, map[string]any{"role": string(message.role), "content": content})
+	}
+	return providerMessages, nil
+}
+
 func (messages chatMessages) requestDisplayText() string {
-	return messages.responseVisibleMessages().openAIResponsesInput()
+	return messages.responseVisibleMessages().openAIResponsesTextInput()
 }
 
 func (messages chatMessages) responseRequestMessages() []map[string]any {

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -32,6 +32,8 @@ const (
 	DefaultMaxRequestTimeoutSeconds = 60 * 60
 	// DefaultMaxPromptBytes limits JSON LLM request bodies accepted by POST /.
 	DefaultMaxPromptBytes = 4 * 1024 * 1024
+	// MaxV2RequestBytes limits each buffered canonical message request.
+	MaxV2RequestBytes = 8 * 1024 * 1024
 	// DefaultMaxAssetBytes bounds one tenant asset upload at the largest supported provider file size.
 	DefaultMaxAssetBytes int64 = 2_000_000_000
 	// DefaultAssetRetentionSeconds keeps uploaded tenant assets for 48 hours.

--- a/internal/proxy/management_provider_key_verification_test.go
+++ b/internal/proxy/management_provider_key_verification_test.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	verificationTransportOpenAI    = "openai"
+	verificationTransportResponses = "responses"
 	verificationTransportChat      = "chat"
 	verificationTransportGemini    = "gemini"
 	verificationTransportAnthropic = "anthropic"
@@ -72,6 +73,7 @@ func TestManagementProviderKeyVerificationUsesEveryCanonicalTransportBeforePersi
 		{provider: proxy.ProviderNameAnthropic, model: proxy.ModelNameClaudeSonnet46, transport: verificationTransportAnthropic},
 		{provider: proxy.ProviderNameMeta, model: proxy.ModelNameMuseSpark11, transport: verificationTransportChat, tokenLimitField: "max_completion_tokens"},
 		{provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok43, transport: verificationTransportChat, tokenLimitField: "max_tokens"},
+		{provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok45, transport: verificationTransportResponses},
 	}
 
 	for _, transportCase := range transportCases {
@@ -150,6 +152,53 @@ func TestManagementProviderKeyVerificationUsesEveryCanonicalTransportBeforePersi
 				subTest.Fatalf("verification usage requests=%d want=0", usage.Totals.Requests)
 			}
 		})
+	}
+}
+
+func TestManagementXAIResponsesVerificationUsesTheXAIEndpoint(t *testing.T) {
+	openAIRequests := atomic.Int32{}
+	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		openAIRequests.Add(1)
+		http.Error(responseWriter, "unexpected OpenAI request", http.StatusBadGateway)
+	}))
+	t.Cleanup(openAIServer.Close)
+
+	xAIRequests := atomic.Int32{}
+	xAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		xAIRequests.Add(1)
+		assertProviderKeyVerificationRequest(t, request, providerKeyVerificationTransportCase{
+			provider:  proxy.ProviderNameXAI,
+			model:     proxy.ModelNameGrok45,
+			transport: verificationTransportResponses,
+		}, "candidate-xai-responses")
+		writeProviderKeyVerificationSuccess(responseWriter, verificationTransportResponses)
+	}))
+	t.Cleanup(xAIServer.Close)
+
+	configuration := providerKeyVerificationConfiguration(openAIServer.URL)
+	configuration.XAIBaseURL = xAIServer.URL
+	router := newOperationalProviderKeyVerificationRouter(
+		t,
+		configuration,
+		zap.NewNop().Sugar(),
+		t.TempDir()+"/managed-tenants.db",
+		TestTimeout,
+	)
+	sessionCookie := managementSessionCookie(t, "xai-responses-verification")
+	tenantID := managementDefaultTenantTestID(t, router, sessionCookie)
+	response := putManagementProviderKey(
+		t,
+		router,
+		sessionCookie,
+		tenantID,
+		proxy.ProviderNameXAI,
+		"candidate-xai-responses",
+		proxy.ModelNameGrok45,
+		"",
+		context.Background(),
+	)
+	if response.Code != http.StatusOK || xAIRequests.Load() != 1 || openAIRequests.Load() != 0 {
+		t.Fatalf("status=%d xai=%d openai=%d body=%q", response.Code, xAIRequests.Load(), openAIRequests.Load(), response.Body.String())
 	}
 }
 
@@ -720,6 +769,17 @@ func assertProviderKeyVerificationRequest(t *testing.T, request *http.Request, t
 			payload["max_output_tokens"] != float64(16) {
 			t.Errorf("OpenAI verification path=%q headers=%v payload=%v", request.URL.Path, request.Header, payload)
 		}
+	case verificationTransportResponses:
+		if request.URL.Path != "/responses" ||
+			request.Header.Get("Authorization") != "Bearer "+candidateKey ||
+			payload["model"] != expectedProviderModel ||
+			payload["store"] != false ||
+			payload["max_output_tokens"] != float64(16) {
+			t.Errorf("synchronous Responses verification path=%q headers=%v payload=%v", request.URL.Path, request.Header, payload)
+		}
+		if _, hasBackground := payload["background"]; hasBackground {
+			t.Errorf("synchronous Responses verification includes background: %v", payload)
+		}
 	case verificationTransportChat:
 		expectedPath := "/chat/completions"
 		if transportCase.provider == proxy.ProviderNameDashScope {
@@ -759,7 +819,7 @@ func writeProviderKeyVerificationSuccess(responseWriter http.ResponseWriter, tra
 	responseWriter.Header().Set("Content-Type", "application/json")
 	responseBody := `{"choices":[{}]}`
 	switch transport {
-	case verificationTransportOpenAI:
+	case verificationTransportOpenAI, verificationTransportResponses:
 		responseBody = `{"id":"verification-response","status":"queued"}`
 	case verificationTransportGemini:
 		responseBody = `{"status":"incomplete"}`

--- a/internal/proxy/media_assets_edges_internal_test.go
+++ b/internal/proxy/media_assets_edges_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"math"
@@ -714,7 +715,7 @@ func TestTenantAssetDeletionAndHTTPErrorContracts(t *testing.T) {
 func TestMediaLimitAndMessageMediaEdgeContracts(t *testing.T) {
 	maximumValue := int64(math.MaxInt64)
 	overflowCatalog := ModelCatalog{Offerings: []ProviderOffering{{MediaLimits: []CatalogMediaLimit{{ID: CatalogMediaLimitIDInlineRequestBytes, Status: CatalogMediaLimitStatusBounded, Value: &maximumValue}}}}}
-	if maximumV2RequestBytes(1, overflowCatalog) != math.MaxInt64 || maximumV2RequestBytes(7, ModelCatalog{}) != 7 {
+	if maximumV2RequestBytes(1, overflowCatalog) != MaxV2RequestBytes || maximumV2RequestBytes(7, ModelCatalog{}) != 7 {
 		t.Fatal("v2 request bound mismatch")
 	}
 	if _, configError := validateConfig(Configuration{AssetStorePath: "relative"}); configError == nil {
@@ -724,7 +725,7 @@ func TestMediaLimitAndMessageMediaEdgeContracts(t *testing.T) {
 	validSource := "https://example.com/limits"
 	validDate := "2026-08-11"
 	base := CatalogMediaLimit{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Transport: CatalogMediaTransportInline, Status: CatalogMediaLimitStatusBounded, Value: &value, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeRequestEncodedBytes, Source: validSource, LastVerified: validDate}
-	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base}, nil, "limits"); validationError == nil {
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base}, nil, openAIResponsesPollableRouteCapabilities, "limits"); validationError == nil {
 		t.Fatal("expected limits without inputs rejection")
 	}
 	invalidLimits := []CatalogMediaLimit{
@@ -744,24 +745,31 @@ func TestMediaLimitAndMessageMediaEdgeContracts(t *testing.T) {
 		if limitIndex == 1 {
 			limits = []CatalogMediaLimit{base, base}
 		}
-		if validationError := validateCatalogMediaLimits(limits, []string{"image"}, "limits"); validationError == nil {
+		if validationError := validateCatalogMediaLimits(limits, []string{"image"}, openAIResponsesPollableRouteCapabilities, "limits"); validationError == nil {
 			t.Fatalf("invalid limit index=%d accepted", limitIndex)
 		}
 	}
-	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base}, []string{"image"}, "limits"); validationError == nil {
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base}, []string{"image"}, openAIResponsesPollableRouteCapabilities, "limits"); validationError == nil {
 		t.Fatal("expected missing required limit rejection")
 	}
 	inlineLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageInlineBytes, MediaType: "image", Transport: CatalogMediaTransportInline, Status: CatalogMediaLimitStatusUnknown, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment, Source: validSource, LastVerified: validDate}
 	wrongCountScope := CatalogMediaLimit{ID: CatalogMediaLimitIDImageCount, MediaType: "image", Transport: CatalogMediaTransportAny, Status: CatalogMediaLimitStatusUnbounded, Unit: CatalogMediaLimitUnitFiles, Scope: CatalogMediaLimitScopeAttachment, Source: validSource, LastVerified: validDate}
-	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base, inlineLimit, wrongCountScope}, []string{"image"}, "limits"); validationError == nil {
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base, inlineLimit, wrongCountScope}, []string{"image"}, openAIResponsesPollableRouteCapabilities, "limits"); validationError == nil {
 		t.Fatal("expected mismatched required limit rejection")
 	}
 	wrongInlineScope := inlineLimit
 	wrongInlineScope.Scope = CatalogMediaLimitScopeRequest
 	validCount := wrongCountScope
 	validCount.Scope = CatalogMediaLimitScopeRequest
-	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base, wrongInlineScope, validCount}, []string{"image"}, "limits"); validationError == nil {
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base, wrongInlineScope, validCount}, []string{"image"}, openAIResponsesPollableRouteCapabilities, "limits"); validationError == nil {
 		t.Fatal("expected request-scoped inline attachment limit rejection")
+	}
+	fileLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageFileBytes, MediaType: "image", Transport: CatalogMediaTransportFile, Status: CatalogMediaLimitStatusBounded, Value: &value, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment, Source: validSource, LastVerified: validDate}
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base, fileLimit, validCount}, []string{"image"}, openAIResponsesPollableRouteCapabilities, "limits"); validationError == nil {
+		t.Fatal("expected inline adapter file-only limit rejection")
+	}
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base, inlineLimit, validCount}, []string{"image"}, geminiInteractionsSynchronousRouteCapabilities, "limits"); validationError == nil {
+		t.Fatal("expected Gemini missing file limit rejection")
 	}
 
 	assetID := " ast_0123456789abcdef0123456789abcdef"
@@ -788,5 +796,64 @@ func TestMediaLimitAndMessageMediaEdgeContracts(t *testing.T) {
 	media = messageMedia{asset: &tenantAssetReader{file: shortFile}, sizeBytes: 1}
 	if _, bytesError := media.bytes(); bytesError == nil {
 		t.Fatal("expected short asset byte rejection")
+	}
+}
+
+func TestV2RouteMIMERejectionClosesTheResolvedAsset(t *testing.T) {
+	tenantIdentifier, tenantError := newTenantID("media-owner")
+	if tenantError != nil {
+		t.Fatalf("tenant identifier: %v", tenantError)
+	}
+	requestTenant := tenant{identifier: tenantIdentifier}
+	assetStore := newTenantAssetStore(t.TempDir(), 1024, 60)
+	mediaBytes := []byte("webp-asset")
+	digest := sha256.Sum256(mediaBytes)
+	assetMetadata, uploadError := assetStore.upload(requestTenant, messageImageMIMEWebP, hex.EncodeToString(digest[:]), bytes.NewReader(mediaBytes))
+	if uploadError != nil {
+		t.Fatalf("upload asset: %v", uploadError)
+	}
+
+	previousAssetOpen := assetOpen
+	var openedAsset *os.File
+	assetOpen = func(path string) (*os.File, error) {
+		file, openError := previousAssetOpen(path)
+		openedAsset = file
+		return file, openError
+	}
+	t.Cleanup(func() { assetOpen = previousAssetOpen })
+
+	offering := ProviderOffering{
+		Provider: ProviderNameXAI, Model: ModelNameGrok45, ProviderModel: ModelNameGrok45,
+		Operations: []string{ModelOperationText}, DefaultOperations: []string{ModelOperationText},
+		WireContract: string(textWireContractOpenAIResponses), ExecutionLifecycle: string(textExecutionLifecycleSynchronousCompletion),
+		MediaInputs: []string{string(messageMediaTypeImage)},
+	}
+	providers := newProviderRegistry(Configuration{
+		XAIKey: "xai-key", XAIBaseURL: "https://provider.test",
+		ModelCatalog: ModelCatalog{Offerings: []ProviderOffering{offering}},
+	})
+	validator := newModelValidator(providers)
+	attachmentBytes, _ := json.Marshal([]chatMessageAttachmentPayload{{
+		Type: string(messageMediaTypeImage), MIMEType: messageImageMIMEWebP,
+		AssetID: &assetMetadata.AssetID, SHA256: assetMetadata.SHA256,
+	}})
+	messages := []chatV2MessagePayload{{Role: string(chatRoleUser), Content: "inspect", Attachments: attachmentBytes}}
+	payload := chatV2RequestPayload{Messages: &messages, Model: ModelNameGrok45}
+	response := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(response)
+	ginContext.Request = httptest.NewRequest(http.MethodPost, "/v2?provider="+ProviderNameXAI, nil)
+	_, accepted := chatRequestFromV2Payload(
+		ginContext,
+		payload,
+		textRequestDefaults{provider: ProviderNameXAI, model: ModelNameGrok45},
+		validator,
+		requestTenant,
+		assetStore,
+	)
+	if accepted || response.Code != http.StatusBadRequest || openedAsset == nil {
+		t.Fatalf("accepted=%v status=%d opened=%v body=%q", accepted, response.Code, openedAsset != nil, response.Body.String())
+	}
+	if _, statError := openedAsset.Stat(); statError == nil {
+		t.Fatal("route MIME rejection left the asset reader open")
 	}
 }

--- a/internal/proxy/media_assets_edges_internal_test.go
+++ b/internal/proxy/media_assets_edges_internal_test.go
@@ -751,6 +751,18 @@ func TestMediaLimitAndMessageMediaEdgeContracts(t *testing.T) {
 	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base}, []string{"image"}, "limits"); validationError == nil {
 		t.Fatal("expected missing required limit rejection")
 	}
+	inlineLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageInlineBytes, MediaType: "image", Transport: CatalogMediaTransportInline, Status: CatalogMediaLimitStatusUnknown, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment, Source: validSource, LastVerified: validDate}
+	wrongCountScope := CatalogMediaLimit{ID: CatalogMediaLimitIDImageCount, MediaType: "image", Transport: CatalogMediaTransportAny, Status: CatalogMediaLimitStatusUnbounded, Unit: CatalogMediaLimitUnitFiles, Scope: CatalogMediaLimitScopeAttachment, Source: validSource, LastVerified: validDate}
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base, inlineLimit, wrongCountScope}, []string{"image"}, "limits"); validationError == nil {
+		t.Fatal("expected mismatched required limit rejection")
+	}
+	wrongInlineScope := inlineLimit
+	wrongInlineScope.Scope = CatalogMediaLimitScopeRequest
+	validCount := wrongCountScope
+	validCount.Scope = CatalogMediaLimitScopeRequest
+	if validationError := validateCatalogMediaLimits([]CatalogMediaLimit{base, wrongInlineScope, validCount}, []string{"image"}, "limits"); validationError == nil {
+		t.Fatal("expected request-scoped inline attachment limit rejection")
+	}
 
 	assetID := " ast_0123456789abcdef0123456789abcdef"
 	if _, mediaError := newMessageMedia(chatMessageAttachmentPayload{Type: "image", MIMEType: "image/png", AssetID: &assetID, SHA256: strings.Repeat("0", 64)}, tenant{}, newTenantAssetStore(t.TempDir(), 10, 60)); mediaError == nil {

--- a/internal/proxy/media_assets_routing_test.go
+++ b/internal/proxy/media_assets_routing_test.go
@@ -100,6 +100,14 @@ func TestV2RejectsJSONAboveCatalogDerivedIngressBound(t *testing.T) {
 	}
 }
 
+func TestV2RejectsJSONAboveTheBufferedServiceLimit(t *testing.T) {
+	router := mediaAssetRouter(t, "https://provider.invalid", t.TempDir(), testfixtures.ModelCatalog(t), 60)
+	response := postV2MediaRequest(t, router, "secret-a", bytes.Repeat([]byte("x"), proxy.MaxV2RequestBytes+1))
+	if response.Code != http.StatusRequestEntityTooLarge || !strings.Contains(response.Body.String(), "prompt payload too large") {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
 func TestGeminiImageCountLimitAdmitsBoundaryAndRejectsOneAbove(t *testing.T) {
 	upstreamCalls := 0
 	upstream := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {

--- a/internal/proxy/media_limits.go
+++ b/internal/proxy/media_limits.go
@@ -20,15 +20,18 @@ const (
 	CatalogMediaLimitUnitBytes = "bytes"
 	CatalogMediaLimitUnitFiles = "files"
 
-	CatalogMediaLimitScopeAttachment          = "attachment"
-	CatalogMediaLimitScopeRequest             = "request"
-	CatalogMediaLimitScopeRequestEncodedBytes = "request_encoded_bytes"
+	CatalogMediaLimitScopeAttachment             = "attachment"
+	CatalogMediaLimitScopeAttachmentEncodedBytes = "attachment_encoded_bytes"
+	CatalogMediaLimitScopeRequest                = "request"
+	CatalogMediaLimitScopeRequestEncodedBytes    = "request_encoded_bytes"
 
 	CatalogMediaLimitTypeAll = "all"
 
 	CatalogMediaLimitIDInlineRequestBytes = "inline_request_bytes"
 	CatalogMediaLimitIDImageCount         = "image_count"
 	CatalogMediaLimitIDAudioCount         = "audio_count"
+	CatalogMediaLimitIDImageInlineBytes   = "image_inline_bytes"
+	CatalogMediaLimitIDAudioInlineBytes   = "audio_inline_bytes"
 	CatalogMediaLimitIDImageFileBytes     = "image_file_bytes"
 	CatalogMediaLimitIDAudioFileBytes     = "audio_file_bytes"
 )
@@ -93,7 +96,7 @@ func validateCatalogMediaLimits(limits []CatalogMediaLimit, mediaInputs []string
 		if limit.Unit != CatalogMediaLimitUnitBytes && limit.Unit != CatalogMediaLimitUnitFiles {
 			return fmt.Errorf("%w: field=%s.unit unit=%s", ErrInvalidModelCatalog, limitField, limit.Unit)
 		}
-		if limit.Scope != CatalogMediaLimitScopeAttachment && limit.Scope != CatalogMediaLimitScopeRequest && limit.Scope != CatalogMediaLimitScopeRequestEncodedBytes {
+		if limit.Scope != CatalogMediaLimitScopeAttachment && limit.Scope != CatalogMediaLimitScopeAttachmentEncodedBytes && limit.Scope != CatalogMediaLimitScopeRequest && limit.Scope != CatalogMediaLimitScopeRequestEncodedBytes {
 			return fmt.Errorf("%w: field=%s.scope scope=%s", ErrInvalidModelCatalog, limitField, limit.Scope)
 		}
 		switch limit.Status {
@@ -120,26 +123,41 @@ func validateCatalogMediaLimits(limits []CatalogMediaLimit, mediaInputs []string
 		{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Transport: CatalogMediaTransportInline, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeRequestEncodedBytes},
 	}
 	for _, mediaInput := range mediaInputs {
+		var inlineLimit CatalogMediaLimit
+		var fileLimit CatalogMediaLimit
 		switch messageMediaType(mediaInput) {
 		case messageMediaTypeImage:
 			requiredLimits = append(requiredLimits,
 				CatalogMediaLimit{ID: CatalogMediaLimitIDImageCount, MediaType: mediaInput, Transport: CatalogMediaTransportAny, Unit: CatalogMediaLimitUnitFiles, Scope: CatalogMediaLimitScopeRequest},
-				CatalogMediaLimit{ID: CatalogMediaLimitIDImageFileBytes, MediaType: mediaInput, Transport: CatalogMediaTransportFile, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment},
 			)
+			inlineLimit = CatalogMediaLimit{ID: CatalogMediaLimitIDImageInlineBytes, MediaType: mediaInput, Transport: CatalogMediaTransportInline, Unit: CatalogMediaLimitUnitBytes}
+			fileLimit = CatalogMediaLimit{ID: CatalogMediaLimitIDImageFileBytes, MediaType: mediaInput, Transport: CatalogMediaTransportFile, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment}
 		case messageMediaTypeAudio:
 			requiredLimits = append(requiredLimits,
 				CatalogMediaLimit{ID: CatalogMediaLimitIDAudioCount, MediaType: mediaInput, Transport: CatalogMediaTransportAny, Unit: CatalogMediaLimitUnitFiles, Scope: CatalogMediaLimitScopeRequest},
-				CatalogMediaLimit{ID: CatalogMediaLimitIDAudioFileBytes, MediaType: mediaInput, Transport: CatalogMediaTransportFile, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment},
 			)
+			inlineLimit = CatalogMediaLimit{ID: CatalogMediaLimitIDAudioInlineBytes, MediaType: mediaInput, Transport: CatalogMediaTransportInline, Unit: CatalogMediaLimitUnitBytes}
+			fileLimit = CatalogMediaLimit{ID: CatalogMediaLimitIDAudioFileBytes, MediaType: mediaInput, Transport: CatalogMediaTransportFile, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment}
+		}
+		if !matchesCatalogInlineAttachmentLimit(configured[inlineLimit.ID], inlineLimit) && !matchesCatalogMediaLimit(configured[fileLimit.ID], fileLimit) {
+			return fmt.Errorf("%w: field=%s required_media_transport_limit=%s|%s", ErrInvalidModelCatalog, field, inlineLimit.ID, fileLimit.ID)
 		}
 	}
 	for _, requiredLimit := range requiredLimits {
 		limit, exists := configured[requiredLimit.ID]
-		if !exists || limit.MediaType != requiredLimit.MediaType || limit.Transport != requiredLimit.Transport || limit.Unit != requiredLimit.Unit || limit.Scope != requiredLimit.Scope {
+		if !exists || !matchesCatalogMediaLimit(limit, requiredLimit) {
 			return fmt.Errorf("%w: field=%s required_limit=%s", ErrInvalidModelCatalog, field, requiredLimit.ID)
 		}
 	}
 	return nil
+}
+
+func matchesCatalogMediaLimit(configured CatalogMediaLimit, required CatalogMediaLimit) bool {
+	return configured.ID == required.ID && configured.MediaType == required.MediaType && configured.Transport == required.Transport && configured.Unit == required.Unit && (required.Scope == "" || configured.Scope == required.Scope)
+}
+
+func matchesCatalogInlineAttachmentLimit(configured CatalogMediaLimit, required CatalogMediaLimit) bool {
+	return matchesCatalogMediaLimit(configured, required) && (configured.Scope == CatalogMediaLimitScopeAttachment || configured.Scope == CatalogMediaLimitScopeAttachmentEncodedBytes)
 }
 
 func boundedCatalogMediaLimit(limits []CatalogMediaLimit, identifier string, mediaType messageMediaType) (int64, bool) {

--- a/internal/proxy/media_limits.go
+++ b/internal/proxy/media_limits.go
@@ -61,7 +61,7 @@ func cloneCatalogMediaLimits(limits []CatalogMediaLimit) []CatalogMediaLimit {
 	return cloned
 }
 
-func validateCatalogMediaLimits(limits []CatalogMediaLimit, mediaInputs []string, field string) error {
+func validateCatalogMediaLimits(limits []CatalogMediaLimit, mediaInputs []string, routeCapabilities textRouteCapabilities, field string) error {
 	if len(mediaInputs) == 0 {
 		if len(limits) != 0 {
 			return fmt.Errorf("%w: field=%s reason=media_limits_without_media_inputs", ErrInvalidModelCatalog, field)
@@ -139,8 +139,15 @@ func validateCatalogMediaLimits(limits []CatalogMediaLimit, mediaInputs []string
 			inlineLimit = CatalogMediaLimit{ID: CatalogMediaLimitIDAudioInlineBytes, MediaType: mediaInput, Transport: CatalogMediaTransportInline, Unit: CatalogMediaLimitUnitBytes}
 			fileLimit = CatalogMediaLimit{ID: CatalogMediaLimitIDAudioFileBytes, MediaType: mediaInput, Transport: CatalogMediaTransportFile, Unit: CatalogMediaLimitUnitBytes, Scope: CatalogMediaLimitScopeAttachment}
 		}
-		if !matchesCatalogInlineAttachmentLimit(configured[inlineLimit.ID], inlineLimit) && !matchesCatalogMediaLimit(configured[fileLimit.ID], fileLimit) {
-			return fmt.Errorf("%w: field=%s required_media_transport_limit=%s|%s", ErrInvalidModelCatalog, field, inlineLimit.ID, fileLimit.ID)
+		switch textRouteMessageMediaLimitTransport(routeCapabilities) {
+		case CatalogMediaTransportInline:
+			if !matchesCatalogInlineAttachmentLimit(configured[inlineLimit.ID], inlineLimit) {
+				return fmt.Errorf("%w: field=%s required_media_transport_limit=%s", ErrInvalidModelCatalog, field, inlineLimit.ID)
+			}
+		case CatalogMediaTransportFile:
+			if !matchesCatalogMediaLimit(configured[fileLimit.ID], fileLimit) {
+				return fmt.Errorf("%w: field=%s required_media_transport_limit=%s", ErrInvalidModelCatalog, field, fileLimit.ID)
+			}
 		}
 	}
 	for _, requiredLimit := range requiredLimits {
@@ -188,7 +195,11 @@ func maximumV2RequestBytes(maxPromptBytes int64, catalog ModelCatalog) int64 {
 		}
 	}
 	if maximumInlineBytes > math.MaxInt64-maxPromptBytes {
-		return math.MaxInt64
+		return MaxV2RequestBytes
 	}
-	return maxPromptBytes + maximumInlineBytes
+	derivedLimit := maxPromptBytes + maximumInlineBytes
+	if derivedLimit > MaxV2RequestBytes {
+		return MaxV2RequestBytes
+	}
+	return derivedLimit
 }

--- a/internal/proxy/message_media.go
+++ b/internal/proxy/message_media.go
@@ -45,37 +45,69 @@ type messageMedia struct {
 	asset     *tenantAssetReader
 }
 
-var providerMessageMediaMIMEs = map[string]map[messageMediaType]map[string]struct{}{
-	ProviderNameOpenAI: {
-		messageMediaTypeImage: {
-			messageImageMIMEJPEG: {},
-			messageImageMIMEPNG:  {},
-			messageImageMIMEWebP: {},
+type textRouteMessageMediaContract struct {
+	mimeTypes                map[messageMediaType]map[string]struct{}
+	attachmentLimitTransport string
+}
+
+var textRouteMessageMediaContracts = map[textRouteCapabilities]textRouteMessageMediaContract{
+	openAIResponsesPollableRouteCapabilities: {
+		attachmentLimitTransport: CatalogMediaTransportInline,
+		mimeTypes: map[messageMediaType]map[string]struct{}{
+			messageMediaTypeImage: {
+				messageImageMIMEJPEG: {},
+				messageImageMIMEPNG:  {},
+				messageImageMIMEWebP: {},
+			},
 		},
 	},
-	ProviderNameAnthropic: {
-		messageMediaTypeImage: {
-			messageImageMIMEJPEG: {},
-			messageImageMIMEPNG:  {},
-			messageImageMIMEWebP: {},
+	openAIResponsesSynchronousRouteCapabilities: {
+		attachmentLimitTransport: CatalogMediaTransportInline,
+		mimeTypes: map[messageMediaType]map[string]struct{}{
+			messageMediaTypeImage: {
+				messageImageMIMEJPEG: {},
+				messageImageMIMEPNG:  {},
+			},
 		},
 	},
-	ProviderNameGemini: {
-		messageMediaTypeAudio: {
-			messageAudioMIMEM4A:  {},
-			messageAudioMIMEMPEG: {},
-			messageAudioMIMEWAV:  {},
-		},
-		messageMediaTypeImage: {
-			messageImageMIMEJPEG: {},
-			messageImageMIMEPNG:  {},
-			messageImageMIMEWebP: {},
+	geminiInteractionsPollableRouteCapabilities: {
+		attachmentLimitTransport: CatalogMediaTransportFile,
+		mimeTypes: map[messageMediaType]map[string]struct{}{
+			messageMediaTypeAudio: {
+				messageAudioMIMEM4A:  {},
+				messageAudioMIMEMPEG: {},
+				messageAudioMIMEWAV:  {},
+			},
+			messageMediaTypeImage: {
+				messageImageMIMEJPEG: {},
+				messageImageMIMEPNG:  {},
+				messageImageMIMEWebP: {},
+			},
 		},
 	},
-	ProviderNameXAI: {
-		messageMediaTypeImage: {
-			messageImageMIMEJPEG: {},
-			messageImageMIMEPNG:  {},
+	geminiInteractionsSynchronousRouteCapabilities: {
+		attachmentLimitTransport: CatalogMediaTransportFile,
+		mimeTypes: map[messageMediaType]map[string]struct{}{
+			messageMediaTypeAudio: {
+				messageAudioMIMEM4A:  {},
+				messageAudioMIMEMPEG: {},
+				messageAudioMIMEWAV:  {},
+			},
+			messageMediaTypeImage: {
+				messageImageMIMEJPEG: {},
+				messageImageMIMEPNG:  {},
+				messageImageMIMEWebP: {},
+			},
+		},
+	},
+	anthropicMessagesSynchronousRouteCapabilities: {
+		attachmentLimitTransport: CatalogMediaTransportInline,
+		mimeTypes: map[messageMediaType]map[string]struct{}{
+			messageMediaTypeImage: {
+				messageImageMIMEJPEG: {},
+				messageImageMIMEPNG:  {},
+				messageImageMIMEWebP: {},
+			},
 		},
 	},
 }
@@ -183,20 +215,25 @@ func decodeHashBoundMessageMedia(rawData string, rawDigest string) ([]byte, erro
 	return decodedData, nil
 }
 
-func providerSupportsMessageMedia(providerName string, mediaInput messageMediaType) bool {
-	_, supported := providerMessageMediaMIMEs[providerName][mediaInput]
+func textRouteSupportsMessageMedia(routeCapabilities textRouteCapabilities, mediaInput messageMediaType) bool {
+	_, supported := textRouteMessageMediaContracts[routeCapabilities].mimeTypes[mediaInput]
 	return supported
 }
 
-func providerSupportsMessageMediaMIME(providerName string, mediaInput messageMediaType, mimeType string) bool {
-	_, supported := providerMessageMediaMIMEs[providerName][mediaInput][mimeType]
+func textRouteSupportsMessageMediaMIME(routeCapabilities textRouteCapabilities, mediaInput messageMediaType, mimeType string) bool {
+	_, supported := textRouteMessageMediaContracts[routeCapabilities].mimeTypes[mediaInput][mimeType]
 	return supported
+}
+
+func textRouteMessageMediaLimitTransport(routeCapabilities textRouteCapabilities) string {
+	return textRouteMessageMediaContracts[routeCapabilities].attachmentLimitTransport
 }
 
 func validateMessageMediaForResolvedTextRoute(provider providerDefinition, model textModelDefinition, messages chatMessages) error {
+	routeCapabilities := textRouteCapabilities{wireContract: model.wireContract, executionLifecycle: model.executionLifecycle}
 	for _, message := range messages {
 		for _, attachment := range message.attachments {
-			if !model.supportsMediaInput(attachment.mediaType) || !providerSupportsMessageMediaMIME(provider.identifier.string(), attachment.mediaType, attachment.mimeType) {
+			if !model.supportsMediaInput(attachment.mediaType) || !textRouteSupportsMessageMediaMIME(routeCapabilities, attachment.mediaType, attachment.mimeType) {
 				return fmt.Errorf(
 					"%w: provider=%s model=%s capability=media_input type=%s mime_type=%s",
 					ErrUnsupportedCapability,
@@ -211,11 +248,11 @@ func validateMessageMediaForResolvedTextRoute(provider providerDefinition, model
 	return nil
 }
 
-func validateInlineMessageMediaLimits(model textModelDefinition, messages chatMessages, payloadBytes []byte) error {
+func validateInlineMessageMediaBeforeSerialization(model textModelDefinition, messages chatMessages) error {
 	if messages.mediaCount() == 0 {
 		return nil
 	}
-	if inlineRequestBytes, bounded := boundedCatalogMediaLimit(model.mediaLimits, CatalogMediaLimitIDInlineRequestBytes, messageMediaTypeImage); bounded && int64(len(payloadBytes)) > inlineRequestBytes {
+	if inlineRequestBytes, bounded := boundedCatalogMediaLimit(model.mediaLimits, CatalogMediaLimitIDInlineRequestBytes, messageMediaTypeImage); bounded && messages.base64MediaBytes() > inlineRequestBytes {
 		return ErrProviderMediaLimit
 	}
 	for _, mediaType := range []messageMediaType{messageMediaTypeImage, messageMediaTypeAudio} {
@@ -243,6 +280,16 @@ func validateInlineMessageMediaLimits(model textModelDefinition, messages chatMe
 				}
 			}
 		}
+	}
+	return nil
+}
+
+func validateInlineMessageMediaRequestLimit(model textModelDefinition, messages chatMessages, payloadBytes []byte) error {
+	if messages.mediaCount() == 0 {
+		return nil
+	}
+	if inlineRequestBytes, bounded := boundedCatalogMediaLimit(model.mediaLimits, CatalogMediaLimitIDInlineRequestBytes, messageMediaTypeImage); bounded && int64(len(payloadBytes)) > inlineRequestBytes {
+		return ErrProviderMediaLimit
 	}
 	return nil
 }

--- a/internal/proxy/message_media.go
+++ b/internal/proxy/message_media.go
@@ -45,10 +45,38 @@ type messageMedia struct {
 	asset     *tenantAssetReader
 }
 
-var providerMessageMediaInputs = map[string]map[messageMediaType]struct{}{
+var providerMessageMediaMIMEs = map[string]map[messageMediaType]map[string]struct{}{
+	ProviderNameOpenAI: {
+		messageMediaTypeImage: {
+			messageImageMIMEJPEG: {},
+			messageImageMIMEPNG:  {},
+			messageImageMIMEWebP: {},
+		},
+	},
+	ProviderNameAnthropic: {
+		messageMediaTypeImage: {
+			messageImageMIMEJPEG: {},
+			messageImageMIMEPNG:  {},
+			messageImageMIMEWebP: {},
+		},
+	},
 	ProviderNameGemini: {
-		messageMediaTypeAudio: {},
-		messageMediaTypeImage: {},
+		messageMediaTypeAudio: {
+			messageAudioMIMEM4A:  {},
+			messageAudioMIMEMPEG: {},
+			messageAudioMIMEWAV:  {},
+		},
+		messageMediaTypeImage: {
+			messageImageMIMEJPEG: {},
+			messageImageMIMEPNG:  {},
+			messageImageMIMEWebP: {},
+		},
+	},
+	ProviderNameXAI: {
+		messageMediaTypeImage: {
+			messageImageMIMEJPEG: {},
+			messageImageMIMEPNG:  {},
+		},
 	},
 }
 
@@ -156,21 +184,63 @@ func decodeHashBoundMessageMedia(rawData string, rawDigest string) ([]byte, erro
 }
 
 func providerSupportsMessageMedia(providerName string, mediaInput messageMediaType) bool {
-	_, supported := providerMessageMediaInputs[providerName][mediaInput]
+	_, supported := providerMessageMediaMIMEs[providerName][mediaInput]
+	return supported
+}
+
+func providerSupportsMessageMediaMIME(providerName string, mediaInput messageMediaType, mimeType string) bool {
+	_, supported := providerMessageMediaMIMEs[providerName][mediaInput][mimeType]
 	return supported
 }
 
 func validateMessageMediaForResolvedTextRoute(provider providerDefinition, model textModelDefinition, messages chatMessages) error {
 	for _, message := range messages {
 		for _, attachment := range message.attachments {
-			if !model.supportsMediaInput(attachment.mediaType) {
+			if !model.supportsMediaInput(attachment.mediaType) || !providerSupportsMessageMediaMIME(provider.identifier.string(), attachment.mediaType, attachment.mimeType) {
 				return fmt.Errorf(
-					"%w: provider=%s model=%s capability=media_input type=%s",
+					"%w: provider=%s model=%s capability=media_input type=%s mime_type=%s",
 					ErrUnsupportedCapability,
 					provider.identifier.string(),
 					model.string(),
 					attachment.mediaType,
+					attachment.mimeType,
 				)
+			}
+		}
+	}
+	return nil
+}
+
+func validateInlineMessageMediaLimits(model textModelDefinition, messages chatMessages, payloadBytes []byte) error {
+	if messages.mediaCount() == 0 {
+		return nil
+	}
+	if inlineRequestBytes, bounded := boundedCatalogMediaLimit(model.mediaLimits, CatalogMediaLimitIDInlineRequestBytes, messageMediaTypeImage); bounded && int64(len(payloadBytes)) > inlineRequestBytes {
+		return ErrProviderMediaLimit
+	}
+	for _, mediaType := range []messageMediaType{messageMediaTypeImage, messageMediaTypeAudio} {
+		countLimitID := CatalogMediaLimitIDImageCount
+		inlineLimitID := CatalogMediaLimitIDImageInlineBytes
+		if mediaType == messageMediaTypeAudio {
+			countLimitID = CatalogMediaLimitIDAudioCount
+			inlineLimitID = CatalogMediaLimitIDAudioInlineBytes
+		}
+		if countLimit, bounded := boundedCatalogMediaLimit(model.mediaLimits, countLimitID, mediaType); bounded && messages.mediaTypeCount(mediaType) > countLimit {
+			return ErrProviderMediaLimit
+		}
+		inlineLimit, bounded := boundedCatalogMediaLimit(model.mediaLimits, inlineLimitID, mediaType)
+		if !bounded {
+			continue
+		}
+		for _, message := range messages {
+			for _, attachment := range message.attachments {
+				attachmentBytes := attachment.sizeBytes
+				if configuredLimit, found := catalogMediaLimit(model.mediaLimits, inlineLimitID, mediaType); found && configuredLimit.Scope == CatalogMediaLimitScopeAttachmentEncodedBytes {
+					attachmentBytes = ((attachment.sizeBytes + 2) / 3) * 4
+				}
+				if attachment.mediaType == mediaType && attachmentBytes > inlineLimit {
+					return ErrProviderMediaLimit
+				}
 			}
 		}
 	}

--- a/internal/proxy/message_media_routing_test.go
+++ b/internal/proxy/message_media_routing_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tyemirov/llm-proxy/internal/proxy"
 	"github.com/tyemirov/llm-proxy/internal/testfixtures"
+	"github.com/tyemirov/llm-proxy/pkg/llmproxycontract"
 	"go.uber.org/zap"
 )
 
@@ -38,6 +39,8 @@ func TestV2RoutesExactOrderedImageAndAudioAttachmentsThroughGemini(testingInstan
 		OpenAIKey:             TestAPIKey,
 		GeminiKey:             testGeminiKey,
 		GeminiBaseURL:         upstreamServer.URL,
+		XAIKey:                testXAIKey,
+		XAIBaseURL:            upstreamServer.URL,
 		LogLevel:              proxy.LogLevelInfo,
 		WorkerCount:           1,
 		QueueSize:             1,
@@ -104,6 +107,248 @@ func TestV2RoutesExactOrderedImageAndAudioAttachmentsThroughGemini(testingInstan
 	}
 }
 
+func TestV2RoutesExactOrderedImagesThroughProviderAdapters(testingInstance *testing.T) {
+	firstImage := []byte("first-image")
+	secondImage := []byte("second-image")
+	for _, testCase := range []struct {
+		name       string
+		provider   string
+		model      string
+		path       string
+		assertBody func(*testing.T, map[string]any)
+	}{
+		{
+			name: "OpenAI Responses", provider: proxy.ProviderNameOpenAI, model: proxy.ModelNameGPT4oMini, path: "/responses",
+			assertBody: func(subTest *testing.T, payload map[string]any) {
+				assertOpenAIImageInput(subTest, payload, "auto", firstImage, secondImage)
+				if payload["background"] != true || payload["store"] != true {
+					subTest.Fatalf("OpenAI persistence fields=%v", payload)
+				}
+			},
+		},
+		{
+			name: "Anthropic Messages", provider: proxy.ProviderNameAnthropic, model: "claude-fable-5", path: "/v1/messages",
+			assertBody: func(subTest *testing.T, payload map[string]any) {
+				messages := payload["messages"].([]any)
+				content := messages[0].(map[string]any)["content"].([]any)
+				if len(content) != 3 {
+					subTest.Fatalf("Anthropic content=%v", content)
+				}
+				assertAnthropicImageBlock(subTest, content[0], "image/png", firstImage)
+				assertAnthropicImageBlock(subTest, content[1], "image/jpeg", secondImage)
+				if textBlock := content[2].(map[string]any); textBlock["type"] != "text" || textBlock["text"] != "Inspect in exact order." {
+					subTest.Fatalf("Anthropic text=%v", textBlock)
+				}
+			},
+		},
+		{
+			name: "xAI Responses", provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok45, path: "/responses",
+			assertBody: func(subTest *testing.T, payload map[string]any) {
+				assertOpenAIImageInput(subTest, payload, "high", firstImage, secondImage)
+				if payload["store"] != false {
+					subTest.Fatalf("xAI store=%v", payload["store"])
+				}
+				if _, found := payload["background"]; found {
+					subTest.Fatalf("xAI payload includes background=%v", payload)
+				}
+			},
+		},
+	} {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			var capturedPayload map[string]any
+			upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+				if httpRequest.Method != http.MethodPost || httpRequest.URL.Path != testCase.path {
+					subTest.Fatalf("upstream request=%s %s", httpRequest.Method, httpRequest.URL.Path)
+				}
+				if decodeError := json.NewDecoder(httpRequest.Body).Decode(&capturedPayload); decodeError != nil {
+					subTest.Fatalf("decode upstream request: %v", decodeError)
+				}
+				responseWriter.Header().Set("Content-Type", "application/json")
+				if testCase.provider == proxy.ProviderNameAnthropic {
+					_, _ = responseWriter.Write([]byte(`{"content":[{"type":"text","text":"media accepted"}],"stop_reason":"end_turn"}`))
+					return
+				}
+				_, _ = responseWriter.Write([]byte(`{"id":"media-input","status":"completed","output_text":"media accepted"}`))
+			}))
+			defer upstreamServer.Close()
+
+			router, buildError := buildRouterWithCatalogs(subTest, proxy.Configuration{
+				Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+				OpenAIKey:             TestAPIKey,
+				OpenAIBaseURL:         upstreamServer.URL,
+				AnthropicKey:          testAnthropicKey,
+				AnthropicBaseURL:      upstreamServer.URL,
+				XAIKey:                testXAIKey,
+				XAIBaseURL:            upstreamServer.URL,
+				LogLevel:              proxy.LogLevelInfo,
+				WorkerCount:           1,
+				QueueSize:             1,
+				RequestTimeoutSeconds: TestTimeout,
+			}, zap.NewNop().Sugar())
+			if buildError != nil {
+				subTest.Fatalf(messageBuildRouterError, buildError)
+			}
+
+			requestBody := mediaV2RequestBody(subTest, testCase.model, "Inspect in exact order.", []map[string]any{
+				messageMediaPayload("image", "image/png", firstImage),
+				messageMediaPayload("image", "image/jpeg", secondImage),
+			})
+			request := httptest.NewRequest(http.MethodPost, "/v2?key="+TestSecret+"&provider="+testCase.provider+"&format=application/json", strings.NewReader(requestBody))
+			request.Header.Set("Content-Type", "application/json")
+			responseRecorder := httptest.NewRecorder()
+			router.ServeHTTP(responseRecorder, request)
+
+			if responseRecorder.Code != http.StatusOK {
+				subTest.Fatalf("status=%d body=%s", responseRecorder.Code, responseRecorder.Body.String())
+			}
+			testCase.assertBody(subTest, capturedPayload)
+		})
+	}
+}
+
+func TestV2AppliesNewProviderMediaLimitsAtTheBoundary(testingInstance *testing.T) {
+	for _, testCase := range []struct {
+		name                string
+		provider            string
+		model               string
+		limitID             string
+		limitValue          int64
+		boundaryAttachments []map[string]any
+		aboveAttachments    []map[string]any
+	}{
+		{
+			name:                "OpenAI image count",
+			provider:            proxy.ProviderNameOpenAI,
+			model:               proxy.ModelNameGPT4oMini,
+			limitID:             proxy.CatalogMediaLimitIDImageCount,
+			limitValue:          1,
+			boundaryAttachments: []map[string]any{messageMediaPayload("image", "image/png", []byte("x"))},
+			aboveAttachments:    []map[string]any{messageMediaPayload("image", "image/png", []byte("x")), messageMediaPayload("image", "image/png", []byte("y"))},
+		},
+		{
+			name:                "Anthropic encoded image bytes",
+			provider:            proxy.ProviderNameAnthropic,
+			model:               "claude-fable-5",
+			limitID:             proxy.CatalogMediaLimitIDImageInlineBytes,
+			limitValue:          4,
+			boundaryAttachments: []map[string]any{messageMediaPayload("image", "image/png", []byte("x"))},
+			aboveAttachments:    []map[string]any{messageMediaPayload("image", "image/png", []byte("xxxx"))},
+		},
+		{
+			name:                "xAI raw image bytes",
+			provider:            proxy.ProviderNameXAI,
+			model:               proxy.ModelNameGrok45,
+			limitID:             proxy.CatalogMediaLimitIDImageInlineBytes,
+			limitValue:          1,
+			boundaryAttachments: []map[string]any{messageMediaPayload("image", "image/png", []byte("x"))},
+			aboveAttachments:    []map[string]any{messageMediaPayload("image", "image/png", []byte("xx"))},
+		},
+	} {
+		testingInstance.Run(testCase.name, func(subTest *testing.T) {
+			upstreamCalls := 0
+			upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+				upstreamCalls++
+				responseWriter.Header().Set("Content-Type", "application/json")
+				if testCase.provider == proxy.ProviderNameAnthropic {
+					_, _ = responseWriter.Write([]byte(`{"content":[{"type":"text","text":"accepted"}],"stop_reason":"end_turn"}`))
+					return
+				}
+				_, _ = responseWriter.Write([]byte(`{"id":"media-limit","status":"completed","output_text":"accepted"}`))
+			}))
+			defer upstreamServer.Close()
+
+			catalog := testfixtures.ModelCatalog(subTest)
+			setProviderMediaLimit(subTest, &catalog, testCase.provider, testCase.model, testCase.limitID, testCase.limitValue)
+			router, buildError := proxy.BuildRouter(proxy.Configuration{
+				Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+				OpenAIKey:             TestAPIKey,
+				OpenAIBaseURL:         upstreamServer.URL,
+				AnthropicKey:          testAnthropicKey,
+				AnthropicBaseURL:      upstreamServer.URL,
+				XAIKey:                testXAIKey,
+				XAIBaseURL:            upstreamServer.URL,
+				ModelCatalog:          catalog,
+				LogLevel:              proxy.LogLevelInfo,
+				WorkerCount:           1,
+				QueueSize:             1,
+				RequestTimeoutSeconds: TestTimeout,
+			}, zap.NewNop().Sugar())
+			if buildError != nil {
+				subTest.Fatalf(messageBuildRouterError, buildError)
+			}
+
+			perform := func(attachments []map[string]any) *httptest.ResponseRecorder {
+				request := httptest.NewRequest(
+					http.MethodPost,
+					"/v2?key="+TestSecret+"&provider="+testCase.provider+"&format=text/plain",
+					strings.NewReader(mediaV2RequestBody(subTest, testCase.model, "inspect", attachments)),
+				)
+				request.Header.Set("Content-Type", "application/json")
+				responseRecorder := httptest.NewRecorder()
+				router.ServeHTTP(responseRecorder, request)
+				return responseRecorder
+			}
+
+			boundaryResponse := perform(testCase.boundaryAttachments)
+			if boundaryResponse.Code != http.StatusOK || upstreamCalls != 1 {
+				subTest.Fatalf("boundary status=%d calls=%d body=%s", boundaryResponse.Code, upstreamCalls, boundaryResponse.Body.String())
+			}
+			aboveResponse := perform(testCase.aboveAttachments)
+			if aboveResponse.Code != http.StatusRequestEntityTooLarge || upstreamCalls != 1 || !strings.Contains(aboveResponse.Body.String(), llmproxycontract.ErrorCodeProviderMediaLimitExceeded) {
+				subTest.Fatalf("above status=%d calls=%d body=%s", aboveResponse.Code, upstreamCalls, aboveResponse.Body.String())
+			}
+		})
+	}
+}
+
+func setProviderMediaLimit(testingInstance *testing.T, catalog *proxy.ModelCatalog, provider string, model string, limitID string, value int64) {
+	testingInstance.Helper()
+	offeringIndex := catalogOfferingIndex(*catalog, provider, model)
+	if offeringIndex < 0 {
+		testingInstance.Fatalf("missing offering provider=%s model=%s", provider, model)
+	}
+	for limitIndex := range catalog.Offerings[offeringIndex].MediaLimits {
+		limit := &catalog.Offerings[offeringIndex].MediaLimits[limitIndex]
+		if limit.ID == limitID {
+			limit.Status = proxy.CatalogMediaLimitStatusBounded
+			limit.Value = &value
+			return
+		}
+	}
+	testingInstance.Fatalf("missing media limit provider=%s model=%s limit=%s", provider, model, limitID)
+}
+
+func assertOpenAIImageInput(testingInstance *testing.T, payload map[string]any, detail string, firstImage []byte, secondImage []byte) {
+	testingInstance.Helper()
+	input := payload["input"].([]any)
+	content := input[0].(map[string]any)["content"].([]any)
+	if len(content) != 3 {
+		testingInstance.Fatalf("Responses content=%v", content)
+	}
+	for index, expected := range []struct {
+		mimeType string
+		data     []byte
+	}{{"image/png", firstImage}, {"image/jpeg", secondImage}} {
+		imageBlock := content[index].(map[string]any)
+		expectedURL := "data:" + expected.mimeType + ";base64," + base64.StdEncoding.EncodeToString(expected.data)
+		if imageBlock["type"] != "input_image" || imageBlock["image_url"] != expectedURL || imageBlock["detail"] != detail {
+			testingInstance.Fatalf("Responses image[%d]=%v", index, imageBlock)
+		}
+	}
+	if textBlock := content[2].(map[string]any); textBlock["type"] != "input_text" || textBlock["text"] != "Inspect in exact order." {
+		testingInstance.Fatalf("Responses text=%v", textBlock)
+	}
+}
+
+func assertAnthropicImageBlock(testingInstance *testing.T, rawBlock any, mimeType string, data []byte) {
+	testingInstance.Helper()
+	block := rawBlock.(map[string]any)
+	source := block["source"].(map[string]any)
+	if block["type"] != "image" || source["type"] != "base64" || source["media_type"] != mimeType || source["data"] != base64.StdEncoding.EncodeToString(data) {
+		testingInstance.Fatalf("Anthropic image=%v", block)
+	}
+}
+
 func TestV2RejectsInvalidOrUnsupportedMediaBeforeUpstreamWork(testingInstance *testing.T) {
 	upstreamCalls := 0
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
@@ -119,6 +364,8 @@ func TestV2RejectsInvalidOrUnsupportedMediaBeforeUpstreamWork(testingInstance *t
 		DeepSeekBaseURL:       upstreamServer.URL,
 		GeminiKey:             testGeminiKey,
 		GeminiBaseURL:         upstreamServer.URL,
+		XAIKey:                testXAIKey,
+		XAIBaseURL:            upstreamServer.URL,
 		LogLevel:              proxy.LogLevelInfo,
 		WorkerCount:           1,
 		QueueSize:             1,
@@ -151,7 +398,8 @@ func TestV2RejectsInvalidOrUnsupportedMediaBeforeUpstreamWork(testingInstance *t
 		{name: "uppercase digest", provider: proxy.ProviderNameGemini, model: proxy.ModelNameGemini25Flash, role: "user", attachments: []any{map[string]any{"type": "image", "mime_type": "image/png", "data": validImage["data"], "sha256": strings.ToUpper(validImage["sha256"].(string))}}},
 		{name: "mismatched digest", provider: proxy.ProviderNameGemini, model: proxy.ModelNameGemini25Flash, role: "user", attachments: []any{map[string]any{"type": "image", "mime_type": "image/png", "data": validImage["data"], "sha256": messageMediaPayload("image", "image/png", []byte("other"))["sha256"]}}},
 		{name: "system attachment", provider: proxy.ProviderNameGemini, model: proxy.ModelNameGemini25Flash, role: "system", attachments: []any{validImage}},
-		{name: "text-only model", provider: proxy.ProviderNameGemini, model: proxy.ModelNameGemini25Pro, role: "user", attachments: []any{validImage}},
+		{name: "text-only model", provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok43, role: "user", attachments: []any{validImage}},
+		{name: "provider MIME", provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok45, role: "user", attachments: []any{messageMediaPayload("image", "image/webp", []byte("webp"))}},
 		{name: "text-only provider", provider: proxy.ProviderNameDeepSeek, model: proxy.ModelNameDeepSeekV4Flash, role: "user", attachments: []any{validImage}},
 	} {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {

--- a/internal/proxy/message_media_routing_test.go
+++ b/internal/proxy/message_media_routing_test.go
@@ -515,6 +515,12 @@ func TestModelCatalogRejectsInvalidMediaInputDeclarations(testingInstance *testi
 			},
 		},
 		{
+			name: "unsupported xAI Chat Completions adapter",
+			configure: func(catalogs proxy.ModelCatalog) {
+				setModelMediaInputs(catalogs, proxy.ProviderNameXAI, proxy.ModelNameGrok43, []string{"image"})
+			},
+		},
+		{
 			name: "unsupported endpoint",
 			configure: func(catalogs proxy.ModelCatalog) {
 				offeringIndex := catalogOfferingIndex(catalogs, proxy.ProviderNameOpenAI, proxy.DefaultDictationModel)

--- a/internal/proxy/model_capabilities.go
+++ b/internal/proxy/model_capabilities.go
@@ -22,7 +22,7 @@ type Reasoning struct {
 // requestPayloadBase contains fields common to all requests.
 type requestPayloadBase struct {
 	Model           string `json:"model"`
-	Input           string `json:"input"`
+	Input           any    `json:"input"`
 	MaxOutputTokens *int   `json:"max_output_tokens,omitempty"`
 	Background      bool   `json:"background"`
 	Store           bool   `json:"store"`
@@ -56,11 +56,11 @@ type Tool struct {
 }
 
 // BuildRequestPayload selects the correct OpenAI Responses payload shape for the configured request profile.
-func BuildRequestPayload(modelIdentifier string, rawRequestProfile string, combinedPrompt string, webSearchEnabled bool, maxTokens *int, reasoningEffort string) any {
+func BuildRequestPayload(modelIdentifier string, rawRequestProfile string, combinedPrompt any, webSearchEnabled bool, maxTokens *int, reasoningEffort string) any {
 	return buildRequestPayload(modelIdentifier, rawRequestProfile, combinedPrompt, webSearchEnabled, maxTokens, reasoningEffort, true, true)
 }
 
-func buildRequestPayload(modelIdentifier string, rawRequestProfile string, combinedPrompt string, webSearchEnabled bool, maxTokens *int, reasoningEffort string, background bool, store bool) any {
+func buildRequestPayload(modelIdentifier string, rawRequestProfile string, combinedPrompt any, webSearchEnabled bool, maxTokens *int, reasoningEffort string, background bool, store bool) any {
 	base := requestPayloadBase{
 		Model:           modelIdentifier,
 		Input:           combinedPrompt,

--- a/internal/proxy/model_catalog.go
+++ b/internal/proxy/model_catalog.go
@@ -389,7 +389,7 @@ func validateProviderOfferings(offerings []ProviderOffering, catalog validatedMo
 			}
 		}
 		modelMediaInputs, _ := validatedExactModelMediaInputs(exactModel.MediaInputs, "catalog.models.media_inputs")
-		offeringMediaInputs, mediaError := validatedMediaInputSet(offering.Provider, offering.MediaInputs, fieldPrefix+".media_inputs")
+		offeringMediaInputs, mediaError := validatedMediaInputSet(offering, fieldPrefix+".media_inputs")
 		if mediaError != nil {
 			return mediaError
 		}
@@ -398,7 +398,11 @@ func validateProviderOfferings(offerings []ProviderOffering, catalog validatedMo
 				return fmt.Errorf("%w: field=%s.media_inputs media_input=%s reason=unsupported_by_model", ErrInvalidModelCatalog, fieldPrefix, mediaInput)
 			}
 		}
-		if mediaLimitError := validateCatalogMediaLimits(offering.MediaLimits, offering.MediaInputs, fieldPrefix+".media_limits"); mediaLimitError != nil {
+		routeCapabilities := textRouteCapabilities{
+			wireContract:       textWireContract(offering.WireContract),
+			executionLifecycle: textExecutionLifecycle(offering.ExecutionLifecycle),
+		}
+		if mediaLimitError := validateCatalogMediaLimits(offering.MediaLimits, offering.MediaInputs, routeCapabilities, fieldPrefix+".media_limits"); mediaLimitError != nil {
 			return mediaLimitError
 		}
 		catalog.offerings[offeringIdentifier] = offering
@@ -592,12 +596,16 @@ func knownModelRequestProfile(requestProfile modelRequestProfile) bool {
 	}
 }
 
-func validatedMediaInputSet(providerName string, rawMediaInputs []string, fieldPrefix string) (map[messageMediaType]struct{}, error) {
-	mediaInputs := make(map[messageMediaType]struct{}, len(rawMediaInputs))
-	for mediaInputIndex, rawMediaInput := range rawMediaInputs {
+func validatedMediaInputSet(offering ProviderOffering, fieldPrefix string) (map[messageMediaType]struct{}, error) {
+	routeCapabilities := textRouteCapabilities{
+		wireContract:       textWireContract(offering.WireContract),
+		executionLifecycle: textExecutionLifecycle(offering.ExecutionLifecycle),
+	}
+	mediaInputs := make(map[messageMediaType]struct{}, len(offering.MediaInputs))
+	for mediaInputIndex, rawMediaInput := range offering.MediaInputs {
 		mediaInput := messageMediaType(rawMediaInput)
-		if rawMediaInput == constants.EmptyString || rawMediaInput != strings.TrimSpace(rawMediaInput) || !providerSupportsMessageMedia(providerName, mediaInput) {
-			return nil, fmt.Errorf("%w: field=%s[%d] provider=%s media_input=%s", ErrInvalidModelCatalog, fieldPrefix, mediaInputIndex, providerName, rawMediaInput)
+		if rawMediaInput == constants.EmptyString || rawMediaInput != strings.TrimSpace(rawMediaInput) || !textRouteSupportsMessageMedia(routeCapabilities, mediaInput) {
+			return nil, fmt.Errorf("%w: field=%s[%d] provider=%s wire_contract=%s execution_lifecycle=%s media_input=%s", ErrInvalidModelCatalog, fieldPrefix, mediaInputIndex, offering.Provider, offering.WireContract, offering.ExecutionLifecycle, rawMediaInput)
 		}
 		if _, duplicate := mediaInputs[mediaInput]; duplicate {
 			return nil, fmt.Errorf("%w: field=%s[%d] duplicate=%s", ErrInvalidModelCatalog, fieldPrefix, mediaInputIndex, rawMediaInput)

--- a/internal/proxy/model_catalog.go
+++ b/internal/proxy/model_catalog.go
@@ -137,7 +137,10 @@ var providerTextRouteCapabilities = map[string]map[textRouteCapabilities]struct{
 	},
 	ProviderNameAnthropic: {anthropicMessagesSynchronousRouteCapabilities: {}},
 	ProviderNameMeta:      {openAIChatCompletionsSynchronousRouteCapabilities: {}},
-	ProviderNameXAI:       {openAIChatCompletionsSynchronousRouteCapabilities: {}},
+	ProviderNameXAI: {
+		openAIChatCompletionsSynchronousRouteCapabilities: {},
+		openAIResponsesSynchronousRouteCapabilities:       {},
+	},
 }
 
 func validateModelCatalog(catalog ModelCatalog) (validatedModelCatalog, error) {

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -76,13 +76,16 @@ func hasFinalMessage(rawPayload []byte) bool {
 
 // openAIRequest sends messages to the OpenAI responses API and returns the resulting text.
 func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIKey string, modelIdentifier textModelDefinition, messages chatMessages, webSearchEnabled bool, maxTokens *int, reasoningEffort string, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	if mediaLimitError := validateInlineMessageMediaBeforeSerialization(modelIdentifier, messages); mediaLimitError != nil {
+		return textGenerationResult{}, mediaLimitError
+	}
 	input, inputError := messages.openAIResponsesInput("auto", false)
 	if inputError != nil {
 		return textGenerationResult{}, inputError
 	}
 	payload := BuildRequestPayload(modelIdentifier.providerString(), modelIdentifier.requestProfile.string(), input, webSearchEnabled, maxTokens, reasoningEffort)
 	payloadBytes, _ := json.Marshal(payload)
-	if mediaLimitError := validateInlineMessageMediaLimits(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
+	if mediaLimitError := validateInlineMessageMediaRequestLimit(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
 		return textGenerationResult{}, mediaLimitError
 	}
 
@@ -117,6 +120,9 @@ func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIK
 }
 
 func (client *OpenAIClient) xAIResponsesRequest(parentContext context.Context, apiKey string, baseURL string, modelIdentifier textModelDefinition, messages chatMessages, maxTokens *int, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	if mediaLimitError := validateInlineMessageMediaBeforeSerialization(modelIdentifier, messages); mediaLimitError != nil {
+		return textGenerationResult{}, mediaLimitError
+	}
 	input, inputError := messages.openAIResponsesInput("high", true)
 	if inputError != nil {
 		return textGenerationResult{}, inputError
@@ -133,7 +139,7 @@ func (client *OpenAIClient) xAIResponsesRequest(parentContext context.Context, a
 		Store:           false,
 	}
 	payloadBytes, _ := json.Marshal(payload)
-	if mediaLimitError := validateInlineMessageMediaLimits(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
+	if mediaLimitError := validateInlineMessageMediaRequestLimit(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
 		return textGenerationResult{}, mediaLimitError
 	}
 	requestURL := strings.TrimRight(baseURL, "/") + "/responses"

--- a/internal/proxy/openai.go
+++ b/internal/proxy/openai.go
@@ -76,8 +76,15 @@ func hasFinalMessage(rawPayload []byte) bool {
 
 // openAIRequest sends messages to the OpenAI responses API and returns the resulting text.
 func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIKey string, modelIdentifier textModelDefinition, messages chatMessages, webSearchEnabled bool, maxTokens *int, reasoningEffort string, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
-	payload := BuildRequestPayload(modelIdentifier.providerString(), modelIdentifier.requestProfile.string(), messages.openAIResponsesInput(), webSearchEnabled, maxTokens, reasoningEffort)
+	input, inputError := messages.openAIResponsesInput("auto", false)
+	if inputError != nil {
+		return textGenerationResult{}, inputError
+	}
+	payload := BuildRequestPayload(modelIdentifier.providerString(), modelIdentifier.requestProfile.string(), input, webSearchEnabled, maxTokens, reasoningEffort)
 	payloadBytes, _ := json.Marshal(payload)
+	if mediaLimitError := validateInlineMessageMediaLimits(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
+		return textGenerationResult{}, mediaLimitError
+	}
 
 	httpRequest, buildError := buildAuthorizedJSONRequest(parentContext, http.MethodPost, client.endpoints.GetResponsesURL(), openAIKey, bytes.NewReader(payloadBytes))
 	if buildError != nil {
@@ -107,6 +114,63 @@ func (client *OpenAIClient) openAIRequest(parentContext context.Context, openAIK
 	}
 
 	return client.resolveOpenAIResponse(parentContext, openAIKey, modelIdentifier, webSearchEnabled, maxTokens, reasoningEffort, responseSnapshot, structuredLogger)
+}
+
+func (client *OpenAIClient) xAIResponsesRequest(parentContext context.Context, apiKey string, baseURL string, modelIdentifier textModelDefinition, messages chatMessages, maxTokens *int, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	input, inputError := messages.openAIResponsesInput("high", true)
+	if inputError != nil {
+		return textGenerationResult{}, inputError
+	}
+	payload := struct {
+		Model           string `json:"model"`
+		Input           any    `json:"input"`
+		MaxOutputTokens *int   `json:"max_output_tokens,omitempty"`
+		Store           bool   `json:"store"`
+	}{
+		Model:           modelIdentifier.providerString(),
+		Input:           input,
+		MaxOutputTokens: maxTokens,
+		Store:           false,
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	if mediaLimitError := validateInlineMessageMediaLimits(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
+		return textGenerationResult{}, mediaLimitError
+	}
+	requestURL := strings.TrimRight(baseURL, "/") + "/responses"
+	httpRequest, buildError := buildAuthorizedJSONRequest(parentContext, http.MethodPost, requestURL, apiKey, bytes.NewReader(payloadBytes))
+	if buildError != nil {
+		structuredLogger.Errorw(logEventBuildHTTPRequest, constants.LogFieldError, buildError)
+		return textGenerationResult{}, buildError
+	}
+	statusCode, responseBytes, _, latencyMillis, requestError := client.performResponsesRequest(httpRequest, structuredLogger, logEventProviderRequestError)
+	if requestError != nil {
+		return textGenerationResult{}, requestError
+	}
+	responseSnapshot, snapshotError := newOpenAIResponseSnapshot(responseBytes)
+	structuredLogger.Infow(logEventOpenAIResponse, logFieldHTTPStatus, statusCode, logFieldAPIStatus, responseSnapshot.status, constants.LogFieldLatencyMilliseconds, latencyMillis)
+	if snapshotError != nil {
+		return textGenerationResult{}, errors.New(errorOpenAIAPI)
+	}
+	return resolveSynchronousResponsesSnapshot(responseSnapshot)
+}
+
+func resolveSynchronousResponsesSnapshot(responseSnapshot openAIResponseSnapshot) (textGenerationResult, error) {
+	switch responseSnapshot.status {
+	case statusCompleted:
+		if utils.IsBlank(responseSnapshot.text) {
+			return textGenerationResult{usage: responseSnapshot.usage}, errors.New(errorOpenAIAPI)
+		}
+		return responseSnapshot.generation(), nil
+	case statusIncomplete:
+		if responseSnapshot.incompleteReason == "max_output_tokens" {
+			return responseSnapshot.generation(), errProviderOutputLimitReached
+		}
+		return textGenerationResult{usage: responseSnapshot.usage}, fmt.Errorf("%w: Responses incomplete reason=%s", ErrProviderAPI, responseSnapshot.incompleteReason)
+	case statusCancelled, statusFailed:
+		return textGenerationResult{usage: responseSnapshot.usage}, errors.New(errorOpenAIFailedStatus)
+	default:
+		return textGenerationResult{usage: responseSnapshot.usage}, errors.New(errorOpenAIAPI)
+	}
 }
 
 type openAIResponseSnapshot struct {

--- a/internal/proxy/provider_key_verifier.go
+++ b/internal/proxy/provider_key_verifier.go
@@ -34,11 +34,13 @@ var (
 		statusCompleted:  {},
 		statusIncomplete: {},
 	}
-	providerKeyVerificationRequestBuilders = map[textWireContract]providerKeyVerificationRequestBuilder{
-		textWireContractOpenAIResponses:       buildOpenAIProviderKeyVerificationRequest,
-		textWireContractOpenAIChatCompletions: buildChatProviderKeyVerificationRequest,
-		textWireContractGeminiInteractions:    buildGeminiProviderKeyVerificationRequest,
-		textWireContractAnthropicMessages:     buildAnthropicProviderKeyVerificationRequest,
+	providerKeyVerificationRequestBuilders = map[textRouteCapabilities]providerKeyVerificationRequestBuilder{
+		openAIResponsesPollableRouteCapabilities:          buildOpenAIProviderKeyVerificationRequest,
+		openAIResponsesSynchronousRouteCapabilities:       buildSynchronousResponsesProviderKeyVerificationRequest,
+		openAIChatCompletionsSynchronousRouteCapabilities: buildChatProviderKeyVerificationRequest,
+		geminiInteractionsPollableRouteCapabilities:       buildGeminiProviderKeyVerificationRequest,
+		geminiInteractionsSynchronousRouteCapabilities:    buildGeminiProviderKeyVerificationRequest,
+		anthropicMessagesSynchronousRouteCapabilities:     buildAnthropicProviderKeyVerificationRequest,
 	}
 	providerKeyVerificationResponseValidators = map[textWireContract]providerKeyVerificationResponseValidator{
 		textWireContractOpenAIResponses:       validOpenAIProviderKeyVerificationResponse,
@@ -92,7 +94,10 @@ func (verifier *operationalProviderKeyVerifier) verify(parentContext context.Con
 	verificationContext, cancelVerification := context.WithTimeout(parentContext, verifier.timeout)
 	defer cancelVerification()
 
-	requestBuilder := providerKeyVerificationRequestBuilders[model.wireContract]
+	requestBuilder := providerKeyVerificationRequestBuilders[textRouteCapabilities{
+		wireContract:       model.wireContract,
+		executionLifecycle: model.executionLifecycle,
+	}]
 	httpRequest, buildError := requestBuilder(verificationContext, verifier.endpoints, provider, model, strings.TrimSpace(apiKey))
 	if buildError != nil {
 		return errProviderKeyVerificationUnavailable
@@ -131,6 +136,23 @@ func buildOpenAIProviderKeyVerificationRequest(requestContext context.Context, e
 	)
 	payloadBytes, _ := json.Marshal(payload)
 	return buildAuthorizedJSONRequest(requestContext, http.MethodPost, endpoints.GetResponsesURL(), apiKey, bytes.NewReader(payloadBytes))
+}
+
+func buildSynchronousResponsesProviderKeyVerificationRequest(requestContext context.Context, _ *Endpoints, provider providerDefinition, model textModelDefinition, apiKey string) (*http.Request, error) {
+	payload := struct {
+		Model           string `json:"model"`
+		Input           string `json:"input"`
+		MaxOutputTokens int    `json:"max_output_tokens"`
+		Store           bool   `json:"store"`
+	}{
+		Model:           model.providerString(),
+		Input:           providerKeyVerificationPrompt,
+		MaxOutputTokens: providerKeyVerificationMaxTokens,
+		Store:           false,
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	requestURL := strings.TrimRight(provider.textBaseURL, "/") + "/responses"
+	return buildAuthorizedJSONRequest(requestContext, http.MethodPost, requestURL, apiKey, bytes.NewReader(payloadBytes))
 }
 
 func buildChatProviderKeyVerificationRequest(requestContext context.Context, _ *Endpoints, provider providerDefinition, model textModelDefinition, apiKey string) (*http.Request, error) {

--- a/internal/proxy/provider_media_edges_internal_test.go
+++ b/internal/proxy/provider_media_edges_internal_test.go
@@ -54,6 +54,24 @@ func TestProviderImageSerializationAndLimitFailureContracts(t *testing.T) {
 		t.Fatalf("Anthropic serialization error=%v", requestError)
 	}
 
+	closedMessages[0].attachments[0].sizeBytes = 2
+	model.mediaLimits = []CatalogMediaLimit{{
+		ID:        CatalogMediaLimitIDImageInlineBytes,
+		MediaType: string(messageMediaTypeImage),
+		Status:    CatalogMediaLimitStatusBounded,
+		Value:     int64Pointer(1),
+		Scope:     CatalogMediaLimitScopeAttachment,
+	}}
+	if _, requestError := openAIClient.openAIRequest(context.Background(), "key", model, closedMessages, false, nil, "", logger); !errors.Is(requestError, ErrProviderMediaLimit) {
+		t.Fatalf("OpenAI pre-serialization media limit error=%v", requestError)
+	}
+	if _, requestError := openAIClient.xAIResponsesRequest(context.Background(), "key", "https://provider.test", model, closedMessages, nil, logger); !errors.Is(requestError, ErrProviderMediaLimit) {
+		t.Fatalf("xAI pre-serialization media limit error=%v", requestError)
+	}
+	if _, requestError := anthropicClient.generateText(context.Background(), "key", "https://provider.test", model, closedMessages, nil, logger); !errors.Is(requestError, ErrProviderMediaLimit) {
+		t.Fatalf("Anthropic pre-serialization media limit error=%v", requestError)
+	}
+
 	inlineMessages := chatMessages{{
 		role:    chatRoleUser,
 		content: "inspect",
@@ -68,7 +86,7 @@ func TestProviderImageSerializationAndLimitFailureContracts(t *testing.T) {
 		ID:        CatalogMediaLimitIDInlineRequestBytes,
 		MediaType: CatalogMediaLimitTypeAll,
 		Status:    CatalogMediaLimitStatusBounded,
-		Value:     int64Pointer(1),
+		Value:     int64Pointer(4),
 	}}
 	if _, requestError := openAIClient.openAIRequest(context.Background(), "key", model, inlineMessages, false, nil, "", logger); !errors.Is(requestError, ErrProviderMediaLimit) {
 		t.Fatalf("OpenAI media limit error=%v", requestError)
@@ -139,27 +157,34 @@ func TestInlineProviderMediaLimitEdges(t *testing.T) {
 	twoImages := chatMessages{{role: chatRoleUser, content: "inspect", attachments: []messageMedia{image, image}}}
 
 	requestLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(4)}
-	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{requestLimit}}, oneImage, []byte("1234")); limitError != nil {
+	if limitError := validateInlineMessageMediaBeforeSerialization(textModelDefinition{mediaLimits: []CatalogMediaLimit{requestLimit}}, oneImage); limitError != nil {
+		t.Fatalf("request pre-serialization boundary error=%v", limitError)
+	}
+	if limitError := validateInlineMessageMediaRequestLimit(textModelDefinition{mediaLimits: []CatalogMediaLimit{requestLimit}}, oneImage, []byte("1234")); limitError != nil {
 		t.Fatalf("request boundary error=%v", limitError)
 	}
-	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{requestLimit}}, oneImage, []byte("12345")); !errors.Is(limitError, ErrProviderMediaLimit) {
+	if limitError := validateInlineMessageMediaRequestLimit(textModelDefinition{mediaLimits: []CatalogMediaLimit{requestLimit}}, oneImage, []byte("12345")); !errors.Is(limitError, ErrProviderMediaLimit) {
 		t.Fatalf("request above error=%v", limitError)
+	}
+	requestLimit.Value = int64Pointer(3)
+	if limitError := validateInlineMessageMediaBeforeSerialization(textModelDefinition{mediaLimits: []CatalogMediaLimit{requestLimit}}, oneImage); !errors.Is(limitError, ErrProviderMediaLimit) {
+		t.Fatalf("encoded request minimum above error=%v", limitError)
 	}
 
 	countLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageCount, MediaType: string(messageMediaTypeImage), Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(1)}
-	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{countLimit}}, oneImage, nil); limitError != nil {
+	if limitError := validateInlineMessageMediaBeforeSerialization(textModelDefinition{mediaLimits: []CatalogMediaLimit{countLimit}}, oneImage); limitError != nil {
 		t.Fatalf("count boundary error=%v", limitError)
 	}
-	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{countLimit}}, twoImages, nil); !errors.Is(limitError, ErrProviderMediaLimit) {
+	if limitError := validateInlineMessageMediaBeforeSerialization(textModelDefinition{mediaLimits: []CatalogMediaLimit{countLimit}}, twoImages); !errors.Is(limitError, ErrProviderMediaLimit) {
 		t.Fatalf("count above error=%v", limitError)
 	}
 
 	encodedLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageInlineBytes, MediaType: string(messageMediaTypeImage), Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(4), Scope: CatalogMediaLimitScopeAttachmentEncodedBytes}
-	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{encodedLimit}}, oneImage, nil); limitError != nil {
+	if limitError := validateInlineMessageMediaBeforeSerialization(textModelDefinition{mediaLimits: []CatalogMediaLimit{encodedLimit}}, oneImage); limitError != nil {
 		t.Fatalf("encoded boundary error=%v", limitError)
 	}
 	encodedLimit.Value = int64Pointer(3)
-	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{encodedLimit}}, oneImage, nil); !errors.Is(limitError, ErrProviderMediaLimit) {
+	if limitError := validateInlineMessageMediaBeforeSerialization(textModelDefinition{mediaLimits: []CatalogMediaLimit{encodedLimit}}, oneImage); !errors.Is(limitError, ErrProviderMediaLimit) {
 		t.Fatalf("encoded above error=%v", limitError)
 	}
 
@@ -167,7 +192,7 @@ func TestInlineProviderMediaLimitEdges(t *testing.T) {
 	rawImage.sizeBytes = 2
 	rawImage.data = []byte("xx")
 	rawLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageInlineBytes, MediaType: string(messageMediaTypeImage), Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(1), Scope: CatalogMediaLimitScopeAttachment}
-	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{rawLimit}}, chatMessages{{role: chatRoleUser, attachments: []messageMedia{rawImage}}}, nil); !errors.Is(limitError, ErrProviderMediaLimit) {
+	if limitError := validateInlineMessageMediaBeforeSerialization(textModelDefinition{mediaLimits: []CatalogMediaLimit{rawLimit}}, chatMessages{{role: chatRoleUser, attachments: []messageMedia{rawImage}}}); !errors.Is(limitError, ErrProviderMediaLimit) {
 		t.Fatalf("raw above error=%v", limitError)
 	}
 }

--- a/internal/proxy/provider_media_edges_internal_test.go
+++ b/internal/proxy/provider_media_edges_internal_test.go
@@ -1,0 +1,173 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestProviderImageSerializationAndLimitFailureContracts(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	closedFile, fileError := os.CreateTemp(t.TempDir(), "closed-provider-media")
+	if fileError != nil {
+		t.Fatalf("create media: %v", fileError)
+	}
+	if closeError := closedFile.Close(); closeError != nil {
+		t.Fatalf("close media: %v", closeError)
+	}
+	closedMessages := chatMessages{{
+		role:    chatRoleUser,
+		content: "inspect",
+		attachments: []messageMedia{{
+			mediaType: messageMediaTypeImage,
+			mimeType:  messageImageMIMEPNG,
+			sizeBytes: 1,
+			asset:     &tenantAssetReader{file: closedFile},
+		}},
+	}}
+	openAIClient := NewOpenAIClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		t.Fatal("serialization failure reached provider")
+		return nil, nil
+	}), NewEndpoints())
+	anthropicClient := newAnthropicMessagesClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		t.Fatal("serialization failure reached provider")
+		return nil, nil
+	}))
+	model := textModelDefinition{
+		providerIdentifier: newModelID("provider-model"),
+		requestProfile:     requestProfileOpenAIResponsesTemperature,
+		outputTokenLimit:   32,
+	}
+	if _, requestError := openAIClient.openAIRequest(context.Background(), "key", model, closedMessages, false, nil, "", logger); !errors.Is(requestError, errAssetStore) {
+		t.Fatalf("OpenAI serialization error=%v", requestError)
+	}
+	if _, requestError := openAIClient.xAIResponsesRequest(context.Background(), "key", "https://provider.test", model, closedMessages, nil, logger); !errors.Is(requestError, errAssetStore) {
+		t.Fatalf("xAI serialization error=%v", requestError)
+	}
+	if _, requestError := anthropicClient.generateText(context.Background(), "key", "https://provider.test", model, closedMessages, nil, logger); !errors.Is(requestError, errAssetStore) {
+		t.Fatalf("Anthropic serialization error=%v", requestError)
+	}
+
+	inlineMessages := chatMessages{{
+		role:    chatRoleUser,
+		content: "inspect",
+		attachments: []messageMedia{{
+			mediaType: messageMediaTypeImage,
+			mimeType:  messageImageMIMEPNG,
+			sizeBytes: 1,
+			data:      []byte("x"),
+		}},
+	}}
+	model.mediaLimits = []CatalogMediaLimit{{
+		ID:        CatalogMediaLimitIDInlineRequestBytes,
+		MediaType: CatalogMediaLimitTypeAll,
+		Status:    CatalogMediaLimitStatusBounded,
+		Value:     int64Pointer(1),
+	}}
+	if _, requestError := openAIClient.openAIRequest(context.Background(), "key", model, inlineMessages, false, nil, "", logger); !errors.Is(requestError, ErrProviderMediaLimit) {
+		t.Fatalf("OpenAI media limit error=%v", requestError)
+	}
+	if _, requestError := openAIClient.xAIResponsesRequest(context.Background(), "key", "https://provider.test", model, inlineMessages, nil, logger); !errors.Is(requestError, ErrProviderMediaLimit) {
+		t.Fatalf("xAI media limit error=%v", requestError)
+	}
+	if _, requestError := anthropicClient.generateText(context.Background(), "key", "https://provider.test", model, inlineMessages, nil, logger); !errors.Is(requestError, ErrProviderMediaLimit) {
+		t.Fatalf("Anthropic media limit error=%v", requestError)
+	}
+}
+
+func TestSynchronousResponsesFailureContracts(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	messages := chatMessages{{role: chatRoleUser, content: "inspect"}}
+	model := textModelDefinition{providerIdentifier: newModelID("grok-test")}
+
+	client := NewOpenAIClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	}), NewEndpoints())
+	if _, requestError := client.xAIResponsesRequest(context.Background(), "key", "http://[::1", model, messages, nil, logger); requestError == nil {
+		t.Fatal("xAI accepted invalid Responses URL")
+	}
+	if _, requestError := client.xAIResponsesRequest(context.Background(), "key", "https://provider.test", model, messages, nil, logger); requestError == nil {
+		t.Fatal("xAI transport error was accepted")
+	}
+
+	client = NewOpenAIClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("{")),
+		}, nil
+	}), NewEndpoints())
+	if _, requestError := client.xAIResponsesRequest(context.Background(), "key", "https://provider.test", model, messages, nil, logger); requestError == nil {
+		t.Fatal("xAI malformed response was accepted")
+	}
+
+	for _, testCase := range []struct {
+		name     string
+		snapshot openAIResponseSnapshot
+		want     error
+	}{
+		{name: "blank completed", snapshot: openAIResponseSnapshot{status: statusCompleted}, want: errors.New(errorOpenAIAPI)},
+		{name: "output limit", snapshot: openAIResponseSnapshot{status: statusIncomplete, incompleteReason: "max_output_tokens", text: "partial"}, want: errProviderOutputLimitReached},
+		{name: "other incomplete", snapshot: openAIResponseSnapshot{status: statusIncomplete, incompleteReason: "content_filter"}, want: ErrProviderAPI},
+		{name: "failed", snapshot: openAIResponseSnapshot{status: statusFailed}, want: errors.New(errorOpenAIFailedStatus)},
+		{name: "unknown", snapshot: openAIResponseSnapshot{status: statusInProgress}, want: errors.New(errorOpenAIAPI)},
+	} {
+		t.Run(testCase.name, func(subTest *testing.T) {
+			_, resolveError := resolveSynchronousResponsesSnapshot(testCase.snapshot)
+			if resolveError == nil {
+				subTest.Fatal("snapshot resolved without error")
+			}
+			if errors.Is(testCase.want, ErrProviderAPI) && !errors.Is(resolveError, ErrProviderAPI) {
+				subTest.Fatalf("resolve error=%v want=%v", resolveError, testCase.want)
+			}
+			if testCase.want == errProviderOutputLimitReached && !errors.Is(resolveError, errProviderOutputLimitReached) {
+				subTest.Fatalf("resolve error=%v want=%v", resolveError, testCase.want)
+			}
+		})
+	}
+}
+
+func TestInlineProviderMediaLimitEdges(t *testing.T) {
+	image := messageMedia{mediaType: messageMediaTypeImage, mimeType: messageImageMIMEPNG, sizeBytes: 1, data: []byte("x")}
+	oneImage := chatMessages{{role: chatRoleUser, content: "inspect", attachments: []messageMedia{image}}}
+	twoImages := chatMessages{{role: chatRoleUser, content: "inspect", attachments: []messageMedia{image, image}}}
+
+	requestLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDInlineRequestBytes, MediaType: CatalogMediaLimitTypeAll, Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(4)}
+	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{requestLimit}}, oneImage, []byte("1234")); limitError != nil {
+		t.Fatalf("request boundary error=%v", limitError)
+	}
+	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{requestLimit}}, oneImage, []byte("12345")); !errors.Is(limitError, ErrProviderMediaLimit) {
+		t.Fatalf("request above error=%v", limitError)
+	}
+
+	countLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageCount, MediaType: string(messageMediaTypeImage), Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(1)}
+	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{countLimit}}, oneImage, nil); limitError != nil {
+		t.Fatalf("count boundary error=%v", limitError)
+	}
+	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{countLimit}}, twoImages, nil); !errors.Is(limitError, ErrProviderMediaLimit) {
+		t.Fatalf("count above error=%v", limitError)
+	}
+
+	encodedLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageInlineBytes, MediaType: string(messageMediaTypeImage), Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(4), Scope: CatalogMediaLimitScopeAttachmentEncodedBytes}
+	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{encodedLimit}}, oneImage, nil); limitError != nil {
+		t.Fatalf("encoded boundary error=%v", limitError)
+	}
+	encodedLimit.Value = int64Pointer(3)
+	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{encodedLimit}}, oneImage, nil); !errors.Is(limitError, ErrProviderMediaLimit) {
+		t.Fatalf("encoded above error=%v", limitError)
+	}
+
+	rawImage := image
+	rawImage.sizeBytes = 2
+	rawImage.data = []byte("xx")
+	rawLimit := CatalogMediaLimit{ID: CatalogMediaLimitIDImageInlineBytes, MediaType: string(messageMediaTypeImage), Status: CatalogMediaLimitStatusBounded, Value: int64Pointer(1), Scope: CatalogMediaLimitScopeAttachment}
+	if limitError := validateInlineMessageMediaLimits(textModelDefinition{mediaLimits: []CatalogMediaLimit{rawLimit}}, chatMessages{{role: chatRoleUser, attachments: []messageMedia{rawImage}}}, nil); !errors.Is(limitError, ErrProviderMediaLimit) {
+		t.Fatalf("raw above error=%v", limitError)
+	}
+}

--- a/internal/proxy/provider_router.go
+++ b/internal/proxy/provider_router.go
@@ -23,12 +23,14 @@ type textRouteAdapter interface {
 }
 
 type openAIResponsesTextRouteAdapter struct{}
+type openAIResponsesSynchronousTextRouteAdapter struct{}
 type openAIChatCompletionsTextRouteAdapter struct{}
 type geminiInteractionsTextRouteAdapter struct{}
 type anthropicMessagesTextRouteAdapter struct{}
 
 var textRouteAdapters = map[textRouteCapabilities]textRouteAdapter{
 	openAIResponsesPollableRouteCapabilities:          openAIResponsesTextRouteAdapter{},
+	openAIResponsesSynchronousRouteCapabilities:       openAIResponsesSynchronousTextRouteAdapter{},
 	openAIChatCompletionsSynchronousRouteCapabilities: openAIChatCompletionsTextRouteAdapter{},
 	geminiInteractionsPollableRouteCapabilities:       geminiInteractionsTextRouteAdapter{},
 	geminiInteractionsSynchronousRouteCapabilities:    geminiInteractionsTextRouteAdapter{},
@@ -84,6 +86,18 @@ func (openAIResponsesTextRouteAdapter) generateText(requestContext context.Conte
 		request.webSearchEnabled,
 		request.maxTokens,
 		request.reasoningEffort,
+		structuredLogger,
+	)
+}
+
+func (openAIResponsesSynchronousTextRouteAdapter) generateText(requestContext context.Context, router *providerRouter, request chatRequestParameters, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	return router.openAIClient.xAIResponsesRequest(
+		requestContext,
+		request.provider.credentialFor(endpointKindText),
+		request.provider.textBaseURL,
+		request.model,
+		request.messages,
+		request.maxTokens,
 		structuredLogger,
 	)
 }

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -258,6 +258,10 @@ func TestProviderRoutingEnumeratesConfiguredTextRouteCapabilities(t *testing.T) 
 					expected.executionLifecycle = "synchronous_completion"
 				}
 			}
+			if providerName == proxy.ProviderNameXAI && offering.Model == proxy.ModelNameGrok45 {
+				expected.wireContract = "openai_responses"
+				expected.executionLifecycle = "synchronous_completion"
+			}
 			if offering.WireContract != expected.wireContract || offering.ExecutionLifecycle != expected.executionLifecycle {
 				t.Fatalf("provider=%s model=%s capabilities=%s/%s want=%s/%s", providerName, offering.Model, offering.WireContract, offering.ExecutionLifecycle, expected.wireContract, expected.executionLifecycle)
 			}
@@ -376,7 +380,6 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 		{name: "MiniMax M2.7", provider: proxy.ProviderNameMiniMax, model: proxy.ModelNameMiniMaxM27, providerModel: "MiniMax-M2.7", tokenParameterField: "max_completion_tokens", expectedAPIKey: "sk-minimax", forbiddenFields: []string{"max_tokens"}},
 		{name: "SiliconFlow DeepSeek R1", provider: proxy.ProviderNameSiliconFlow, model: proxy.ModelNameSiliconFlowDeepSeek, providerModel: "deepseek-ai/DeepSeek-R1", tokenParameterField: "max_tokens", expectedAPIKey: testSiliconFlowKey},
 		{name: "Zhipu GLM 5.2", provider: proxy.ProviderNameZhipu, model: "glm-5.2", tokenParameterField: "max_tokens", forbiddenFields: []string{"thinking", "reasoning_effort"}},
-		{name: "Grok 4.5", provider: proxy.ProviderNameXAI, model: "grok-4.5", tokenParameterField: "max_tokens"},
 		{name: "Grok 4.20 reasoning", provider: proxy.ProviderNameXAI, model: "grok-4.20-0309-reasoning", tokenParameterField: "max_tokens"},
 	}
 	for _, testCase := range testCases {

--- a/internal/proxy/provider_types.go
+++ b/internal/proxy/provider_types.go
@@ -107,6 +107,8 @@ const (
 	ModelNameGrok43 = "grok-4.3"
 	// ModelNameGrok43Latest identifies the Grok 4.3 latest alias.
 	ModelNameGrok43Latest = "grok-4.3-latest"
+	// ModelNameGrok45 identifies the Grok 4.5 model.
+	ModelNameGrok45 = "grok-4.5"
 	// ModelNameGrokLatest identifies the current Grok latest alias.
 	ModelNameGrokLatest = "grok-latest"
 	// ModelNameGrokBuild01 identifies the Grok Build coding model.
@@ -151,6 +153,10 @@ var (
 	openAIResponsesPollableRouteCapabilities = textRouteCapabilities{
 		wireContract:       textWireContractOpenAIResponses,
 		executionLifecycle: textExecutionLifecyclePollableResource,
+	}
+	openAIResponsesSynchronousRouteCapabilities = textRouteCapabilities{
+		wireContract:       textWireContractOpenAIResponses,
+		executionLifecycle: textExecutionLifecycleSynchronousCompletion,
 	}
 	openAIChatCompletionsSynchronousRouteCapabilities = textRouteCapabilities{
 		wireContract:       textWireContractOpenAIChatCompletions,

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -196,7 +197,7 @@ func chatJSONHandler(upstreamProviders *providerRouter, providers *providerRegis
 			return
 		}
 		var payload chatRequestPayload
-		jsonDecoder := json.NewDecoder(strings.NewReader(string(bodyBytes)))
+		jsonDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
 		jsonDecoder.DisallowUnknownFields()
 		if decodeError := jsonDecoder.Decode(&payload); decodeError != nil {
 			ginContext.String(http.StatusBadRequest, errorInvalidJSONRequest)
@@ -234,7 +235,7 @@ func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerReg
 			return
 		}
 		var payload chatV2RequestPayload
-		jsonDecoder := json.NewDecoder(strings.NewReader(string(bodyBytes)))
+		jsonDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
 		jsonDecoder.DisallowUnknownFields()
 		if decodeError := jsonDecoder.Decode(&payload); decodeError != nil {
 			ginContext.String(http.StatusBadRequest, errorInvalidJSONRequest)
@@ -478,6 +479,7 @@ func chatRequestFromV2Payload(ginContext *gin.Context, payload chatV2RequestPayl
 		return chatRequestParameters{}, false
 	}
 	if mediaCapabilityError := validateMessageMediaForResolvedTextRoute(providerDefinition, resolvedModel, messages); mediaCapabilityError != nil {
+		messages.closeMedia()
 		ginContext.String(statusCodeForError(mediaCapabilityError), responseMessageForError(mediaCapabilityError))
 		return chatRequestParameters{}, false
 	}

--- a/scripts/render_public_site.mjs
+++ b/scripts/render_public_site.mjs
@@ -513,7 +513,7 @@ function parseCatalogMediaLimit(rawLimit, field) {
       || !new Set(["any", "inline", "file"]).has(transport)
       || !new Set(["bounded", "unbounded", "unknown"]).has(status)
       || !new Set(["bytes", "files"]).has(unit)
-      || !new Set(["attachment", "request", "request_encoded_bytes"]).has(scope)
+      || !new Set(["attachment", "attachment_encoded_bytes", "request", "request_encoded_bytes"]).has(scope)
       || (status === "bounded" ? value === null || value === 0 : value !== null)) {
     throw new Error(`public_capabilities_invalid: ${field} media limit`);
   }

--- a/scripts/test_live_providers.sh
+++ b/scripts/test_live_providers.sh
@@ -3,12 +3,14 @@ set -euo pipefail
 
 usage() {
   builtin printf '%s\n' 'Usage:
-  scripts/test_live_providers.sh [--preflight | --write-config <path>]
+  scripts/test_live_providers.sh [--media | --preflight | --write-config <path>]
 
 Builds the current llm-proxy binary, verifies each available provider key
 through the authenticated management operation, and only then runs its live
-text smoke test. The preflight mode builds a temporary static configuration and
-verifies authenticated routing without making an upstream provider call.
+text smoke test. Media mode verifies the four current image providers and then
+runs one canonical image request for each. The preflight mode builds a temporary
+static configuration and verifies authenticated routing without an upstream
+provider call.
 
 Required environment:
   At least one provider API key, unless no-op skip behavior is desired.
@@ -37,6 +39,8 @@ Optional environment:
   GO                         Go binary. Default: go.
 
 Options:
+  --media                  Run the paid OpenAI, Anthropic, Gemini, and xAI image
+                           matrix. LLM_PROXY_LIVE_PROVIDERS can select a subset.
   --preflight                Verify the disposable static config without an
                              upstream provider call.
   --write-config <path>      Write the disposable static config and exit
@@ -188,6 +192,34 @@ provider_model() {
     return
   fi
   provider_default_model "${provider}"
+}
+
+provider_image_model() {
+  local provider="$1"
+  local verified_model
+  verified_model="$(provider_model "${provider}")"
+  python3 -c '
+import json
+import pathlib
+import sys
+
+catalog = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+offerings = catalog.get("offerings", [])
+candidates = sorted({
+    offering.get("model")
+    for offering in offerings
+    if offering.get("provider") == sys.argv[2]
+    and "image_input" in offering.get("capabilities", [])
+    and isinstance(offering.get("model"), str)
+    and offering.get("model")
+})
+if sys.argv[3] in candidates:
+    print(sys.argv[3])
+elif len(candidates) == 1:
+    print(candidates[0])
+else:
+    raise SystemExit(1)
+' "${PUBLIC_CAPABILITIES_RESPONSE_PATH}" "${provider}" "${verified_model}"
 }
 
 validate_provider_name() {
@@ -484,13 +516,18 @@ verification_failure_code() {
 
 verify_provider_key() {
   local provider="$1"
+  local requested_model="${2:-}"
   local key_variable
   local model
   local request_path
   local response_path
   local http_status
   key_variable="$(provider_key_variable "${provider}")"
-  model="$(provider_model "${provider}")"
+  if [[ -n "${requested_model}" ]]; then
+    model="${requested_model}"
+  else
+    model="$(provider_model "${provider}")"
+  fi
   request_path="${TMP_DIR}/${provider}-verification-request.json"
   response_path="${TMP_DIR}/${provider}-verification-response.json"
   python3 -c '
@@ -567,6 +604,124 @@ run_text_smoke() {
   echo "live provider smoke passed: provider=${provider} model=${request_model_label} status=${http_status}"
 }
 
+fetch_public_capabilities() {
+  local http_status
+  http_status="$(
+    curl -sS --max-time 5 \
+      -o "${PUBLIC_CAPABILITIES_RESPONSE_PATH}" \
+      -w "%{http_code}" \
+      "http://127.0.0.1:${PORT}/api/public/capabilities"
+  )"
+  if [[ "${http_status}" != "200" ]] || ! python3 -c '
+import json
+import pathlib
+import sys
+
+catalog = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if not isinstance(catalog.get("offerings"), list):
+    raise SystemExit(1)
+' "${PUBLIC_CAPABILITIES_RESPONSE_PATH}"; then
+    echo "error: live provider capability discovery failed: status=${http_status}" >&2
+    redact_log
+    exit 1
+  fi
+}
+
+write_image_smoke_request() {
+  local model="$1"
+  local request_path="$2"
+  python3 -c '
+import base64
+import binascii
+import hashlib
+import json
+import pathlib
+import struct
+import sys
+import zlib
+
+def png_chunk(chunk_type, payload):
+    return struct.pack(">I", len(payload)) + chunk_type + payload + struct.pack(
+        ">I", binascii.crc32(chunk_type + payload) & 0xFFFFFFFF
+    )
+
+width = 256
+height = 256
+scanlines = b"".join(b"\x00" + (b"\xff\x00\x00" * width) for _ in range(height))
+image = (
+    b"\x89PNG\r\n\x1a\n"
+    + png_chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+    + png_chunk(b"IDAT", zlib.compress(scanlines, level=9))
+    + png_chunk(b"IEND", b"")
+)
+payload = {
+    "messages": [{
+        "role": "user",
+        "content": "Identify the solid color in this image. Reply with exactly RED and no punctuation.",
+        "attachments": [{
+            "type": "image",
+            "mime_type": "image/png",
+            "data": base64.b64encode(image).decode("ascii"),
+            "sha256": hashlib.sha256(image).hexdigest(),
+        }],
+    }],
+    "model": sys.argv[1],
+    "web_search": False,
+}
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(payload, separators=(",", ":")),
+    encoding="utf-8",
+)
+' "${model}" "${request_path}"
+}
+
+validated_response_request_id() {
+  local headers_path="$1"
+  python3 -c '
+import re
+import sys
+
+with open(sys.argv[1], encoding="utf-8", errors="strict") as header_file:
+    values = [
+        line.split(":", 1)[1].strip()
+        for line in header_file
+        if line.lower().startswith("x-llm-proxy-request-id:")
+    ]
+if len(values) != 1 or re.fullmatch(r"[A-Z2-7]{26,}", values[0]) is None:
+    raise SystemExit(1)
+' "${headers_path}"
+}
+
+run_image_smoke() {
+  local provider="$1"
+  local model="$2"
+  local request_path="${TMP_DIR}/${provider}-image-request.json"
+  local headers_path="${TMP_DIR}/${provider}-image-headers.txt"
+  local response_path="${TMP_DIR}/${provider}-image-response.txt"
+  local http_status
+  local response_text
+  write_image_smoke_request "${model}" "${request_path}"
+
+  http_status="$(
+    curl -sS --max-time "${LIVE_TIMEOUT}" \
+      -X POST \
+      -D "${headers_path}" \
+      -H "Content-Type: application/json" \
+      --data-binary "@${request_path}" \
+      -o "${response_path}" \
+      -w "%{http_code}" \
+      "http://127.0.0.1:${PORT}/v2?provider=${provider}&format=text/plain&key=${SERVICE_SECRET}"
+  )"
+
+  response_text="$(tr -d '\r\n' <"${response_path}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  if [[ "${http_status}" != "200" || "${response_text}" != "RED" ]] || ! validated_response_request_id "${headers_path}"; then
+    echo "error: live provider image smoke failed: provider=${provider} model=${model} status=${http_status}" >&2
+    redact_log
+    exit 1
+  fi
+  echo "live provider image smoke passed: provider=${provider} model=${model} status=${http_status}"
+}
+
 run_static_config_preflight() {
   local response_path="${TMP_DIR}/preflight-response.txt"
   local http_status
@@ -585,9 +740,14 @@ run_static_config_preflight() {
 }
 
 PREFLIGHT_ONLY=false
+MEDIA_ONLY=false
 WRITE_CONFIG_PATH=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --media)
+      MEDIA_ONLY=true
+      shift
+      ;;
     --preflight)
       PREFLIGHT_ONLY=true
       shift
@@ -608,13 +768,16 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
-if [[ "${PREFLIGHT_ONLY}" == "true" && -n "${WRITE_CONFIG_PATH}" ]]; then
-  echo "error: --preflight and --write-config are mutually exclusive" >&2
+if [[ "${MEDIA_ONLY}" == "true" && ( "${PREFLIGHT_ONLY}" == "true" || -n "${WRITE_CONFIG_PATH}" ) ]] ||
+  [[ "${PREFLIGHT_ONLY}" == "true" && -n "${WRITE_CONFIG_PATH}" ]]; then
+  echo "error: --media, --preflight, and --write-config are mutually exclusive" >&2
   exit 1
 fi
 
 SUPPORTED_PROVIDERS=(openai deepseek dashscope moonshot minimax siliconflow zhipu gemini anthropic meta xai)
+MEDIA_PROVIDERS=(openai anthropic gemini xai)
 LIVE_PROVIDERS=()
+IMAGE_MODELS=()
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 PROXY_PID=""
@@ -640,6 +803,9 @@ if [[ -n "${LIVE_ENV_FILE:-}" ]]; then
 fi
 
 if [[ "${PREFLIGHT_ONLY}" != "true" && -z "${WRITE_CONFIG_PATH}" ]]; then
+  if [[ "${MEDIA_ONLY}" == "true" && -z "${LLM_PROXY_LIVE_PROVIDERS:-}" ]]; then
+    LLM_PROXY_LIVE_PROVIDERS="$(IFS=,; builtin printf '%s' "${MEDIA_PROVIDERS[*]}")"
+  fi
   discover_live_providers
   if [[ "${#LIVE_PROVIDERS[@]}" -eq 0 ]]; then
     echo "live provider smoke skipped: no provider API keys found"
@@ -665,6 +831,7 @@ else
   CONFIG_PATH="${TMP_DIR}/config.yml"
 fi
 LOG_PATH="${TMP_DIR}/llm-proxy.log"
+PUBLIC_CAPABILITIES_RESPONSE_PATH="${TMP_DIR}/public-capabilities.json"
 export LLM_PROXY_LIVE_PORT="${PORT}"
 if [[ "${PREFLIGHT_ONLY}" == "true" || -n "${WRITE_CONFIG_PATH}" ]]; then
   export SERVICE_SECRET="${SERVICE_SECRET:-live-service-secret}"
@@ -701,7 +868,24 @@ if [[ "${PREFLIGHT_ONLY}" == "true" ]]; then
 fi
 
 initialize_live_management
-for live_provider in "${LIVE_PROVIDERS[@]}"; do
-  verify_provider_key "${live_provider}"
-  run_text_smoke "${live_provider}"
-done
+if [[ "${MEDIA_ONLY}" == "true" ]]; then
+  fetch_public_capabilities
+  for live_provider in "${LIVE_PROVIDERS[@]}"; do
+    if ! image_model="$(provider_image_model "${live_provider}")"; then
+      echo "error: live provider image model is unavailable or ambiguous: provider=${live_provider}" >&2
+      exit 1
+    fi
+    IMAGE_MODELS+=("${image_model}")
+  done
+  for live_provider_index in "${!LIVE_PROVIDERS[@]}"; do
+    verify_provider_key "${LIVE_PROVIDERS[${live_provider_index}]}" "${IMAGE_MODELS[${live_provider_index}]}"
+  done
+  for live_provider_index in "${!LIVE_PROVIDERS[@]}"; do
+    run_image_smoke "${LIVE_PROVIDERS[${live_provider_index}]}" "${IMAGE_MODELS[${live_provider_index}]}"
+  done
+else
+  for live_provider in "${LIVE_PROVIDERS[@]}"; do
+    verify_provider_key "${live_provider}"
+    run_text_smoke "${live_provider}"
+  done
+fi

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="9f75f00a49eefffc9d8c53ce99fc48a8c52cf95ab3975b07fbaaf693841338ef">
+    <meta name="openapi-source-sha256" content="1ed682df2b8d9082e68aeab7fb83444e5dbdbc029293f870a770ea2da07952f9">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.css">
     <link rel="stylesheet" href="/assets/llm-proxy/public-shell.css">
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="9f75f00a49eefffc9d8c53ce99fc48a8c52cf95ab3975b07fbaaf693841338ef">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="1ed682df2b8d9082e68aeab7fb83444e5dbdbc029293f870a770ea2da07952f9">
     <mpr-header
       class="public-site-header"
       data-config-url="/config-ui.yaml"
@@ -49,7 +49,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>9f75f00a49eefffc9d8c53ce99fc48a8c52cf95ab3975b07fbaaf693841338ef</code></span>
+          <span>Source SHA-256 <code>1ed682df2b8d9082e68aeab7fb83444e5dbdbc029293f870a770ea2da07952f9</code></span>
         </div>
         <div class="resource-actions" aria-label="OpenAPI schema actions">
           <a class="resource-button" href="#openapi-yaml">View YAML</a>
@@ -1710,6 +1710,7 @@ components:
           type: string
           enum:
             - attachment
+            - attachment_encoded_bytes
             - request
             - request_encoded_bytes
         source:

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="1ed682df2b8d9082e68aeab7fb83444e5dbdbc029293f870a770ea2da07952f9">
+    <meta name="openapi-source-sha256" content="f7906ac6ef227ecff8defca0bfcf83863b2b16d835679e55f0ea2ea1fc4995c1">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.css">
     <link rel="stylesheet" href="/assets/llm-proxy/public-shell.css">
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="1ed682df2b8d9082e68aeab7fb83444e5dbdbc029293f870a770ea2da07952f9">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="f7906ac6ef227ecff8defca0bfcf83863b2b16d835679e55f0ea2ea1fc4995c1">
     <mpr-header
       class="public-site-header"
       data-config-url="/config-ui.yaml"
@@ -49,7 +49,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>1ed682df2b8d9082e68aeab7fb83444e5dbdbc029293f870a770ea2da07952f9</code></span>
+          <span>Source SHA-256 <code>f7906ac6ef227ecff8defca0bfcf83863b2b16d835679e55f0ea2ea1fc4995c1</code></span>
         </div>
         <div class="resource-actions" aria-label="OpenAPI schema actions">
           <a class="resource-button" href="#openapi-yaml">View YAML</a>
@@ -180,7 +180,9 @@ paths:
         the tenant or route default. A supplied value must be non-blank and
         supported by the resolved route. The selected provider offering owns
         media admission and transport limits. Unsupported media or route
-        capabilities return HTTP 400 before an upstream call.
+        capabilities return HTTP 400 before an upstream call. The service
+        rejects an encoded request body above 8 MiB before JSON decoding. A
+        smaller catalog-derived body limit applies when configured.
       tags:
         - Proxy
       security:
@@ -3930,7 +3932,7 @@ components:
           <span class="api-operation-id">postV2Messages</span>
         </header>
         <h2>Generate text from canonical messages</h2>
-        <p>The current messages-only operation. `messages` is required. User messages may include ordered inline or tenant-asset-backed image and audio attachments. `model`, `web_search`, `max_tokens`, and `reasoning_effort` are optional. Omitting `reasoning_effort` selects the tenant or route default. A supplied value must be non-blank and supported by the resolved route. The selected provider offering owns media admission and transport limits. Unsupported media or route capabilities return HTTP 400 before an upstream call.</p>
+        <p>The current messages-only operation. `messages` is required. User messages may include ordered inline or tenant-asset-backed image and audio attachments. `model`, `web_search`, `max_tokens`, and `reasoning_effort` are optional. Omitting `reasoning_effort` selects the tenant or route default. A supplied value must be non-blank and supported by the resolved route. The selected provider offering owns media admission and transport limits. Unsupported media or route capabilities return HTTP 400 before an upstream call. The service rejects an encoded request body above 8 MiB before JSON decoding. A smaller catalog-derived body limit applies when configured.</p>
         <p class="api-security"><strong>Authentication:</strong> TenantClientKey (query key)</p>
         <div class="api-contract-block">
           <h3>Parameters</h3>

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -174,78 +175,56 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 	}
 }
 
-func TestPublicCapabilityCatalogPublishesExactGeminiMediaLimits(testingInstance *testing.T) {
+func TestPublicCapabilityCatalogPublishesExactProviderMediaLimits(testingInstance *testing.T) {
 	catalog, catalogError := proxy.NewPublicCapabilityCatalog(proxy.Configuration{
 		ModelCatalog: testfixtures.ModelCatalog(testingInstance),
 	})
 	if catalogError != nil {
 		testingInstance.Fatalf("NewPublicCapabilityCatalog error: %v", catalogError)
 	}
-	expectedLimits := map[string]struct {
-		mediaType string
-		transport string
-		status    string
-		value     int64
-		unit      string
-		scope     string
-		source    string
-	}{
-		proxy.CatalogMediaLimitIDInlineRequestBytes: {
-			mediaType: proxy.CatalogMediaLimitTypeAll, transport: proxy.CatalogMediaTransportInline,
-			status: proxy.CatalogMediaLimitStatusBounded, value: 20_000_000,
-			unit: proxy.CatalogMediaLimitUnitBytes, scope: proxy.CatalogMediaLimitScopeRequestEncodedBytes,
-			source: "https://ai.google.dev/gemini-api/docs/file-input-methods",
-		},
-		proxy.CatalogMediaLimitIDImageCount: {
-			mediaType: "image", transport: proxy.CatalogMediaTransportAny,
-			status: proxy.CatalogMediaLimitStatusBounded, value: 3_600,
-			unit: proxy.CatalogMediaLimitUnitFiles, scope: proxy.CatalogMediaLimitScopeRequest,
-			source: "https://ai.google.dev/gemini-api/docs/image-understanding",
-		},
-		proxy.CatalogMediaLimitIDAudioCount: {
-			mediaType: "audio", transport: proxy.CatalogMediaTransportAny,
-			status: proxy.CatalogMediaLimitStatusUnknown,
-			unit:   proxy.CatalogMediaLimitUnitFiles, scope: proxy.CatalogMediaLimitScopeRequest,
-			source: "https://ai.google.dev/gemini-api/docs/audio",
-		},
-		proxy.CatalogMediaLimitIDImageFileBytes: {
-			mediaType: "image", transport: proxy.CatalogMediaTransportFile,
-			status: proxy.CatalogMediaLimitStatusBounded, value: 2_000_000_000,
-			unit: proxy.CatalogMediaLimitUnitBytes, scope: proxy.CatalogMediaLimitScopeAttachment,
-			source: "https://ai.google.dev/gemini-api/docs/files",
-		},
-		proxy.CatalogMediaLimitIDAudioFileBytes: {
-			mediaType: "audio", transport: proxy.CatalogMediaTransportFile,
-			status: proxy.CatalogMediaLimitStatusBounded, value: 2_000_000_000,
-			unit: proxy.CatalogMediaLimitUnitBytes, scope: proxy.CatalogMediaLimitScopeAttachment,
-			source: "https://ai.google.dev/gemini-api/docs/files",
-		},
+	expectedOfferingCounts := map[string]int{
+		proxy.ProviderNameOpenAI:    11,
+		proxy.ProviderNameGemini:    7,
+		proxy.ProviderNameAnthropic: 10,
+		proxy.ProviderNameXAI:       1,
 	}
-
-	mediaOfferingCount := 0
+	observedOfferingCounts := map[string]int{}
 	for _, offering := range catalog.Offerings {
 		if len(offering.MediaLimits) == 0 {
 			continue
 		}
-		mediaOfferingCount++
-		if offering.Provider != proxy.ProviderNameGemini || (offering.Model != proxy.ModelNameGemini35Flash && offering.Model != proxy.ModelNameGemini25Flash) || len(offering.MediaLimits) != len(expectedLimits) {
+		observedOfferingCounts[offering.Provider]++
+		expectedLimitCount := 3
+		if offering.Provider == proxy.ProviderNameGemini {
+			expectedLimitCount = 5
+		}
+		if _, expectedProvider := expectedOfferingCounts[offering.Provider]; !expectedProvider || len(offering.MediaLimits) != expectedLimitCount {
 			testingInstance.Fatalf("unexpected media offering=%+v", offering)
 		}
+		observedLimitIDs := map[string]proxy.CatalogMediaLimit{}
 		for _, limit := range offering.MediaLimits {
-			expected, exists := expectedLimits[limit.ID]
-			if !exists || limit.MediaType != expected.mediaType || limit.Transport != expected.transport || limit.Status != expected.status || limit.Unit != expected.unit || limit.Scope != expected.scope || limit.Source != expected.source || limit.LastVerified != "2026-08-11" {
+			if limit.LastVerified != "2026-08-11" {
 				testingInstance.Fatalf("media limit=%+v", limit)
 			}
-			if expected.status == proxy.CatalogMediaLimitStatusBounded && (limit.Value == nil || *limit.Value != expected.value) {
-				testingInstance.Fatalf("bounded media limit=%+v", limit)
-			}
-			if expected.status != proxy.CatalogMediaLimitStatusBounded && limit.Value != nil {
-				testingInstance.Fatalf("non-bounded media limit=%+v", limit)
+			observedLimitIDs[limit.ID] = limit
+		}
+		for _, requiredLimitID := range []string{proxy.CatalogMediaLimitIDInlineRequestBytes, proxy.CatalogMediaLimitIDImageCount} {
+			if _, found := observedLimitIDs[requiredLimitID]; !found {
+				testingInstance.Fatalf("provider=%s model=%s missing media limit=%s", offering.Provider, offering.Model, requiredLimitID)
 			}
 		}
+		if offering.Provider == proxy.ProviderNameGemini {
+			for _, requiredLimitID := range []string{proxy.CatalogMediaLimitIDAudioCount, proxy.CatalogMediaLimitIDImageFileBytes, proxy.CatalogMediaLimitIDAudioFileBytes} {
+				if _, found := observedLimitIDs[requiredLimitID]; !found {
+					testingInstance.Fatalf("provider=%s model=%s missing media limit=%s", offering.Provider, offering.Model, requiredLimitID)
+				}
+			}
+		} else if _, found := observedLimitIDs[proxy.CatalogMediaLimitIDImageInlineBytes]; !found {
+			testingInstance.Fatalf("provider=%s model=%s missing inline image limit", offering.Provider, offering.Model)
+		}
 	}
-	if mediaOfferingCount != 2 {
-		testingInstance.Fatalf("media offerings=%d want=2", mediaOfferingCount)
+	if !reflect.DeepEqual(observedOfferingCounts, expectedOfferingCounts) {
+		testingInstance.Fatalf("media offering counts=%v want=%v", observedOfferingCounts, expectedOfferingCounts)
 	}
 }
 

--- a/tests/e2e/management-ui.spec.js
+++ b/tests/e2e/management-ui.spec.js
@@ -855,6 +855,11 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(catalog.getByRole("columnheader")).toHaveText(["Publisher", "Model", "Provider offerings and capabilities"]);
   await expect(catalog.locator("[data-catalog-row]")).toHaveCount(57);
   await expect(catalog.locator('[data-model="gpt-4o-mini-transcribe"]')).toContainText("Dictation");
+  await expect(catalog.locator('[data-model="gpt-4o-mini"]')).toContainText("Image input");
+  await expect(catalog.locator('[data-model="claude-fable-5"]')).toContainText("Image input");
+  await expect(catalog.locator('[data-model="grok-4.5"]')).toContainText("Image input");
+  await expect(catalog.locator('[data-model="gemini-3.5-flash"]')).toContainText("Image input");
+  await expect(catalog.locator('[data-model="gemini-3.5-flash"]')).toContainText("Audio message input");
 
   const footer = page.locator(".public-site-footer-fallback");
   await expect(footer).toBeVisible();
@@ -881,6 +886,8 @@ test("visitors can filter and choose a model family, exact model, and provider o
   const proprietaryFilter = routingTree.locator('[data-route-weight-access="proprietary"]');
   const openWeightsFilter = routingTree.locator('[data-route-weight-access="open_weights"]');
   const textFilter = routingTree.locator('[data-route-capability="text"]');
+  const imageInputFilter = routingTree.locator('[data-route-capability="image_input"]');
+  const audioInputFilter = routingTree.locator('[data-route-capability="audio_input"]');
   const webSearchFilter = routingTree.locator('[data-route-capability="web_search"]');
   await expect(routingTree).toHaveAttribute("data-enhanced", "true");
   await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "true");
@@ -910,6 +917,33 @@ test("visitors can filter and choose a model family, exact model, and provider o
   expect(routeCanvasDimensions.width).toBeGreaterThan(0);
   await expectFiveStageRouteOrder(routingTree);
   await expectSelectedRoutingFanEndpoints(routingTree);
+
+  await imageInputFilter.click();
+  await expect(imageInputFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(textFilter).toHaveAttribute("aria-pressed", "false");
+  await expect(counts).toHaveText("8 families · 29 exact models · 29 offerings");
+  await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(8);
+  await routingTree.locator('[data-route-family="grok"]').click();
+  await expect(routingTree.locator('[data-route-model-group="grok"] [data-route-model]:visible')).toHaveCount(1);
+  await expect(routingTree.locator('[data-route-model="grok-4.5"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-provider-group="grok-4.5"] [data-route-provider="xai"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(selectedModel).toHaveText("grok-4.5");
+  await expect(selectedProvider).toHaveText("xai");
+
+  await audioInputFilter.click();
+  await expect(audioInputFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(imageInputFilter).toHaveAttribute("aria-pressed", "false");
+  await expect(counts).toHaveText("1 family · 7 exact models · 7 offerings");
+  await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(1);
+  await expect(routingTree.locator('[data-route-family="gemini"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(routingTree.locator('[data-route-model-group="gemini"] [data-route-model]')).toHaveCount(7);
+  await expect(selectedProvider).toHaveText("gemini");
+
+  await textFilter.click();
+  await routingTree.locator('[data-route-family="claude-fable"]').click();
+  await expect(counts).toHaveText("12 families · 40 exact models · 40 offerings");
+  await expect(selectedModel).toHaveText("claude-fable-5");
+  await expect(selectedProvider).toHaveText("anthropic");
 
   await openWeightsFilter.click();
   await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "true");
@@ -1127,12 +1161,12 @@ test("visitors can disclose filters, search every characteristic, and sort throu
   await catalog.getByRole("button", { name: "Reset" }).click();
   await catalog.getByRole("checkbox", { name: "Image input" }).check();
   await catalog.getByRole("checkbox", { name: "Audio message input" }).check();
-  await expect(resultCount).toHaveText("2 of 57 models");
-  await expect(visibleRows).toHaveCount(2);
+  await expect(resultCount).toHaveText("7 of 57 models");
+  await expect(visibleRows).toHaveCount(7);
 
   await searchSubmit.click();
   await expect(filterPanel).toBeHidden();
-  await expect(resultCount).toHaveText("2 of 57 models");
+  await expect(resultCount).toHaveText("7 of 57 models");
   await searchSubmit.click();
   await expect(filterPanel).toBeVisible();
   await expect(catalog.getByRole("checkbox", { name: "Image input" })).toBeChecked();

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -3,6 +3,9 @@ package tests_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"net"
 	"net/url"
@@ -36,7 +39,7 @@ func TestOperationalHelpCommandsUseBuiltinOutput(testingInstance *testing.T) {
 		path             string
 		expectedFragment string
 	}{
-		{name: "live-providers", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), expectedFragment: "scripts/test_live_providers.sh [--preflight | --write-config <path>]"},
+		{name: "live-providers", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), expectedFragment: "scripts/test_live_providers.sh [--media | --preflight | --write-config <path>]"},
 		{name: "production-live-test", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "live_test.sh"), expectedFragment: "Usage: make live-test"},
 	}
 	for _, helpCommand := range helpCommands {
@@ -1501,6 +1504,154 @@ func TestOperationalLiveHarnessVerifiesEachKeyBeforeItsSmokeRequest(testingInsta
 	assertOperationalProxyChildStopped(testingInstance, fixture.proxyPIDPath)
 }
 
+func TestOperationalLiveHarnessRunsCatalogSelectedImageMatrixAfterVerification(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixture := newOperationalLiveHarnessFixture(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	environmentFile := filepath.Join(fixtureRoot, "live.env")
+	operationCapture := filepath.Join(fixtureRoot, "operations.log")
+	providerKeys := map[string]string{
+		"OPENAI_API_KEY":    "test-live-openai-key",
+		"ANTHROPIC_API_KEY": "test-live-anthropic-key",
+		"GEMINI_API_KEY":    "test-live-gemini-key",
+		"XAI_API_KEY":       "test-live-xai-key",
+	}
+	environmentContents := ""
+	for variableName, variableValue := range providerKeys {
+		environmentContents += variableName + "=" + variableValue + "\n"
+	}
+	writeOperationalFile(testingInstance, environmentFile, environmentContents, 0o600)
+	environment := []string{
+		"PATH=" + fixture.toolDirectory + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"GO=" + filepath.Join(fixture.toolDirectory, "go"),
+		"LLM_PROXY_LIVE_PORT=" + strconv.Itoa(operationalLoopbackPort(testingInstance)),
+		"PROXY_PID_CAPTURE=" + fixture.proxyPIDPath,
+		"LIVE_ENV_FILE=" + environmentFile,
+		"LIVE_OPERATION_CAPTURE=" + operationCapture,
+	}
+	command := exec.Command(filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), "--media")
+	command.Dir = repositoryRoot
+	command.Env = environment
+	output, commandError := command.CombinedOutput()
+	if commandError != nil {
+		testingInstance.Fatalf("live provider image matrix failed: %v\n%s", commandError, output)
+	}
+	outputText := string(output)
+	expectedModels := []string{"gpt-4.1", "claude-sonnet-4-6", "gemini-2.5-flash", "grok-4.5"}
+	expectedProviders := []string{"openai", "anthropic", "gemini", "xai"}
+	for index, provider := range expectedProviders {
+		expectedVerification := "live provider verification passed: provider=" + provider + " model=" + expectedModels[index] + " status=200"
+		expectedSuccess := "live provider image smoke passed: provider=" + provider + " model=" + expectedModels[index] + " status=200"
+		if !strings.Contains(outputText, expectedVerification) || !strings.Contains(outputText, expectedSuccess) {
+			testingInstance.Fatalf("live provider image matrix omitted provider=%s proof: %s", provider, output)
+		}
+	}
+	for _, forbiddenValue := range append([]string{"live-generated-secret", "iVBOR"}, mapValues(providerKeys)...) {
+		if strings.Contains(outputText, forbiddenValue) {
+			testingInstance.Fatalf("live provider image matrix output exposed credential or image material: %s", output)
+		}
+	}
+	captureBytes, readError := os.ReadFile(operationCapture)
+	if readError != nil {
+		testingInstance.Fatalf("read live image operation capture: %v", readError)
+	}
+	capture := string(captureBytes)
+	lastVerificationOffset := strings.LastIndex(capture, "verify PUT ")
+	firstImageOffset := strings.Index(capture, "image POST ")
+	if strings.Count(capture, "verify PUT ") != 4 || strings.Count(capture, "image POST ") != 4 || firstImageOffset <= lastVerificationOffset {
+		testingInstance.Fatalf("live image operations were not four verifications followed by four images: %s", capture)
+	}
+	imagePayloadLines := []string{}
+	for _, line := range strings.Split(capture, "\n") {
+		if strings.HasPrefix(line, "image-payload ") {
+			imagePayloadLines = append(imagePayloadLines, strings.TrimPrefix(line, "image-payload "))
+		}
+	}
+	if len(imagePayloadLines) != len(expectedModels) {
+		testingInstance.Fatalf("live image payload count=%d capture=%s", len(imagePayloadLines), capture)
+	}
+	for index, payloadLine := range imagePayloadLines {
+		assertOperationalImageSmokePayload(testingInstance, payloadLine, expectedModels[index])
+	}
+	assertOperationalProxyChildStopped(testingInstance, fixture.proxyPIDPath)
+}
+
+func TestOperationalLiveHarnessRejectsProviderWithoutCatalogImageBeforeVerification(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixture := newOperationalLiveHarnessFixture(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	environmentFile := filepath.Join(fixtureRoot, "live.env")
+	operationCapture := filepath.Join(fixtureRoot, "operations.log")
+	const providerKey = "test-live-deepseek-key"
+	writeOperationalFile(testingInstance, environmentFile, "DEEPSEEK_API_KEY="+providerKey+"\n", 0o600)
+	command := exec.Command(filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), "--media")
+	command.Dir = repositoryRoot
+	command.Env = []string{
+		"PATH=" + fixture.toolDirectory + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"GO=" + filepath.Join(fixture.toolDirectory, "go"),
+		"LLM_PROXY_LIVE_PORT=" + strconv.Itoa(operationalLoopbackPort(testingInstance)),
+		"PROXY_PID_CAPTURE=" + fixture.proxyPIDPath,
+		"LIVE_ENV_FILE=" + environmentFile,
+		"LLM_PROXY_LIVE_PROVIDERS=deepseek",
+		"LIVE_OPERATION_CAPTURE=" + operationCapture,
+	}
+	output, commandError := command.CombinedOutput()
+	if commandError == nil {
+		testingInstance.Fatalf("live provider image matrix accepted a provider without an image route: %s", output)
+	}
+	outputText := string(output)
+	if !strings.Contains(outputText, "live provider image model is unavailable or ambiguous: provider=deepseek") || strings.Contains(outputText, providerKey) {
+		testingInstance.Fatalf("live provider image rejection was not safe: %s", output)
+	}
+	if captureBytes, readError := os.ReadFile(operationCapture); readError == nil && len(captureBytes) != 0 {
+		testingInstance.Fatalf("live provider image rejection performed paid work: %s", captureBytes)
+	} else if readError != nil && !os.IsNotExist(readError) {
+		testingInstance.Fatalf("inspect rejected image operations: %v", readError)
+	}
+	assertOperationalProxyChildStopped(testingInstance, fixture.proxyPIDPath)
+}
+
+func assertOperationalImageSmokePayload(testingInstance *testing.T, payloadText string, expectedModel string) {
+	testingInstance.Helper()
+	var payload struct {
+		Messages []struct {
+			Role        string `json:"role"`
+			Content     string `json:"content"`
+			Attachments []struct {
+				Type     string `json:"type"`
+				MIMEType string `json:"mime_type"`
+				Data     string `json:"data"`
+				SHA256   string `json:"sha256"`
+			} `json:"attachments"`
+		} `json:"messages"`
+		Model     string `json:"model"`
+		WebSearch bool   `json:"web_search"`
+	}
+	if decodeError := json.Unmarshal([]byte(payloadText), &payload); decodeError != nil {
+		testingInstance.Fatalf("decode live image payload: %v", decodeError)
+	}
+	if payload.Model != expectedModel || payload.WebSearch || len(payload.Messages) != 1 || payload.Messages[0].Role != "user" || len(payload.Messages[0].Attachments) != 1 {
+		testingInstance.Fatalf("live image payload shape=%+v", payload)
+	}
+	attachment := payload.Messages[0].Attachments[0]
+	imageBytes, decodeError := base64.StdEncoding.DecodeString(attachment.Data)
+	if decodeError != nil {
+		testingInstance.Fatalf("decode live image data: %v", decodeError)
+	}
+	imageDigest := sha256.Sum256(imageBytes)
+	if attachment.Type != "image" || attachment.MIMEType != "image/png" || !bytes.HasPrefix(imageBytes, []byte("\x89PNG\r\n\x1a\n")) || attachment.SHA256 != hex.EncodeToString(imageDigest[:]) {
+		testingInstance.Fatalf("live image attachment=%+v bytes=%d", attachment, len(imageBytes))
+	}
+}
+
+func mapValues(values map[string]string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, value)
+	}
+	return result
+}
+
 func TestOperationalLiveHarnessReapsOwnedProxyChild(testingInstance *testing.T) {
 	repositoryRoot := operationalRepositoryRoot(testingInstance)
 	reservedPort := operationalLoopbackPort(testingInstance)
@@ -1596,6 +1747,7 @@ if [[ ! -f "${PROXY_PID_CAPTURE:?}" ]]; then
 fi
 
 output_path=""
+response_headers_path=""
 request_body_path=""
 request_method="GET"
 request_url=""
@@ -1607,6 +1759,10 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     -X)
       request_method="$2"
+      shift 2
+      ;;
+    -D)
+      response_headers_path="$2"
       shift 2
       ;;
     --data-binary)
@@ -1623,13 +1779,23 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+write_response_headers() {
+  if [[ -n "${response_headers_path}" ]]; then
+    builtin printf '%s\r\n' 'HTTP/1.1 200 OK' 'X-LLM-Proxy-Request-ID: ABCDEFGHIJKLMNOPQRSTUVWXYZ234567' '' >"${response_headers_path}"
+  fi
+}
+
 case "${request_url}" in
+  */api/public/capabilities)
+    builtin printf '%s' '{"offerings":[{"provider":"openai","model":"gpt-4.1","capabilities":["image_input","text"]},{"provider":"anthropic","model":"claude-sonnet-4-6","capabilities":["image_input","text"]},{"provider":"gemini","model":"gemini-2.5-flash","capabilities":["audio_input","image_input","text"]},{"provider":"xai","model":"grok-4.5","capabilities":["image_input","text"]}]}' >"${output_path}"
+    builtin printf '%s' 200
+    ;;
   */api/management/account)
     builtin printf '%s' '{"tenants":[{"id":"tenant-live"}]}' >"${output_path}"
     builtin printf '%s' 200
     ;;
   */api/management/tenants/tenant-live/secrets)
-    builtin printf '%s' '{"secret":"live-generated-secret","profile":{"providers":[{"id":"openai","text_default_model":"gpt-4.1"}]}}' >"${output_path}"
+    builtin printf '%s' '{"secret":"live-generated-secret","profile":{"providers":[{"id":"openai","text_default_model":"gpt-4.1"},{"id":"anthropic","text_default_model":"claude-sonnet-4-6"},{"id":"gemini","text_default_model":"gemini-2.5-flash"},{"id":"xai","text_default_model":"grok-4.3"},{"id":"deepseek","text_default_model":"deepseek-v4-flash"}]}}' >"${output_path}"
     builtin printf '%s' 200
     ;;
   */api/management/tenants/tenant-live/provider-keys/*)
@@ -1648,6 +1814,17 @@ case "${request_url}" in
       sleep "${CURL_PREFLIGHT_BLOCK_SECONDS:-1}"
     fi
     builtin printf '%s' 400
+    ;;
+  */v2?provider=*)
+    if [[ -n "${LIVE_OPERATION_CAPTURE:-}" ]]; then
+      builtin printf 'image %s %s\n' "${request_method}" "${request_url}" >>"${LIVE_OPERATION_CAPTURE}"
+      builtin printf 'image-payload ' >>"${LIVE_OPERATION_CAPTURE}"
+      command cat "${request_body_path}" >>"${LIVE_OPERATION_CAPTURE}"
+      builtin printf '\n' >>"${LIVE_OPERATION_CAPTURE}"
+    fi
+    write_response_headers
+    builtin printf '%s' RED >"${output_path}"
+    builtin printf '%s' 200
     ;;
   *provider=*)
     if [[ -n "${LIVE_OPERATION_CAPTURE:-}" ]]; then


### PR DESCRIPTION
## Summary

- Expand canonical media routing to select providers based on model-declared image and audio capabilities rather than limiting media inputs to Gemini.
- Add image support for OpenAI GPT-4/GPT-5 catalog models, Anthropic Claude catalog models, all configured Gemini text models, and xAI `grok-4.5`; retain Gemini as the only configured conversational-audio route.
- Implement provider-specific inline image transports:
  - OpenAI Responses requests with ordered image Data URLs.
  - Anthropic Messages requests with ordered base64 image blocks.
  - xAI synchronous Responses requests for `grok-4.5`.
- Enforce provider MIME validation plus offering-owned request, attachment-count, and media-size limits.
- Update xAI routing so `grok-4.5` uses its Responses integration while other xAI text models retain the compatible chat-completions path.
- Document supported media routes, encoded attachment-byte handling, and provider transport behavior.

## Validation

- Add routing and boundary coverage for model capability checks, provider media limits, image payload construction, ordering, and unsupported-model rejection.
- Add a paid live image smoke matrix that verifies provider credentials before sending a deterministic canonical image request to OpenAI, Anthropic, Gemini, or xAI.
- Extend capability, operational-contract, browser, and live-harness tests to cover the expanded media route matrix.