### PR TITLE
Add Kimi reasoning and image routes

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -401,7 +401,7 @@ retain satisfied historical dependencies.
   - Keep credentials, prompts, and response bodies out of test output.
   - Run `make ci` after the last application change.
 
-- [ ] [I227] (P1) {I223} Add Kimi reasoning and image route capabilities.
+- [!] [I227] (P1) {I223} Add Kimi reasoning and image route capabilities.
   Goal:
   Expose verified Kimi reasoning and image capabilities through the current
   Moonshot provider and canonical message contract.
@@ -444,6 +444,9 @@ retain satisfied historical dependencies.
   - Run one paid image request through each enabled Moonshot image model.
   - Keep credentials, image data, and response bodies out of test output.
   - Run `make ci` after the last application change.
+  Blocked: A Moonshot credential and paid-call authorization are not available
+  in this workspace. The operator must supply `MOONSHOT_API_KEY` and authorize
+  the eight paid live calls for four key checks and four image requests.
 
 - [!] [I226] (P1) {I038,I223} Add current Qwen text models to DashScope.
   Goal:

--- a/README.md
+++ b/README.md
@@ -452,6 +452,19 @@ Provider-specific details:
   missing-suffix loop and accepts the assembled text only after
   `finish_reason=stop`; `content_filter`, `tool_calls`, missing, and
   provider-specific non-stop reasons are upstream failures.
+* Moonshot Kimi K3 accepts exact public `reasoning_effort` values `low`,
+  `high`, and `max`. The adapter sends the selected value as the top-level
+  provider field and omits it when no value is selected. Kimi K2.6 and both
+  Kimi K2.7 Code routes keep Moonshot's thinking default because the proxy does
+  not send a `thinking` field. Kimi K3, K2.6, K2.7 Code, and K2.7 Code
+  Highspeed accept ordered JPEG, PNG, or WebP inputs through canonical
+  `POST /v2` messages. The adapter sends exact bytes as ordered Data URL blocks
+  before message text. Only visible answer `content` enters the proxy response
+  and usage path. Provider `reasoning_content` stays private. See Moonshot's
+  [Kimi K3 guide](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart),
+  [reasoning-effort guide](https://platform.kimi.ai/docs/guide/use-reasoning-effort),
+  [vision guide](https://platform.kimi.ai/docs/guide/use-kimi-vision-model),
+  and [Chat Completions reference](https://platform.kimi.ai/docs/api/chat).
 * MiniMax uses selector `minimax`, exact model `minimax-m2.7`,
   `${MINIMAX_API_KEY}`, and `https://api.minimax.io/v1`. The shared compatible
   Chat Completions adapter maps public `max_tokens` to upstream
@@ -1340,7 +1353,7 @@ This repository exposes the standard local targets used by MPR app repos:
 | `make ci` | Prepare pinned frontend dependencies, then run format checks, Go lint (`go vet`, `staticcheck`, `ineffassign`), Python strict mypy, frontend syntax checks, the 100% coverage-gated Go test suite, Python pytest, Playwright browser tests, the app lifecycle contract test, and the non-paid live-harness preflight. A successful run ends with a per-gate table, current-run coverage, and an explicit `CI PASSED` receipt. |
 | `make test-live-provider-harness` | Generate the temporary static-mode live-test config and verify authenticated routing without an upstream call. |
 | `make test-live-providers` | Start a disposable managed tenant, verify every available provider key through the canonical management operation, and run that provider's live text smoke only after verification succeeds; use `LIVE_ENV_FILE=/path/to/env` to load key values. |
-| `make test-live-provider-media` | Verify OpenAI, Anthropic, Gemini, and xAI keys, then send one paid canonical image request through each provider. |
+| `make test-live-provider-media` | Verify OpenAI, Anthropic, Gemini, Moonshot, and xAI keys, then send one paid canonical image request through each provider. |
 | `make test-live-gemini` | Compatibility wrapper for `make test-live-providers` with `LLM_PROXY_LIVE_PROVIDERS=gemini`. |
 | `make live-test` | Send paid production `POST /v2` requests through the Default tenant using only `LLM_PROXY_SECRET`: echo checks for OpenAI, Anthropic, Meta, Gemini, and Moonshot, plus large completion cases for OpenAI, Anthropic, Meta, and Gemini. |
 | `make release` | Delegate this clean checkout and its schema-v4 resource declaration to the exact sibling `../mprlab-gateway` release transaction. |
@@ -1410,12 +1423,22 @@ safe `200` keyed-profile result, and only then sends that provider's smoke
 request. Candidate payloads, session material, provider responses, and proxy
 responses are never printed, and the temporary state is removed at exit.
 
-The paid image matrix uses OpenAI, Anthropic, Gemini, and xAI by default. It
-requires all four provider keys. Set `LLM_PROXY_LIVE_PROVIDERS` to run a
-selected subset. The harness selects each image model from the validated public
-provider catalog. It uses the configured default when that model supports image
-input. Otherwise, it requires one exact image model for that provider. The key
-verification uses the selected image model.
+The paid image matrix uses OpenAI, Anthropic, Gemini, Moonshot, and xAI by
+default. It requires all five provider keys. Set `LLM_PROXY_LIVE_PROVIDERS` to
+run a selected subset. The harness selects each image model from the validated
+public provider catalog. It uses the configured default when that model supports
+image input. Otherwise, it requires one exact image model for that provider.
+The key verification uses the selected image model.
+
+Set `LLM_PROXY_LIVE_ALL_MODELS=true` with media mode to verify and call every
+image route for each selected provider. This command runs the complete current
+Moonshot image matrix:
+
+```shell
+LLM_PROXY_LIVE_PROVIDERS=moonshot \
+  LLM_PROXY_LIVE_ALL_MODELS=true \
+  make test-live-provider-media LIVE_ENV_FILE=configs/.env
+```
 
 Each image case creates the same deterministic 256 by 256 red PNG. The request
 sends canonical padded base64 data and its matching SHA-256 through `POST /v2`.
@@ -2239,7 +2262,7 @@ tools; use a model marked `Yes` below for web search. A dash in the proxy
 `max_tokens` limit column means the proxy validates only that `max_tokens` is
 positive and lets the upstream provider enforce any provider-side model limit.
 
-### OpenAI reasoning-effort capabilities
+### Reasoning-effort capabilities
 
 The checked-in OpenAI catalog follows the current model documentation and keeps
 each model's list separate. GPT-4.1 is explicitly a non-reasoning model and
@@ -2261,6 +2284,10 @@ See OpenAI's [GPT-4.1 model reference](https://developers.openai.com/api/docs/mo
 [GPT-5.5 model reference](https://developers.openai.com/api/docs/models/gpt-5.5),
 [GPT-5.5 Pro model reference](https://developers.openai.com/api/docs/models/gpt-5.5-pro),
 and [latest-model guide](https://developers.openai.com/api/docs/guides/latest-model).
+
+Kimi K3 accepts `low`, `high`, and `max`. Omission keeps Moonshot's provider
+default. Kimi K2.6 and the Kimi K2.7 Code routes do not expose a selectable
+effort through the proxy.
 
 ### Model capabilities
 

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -62,7 +62,7 @@ providers:
     base_url: https://api.x.ai/v1
     transcriptions_url: https://api.x.ai/v1/stt
 catalog:
-  revision: 2026-08-13.i226.1
+  revision: 2026-08-13.i227.1
   operations:
   - id: text
     input_artifacts:
@@ -402,24 +402,32 @@ catalog:
     version: kimi-k2.6
     operations:
     - text
+    media_inputs:
+    - image
   - id: kimi-k3
     publisher: moonshot
     family: kimi-k3
     version: kimi-k3
     operations:
     - text
+    media_inputs:
+    - image
   - id: kimi-k2.7-code
     publisher: moonshot
     family: kimi-k2
     version: kimi-k2.7-code
     operations:
     - text
+    media_inputs:
+    - image
   - id: kimi-k2.7-code-highspeed
     publisher: moonshot
     family: kimi-k2
     version: kimi-k2.7-code-highspeed
     operations:
     - text
+    media_inputs:
+    - image
   - id: minimax-m2.7
     publisher: minimax
     family: minimax-m2
@@ -1271,6 +1279,34 @@ catalog:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 100000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: unbounded
+      unit: files
+      scope: request
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
   - provider: moonshot
     model: kimi-k3
     provider_model: kimi-k3
@@ -1278,6 +1314,40 @@ catalog:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
+    reasoning_effort:
+      adapter: moonshot_chat_completions
+      efforts:
+      - low
+      - high
+      - max
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 100000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: unbounded
+      unit: files
+      scope: request
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
   - provider: moonshot
     model: kimi-k2.7-code
     provider_model: kimi-k2.7-code
@@ -1285,6 +1355,34 @@ catalog:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 100000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: unbounded
+      unit: files
+      scope: request
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
   - provider: moonshot
     model: kimi-k2.7-code-highspeed
     provider_model: kimi-k2.7-code-highspeed
@@ -1292,6 +1390,34 @@ catalog:
     - text
     wire_contract: openai_chat_completions
     execution_lifecycle: synchronous_completion
+    media_inputs:
+    - image
+    media_limits:
+    - id: inline_request_bytes
+      media_type: all
+      transport: inline
+      status: bounded
+      value: 100000000
+      unit: bytes
+      scope: request_encoded_bytes
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
+    - id: image_count
+      media_type: image
+      transport: any
+      status: unbounded
+      unit: files
+      scope: request
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
+    - id: image_inline_bytes
+      media_type: image
+      transport: inline
+      status: unknown
+      unit: bytes
+      scope: attachment
+      source: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+      last_verified: "2026-08-13"
   - provider: minimax
     model: minimax-m2.7
     provider_model: MiniMax-M2.7

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -226,10 +226,14 @@ provider offerings. Provider-native model identifiers exist only in offerings.
 
 The README model-capability table mirrors `config.yml`; refresh those two
 catalog representations together and do not hardcode model ids in provider
-transports. Moonshot's current Kimi Chat Completions route receives
+transports. Moonshot's current Kimi Chat Completions routes receive
 `max_completion_tokens` when a caller supplies the proxy `max_tokens` value.
-It deliberately omits sampling controls because Kimi K3 fixes those values
-upstream.
+Kimi K3 maps exact proxy reasoning efforts `low`, `high`, and `max` to the
+top-level provider field. Omission keeps Moonshot's default. Kimi K2.6 and
+both Kimi K2.7 Code routes receive no `thinking` field, which keeps their
+provider default. All four routes serialize ordered canonical JPEG, PNG, and
+WebP inputs as Data URL Chat Completions blocks before message text. Only
+visible answer content leaves the adapter. `reasoning_content` is private.
 MiniMax M2.7 maps public `max_tokens` to
 `max_completion_tokens` and carries a configured 2048-token output ceiling.
 GLM-5.2 uses the international Z.AI Chat Completions endpoint. Its
@@ -568,15 +572,16 @@ port unless `LLM_PROXY_LIVE_PORT` explicitly provides one, and cleanup
 terminates only the proxy child started by the harness rather than a process
 discovered through a shared port.
 
-The explicit `--media` mode selects OpenAI, Anthropic, Gemini, and xAI by
-default. It verifies all four provider keys before it sends image requests.
+The explicit `--media` mode selects OpenAI, Anthropic, Gemini, Moonshot, and
+xAI by default. It verifies all selected provider keys before image requests.
 Each case selects its exact image model from the validated public provider
 catalog. It uses the verified model when that route supports image input.
 Otherwise, it requires one exact provider image route. Key verification uses
 the selected image model. Each request sends the same deterministic inline PNG
 through canonical `POST /v2`. The case requires HTTP `200`, the exact response
 marker, and one valid proxy request identifier. The paid media mode remains
-outside `make ci`.
+outside `make ci`. `LLM_PROXY_LIVE_ALL_MODELS=true` expands media mode to
+every image route for each selected provider, including all four Kimi routes.
 
 `make live-test` is deliberately a different boundary: it calls only the
 production API origin with `LLM_PROXY_SECRET`, the Default tenant client

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -120,7 +120,9 @@ paths:
         media admission and transport limits. Unsupported media or route
         capabilities return HTTP 400 before an upstream call. The service
         rejects an encoded request body above 8 MiB before JSON decoding. A
-        smaller catalog-derived body limit applies when configured.
+        smaller catalog-derived body limit applies when configured. Current
+        Moonshot Kimi image routes preserve attachment order and exact bytes
+        through Chat Completions Data URL blocks.
       tags:
         - Proxy
       security:
@@ -1820,7 +1822,7 @@ components:
           type: integer
           minimum: 0
     MessageAttachment:
-      description: One provider-neutral image or audio input with a MIME type that matches its declared media type.
+      description: One provider-neutral image or audio input with a MIME type that matches its declared media type. The resolved catalog route determines support. Current Moonshot Kimi image routes accept the image variants.
       oneOf:
         - $ref: '#/components/schemas/ImageMessageAttachment'
         - $ref: '#/components/schemas/AudioMessageAttachment'
@@ -2086,7 +2088,7 @@ components:
         reasoning_effort:
           type: string
           minLength: 1
-          description: Omission selects the tenant or route default. An explicit value must be non-blank and supported by the resolved provider/model route.
+          description: Omission selects the tenant or route default. An explicit value must be non-blank and supported by the resolved provider/model route. Kimi K3 accepts low, high, or max.
     DictationRequest:
       type: object
       additionalProperties: false

--- a/internal/proxy/chat_messages.go
+++ b/internal/proxy/chat_messages.go
@@ -285,6 +285,34 @@ func (messages chatMessages) openAIResponsesInput(imageDetail string, preserveRo
 	return providerMessages, nil
 }
 
+func (messages chatMessages) chatCompletionMessages() ([]chatCompletionMessage, error) {
+	providerMessages := make([]chatCompletionMessage, 0, len(messages))
+	for messageIndex := range messages {
+		message := &messages[messageIndex]
+		if len(message.attachments) == 0 {
+			providerMessages = append(providerMessages, chatCompletionMessage{Role: string(message.role), Content: message.content})
+			continue
+		}
+		content := make([]map[string]any, 0, len(message.attachments)+1)
+		for attachmentIndex := range message.attachments {
+			attachment := &message.attachments[attachmentIndex]
+			data, dataError := attachment.bytes()
+			if dataError != nil {
+				return nil, dataError
+			}
+			content = append(content, map[string]any{
+				"type": "image_url",
+				"image_url": map[string]string{
+					"url": "data:" + attachment.mimeType + ";base64," + base64.StdEncoding.EncodeToString(data),
+				},
+			})
+		}
+		content = append(content, map[string]any{"type": "text", "text": message.content})
+		providerMessages = append(providerMessages, chatCompletionMessage{Role: string(message.role), Content: content})
+	}
+	return providerMessages, nil
+}
+
 func (messages chatMessages) requestDisplayText() string {
 	return messages.responseVisibleMessages().openAIResponsesTextInput()
 }

--- a/internal/proxy/coverage_edges_test.go
+++ b/internal/proxy/coverage_edges_test.go
@@ -1602,7 +1602,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 			requestBytes, _ := io.ReadAll(httpRequest.Body)
 			_ = json.Unmarshal(requestBytes, &capturedPayload)
 			responseWriter.Header().Set("Content-Type", "application/json")
-			_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"reasoning_content":"reasoned answer"},"finish_reason":"stop"}]}`))
+			_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"visible answer","reasoning_content":"private reasoning"},"finish_reason":"stop"}]}`))
 		}))
 		subTest.Cleanup(upstreamServer.Close)
 		router := coverageRouter(subTest, proxy.Configuration{
@@ -1619,7 +1619,7 @@ func TestCoverageProviderRoutingEdges(t *testing.T) {
 		queryParameters.Set("provider", "qwen")
 		queryParameters.Set("system_prompt", "system text")
 		statusCode, body, _ := performCoverageTextRequest(subTest, router, queryParameters, "")
-		if statusCode != http.StatusOK || body != "reasoned answer" {
+		if statusCode != http.StatusOK || body != "visible answer" || strings.Contains(body, "private reasoning") {
 			subTest.Fatalf("status=%d body=%q", statusCode, body)
 		}
 		messages, ok := capturedPayload["messages"].([]any)

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -944,6 +944,7 @@ func TestManagementRoutingDefaultsRequireAnExactTextRouteReasoningEffort(t *test
 	}{
 		{provider: proxy.ProviderNameOpenAI, apiKey: testManagementOpenAIKey, model: proxy.ModelNameGPT5},
 		{provider: proxy.ProviderNameDeepSeek, apiKey: testManagementDeepSeekKey, model: proxy.ModelNameDeepSeekV4Flash},
+		{provider: proxy.ProviderNameMoonshot, apiKey: "sk-moonshot", model: proxy.ModelNameMoonshotKimiK3},
 	} {
 		request := authenticatedJSONRequest(http.MethodPut, tenantPath+"/provider-keys/"+providerKeyRequest.provider, managementProviderKeyRequestBody(t, providerKeyRequest.apiKey, providerKeyRequest.model, ""), sessionCookie)
 		response := httptest.NewRecorder()
@@ -976,6 +977,14 @@ func TestManagementRoutingDefaultsRequireAnExactTextRouteReasoningEffort(t *test
 	gpt56Response := saveReasoningDefault(proxy.ProviderNameOpenAI, proxy.ModelNameGPT56, "max")
 	if gpt56Response.Code != http.StatusOK {
 		t.Fatalf("save GPT-5.6 reasoning defaults status=%d body=%s", gpt56Response.Code, gpt56Response.Body.String())
+	}
+	kimiK3Response := saveReasoningDefault(proxy.ProviderNameMoonshot, proxy.ModelNameMoonshotKimiK3, "high")
+	if kimiK3Response.Code != http.StatusOK {
+		t.Fatalf("save Kimi K3 reasoning defaults status=%d body=%s", kimiK3Response.Code, kimiK3Response.Body.String())
+	}
+	gpt56Response = saveReasoningDefault(proxy.ProviderNameOpenAI, proxy.ModelNameGPT56, "max")
+	if gpt56Response.Code != http.StatusOK {
+		t.Fatalf("restore GPT-5.6 reasoning defaults status=%d body=%s", gpt56Response.Code, gpt56Response.Body.String())
 	}
 
 	profileRequest := httptest.NewRequest(http.MethodGet, tenantPath, nil)
@@ -1026,25 +1035,32 @@ func TestManagementRoutingDefaultsRequireAnExactTextRouteReasoningEffort(t *test
 		proxy.ModelNameGPT55Pro: {"medium", "high", "xhigh"},
 	}
 	matchedModelEfforts := map[string]bool{}
+	matchedKimiK3 := false
 	for _, provider := range profile.Providers {
-		if provider.ID != proxy.ProviderNameOpenAI {
-			continue
-		}
-		if len(provider.ReasoningEffort) != 0 {
-			t.Fatalf("OpenAI profile retains provider-level reasoning capability=%s", string(provider.ReasoningEffort))
-		}
-		for _, model := range provider.TextModels {
-			expectedEfforts, required := expectedModelEfforts[model.ID]
-			if required {
-				if model.ReasoningEffort == nil || model.ReasoningEffort.Adapter != "openai_responses" || !reflect.DeepEqual(model.ReasoningEffort.Efforts, expectedEfforts) {
-					t.Fatalf("model=%s reasoning capability=%+v want=%v", model.ID, model.ReasoningEffort, expectedEfforts)
+		if provider.ID == proxy.ProviderNameOpenAI {
+			if len(provider.ReasoningEffort) != 0 {
+				t.Fatalf("OpenAI profile retains provider-level reasoning capability=%s", string(provider.ReasoningEffort))
+			}
+			for _, model := range provider.TextModels {
+				expectedEfforts, required := expectedModelEfforts[model.ID]
+				if required {
+					if model.ReasoningEffort == nil || model.ReasoningEffort.Adapter != "openai_responses" || !reflect.DeepEqual(model.ReasoningEffort.Efforts, expectedEfforts) {
+						t.Fatalf("model=%s reasoning capability=%+v want=%v", model.ID, model.ReasoningEffort, expectedEfforts)
+					}
+					matchedModelEfforts[model.ID] = true
 				}
-				matchedModelEfforts[model.ID] = true
+			}
+		}
+		if provider.ID == proxy.ProviderNameMoonshot {
+			for _, model := range provider.TextModels {
+				if model.ID == proxy.ModelNameMoonshotKimiK3 && model.ReasoningEffort != nil && model.ReasoningEffort.Adapter == "moonshot_chat_completions" && reflect.DeepEqual(model.ReasoningEffort.Efforts, []string{"low", "high", "max"}) {
+					matchedKimiK3 = true
+				}
 			}
 		}
 	}
-	if len(matchedModelEfforts) != len(expectedModelEfforts) {
-		t.Fatalf("profile model capabilities=%v want=%v", matchedModelEfforts, expectedModelEfforts)
+	if len(matchedModelEfforts) != len(expectedModelEfforts) || !matchedKimiK3 {
+		t.Fatalf("profile model capabilities=%v Kimi K3=%t want=%v", matchedModelEfforts, matchedKimiK3, expectedModelEfforts)
 	}
 
 	incompatibleResponse := saveReasoningDefault(proxy.ProviderNameOpenAI, proxy.ModelNameGPT5, "max")

--- a/internal/proxy/message_media.go
+++ b/internal/proxy/message_media.go
@@ -70,6 +70,16 @@ var textRouteMessageMediaContracts = map[textRouteCapabilities]textRouteMessageM
 			},
 		},
 	},
+	openAIChatCompletionsSynchronousRouteCapabilities: {
+		attachmentLimitTransport: CatalogMediaTransportInline,
+		mimeTypes: map[messageMediaType]map[string]struct{}{
+			messageMediaTypeImage: {
+				messageImageMIMEJPEG: {},
+				messageImageMIMEPNG:  {},
+				messageImageMIMEWebP: {},
+			},
+		},
+	},
 	geminiInteractionsPollableRouteCapabilities: {
 		attachmentLimitTransport: CatalogMediaTransportFile,
 		mimeTypes: map[messageMediaType]map[string]struct{}{

--- a/internal/proxy/message_media_routing_test.go
+++ b/internal/proxy/message_media_routing_test.go
@@ -153,6 +153,30 @@ func TestV2RoutesExactOrderedImagesThroughProviderAdapters(testingInstance *test
 				}
 			},
 		},
+		{
+			name: "Moonshot Kimi K2.6", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK26, path: "/chat/completions",
+			assertBody: func(subTest *testing.T, payload map[string]any) {
+				assertChatCompletionImageInput(subTest, payload, firstImage, secondImage)
+			},
+		},
+		{
+			name: "Moonshot Kimi K3", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK3, path: "/chat/completions",
+			assertBody: func(subTest *testing.T, payload map[string]any) {
+				assertChatCompletionImageInput(subTest, payload, firstImage, secondImage)
+			},
+		},
+		{
+			name: "Moonshot Kimi K2.7 Code", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK27Code, path: "/chat/completions",
+			assertBody: func(subTest *testing.T, payload map[string]any) {
+				assertChatCompletionImageInput(subTest, payload, firstImage, secondImage)
+			},
+		},
+		{
+			name: "Moonshot Kimi K2.7 Code Highspeed", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK27CodeHighSpeed, path: "/chat/completions",
+			assertBody: func(subTest *testing.T, payload map[string]any) {
+				assertChatCompletionImageInput(subTest, payload, firstImage, secondImage)
+			},
+		},
 	} {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			var capturedPayload map[string]any
@@ -168,6 +192,10 @@ func TestV2RoutesExactOrderedImagesThroughProviderAdapters(testingInstance *test
 					_, _ = responseWriter.Write([]byte(`{"content":[{"type":"text","text":"media accepted"}],"stop_reason":"end_turn"}`))
 					return
 				}
+				if testCase.provider == proxy.ProviderNameMoonshot {
+					_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"media accepted"},"finish_reason":"stop"}]}`))
+					return
+				}
 				_, _ = responseWriter.Write([]byte(`{"id":"media-input","status":"completed","output_text":"media accepted"}`))
 			}))
 			defer upstreamServer.Close()
@@ -178,6 +206,8 @@ func TestV2RoutesExactOrderedImagesThroughProviderAdapters(testingInstance *test
 				OpenAIBaseURL:         upstreamServer.URL,
 				AnthropicKey:          testAnthropicKey,
 				AnthropicBaseURL:      upstreamServer.URL,
+				MoonshotKey:           "sk-moonshot",
+				MoonshotBaseURL:       upstreamServer.URL,
 				XAIKey:                testXAIKey,
 				XAIBaseURL:            upstreamServer.URL,
 				LogLevel:              proxy.LogLevelInfo,
@@ -243,6 +273,15 @@ func TestV2AppliesNewProviderMediaLimitsAtTheBoundary(testingInstance *testing.T
 			boundaryAttachments: []map[string]any{messageMediaPayload("image", "image/png", []byte("x"))},
 			aboveAttachments:    []map[string]any{messageMediaPayload("image", "image/png", []byte("xx"))},
 		},
+		{
+			name:                "Moonshot raw image bytes",
+			provider:            proxy.ProviderNameMoonshot,
+			model:               proxy.ModelNameMoonshotKimiK3,
+			limitID:             proxy.CatalogMediaLimitIDImageInlineBytes,
+			limitValue:          1,
+			boundaryAttachments: []map[string]any{messageMediaPayload("image", "image/png", []byte("x"))},
+			aboveAttachments:    []map[string]any{messageMediaPayload("image", "image/png", []byte("xx"))},
+		},
 	} {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
 			upstreamCalls := 0
@@ -251,6 +290,10 @@ func TestV2AppliesNewProviderMediaLimitsAtTheBoundary(testingInstance *testing.T
 				responseWriter.Header().Set("Content-Type", "application/json")
 				if testCase.provider == proxy.ProviderNameAnthropic {
 					_, _ = responseWriter.Write([]byte(`{"content":[{"type":"text","text":"accepted"}],"stop_reason":"end_turn"}`))
+					return
+				}
+				if testCase.provider == proxy.ProviderNameMoonshot {
+					_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"content":"accepted"},"finish_reason":"stop"}]}`))
 					return
 				}
 				_, _ = responseWriter.Write([]byte(`{"id":"media-limit","status":"completed","output_text":"accepted"}`))
@@ -265,6 +308,8 @@ func TestV2AppliesNewProviderMediaLimitsAtTheBoundary(testingInstance *testing.T
 				OpenAIBaseURL:         upstreamServer.URL,
 				AnthropicKey:          testAnthropicKey,
 				AnthropicBaseURL:      upstreamServer.URL,
+				MoonshotKey:           "sk-moonshot",
+				MoonshotBaseURL:       upstreamServer.URL,
 				XAIKey:                testXAIKey,
 				XAIBaseURL:            upstreamServer.URL,
 				ModelCatalog:          catalog,
@@ -298,6 +343,29 @@ func TestV2AppliesNewProviderMediaLimitsAtTheBoundary(testingInstance *testing.T
 				subTest.Fatalf("above status=%d calls=%d body=%s", aboveResponse.Code, upstreamCalls, aboveResponse.Body.String())
 			}
 		})
+	}
+}
+
+func assertChatCompletionImageInput(testingInstance *testing.T, payload map[string]any, firstImage []byte, secondImage []byte) {
+	testingInstance.Helper()
+	messages := payload["messages"].([]any)
+	content := messages[0].(map[string]any)["content"].([]any)
+	if len(content) != 3 {
+		testingInstance.Fatalf("Chat Completions content=%v", content)
+	}
+	for index, expected := range []struct {
+		mimeType string
+		data     []byte
+	}{{"image/png", firstImage}, {"image/jpeg", secondImage}} {
+		block := content[index].(map[string]any)
+		imageURL := block["image_url"].(map[string]any)["url"]
+		expectedURL := "data:" + expected.mimeType + ";base64," + base64.StdEncoding.EncodeToString(expected.data)
+		if block["type"] != "image_url" || imageURL != expectedURL {
+			testingInstance.Fatalf("Chat Completions image[%d]=%v want=%s", index, block, expectedURL)
+		}
+	}
+	if textBlock := content[2].(map[string]any); textBlock["type"] != "text" || textBlock["text"] != "Inspect in exact order." {
+		testingInstance.Fatalf("Chat Completions text=%v", textBlock)
 	}
 }
 
@@ -364,6 +432,8 @@ func TestV2RejectsInvalidOrUnsupportedMediaBeforeUpstreamWork(testingInstance *t
 		DeepSeekBaseURL:       upstreamServer.URL,
 		GeminiKey:             testGeminiKey,
 		GeminiBaseURL:         upstreamServer.URL,
+		MoonshotKey:           "sk-moonshot",
+		MoonshotBaseURL:       upstreamServer.URL,
 		XAIKey:                testXAIKey,
 		XAIBaseURL:            upstreamServer.URL,
 		LogLevel:              proxy.LogLevelInfo,
@@ -400,6 +470,7 @@ func TestV2RejectsInvalidOrUnsupportedMediaBeforeUpstreamWork(testingInstance *t
 		{name: "system attachment", provider: proxy.ProviderNameGemini, model: proxy.ModelNameGemini25Flash, role: "system", attachments: []any{validImage}},
 		{name: "text-only model", provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok43, role: "user", attachments: []any{validImage}},
 		{name: "provider MIME", provider: proxy.ProviderNameXAI, model: proxy.ModelNameGrok45, role: "user", attachments: []any{messageMediaPayload("image", "image/webp", []byte("webp"))}},
+		{name: "Moonshot unsupported audio", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK3, role: "user", attachments: []any{validAudio}},
 		{name: "text-only provider", provider: proxy.ProviderNameDeepSeek, model: proxy.ModelNameDeepSeekV4Flash, role: "user", attachments: []any{validImage}},
 	} {
 		testingInstance.Run(testCase.name, func(subTest *testing.T) {
@@ -518,6 +589,12 @@ func TestModelCatalogRejectsInvalidMediaInputDeclarations(testingInstance *testi
 			name: "unsupported xAI Chat Completions adapter",
 			configure: func(catalogs proxy.ModelCatalog) {
 				setModelMediaInputs(catalogs, proxy.ProviderNameXAI, proxy.ModelNameGrok43, []string{"image"})
+			},
+		},
+		{
+			name: "unsupported Chat Completions audio input",
+			configure: func(catalogs proxy.ModelCatalog) {
+				setModelMediaInputs(catalogs, proxy.ProviderNameMoonshot, proxy.ModelNameMoonshotKimiK3, []string{"audio"})
 			},
 		},
 		{

--- a/internal/proxy/model_catalog.go
+++ b/internal/proxy/model_catalog.go
@@ -456,8 +456,17 @@ func validateTextOffering(offering ProviderOffering, fieldPrefix string) error {
 	if reasoningError != nil {
 		return reasoningError
 	}
-	if reasoningEffort != nil && (reasoningEffort.adapter != reasoningEffortAdapterOpenAIResponses || offering.Provider != ProviderNameOpenAI || modelRequestProfile(offering.RequestProfile) != requestProfileOpenAIResponsesReasoningTools) {
-		return fmt.Errorf("%w: field=%s.reasoning_effort adapter=%s", ErrInvalidModelCatalog, fieldPrefix, reasoningEffort.adapter)
+	if reasoningEffort != nil {
+		switch reasoningEffort.adapter {
+		case reasoningEffortAdapterOpenAIResponses:
+			if offering.Provider != ProviderNameOpenAI || modelRequestProfile(offering.RequestProfile) != requestProfileOpenAIResponsesReasoningTools {
+				return fmt.Errorf("%w: field=%s.reasoning_effort adapter=%s", ErrInvalidModelCatalog, fieldPrefix, reasoningEffort.adapter)
+			}
+		case reasoningEffortAdapterMoonshotChatCompletions:
+			if offering.Provider != ProviderNameMoonshot || offering.Model != ModelNameMoonshotKimiK3 || capabilities != openAIChatCompletionsSynchronousRouteCapabilities || offering.RequestProfile != constants.EmptyString {
+				return fmt.Errorf("%w: field=%s.reasoning_effort adapter=%s", ErrInvalidModelCatalog, fieldPrefix, reasoningEffort.adapter)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/proxy/openai_compatible_chat.go
+++ b/internal/proxy/openai_compatible_chat.go
@@ -20,7 +20,7 @@ type openAICompatibleChatClient struct {
 
 type chatCompletionMessage struct {
 	Role    string `json:"role"`
-	Content string `json:"content"`
+	Content any    `json:"content"`
 }
 
 type chatCompletionRequest struct {
@@ -28,6 +28,7 @@ type chatCompletionRequest struct {
 	Messages            []chatCompletionMessage `json:"messages"`
 	MaxTokens           *int                    `json:"max_tokens,omitempty"`
 	MaxCompletionTokens *int                    `json:"max_completion_tokens,omitempty"`
+	ReasoningEffort     string                  `json:"reasoning_effort,omitempty"`
 }
 
 type chatCompletionResponse struct {
@@ -41,8 +42,7 @@ type chatCompletionChoice struct {
 }
 
 type chatCompletionResponseMessage struct {
-	Content          string `json:"content"`
-	ReasoningContent string `json:"reasoning_content"`
+	Content string `json:"content"`
 }
 
 func newOpenAICompatibleChatClient(httpClient HTTPDoer) *openAICompatibleChatClient {
@@ -51,10 +51,20 @@ func newOpenAICompatibleChatClient(httpClient HTTPDoer) *openAICompatibleChatCli
 	}
 }
 
-func (client *openAICompatibleChatClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier textModelDefinition, messages chatMessages, maxTokens *int, tokenLimitParameter chatCompletionTokenLimitParameter, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+func (client *openAICompatibleChatClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier textModelDefinition, messages chatMessages, maxTokens *int, tokenLimitParameter chatCompletionTokenLimitParameter, reasoningEffort string, structuredLogger *zap.SugaredLogger) (textGenerationResult, error) {
+	if mediaLimitError := validateInlineMessageMediaBeforeSerialization(modelIdentifier, messages); mediaLimitError != nil {
+		return textGenerationResult{}, mediaLimitError
+	}
+	providerMessages, messagesError := messages.chatCompletionMessages()
+	if messagesError != nil {
+		return textGenerationResult{}, messagesError
+	}
 	payload := chatCompletionRequest{
 		Model:    modelIdentifier.providerString(),
-		Messages: messages.chatCompletionMessages(),
+		Messages: providerMessages,
+	}
+	if modelIdentifier.reasoningEffort != nil && modelIdentifier.reasoningEffort.adapter == reasoningEffortAdapterMoonshotChatCompletions {
+		payload.ReasoningEffort = reasoningEffort
 	}
 	if maxTokens != nil {
 		switch tokenLimitParameter {
@@ -65,6 +75,9 @@ func (client *openAICompatibleChatClient) generateText(parentContext context.Con
 		}
 	}
 	payloadBytes, _ := json.Marshal(payload)
+	if mediaLimitError := validateInlineMessageMediaRequestLimit(modelIdentifier, messages, payloadBytes); mediaLimitError != nil {
+		return textGenerationResult{}, mediaLimitError
+	}
 
 	requestURL := strings.TrimRight(baseURL, "/") + "/chat/completions"
 	httpRequest, buildError := buildAuthorizedJSONRequest(parentContext, http.MethodPost, requestURL, apiKey, bytes.NewReader(payloadBytes))
@@ -83,14 +96,6 @@ func (client *openAICompatibleChatClient) generateText(parentContext context.Con
 	return generation, nil
 }
 
-func (messages chatMessages) chatCompletionMessages() []chatCompletionMessage {
-	chatMessagesPayload := make([]chatCompletionMessage, 0, len(messages))
-	for _, message := range messages {
-		chatMessagesPayload = append(chatMessagesPayload, chatCompletionMessage{Role: string(message.role), Content: message.content})
-	}
-	return chatMessagesPayload
-}
-
 func parseChatCompletionResponse(responseBytes []byte) (textGenerationResult, error) {
 	var response chatCompletionResponse
 	if decodeError := json.Unmarshal(responseBytes, &response); decodeError != nil {
@@ -107,9 +112,6 @@ func parseChatCompletionResponse(responseBytes []byte) (textGenerationResult, er
 			return generation, fmt.Errorf("%w: chat completion missing finish_reason", ErrProviderAPI)
 		}
 		visibleText := choice.Message.Content
-		if utils.IsBlank(visibleText) {
-			visibleText = choice.Message.ReasoningContent
-		}
 		choiceGeneration := textGenerationResult{text: visibleText, usage: usage}
 		if finishReason == "length" {
 			return choiceGeneration, errProviderOutputLimitReached

--- a/internal/proxy/provider_media_edges_internal_test.go
+++ b/internal/proxy/provider_media_edges_internal_test.go
@@ -39,6 +39,10 @@ func TestProviderImageSerializationAndLimitFailureContracts(t *testing.T) {
 		t.Fatal("serialization failure reached provider")
 		return nil, nil
 	}))
+	chatClient := newOpenAICompatibleChatClient(geminiEdgeDoer(func(*http.Request) (*http.Response, error) {
+		t.Fatal("serialization failure reached provider")
+		return nil, nil
+	}))
 	model := textModelDefinition{
 		providerIdentifier: newModelID("provider-model"),
 		requestProfile:     requestProfileOpenAIResponsesTemperature,
@@ -52,6 +56,9 @@ func TestProviderImageSerializationAndLimitFailureContracts(t *testing.T) {
 	}
 	if _, requestError := anthropicClient.generateText(context.Background(), "key", "https://provider.test", model, closedMessages, nil, logger); !errors.Is(requestError, errAssetStore) {
 		t.Fatalf("Anthropic serialization error=%v", requestError)
+	}
+	if _, requestError := chatClient.generateText(context.Background(), "key", "https://provider.test", model, closedMessages, nil, chatCompletionTokenLimitMaxTokens, "", logger); !errors.Is(requestError, errAssetStore) {
+		t.Fatalf("Chat Completions serialization error=%v", requestError)
 	}
 
 	closedMessages[0].attachments[0].sizeBytes = 2
@@ -96,6 +103,9 @@ func TestProviderImageSerializationAndLimitFailureContracts(t *testing.T) {
 	}
 	if _, requestError := anthropicClient.generateText(context.Background(), "key", "https://provider.test", model, inlineMessages, nil, logger); !errors.Is(requestError, ErrProviderMediaLimit) {
 		t.Fatalf("Anthropic media limit error=%v", requestError)
+	}
+	if _, requestError := chatClient.generateText(context.Background(), "key", "https://provider.test", model, inlineMessages, nil, chatCompletionTokenLimitMaxTokens, "", logger); !errors.Is(requestError, ErrProviderMediaLimit) {
+		t.Fatalf("Chat Completions media limit error=%v", requestError)
 	}
 }
 

--- a/internal/proxy/provider_router.go
+++ b/internal/proxy/provider_router.go
@@ -111,6 +111,7 @@ func (openAIChatCompletionsTextRouteAdapter) generateText(requestContext context
 		request.messages,
 		request.maxTokens,
 		request.provider.chatTokenLimitParameter,
+		request.reasoningEffort,
 		structuredLogger,
 	)
 }

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -37,6 +37,13 @@ func openAIResponsesReasoningEffortCapability() *proxy.ReasoningEffortCapability
 	}
 }
 
+func moonshotChatReasoningEffortCapability() *proxy.ReasoningEffortCapability {
+	return &proxy.ReasoningEffortCapability{
+		Adapter: "moonshot_chat_completions",
+		Efforts: []string{"low", "high", "max"},
+	}
+}
+
 func TestProviderRoutingUsesConfiguredOpenAIURLsForTextAndDictation(t *testing.T) {
 	var capturedPaths []string
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
@@ -377,9 +384,10 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 		{name: "DashScope Qwen 3.7 Max", provider: proxy.ProviderNameDashScope, model: proxy.ModelNameDashScopeQwen37Max, tokenParameterField: "max_tokens", expectedAPIKey: "sk-dashscope"},
 		{name: "DashScope Qwen 3.7 Plus", provider: proxy.ProviderNameDashScope, model: proxy.ModelNameDashScopeQwen37Plus, tokenParameterField: "max_tokens", expectedAPIKey: "sk-dashscope"},
 		{name: "DashScope Qwen 3.6 Flash", provider: proxy.ProviderNameDashScope, model: proxy.ModelNameDashScopeQwen36Flash, tokenParameterField: "max_tokens", expectedAPIKey: "sk-dashscope"},
-		{name: "Moonshot Kimi K2.6", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK26, tokenParameterField: "max_completion_tokens"},
-		{name: "Moonshot Kimi K3", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK3, tokenParameterField: "max_completion_tokens", forbiddenFields: []string{"temperature", "top_p", "n", "presence_penalty", "frequency_penalty"}},
-		{name: "Moonshot Kimi K2.7 Code", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK27Code, tokenParameterField: "max_completion_tokens", forbiddenFields: []string{"temperature", "top_p", "n", "presence_penalty", "frequency_penalty"}},
+		{name: "Moonshot Kimi K2.6", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK26, tokenParameterField: "max_completion_tokens", forbiddenFields: []string{"thinking", "reasoning_effort"}},
+		{name: "Moonshot Kimi K3", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK3, tokenParameterField: "max_completion_tokens", forbiddenFields: []string{"temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "thinking", "reasoning_effort"}},
+		{name: "Moonshot Kimi K2.7 Code", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK27Code, tokenParameterField: "max_completion_tokens", forbiddenFields: []string{"temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "thinking", "reasoning_effort"}},
+		{name: "Moonshot Kimi K2.7 Code Highspeed", provider: proxy.ProviderNameMoonshot, model: proxy.ModelNameMoonshotKimiK27CodeHighSpeed, tokenParameterField: "max_completion_tokens", forbiddenFields: []string{"thinking", "reasoning_effort"}},
 		{name: "MiniMax M2.7", provider: proxy.ProviderNameMiniMax, model: proxy.ModelNameMiniMaxM27, providerModel: "MiniMax-M2.7", tokenParameterField: "max_completion_tokens", expectedAPIKey: "sk-minimax", forbiddenFields: []string{"max_tokens"}},
 		{name: "SiliconFlow DeepSeek R1", provider: proxy.ProviderNameSiliconFlow, model: proxy.ModelNameSiliconFlowDeepSeek, providerModel: "deepseek-ai/DeepSeek-R1", tokenParameterField: "max_tokens", expectedAPIKey: testSiliconFlowKey},
 		{name: "ZAI GLM 5.2", provider: proxy.ProviderNameZAI, model: "glm-5.2", tokenParameterField: "max_tokens", forbiddenFields: []string{"thinking", "reasoning_effort"}},
@@ -479,6 +487,70 @@ func TestProviderRoutingSupportsCurrentOpenAICompatibleCatalogModels(t *testing.
 				subTest.Fatalf("continuation messages=%v", capturedPayload["messages"])
 			}
 		})
+	}
+}
+
+func TestProviderRoutingMapsKimiK3ReasoningEffortWithoutExposingReasoningContent(t *testing.T) {
+	capturedPayloads := make([]map[string]any, 0, 4)
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		var payload map[string]any
+		if decodeError := json.NewDecoder(request.Body).Decode(&payload); decodeError != nil {
+			t.Fatalf("decode upstream request: %v", decodeError)
+		}
+		capturedPayloads = append(capturedPayloads, payload)
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, _ = responseWriter.Write([]byte(`{"choices":[{"message":{"reasoning_content":"private reasoning","content":"visible answer"},"finish_reason":"stop"}]}`))
+	}))
+	defer upstreamServer.Close()
+
+	router, buildError := buildRouterWithCatalogs(t, proxy.Configuration{
+		Tenants:               proxy.SingleTenantConfigurations("test", TestSecret),
+		OpenAIKey:             TestAPIKey,
+		MoonshotKey:           "sk-moonshot",
+		MoonshotBaseURL:       upstreamServer.URL,
+		LogLevel:              proxy.LogLevelInfo,
+		WorkerCount:           1,
+		QueueSize:             1,
+		RequestTimeoutSeconds: TestTimeout,
+	}, zap.NewNop().Sugar())
+	if buildError != nil {
+		t.Fatalf(messageBuildRouterError, buildError)
+	}
+
+	for _, effort := range []string{"low", "high", "max", ""} {
+		queryParameters := url.Values{
+			"key":      {TestSecret},
+			"prompt":   {TestPrompt},
+			"provider": {proxy.ProviderNameMoonshot},
+			"model":    {proxy.ModelNameMoonshotKimiK3},
+		}
+		if effort != "" {
+			queryParameters.Set("reasoning_effort", effort)
+		}
+		responseRecorder := httptest.NewRecorder()
+		router.ServeHTTP(responseRecorder, httptest.NewRequest(http.MethodGet, "/?"+queryParameters.Encode(), nil))
+		if responseRecorder.Code != http.StatusOK || responseRecorder.Body.String() != "visible answer" {
+			t.Fatalf("effort=%q status=%d body=%q", effort, responseRecorder.Code, responseRecorder.Body.String())
+		}
+		payload := capturedPayloads[len(capturedPayloads)-1]
+		mappedEffort, present := payload["reasoning_effort"]
+		if effort == "" && present {
+			t.Fatalf("omitted reasoning_effort was serialized: %v", payload)
+		}
+		if effort != "" && mappedEffort != effort {
+			t.Fatalf("reasoning_effort=%v want=%s payload=%v", mappedEffort, effort, payload)
+		}
+		if _, present := payload["thinking"]; present {
+			t.Fatalf("Kimi payload includes thinking=%v", payload)
+		}
+	}
+
+	requestCount := len(capturedPayloads)
+	invalidRequest := httptest.NewRequest(http.MethodGet, "/?key="+TestSecret+"&prompt=review&provider=moonshot&model=kimi-k3&reasoning_effort=medium", nil)
+	invalidResponse := httptest.NewRecorder()
+	router.ServeHTTP(invalidResponse, invalidRequest)
+	if invalidResponse.Code != http.StatusBadRequest || len(capturedPayloads) != requestCount || !strings.Contains(invalidResponse.Body.String(), "invalid reasoning_effort parameter") {
+		t.Fatalf("unsupported effort status=%d upstream=%d body=%s", invalidResponse.Code, len(capturedPayloads)-requestCount, invalidResponse.Body.String())
 	}
 }
 
@@ -951,6 +1023,27 @@ func TestProviderRoutingRejectsInvalidReasoningEffortCatalogCapabilities(t *test
 			name: "dictation capability is forbidden",
 			configure: func(catalogs proxy.ModelCatalog) {
 				catalogs.Offerings[catalogOfferingIndex(catalogs, proxy.ProviderNameOpenAI, proxy.DefaultDictationModel)].ReasoningEffort = openAIResponsesReasoningEffortCapability()
+			},
+		},
+		{
+			name: "Moonshot adapter is exact to Kimi K3",
+			configure: func(catalogs proxy.ModelCatalog) {
+				catalogs.Offerings[catalogOfferingIndex(catalogs, proxy.ProviderNameMoonshot, proxy.ModelNameMoonshotKimiK3)].ReasoningEffort = nil
+				catalogs.Offerings[catalogOfferingIndex(catalogs, proxy.ProviderNameMoonshot, proxy.ModelNameMoonshotKimiK26)].ReasoningEffort = moonshotChatReasoningEffortCapability()
+			},
+		},
+		{
+			name: "Moonshot adapter is provider exact",
+			configure: func(catalogs proxy.ModelCatalog) {
+				catalogs.Offerings[catalogOfferingIndex(catalogs, proxy.ProviderNameDeepSeek, proxy.ModelNameDeepSeekV4Flash)].ReasoningEffort = moonshotChatReasoningEffortCapability()
+			},
+		},
+		{
+			name: "Moonshot adapter rejects unsupported effort",
+			configure: func(catalogs proxy.ModelCatalog) {
+				capability := moonshotChatReasoningEffortCapability()
+				capability.Efforts = []string{"medium"}
+				catalogs.Offerings[catalogOfferingIndex(catalogs, proxy.ProviderNameMoonshot, proxy.ModelNameMoonshotKimiK3)].ReasoningEffort = capability
 			},
 		},
 	}

--- a/internal/proxy/provider_types.go
+++ b/internal/proxy/provider_types.go
@@ -221,8 +221,9 @@ const (
 type reasoningEffortAdapter string
 
 const (
-	reasoningEffortAdapterNone            reasoningEffortAdapter = ""
-	reasoningEffortAdapterOpenAIResponses reasoningEffortAdapter = "openai_responses"
+	reasoningEffortAdapterNone                    reasoningEffortAdapter = ""
+	reasoningEffortAdapterOpenAIResponses         reasoningEffortAdapter = "openai_responses"
+	reasoningEffortAdapterMoonshotChatCompletions reasoningEffortAdapter = "moonshot_chat_completions"
 )
 
 type reasoningEffortCapability struct {
@@ -241,6 +242,11 @@ var reasoningEffortAdapterSupportedValues = map[reasoningEffortAdapter]map[strin
 		"high":    {},
 		"xhigh":   {},
 		"max":     {},
+	},
+	reasoningEffortAdapterMoonshotChatCompletions: {
+		"low":  {},
+		"high": {},
+		"max":  {},
 	},
 }
 

--- a/pkg/llmproxyclient/media_test.go
+++ b/pkg/llmproxyclient/media_test.go
@@ -118,6 +118,47 @@ func TestClientPostMessagesSerializesImmutableOrderedMediaAttachments(testingIns
 	}
 }
 
+func TestClientSerializesKimiK3ImageAndReasoningSelection(testingInstance *testing.T) {
+	var capturedBody map[string]any
+	var capturedProvider string
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, httpRequest *http.Request) {
+		capturedProvider = httpRequest.URL.Query().Get("provider")
+		if decodeError := json.NewDecoder(httpRequest.Body).Decode(&capturedBody); decodeError != nil {
+			testingInstance.Fatalf("decode request body: %v", decodeError)
+		}
+		_, _ = responseWriter.Write([]byte("kimi ok"))
+	}))
+	defer server.Close()
+
+	imageAttachment, imageError := llmproxyclient.NewImageAttachment(llmproxyclient.ImageAttachmentInput{MIMEType: "image/webp", Data: []byte("kimi-image")})
+	if imageError != nil {
+		testingInstance.Fatalf("image attachment: %v", imageError)
+	}
+	reasoningEffort := "max"
+	request, requestError := llmproxyclient.NewMessagesRequest(llmproxyclient.MessagesRequestInput{
+		Messages:        []llmproxyclient.MessageInput{{Role: "user", Content: "Inspect.", Attachments: []llmproxyclient.MessageAttachment{imageAttachment}}},
+		Model:           "kimi-k3",
+		ReasoningEffort: &reasoningEffort,
+	})
+	if requestError != nil {
+		testingInstance.Fatalf("messages request: %v", requestError)
+	}
+	config, configError := llmproxyclient.NewConfig(llmproxyclient.ConfigInput{BaseURL: server.URL, Secret: "sekret", Provider: "moonshot"})
+	if configError != nil {
+		testingInstance.Fatalf("client config: %v", configError)
+	}
+	client, clientError := llmproxyclient.NewClient(config, server.Client())
+	if clientError != nil {
+		testingInstance.Fatalf("client: %v", clientError)
+	}
+	if response, postError := client.PostMessages(context.Background(), request); postError != nil || response != "kimi ok" {
+		testingInstance.Fatalf("response=%q error=%v", response, postError)
+	}
+	if capturedProvider != "moonshot" || capturedBody["model"] != "kimi-k3" || capturedBody["reasoning_effort"] != "max" {
+		testingInstance.Fatalf("provider=%s payload=%v", capturedProvider, capturedBody)
+	}
+}
+
 func TestClientUploadsAssetAndSerializesImageAndAudioAssetReferences(testingInstance *testing.T) {
 	imageBytes := []byte("uploaded-image")
 	imageDigest := sha256.Sum256(imageBytes)

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -65,6 +65,33 @@ def test_media_attachment_constructors_serialize_inline_and_asset_union_variants
         ClientMessage(role="assistant", content="invalid", attachments=(inline,))
 
 
+def test_client_serializes_kimi_k3_image_and_reasoning_selection(running_server: RunningServer) -> None:
+    """The Python client sends one canonical Kimi K3 image request."""
+
+    client = Client(ClientConfig(base_url=running_server.url, secret="test-secret", provider="moonshot"))
+    response = client.post_messages(
+        ClientMessagesRequest(
+            messages=(
+                ClientMessage(
+                    role="user",
+                    content="Inspect.",
+                    attachments=(image_attachment(b"kimi-image", "image/webp"),),
+                ),
+            ),
+            model="kimi-k3",
+            reasoning_effort="max",
+        )
+    )
+
+    captured_request = CapturingHandler.captured_request
+    assert response == "reviewed"
+    assert urllib.parse.parse_qs(urllib.parse.urlparse(captured_request.path).query)["provider"] == ["moonshot"]
+    assert captured_request.body is not None
+    assert captured_request.body["model"] == "kimi-k3"
+    assert captured_request.body["reasoning_effort"] == "max"
+    assert captured_request.body["messages"][0]["attachments"][0]["mime_type"] == "image/webp"
+
+
 def test_client_upload_asset_validates_exact_response_without_exposing_bytes() -> None:
     """The asset client sends exact bytes and validates the hash-bound record."""
 

--- a/scripts/test_live_providers.sh
+++ b/scripts/test_live_providers.sh
@@ -7,8 +7,8 @@ usage() {
 
 Builds the current llm-proxy binary, verifies each available provider key
 through the authenticated management operation, and only then runs its live
-text smoke test. Media mode verifies the four current image providers and then
-runs one canonical image request for each. The preflight mode builds a temporary
+text smoke test. Media mode verifies the five current image providers and then
+runs canonical image requests for their selected catalog routes. The preflight mode builds a temporary
 static configuration and verifies authenticated routing without an upstream
 provider call.
 
@@ -42,8 +42,10 @@ Optional environment:
   GO                         Go binary. Default: go.
 
 Options:
-  --media                  Run the paid OpenAI, Anthropic, Gemini, and xAI image
-                           matrix. LLM_PROXY_LIVE_PROVIDERS can select a subset.
+  --media                    Run the paid OpenAI, Anthropic, Gemini, Moonshot,
+                             and xAI image matrix. LLM_PROXY_LIVE_PROVIDERS can
+                             select a subset. LLM_PROXY_LIVE_ALL_MODELS=true
+                             runs every selected provider image route.
   --preflight                Verify the disposable static config without an
                              upstream provider call.
   --write-config <path>      Write the disposable static config and exit
@@ -238,6 +240,28 @@ models = sorted({
     for offering in catalog.get("offerings", [])
     if offering.get("provider") == sys.argv[2]
     and "text" in offering.get("capabilities", [])
+    and isinstance(offering.get("model"), str)
+    and offering.get("model")
+})
+if not models:
+    raise SystemExit(1)
+print("\n".join(models))
+' "${PUBLIC_CAPABILITIES_RESPONSE_PATH}" "${provider}"
+}
+
+provider_catalog_image_models() {
+	local provider="$1"
+	python3 -c '
+import json
+import pathlib
+import sys
+
+catalog = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+models = sorted({
+    offering.get("model")
+    for offering in catalog.get("offerings", [])
+    if offering.get("provider") == sys.argv[2]
+    and "image_input" in offering.get("capabilities", [])
     and isinstance(offering.get("model"), str)
     and offering.get("model")
 })
@@ -805,8 +829,9 @@ if [[ "${MEDIA_ONLY}" == "true" && ( "${PREFLIGHT_ONLY}" == "true" || -n "${WRIT
 fi
 
 SUPPORTED_PROVIDERS=(openai deepseek dashscope moonshot minimax siliconflow zai gemini anthropic meta xai)
-MEDIA_PROVIDERS=(openai anthropic gemini xai)
+MEDIA_PROVIDERS=(openai anthropic gemini moonshot xai)
 LIVE_PROVIDERS=()
+IMAGE_PROVIDERS=()
 IMAGE_MODELS=()
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
@@ -906,17 +931,30 @@ initialize_live_management
 if [[ "${MEDIA_ONLY}" == "true" ]]; then
   fetch_public_capabilities
   for live_provider in "${LIVE_PROVIDERS[@]}"; do
-    if ! image_model="$(provider_image_model "${live_provider}")"; then
-      echo "error: live provider image model is unavailable or ambiguous: provider=${live_provider}" >&2
-      exit 1
+    if [[ "${LIVE_ALL_MODELS}" == "true" ]]; then
+      if ! live_models="$(provider_catalog_image_models "${live_provider}")"; then
+        echo "error: live provider image models are unavailable: provider=${live_provider}" >&2
+        exit 1
+      fi
+      while IFS= read -r image_model; do
+        [[ -n "${image_model}" ]] || continue
+        IMAGE_PROVIDERS+=("${live_provider}")
+        IMAGE_MODELS+=("${image_model}")
+      done <<<"${live_models}"
+    else
+      if ! image_model="$(provider_image_model "${live_provider}")"; then
+        echo "error: live provider image model is unavailable or ambiguous: provider=${live_provider}" >&2
+        exit 1
+      fi
+      IMAGE_PROVIDERS+=("${live_provider}")
+      IMAGE_MODELS+=("${image_model}")
     fi
-    IMAGE_MODELS+=("${image_model}")
   done
-  for live_provider_index in "${!LIVE_PROVIDERS[@]}"; do
-    verify_provider_key "${LIVE_PROVIDERS[${live_provider_index}]}" "${IMAGE_MODELS[${live_provider_index}]}"
+  for live_provider_index in "${!IMAGE_PROVIDERS[@]}"; do
+    verify_provider_key "${IMAGE_PROVIDERS[${live_provider_index}]}" "${IMAGE_MODELS[${live_provider_index}]}"
   done
-  for live_provider_index in "${!LIVE_PROVIDERS[@]}"; do
-    run_image_smoke "${LIVE_PROVIDERS[${live_provider_index}]}" "${IMAGE_MODELS[${live_provider_index}]}"
+  for live_provider_index in "${!IMAGE_PROVIDERS[@]}"; do
+    run_image_smoke "${IMAGE_PROVIDERS[${live_provider_index}]}" "${IMAGE_MODELS[${live_provider_index}]}"
   done
 else
   if [[ "${LIVE_ALL_MODELS}" == "true" ]]; then

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="0bcfb8f3698a6d574409b469c6694a8469590cfac754da3644c9371f397780ef">
+    <meta name="openapi-source-sha256" content="8267e6ad74609a11074e56f2a604986e22bf29bb8ba150504f53f417f5f68026">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.css">
     <link rel="stylesheet" href="/assets/llm-proxy/public-shell.css">
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="0bcfb8f3698a6d574409b469c6694a8469590cfac754da3644c9371f397780ef">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="8267e6ad74609a11074e56f2a604986e22bf29bb8ba150504f53f417f5f68026">
     <mpr-header
       class="public-site-header"
       data-config-url="/config-ui.yaml"
@@ -49,7 +49,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>0bcfb8f3698a6d574409b469c6694a8469590cfac754da3644c9371f397780ef</code></span>
+          <span>Source SHA-256 <code>8267e6ad74609a11074e56f2a604986e22bf29bb8ba150504f53f417f5f68026</code></span>
         </div>
         <div class="resource-actions" aria-label="OpenAPI schema actions">
           <a class="resource-button" href="#openapi-yaml">View YAML</a>
@@ -182,7 +182,9 @@ paths:
         media admission and transport limits. Unsupported media or route
         capabilities return HTTP 400 before an upstream call. The service
         rejects an encoded request body above 8 MiB before JSON decoding. A
-        smaller catalog-derived body limit applies when configured.
+        smaller catalog-derived body limit applies when configured. Current
+        Moonshot Kimi image routes preserve attachment order and exact bytes
+        through Chat Completions Data URL blocks.
       tags:
         - Proxy
       security:
@@ -1882,7 +1884,7 @@ components:
           type: integer
           minimum: 0
     MessageAttachment:
-      description: One provider-neutral image or audio input with a MIME type that matches its declared media type.
+      description: One provider-neutral image or audio input with a MIME type that matches its declared media type. The resolved catalog route determines support. Current Moonshot Kimi image routes accept the image variants.
       oneOf:
         - $ref: &#39;#/components/schemas/ImageMessageAttachment&#39;
         - $ref: &#39;#/components/schemas/AudioMessageAttachment&#39;
@@ -2148,7 +2150,7 @@ components:
         reasoning_effort:
           type: string
           minLength: 1
-          description: Omission selects the tenant or route default. An explicit value must be non-blank and supported by the resolved provider/model route.
+          description: Omission selects the tenant or route default. An explicit value must be non-blank and supported by the resolved provider/model route. Kimi K3 accepts low, high, or max.
     DictationRequest:
       type: object
       additionalProperties: false
@@ -3932,7 +3934,7 @@ components:
           <span class="api-operation-id">postV2Messages</span>
         </header>
         <h2>Generate text from canonical messages</h2>
-        <p>The current messages-only operation. `messages` is required. User messages may include ordered inline or tenant-asset-backed image and audio attachments. `model`, `web_search`, `max_tokens`, and `reasoning_effort` are optional. Omitting `reasoning_effort` selects the tenant or route default. A supplied value must be non-blank and supported by the resolved route. The selected provider offering owns media admission and transport limits. Unsupported media or route capabilities return HTTP 400 before an upstream call. The service rejects an encoded request body above 8 MiB before JSON decoding. A smaller catalog-derived body limit applies when configured.</p>
+        <p>The current messages-only operation. `messages` is required. User messages may include ordered inline or tenant-asset-backed image and audio attachments. `model`, `web_search`, `max_tokens`, and `reasoning_effort` are optional. Omitting `reasoning_effort` selects the tenant or route default. A supplied value must be non-blank and supported by the resolved route. The selected provider offering owns media admission and transport limits. Unsupported media or route capabilities return HTTP 400 before an upstream call. The service rejects an encoded request body above 8 MiB before JSON decoding. A smaller catalog-derived body limit applies when configured. Current Moonshot Kimi image routes preserve attachment order and exact bytes through Chat Completions Data URL blocks.</p>
         <p class="api-security"><strong>Authentication:</strong> TenantClientKey (query key)</p>
         <div class="api-contract-block">
           <h3>Parameters</h3>
@@ -3959,7 +3961,7 @@ components:
 <tr><td><code>model</code></td><td>No</td><td>string</td><td>Omission selects the resolved provider default.</td></tr>
 <tr><td><code>web_search</code></td><td>No</td><td>boolean</td><td>The resolved route must declare web-search capability when true.</td></tr>
 <tr><td><code>max_tokens</code></td><td>No</td><td>integer</td><td>Initial per-attempt output budget. Reused for missing-suffix attempts, with any zero-progress increase bounded by the configured model output limit.</td></tr>
-<tr><td><code>reasoning_effort</code></td><td>No</td><td>string</td><td>Omission selects the tenant or route default. An explicit value must be non-blank and supported by the resolved provider/model route.</td></tr>
+<tr><td><code>reasoning_effort</code></td><td>No</td><td>string</td><td>Omission selects the tenant or route default. An explicit value must be non-blank and supported by the resolved provider/model route. Kimi K3 accepts low, high, or max.</td></tr>
               </tbody>
             </table>
           </div>

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -143,6 +143,12 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 	}
 	geminiCapabilityFound := false
 	openAIDictationCapabilityFound := false
+	expectedKimiModels := map[string]struct{}{
+		proxy.ModelNameMoonshotKimiK26:              {},
+		proxy.ModelNameMoonshotKimiK3:               {},
+		proxy.ModelNameMoonshotKimiK27Code:          {},
+		proxy.ModelNameMoonshotKimiK27CodeHighSpeed: {},
+	}
 	for _, model := range catalog.Models {
 		for _, capability := range model.Capabilities {
 			if capability == "background" || capability == "synchronous" {
@@ -163,14 +169,30 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 			if !slices.Equal(model.Capabilities, []string{proxy.PublicModelCapabilityDictation}) {
 				testingInstance.Fatalf("OpenAI dictation capability=%+v", model)
 			}
+		default:
+			if _, expected := expectedKimiModels[model.Identifier]; expected {
+				expectedCapabilities := []string{proxy.PublicModelCapabilityImageInput, proxy.PublicModelCapabilityText}
+				if model.Identifier == proxy.ModelNameMoonshotKimiK3 {
+					expectedCapabilities = []string{proxy.PublicModelCapabilityImageInput, proxy.PublicModelCapabilityReasoning, proxy.PublicModelCapabilityText}
+				}
+				if !slices.Equal(model.Capabilities, expectedCapabilities) {
+					testingInstance.Fatalf("Kimi model=%s capabilities=%v", model.Identifier, model.Capabilities)
+				}
+				delete(expectedKimiModels, model.Identifier)
+			}
 		}
 	}
 	for _, offering := range catalog.Offerings {
 		if offering.Provider == proxy.ProviderNameOpenAI && offering.Model == proxy.DefaultDictationModel {
 			openAIDictationCapabilityFound = true
 		}
+		if offering.Provider == proxy.ProviderNameMoonshot && offering.Model == proxy.ModelNameMoonshotKimiK3 {
+			if !reflect.DeepEqual(offering.ReasoningEfforts, []string{"low", "high", "max"}) {
+				testingInstance.Fatalf("Kimi K3 reasoning efforts=%v", offering.ReasoningEfforts)
+			}
+		}
 	}
-	if !geminiCapabilityFound || !openAIDictationCapabilityFound {
+	if !geminiCapabilityFound || !openAIDictationCapabilityFound || len(expectedKimiModels) != 0 {
 		testingInstance.Fatalf("public capability catalog projections missing gemini=%t openai_dictation=%t", geminiCapabilityFound, openAIDictationCapabilityFound)
 	}
 
@@ -229,6 +251,7 @@ func TestPublicCapabilityCatalogPublishesExactProviderMediaLimits(testingInstanc
 		proxy.ProviderNameOpenAI:    11,
 		proxy.ProviderNameGemini:    7,
 		proxy.ProviderNameAnthropic: 10,
+		proxy.ProviderNameMoonshot:  4,
 		proxy.ProviderNameXAI:       1,
 	}
 	observedOfferingCounts := map[string]int{}
@@ -246,7 +269,11 @@ func TestPublicCapabilityCatalogPublishesExactProviderMediaLimits(testingInstanc
 		}
 		observedLimitIDs := map[string]proxy.CatalogMediaLimit{}
 		for _, limit := range offering.MediaLimits {
-			if limit.LastVerified != "2026-08-11" {
+			expectedVerificationDate := "2026-08-11"
+			if offering.Provider == proxy.ProviderNameMoonshot {
+				expectedVerificationDate = "2026-08-13"
+			}
+			if limit.LastVerified != expectedVerificationDate {
 				testingInstance.Fatalf("media limit=%+v", limit)
 			}
 			observedLimitIDs[limit.ID] = limit
@@ -264,6 +291,14 @@ func TestPublicCapabilityCatalogPublishesExactProviderMediaLimits(testingInstanc
 			}
 		} else if _, found := observedLimitIDs[proxy.CatalogMediaLimitIDImageInlineBytes]; !found {
 			testingInstance.Fatalf("provider=%s model=%s missing inline image limit", offering.Provider, offering.Model)
+		}
+		if offering.Provider == proxy.ProviderNameMoonshot {
+			requestLimit := observedLimitIDs[proxy.CatalogMediaLimitIDInlineRequestBytes]
+			imageCount := observedLimitIDs[proxy.CatalogMediaLimitIDImageCount]
+			imageBytes := observedLimitIDs[proxy.CatalogMediaLimitIDImageInlineBytes]
+			if requestLimit.Status != proxy.CatalogMediaLimitStatusBounded || requestLimit.Value == nil || *requestLimit.Value != 100000000 || imageCount.Status != proxy.CatalogMediaLimitStatusUnbounded || imageCount.Value != nil || imageBytes.Status != proxy.CatalogMediaLimitStatusUnknown || imageBytes.Value != nil {
+				testingInstance.Fatalf("Moonshot media limits=%+v", offering.MediaLimits)
+			}
 		}
 	}
 	if !reflect.DeepEqual(observedOfferingCounts, expectedOfferingCounts) {

--- a/tests/e2e/management-ui.spec.js
+++ b/tests/e2e/management-ui.spec.js
@@ -445,6 +445,7 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).toContain('data-route-family="muse-spark"');
   expect(html).toContain('data-route-family="qwen"');
   expect(html).toContain('data-route-model="kimi-k2.6" data-route-model-family="kimi-k2"');
+  expect(html).toContain('data-route-model="kimi-k3" data-route-model-family="kimi-k3"');
   expect(html).toContain('data-route-model="qwen-plus" data-route-model-family="qwen"');
   expect(html).toContain('data-route-model="qwen3.7-max" data-route-model-family="qwen"');
   expect(html).toContain('data-route-model="qwen3.7-plus" data-route-model-family="qwen"');
@@ -863,6 +864,8 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(catalog.locator('[data-model="grok-4.5"]')).toContainText("Image input");
   await expect(catalog.locator('[data-model="gemini-3.5-flash"]')).toContainText("Image input");
   await expect(catalog.locator('[data-model="gemini-3.5-flash"]')).toContainText("Audio message input");
+  await expect(catalog.locator('[data-model="kimi-k2.6"]')).toContainText("Image input");
+  await expect(catalog.locator('[data-model="kimi-k3"]')).toContainText("Reasoning");
 
   const footer = page.locator(".public-site-footer-fallback");
   await expect(footer).toBeVisible();
@@ -926,6 +929,11 @@ test("visitors can filter and choose a model family, exact model, and provider o
   await expect(textFilter).toHaveAttribute("aria-pressed", "false");
   await expect(counts).toHaveText("8 families · 29 exact models · 29 offerings");
   await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(8);
+  await openWeightsFilter.click();
+  await expect(counts).toHaveText("10 families · 33 exact models · 33 offerings");
+  await expect(routingTree.locator('[data-route-family="kimi-k2"]')).toBeVisible();
+  await expect(routingTree.locator('[data-route-family="kimi-k3"]')).toBeVisible();
+  await openWeightsFilter.click();
   await routingTree.locator('[data-route-family="grok"]').click();
   await expect(routingTree.locator('[data-route-model-group="grok"] [data-route-model]:visible')).toHaveCount(1);
   await expect(routingTree.locator('[data-route-model="grok-4.5"]')).toHaveAttribute("aria-pressed", "true");
@@ -3908,7 +3916,7 @@ test("reasoning effort is exact to the selected text route and the controls rema
     }
   });
   await installAssetRoutes(page);
-  await installManagementRoutes(page);
+  await installManagementRoutes(page, { savedProviderIDs: ["openai", "deepseek", "meta", "moonshot"] });
 
   await page.goto(`${baseURL}${applicationPath}`);
   await page.getByTestId("avatar-menu").click();
@@ -3922,6 +3930,18 @@ test("reasoning effort is exact to the selected text route and the controls rema
   const unsupportedEffort = textRoutingControls.locator(".reasoning-effort-unsupported");
 
   await expect(unsupportedEffort).toBeVisible();
+
+  await textProvider.selectOption("moonshot");
+  await expect(textModel).toHaveValue("kimi-k2.6");
+  await expect(reasoningEffort).toBeHidden();
+  await textModel.selectOption("kimi-k3");
+  await expect(reasoningEffort).toBeVisible();
+  await expect(reasoningEffort.locator("option")).toHaveText(["Not set", "low", "high", "max"]);
+  await reasoningEffort.selectOption("max");
+  await expect.poll(() => defaultsMutations.some((defaults) => (
+    defaults.provider === "moonshot" && defaults.model === "kimi-k3" && defaults.reasoning_effort === "max"
+  ))).toBe(true);
+  await textProvider.selectOption("openai");
   await expect(unsupportedEffort).toContainText("Not supported");
   await expect(reasoningEffort).toBeHidden();
   await textModel.selectOption("gpt-5-mini");
@@ -6325,6 +6345,30 @@ function managementProfile(isAdmin = false, hasSecret = true) {
         system_prompt: "",
         text_default_model: "muse-spark-1.1",
         text_models: [{ id: "muse-spark-1.1" }],
+        supports_dictation: false,
+        dictation_models: [],
+      },
+      {
+        id: "moonshot",
+        label: "Moonshot",
+        aliases: ["kimi"],
+        has_key: false,
+        base_url: "",
+        text_model: "kimi-k2.6",
+        system_prompt: "",
+        text_default_model: "kimi-k2.6",
+        text_models: [
+          { id: "kimi-k2.6" },
+          { id: "kimi-k2.7-code" },
+          { id: "kimi-k2.7-code-highspeed" },
+          {
+            id: "kimi-k3",
+            reasoning_effort: {
+              adapter: "moonshot_chat_completions",
+              efforts: ["low", "high", "max"],
+            },
+          },
+        ],
         supports_dictation: false,
         dictation_models: [],
       },

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -1569,6 +1569,7 @@ func TestOperationalLiveHarnessRunsCatalogSelectedImageMatrixAfterVerification(t
 		"OPENAI_API_KEY":    "test-live-openai-key",
 		"ANTHROPIC_API_KEY": "test-live-anthropic-key",
 		"GEMINI_API_KEY":    "test-live-gemini-key",
+		"MOONSHOT_API_KEY":  "test-live-moonshot-key",
 		"XAI_API_KEY":       "test-live-xai-key",
 	}
 	environmentContents := ""
@@ -1583,6 +1584,7 @@ func TestOperationalLiveHarnessRunsCatalogSelectedImageMatrixAfterVerification(t
 		"PROXY_PID_CAPTURE=" + fixture.proxyPIDPath,
 		"LIVE_ENV_FILE=" + environmentFile,
 		"LIVE_OPERATION_CAPTURE=" + operationCapture,
+		"LLM_PROXY_LIVE_ALL_MODELS=true",
 	}
 	command := exec.Command(filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), "--media")
 	command.Dir = repositoryRoot
@@ -1592,8 +1594,8 @@ func TestOperationalLiveHarnessRunsCatalogSelectedImageMatrixAfterVerification(t
 		testingInstance.Fatalf("live provider image matrix failed: %v\n%s", commandError, output)
 	}
 	outputText := string(output)
-	expectedModels := []string{"gpt-4.1", "claude-sonnet-4-6", "gemini-2.5-flash", "grok-4.5"}
-	expectedProviders := []string{"openai", "anthropic", "gemini", "xai"}
+	expectedModels := []string{"gpt-4.1", "claude-sonnet-4-6", "gemini-2.5-flash", "kimi-k2.6", "kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k3", "grok-4.5"}
+	expectedProviders := []string{"openai", "anthropic", "gemini", "moonshot", "moonshot", "moonshot", "moonshot", "xai"}
 	for index, provider := range expectedProviders {
 		expectedVerification := "live provider verification passed: provider=" + provider + " model=" + expectedModels[index] + " status=200"
 		expectedSuccess := "live provider image smoke passed: provider=" + provider + " model=" + expectedModels[index] + " status=200"
@@ -1613,8 +1615,8 @@ func TestOperationalLiveHarnessRunsCatalogSelectedImageMatrixAfterVerification(t
 	capture := string(captureBytes)
 	lastVerificationOffset := strings.LastIndex(capture, "verify PUT ")
 	firstImageOffset := strings.Index(capture, "image POST ")
-	if strings.Count(capture, "verify PUT ") != 4 || strings.Count(capture, "image POST ") != 4 || firstImageOffset <= lastVerificationOffset {
-		testingInstance.Fatalf("live image operations were not four verifications followed by four images: %s", capture)
+	if strings.Count(capture, "verify PUT ") != 8 || strings.Count(capture, "image POST ") != 8 || firstImageOffset <= lastVerificationOffset {
+		testingInstance.Fatalf("live image operations were not eight verifications followed by eight images: %s", capture)
 	}
 	imagePayloadLines := []string{}
 	for _, line := range strings.Split(capture, "\n") {
@@ -1847,7 +1849,7 @@ write_response_headers() {
 
 case "${request_url}" in
   */api/public/capabilities)
-    builtin printf '%s' '{"offerings":[{"provider":"openai","model":"gpt-4.1","capabilities":["image_input","text"]},{"provider":"anthropic","model":"claude-sonnet-4-6","capabilities":["image_input","text"]},{"provider":"gemini","model":"gemini-2.5-flash","capabilities":["audio_input","image_input","text"]},{"provider":"xai","model":"grok-4.5","capabilities":["image_input","text"]},{"provider":"dashscope","model":"qwen-plus","capabilities":["text"]},{"provider":"dashscope","model":"qwen3.6-flash","capabilities":["text"]},{"provider":"dashscope","model":"qwen3.7-max","capabilities":["text"]},{"provider":"dashscope","model":"qwen3.7-plus","capabilities":["text"]}]}' >"${output_path}"
+    builtin printf '%s' '{"offerings":[{"provider":"openai","model":"gpt-4.1","capabilities":["image_input","text"]},{"provider":"anthropic","model":"claude-sonnet-4-6","capabilities":["image_input","text"]},{"provider":"gemini","model":"gemini-2.5-flash","capabilities":["audio_input","image_input","text"]},{"provider":"moonshot","model":"kimi-k2.6","capabilities":["image_input","text"]},{"provider":"moonshot","model":"kimi-k2.7-code","capabilities":["image_input","text"]},{"provider":"moonshot","model":"kimi-k2.7-code-highspeed","capabilities":["image_input","text"]},{"provider":"moonshot","model":"kimi-k3","capabilities":["image_input","text"]},{"provider":"xai","model":"grok-4.5","capabilities":["image_input","text"]},{"provider":"dashscope","model":"qwen-plus","capabilities":["text"]},{"provider":"dashscope","model":"qwen3.6-flash","capabilities":["text"]},{"provider":"dashscope","model":"qwen3.7-max","capabilities":["text"]},{"provider":"dashscope","model":"qwen3.7-plus","capabilities":["text"]}]}' >"${output_path}"
     builtin printf '%s' 200
     ;;
   */api/management/account)
@@ -1855,7 +1857,7 @@ case "${request_url}" in
     builtin printf '%s' 200
     ;;
   */api/management/tenants/tenant-live/secrets)
-    builtin printf '%s' '{"secret":"live-generated-secret","profile":{"providers":[{"id":"openai","text_default_model":"gpt-4.1"},{"id":"anthropic","text_default_model":"claude-sonnet-4-6"},{"id":"gemini","text_default_model":"gemini-2.5-flash"},{"id":"xai","text_default_model":"grok-4.3"},{"id":"deepseek","text_default_model":"deepseek-v4-flash"}]}}' >"${output_path}"
+    builtin printf '%s' '{"secret":"live-generated-secret","profile":{"providers":[{"id":"openai","text_default_model":"gpt-4.1"},{"id":"anthropic","text_default_model":"claude-sonnet-4-6"},{"id":"gemini","text_default_model":"gemini-2.5-flash"},{"id":"moonshot","text_default_model":"kimi-k2.6"},{"id":"xai","text_default_model":"grok-4.3"},{"id":"deepseek","text_default_model":"deepseek-v4-flash"}]}}' >"${output_path}"
     builtin printf '%s' 200
     ;;
   */api/management/tenants/tenant-live/provider-keys/*)


### PR DESCRIPTION
Summary
- add the exact Moonshot Kimi K3 reasoning-effort adapter for low, high, and max
- add ordered canonical image input to Kimi K3, K2.7 Code, K2.7 Code Highspeed, and K2.6
- publish provider limits and capabilities across management, public, browser, OpenAPI, Go, and Python surfaces
- extend the paid image harness to Moonshot and all selected image models

Validation
- make ci
- 93 Playwright tests passed
- 39 Python tests passed
- Go statement coverage: 100.0%

Acceptance boundary
- paid Moonshot verification remains blocked because MOONSHOT_API_KEY and paid-call authorization are unavailable
- the operator command is documented in README.md and I227 remains marked blocked until the four-model paid image matrix passes