### PR TITLE
feature/f021-oauth-resource-manifest

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -2413,7 +2413,7 @@ retain satisfied historical dependencies.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair for the implementation, with
     the final run after the last code edit.
-- [!] [F021] (P1) Add OAuth-authenticated tenant-scoped MCP access.
+- [ ] [F021] (P1) Add OAuth-authenticated tenant-scoped MCP access.
   Goal:
   An authenticated user can connect a remote MCP client to one owned tenant.
   The server uses that tenant's saved provider credentials, routing defaults,
@@ -2424,15 +2424,18 @@ retain satisfied historical dependencies.
   - Provider credentials remain on the server and belong to one tenant.
   - TAuth provides the OAuth authorization-server contract that a remote MCP
     client requires.
-  - The gateway cannot yet generate the root OAuth block or tenant OAuth policy.
+  - The gateway generates the root OAuth block and the tenant OAuth policy.
+  - The deployment manifest declares the protected API origin and the
+    `llm-proxy:use` scope.
   Requirements:
   - Serve MCP protocol version `2026-07-28` at the exact resource URL
     `https://llm-proxy-api.mprlab.com/mcp/{tenant_id}`.
   - Use the official Go MCP SDK in stateless Streamable HTTP mode. Return JSON
     responses and reject every unsupported protocol version.
   - Do not create an MCP session or implement an earlier MCP transport.
-  - Treat the exact MCP URL as the OAuth protected-resource identifier and
-    access-token audience.
+  - Use `https://llm-proxy-api.mprlab.com` as the OAuth protected-resource
+    identifier and access-token audience.
+  - Confirm the token subject owns the exact `{tenant_id}` path resource.
   - Publish path-specific OAuth Protected Resource Metadata at
     `/.well-known/oauth-protected-resource/mcp/{tenant_id}`.
   - Return an RFC-compliant Bearer challenge for an unauthenticated MCP
@@ -2500,8 +2503,8 @@ retain satisfied historical dependencies.
     acceptance. Record live-host acceptance as a separate deployment result.
   - Run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair.
-  Blocked: mprlab-gateway F001 must complete the TAuth OAuth aggregate
-  deployment contract before this feature can declare its protected resources.
+  Dependency handoff: 2026-08-15 — gateway F001 and both application manifests
+  passed local contract validation. Production activation remains separate.
 
 - [ ] [F028] (P2) {F027} Add HeyGen Avatar V as a gateway-owned avatar engine.
   Goal:

--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -181,3 +181,16 @@ mprlab_resources:
           domain: .mprlab.com
           session_name: app_session_llm_proxy
           refresh_name: app_refresh_llm_proxy
+        oauth:
+          access_token_ttl: 5m
+          refresh_token_ttl: 720h
+          consent_ttl: 720h
+          allow_client_metadata_documents: true
+          resources:
+            - identifier: https://llm-proxy-api.mprlab.com
+              display_name: LLM Proxy API
+              scopes:
+                - identifier: llm-proxy:use
+                  display_name: Use LLM Proxy
+                  description: Use the LLM Proxy API.
+          clients: []

--- a/tests/lifecycle_contract_test.go
+++ b/tests/lifecycle_contract_test.go
@@ -137,6 +137,27 @@ func TestOperationalRepositoryOwnsSchemaV4Lifecycle(testingInstance *testing.T) 
 		testingInstance.Fatalf("unexpected private-value bindings: %#v", privateBindings)
 	}
 
+	authenticationTenant := resourcesByIdentity["tauth_tenant/authentication"]["tenant"].(map[string]any)
+	expectedOAuthPolicy := map[string]any{
+		"access_token_ttl":                "5m",
+		"refresh_token_ttl":               "720h",
+		"consent_ttl":                     "720h",
+		"allow_client_metadata_documents": true,
+		"resources": []any{map[string]any{
+			"identifier":   "https://llm-proxy-api.mprlab.com",
+			"display_name": "LLM Proxy API",
+			"scopes": []any{map[string]any{
+				"identifier":   "llm-proxy:use",
+				"display_name": "Use LLM Proxy",
+				"description":  "Use the LLM Proxy API.",
+			}},
+		}},
+		"clients": []any{},
+	}
+	if !reflect.DeepEqual(authenticationTenant["oauth"], expectedOAuthPolicy) {
+		testingInstance.Fatalf("unexpected TAuth tenant OAuth policy: %#v", authenticationTenant["oauth"])
+	}
+
 	runtimeServices, servicesAvailable := resourcesByIdentity["compose_project/runtime"]["services"].([]any)
 	if !servicesAvailable || len(runtimeServices) != 1 {
 		testingInstance.Fatalf("unexpected runtime services: %#v", resourcesByIdentity["compose_project/runtime"]["services"])


### PR DESCRIPTION
## Summary

Declare the LLM Proxy API as an OAuth-protected resource in the deployment manifest.

## Changes

- Add the `https://llm-proxy-api.mprlab.com` protected-resource identifier and `llm-proxy:use` scope.
- Configure OAuth token and consent lifetimes, client metadata document support, and an empty client allowlist for the authentication tenant.
- Extend lifecycle contract coverage to enforce the complete OAuth policy.
- Update F021 planning notes to reflect that the OAuth deployment dependency is satisfied while production activation remains separate.

## Why

F021 requires a stable OAuth resource identifier, audience, and scope for tenant-scoped MCP access. This establishes that deployment contract so clients can request authorization for the LLM Proxy API.