### PR TITLE
gix/record-failed-requests-with-provider-default-model

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -29,26 +29,32 @@ retain satisfied historical dependencies.
   Goal:
   Usage reports show the model route that the request contract selects.
   Evidence:
-  - Expected: An explicit provider with no model uses that provider's saved
-    default model.
+  - Expected: An explicit provider with no model uses its saved model or its
+    catalog default.
   - Actual: A failed Gemini request can use the tenant-wide OpenAI model in
     usage data.
   - The dashboard then shows an invalid pair such as
     `gemini / gpt-5.6-terra`.
+  - A registered provider without saved settings can record an empty model.
   Requirements:
   - Derive the failed request provider and model from one route default.
   - Use the same provider-specific default that request validation uses.
+  - Use the provider catalog default when no saved provider model exists.
   - Do not change successful request usage or public response behavior.
   Validation:
   - Prove failed `GET /`, `POST /`, and `POST /v2` requests use the selected
     provider's saved model.
   - Prove usage summaries contain no tenant-wide model under that provider.
+  - Prove the documented unconfigured-provider `503` records the catalog
+    default model.
   - Run `make ci` after the last application change.
 
   Resolution:
-  - Each text handler now selects one provider-specific route default before
-    validation.
-  - Failed requests now use that default for provider and model usage.
+  - An explicit registered provider now selects its catalog default before
+    request validation.
+  - A saved managed-provider model replaces that catalog default.
+  - Failed `GET /`, `POST /`, and `POST /v2` requests now record the selected
+    provider model.
   - The final `make ci` passed all 11 gates with 94 browser scenarios and
     100.0% Go statement coverage.
 
@@ -135,6 +141,8 @@ retain satisfied historical dependencies.
   - Prove that `go list -m -versions github.com/tyemirov/llm-proxy` includes
     `v1.1.0`.
   - Run the LLM Proxy CI gate.
+  - Run the Creative Director CI gate without a Go workspace or replace
+    directive.
   Completion evidence:
   - Tag `v1.1.0` points to commit
     `fe48b5b2259b022eca2156b81be3697465453d8a`.
@@ -142,13 +150,6 @@ retain satisfied historical dependencies.
   - The exact release tree passed all 11 CI gates with 100.0% Go statement
     coverage.
   - Creative Director selects `v1.1.0` and passes CI without a workspace.
-  - Run the Creative Director CI gate without a Go workspace or replace
-    directive.
-  Blocked:
-  The local implementation passes all 11 LLM Proxy CI gates and the Creative
-  Director CI gate. Repository rules require explicit authorization for the
-  execution chain to publish the `v1.1.0` tag. The existing `v3.1.0` product
-  release is not a selectable release of the declared Go module.
 
 - [x] [B140] (P1) Remove gateway-owned Pages markers.
   Goal:

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -25,6 +25,33 @@ retain satisfied historical dependencies.
 
 ## BugFixes
 
+- [x] [B145] (P1) Keep failed request usage on one model route.
+  Goal:
+  Usage reports show the model route that the request contract selects.
+  Evidence:
+  - Expected: An explicit provider with no model uses that provider's saved
+    default model.
+  - Actual: A failed Gemini request can use the tenant-wide OpenAI model in
+    usage data.
+  - The dashboard then shows an invalid pair such as
+    `gemini / gpt-5.6-terra`.
+  Requirements:
+  - Derive the failed request provider and model from one route default.
+  - Use the same provider-specific default that request validation uses.
+  - Do not change successful request usage or public response behavior.
+  Validation:
+  - Prove failed `GET /`, `POST /`, and `POST /v2` requests use the selected
+    provider's saved model.
+  - Prove usage summaries contain no tenant-wide model under that provider.
+  - Run `make ci` after the last application change.
+
+  Resolution:
+  - Each text handler now selects one provider-specific route default before
+    validation.
+  - Failed requests now use that default for provider and model usage.
+  - The final `make ci` passed all 11 gates with 94 browser scenarios and
+    100.0% Go statement coverage.
+
 - [x] [B144] (P1) Use preinstalled Playwright OS packages in hosted CI.
   Goal:
   Hosted CI completes the canonical gate within its 350-second watchdog.
@@ -83,27 +110,45 @@ retain satisfied historical dependencies.
   - The final `make ci` passed all 11 gates with 94 browser scenarios and
     100.0% Go statement coverage.
 
-- [!] [B142] (P1) {I229} Publish the structured-request client contract.
+- [x] [B142] (P1) {I229} Publish the structured-request client contract.
   Goal:
   Let Creative Director consume the declared structured-output and durable
   request API from an official released Go module.
   Evidence:
-  - The current released module is `v1.0.0`.
+  - Before this change, the current released module was `v1.0.0`.
   - That release has no structured-output request fields and no durable request
     reconciliation method.
+  - Product release `v3.1.0` contains the client at commit `fe48b5b`, but Go
+    rejects that tag because the module path does not end in `/v3`.
   Requirements:
   - Keep structured request construction and reconciliation in the official Go
     client.
   - Remove provider, model, and format query values from reconciliation calls.
-  - Publish one valid module release and update Creative Director to use it.
+  - Publish commit `fe48b5b` as Go module `v1.1.0` for the unchanged module
+    path `github.com/tyemirov/llm-proxy`.
+  - Do not use a pseudo-version, a replace directive, or a local workspace as
+    released dependency evidence.
+  - Update Creative Director to use `v1.1.0`.
   Validation:
   - Prove the official client sends the structured schema and idempotency key.
   - Prove reconciliation sends no provider request selection.
-  - Run the LLM Proxy and Creative Director CI gates.
+  - Prove that `go list -m -versions github.com/tyemirov/llm-proxy` includes
+    `v1.1.0`.
+  - Run the LLM Proxy CI gate.
+  Completion evidence:
+  - Tag `v1.1.0` points to commit
+    `fe48b5b2259b022eca2156b81be3697465453d8a`.
+  - The public Go module graph lists `v1.1.0`.
+  - The exact release tree passed all 11 CI gates with 100.0% Go statement
+    coverage.
+  - Creative Director selects `v1.1.0` and passes CI without a workspace.
+  - Run the Creative Director CI gate without a Go workspace or replace
+    directive.
   Blocked:
   The local implementation passes all 11 LLM Proxy CI gates and the Creative
   Director CI gate. Repository rules require explicit authorization for the
-  commit, tag, and push that make the module available to Creative Director.
+  execution chain to publish the `v1.1.0` tag. The existing `v3.1.0` product
+  release is not a selectable release of the declared Go module.
 
 - [x] [B140] (P1) Remove gateway-owned Pages markers.
   Goal:

--- a/internal/proxy/management_internal_test.go
+++ b/internal/proxy/management_internal_test.go
@@ -248,14 +248,14 @@ func TestTextRequestDefaultsForProviderInternalEdges(t *testing.T) {
 		}),
 	}
 	staticExplicitDefaults := textRequestDefaultsForProvider(ProviderNameDeepSeek, staticTenant, providers)
-	if staticExplicitDefaults.model != "" || staticExplicitDefaults.systemPrompt != "tenant system" {
+	if staticExplicitDefaults.model != ModelNameDeepSeekV4Flash || staticExplicitDefaults.systemPrompt != "tenant system" {
 		t.Fatalf("static explicit defaults=%+v", staticExplicitDefaults)
 	}
 
 	managedTenant := staticTenant
 	managedTenant.managed = true
 	managedNoSettingsDefaults := textRequestDefaultsForProvider(ProviderNameOpenAI, managedTenant, providers)
-	if managedNoSettingsDefaults.model != "" || managedNoSettingsDefaults.systemPrompt != "tenant system" {
+	if managedNoSettingsDefaults.model != ModelNameGPT41 || managedNoSettingsDefaults.systemPrompt != "tenant system" {
 		t.Fatalf("managed no-settings defaults=%+v", managedNoSettingsDefaults)
 	}
 	managedUnknownProviderDefaults := textRequestDefaultsForProvider("unknown-provider", managedTenant, providers)

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -1968,6 +1968,81 @@ func TestManagementValidationFailureUsageUsesSelectedProviderDefaultModel(t *tes
 	}
 }
 
+func TestManagementUnconfiguredProviderUsageUsesCatalogDefaultModel(t *testing.T) {
+	router := newManagementRouter(t, proxy.Configuration{})
+	sessionCookie := managementSessionCookie(t, "usage-catalog-default-user")
+	tenantPath := managementDefaultTenantTestPath(t, router, sessionCookie, "")
+
+	providerRequest := authenticatedJSONRequest(
+		http.MethodPut,
+		tenantPath+"/provider-keys/"+proxy.ProviderNameOpenAI,
+		managementProviderKeyRequestBody(t, testManagementOpenAIKey, proxy.ModelNameGPT41, ""),
+		sessionCookie,
+	)
+	providerResponse := httptest.NewRecorder()
+	router.ServeHTTP(providerResponse, providerRequest)
+	if providerResponse.Code != http.StatusOK {
+		t.Fatalf("save provider status=%d body=%s", providerResponse.Code, providerResponse.Body.String())
+	}
+
+	secretRequest := authenticatedJSONRequest(http.MethodPost, tenantPath+"/secrets", `{}`, sessionCookie)
+	secretResponse := httptest.NewRecorder()
+	router.ServeHTTP(secretResponse, secretRequest)
+	if secretResponse.Code != http.StatusOK {
+		t.Fatalf("secret status=%d body=%s", secretResponse.Code, secretResponse.Body.String())
+	}
+	var secretPayload struct {
+		Secret string `json:"secret"`
+	}
+	if decodeError := json.Unmarshal(secretResponse.Body.Bytes(), &secretPayload); decodeError != nil {
+		t.Fatalf("decode secret: %v", decodeError)
+	}
+
+	requestCases := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{method: http.MethodGet, path: "/", body: ""},
+		{method: http.MethodPost, path: "/", body: `{"prompt":"hello"}`},
+		{method: http.MethodPost, path: "/v2", body: `{"messages":[{"role":"user","content":"hello"}]}`},
+	}
+	for _, requestCase := range requestCases {
+		query := url.Values{
+			"key":      []string{secretPayload.Secret},
+			"provider": []string{proxy.ProviderNameGemini},
+		}
+		if requestCase.method == http.MethodGet {
+			query.Set("prompt", "hello")
+		}
+		request := httptest.NewRequest(
+			requestCase.method,
+			requestCase.path+"?"+query.Encode(),
+			strings.NewReader(requestCase.body),
+		)
+		if requestCase.method == http.MethodPost {
+			request.Header.Set("Content-Type", "application/json")
+		}
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code != http.StatusServiceUnavailable {
+			t.Fatalf("method=%s path=%s status=%d body=%s", requestCase.method, requestCase.path, response.Code, response.Body.String())
+		}
+	}
+
+	usage := waitForManagementValue(t, func() managementUsageTestResponse {
+		return requestManagementUsage(t, router, sessionCookie, "30d")
+	}, func(payload managementUsageTestResponse) bool {
+		return payload.Totals.Requests == len(requestCases)
+	})
+	if len(usage.Providers) != 1 || usage.Providers[0].Provider != proxy.ProviderNameGemini || usage.Providers[0].Data.Requests != len(requestCases) {
+		t.Fatalf("providers=%+v", usage.Providers)
+	}
+	if len(usage.Models) != 1 || usage.Models[0].Provider != proxy.ProviderNameGemini || usage.Models[0].Model != proxy.ModelNameGemini25Flash || usage.Models[0].Data.Requests != len(requestCases) {
+		t.Fatalf("models=%+v", usage.Models)
+	}
+}
+
 func TestManagementAdminUsersDashboard(t *testing.T) {
 	chatServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		responseWriter.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -1883,6 +1883,91 @@ func TestManagementUsageSummaryRecordsManagedProxyRequests(t *testing.T) {
 	}
 }
 
+func TestManagementValidationFailureUsageUsesSelectedProviderDefaultModel(t *testing.T) {
+	router := newManagementRouter(t, proxy.Configuration{})
+	sessionCookie := managementSessionCookie(t, "usage-provider-default-user")
+	tenantPath := managementDefaultTenantTestPath(t, router, sessionCookie, "")
+
+	for _, providerKey := range []struct {
+		provider string
+		apiKey   string
+		model    string
+	}{
+		{provider: proxy.ProviderNameOpenAI, apiKey: testManagementOpenAIKey, model: proxy.ModelNameGPT41},
+		{provider: proxy.ProviderNameGemini, apiKey: testGeminiKey, model: proxy.ModelNameGemini25Flash},
+	} {
+		request := authenticatedJSONRequest(
+			http.MethodPut,
+			tenantPath+"/provider-keys/"+providerKey.provider,
+			managementProviderKeyRequestBody(t, providerKey.apiKey, providerKey.model, ""),
+			sessionCookie,
+		)
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code != http.StatusOK {
+			t.Fatalf("save provider=%s status=%d body=%s", providerKey.provider, response.Code, response.Body.String())
+		}
+	}
+
+	secretRequest := authenticatedJSONRequest(http.MethodPost, tenantPath+"/secrets", `{}`, sessionCookie)
+	secretResponse := httptest.NewRecorder()
+	router.ServeHTTP(secretResponse, secretRequest)
+	if secretResponse.Code != http.StatusOK {
+		t.Fatalf("secret status=%d body=%s", secretResponse.Code, secretResponse.Body.String())
+	}
+	var secretPayload struct {
+		Secret string `json:"secret"`
+	}
+	if decodeError := json.Unmarshal(secretResponse.Body.Bytes(), &secretPayload); decodeError != nil {
+		t.Fatalf("decode secret: %v", decodeError)
+	}
+
+	requestCases := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{method: http.MethodGet, path: "/"},
+		{method: http.MethodPost, path: "/", body: `{"prompt":"hello","max_tokens":0}`},
+		{method: http.MethodPost, path: "/v2", body: `{"messages":[{"role":"user","content":"hello"}],"max_tokens":0}`},
+	}
+	for _, requestCase := range requestCases {
+		query := url.Values{
+			"key":      []string{secretPayload.Secret},
+			"provider": []string{proxy.ProviderNameGemini},
+		}
+		if requestCase.method == http.MethodGet {
+			query.Set("prompt", "hello")
+			query.Set("max_tokens", "0")
+		}
+		request := httptest.NewRequest(
+			requestCase.method,
+			requestCase.path+"?"+query.Encode(),
+			strings.NewReader(requestCase.body),
+		)
+		if requestCase.method == http.MethodPost {
+			request.Header.Set("Content-Type", "application/json")
+		}
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("method=%s path=%s status=%d body=%s", requestCase.method, requestCase.path, response.Code, response.Body.String())
+		}
+	}
+
+	usage := waitForManagementValue(t, func() managementUsageTestResponse {
+		return requestManagementUsage(t, router, sessionCookie, "30d")
+	}, func(payload managementUsageTestResponse) bool {
+		return payload.Totals.Requests == len(requestCases)
+	})
+	if len(usage.Providers) != 1 || usage.Providers[0].Provider != proxy.ProviderNameGemini || usage.Providers[0].Data.Requests != len(requestCases) {
+		t.Fatalf("providers=%+v", usage.Providers)
+	}
+	if len(usage.Models) != 1 || usage.Models[0].Provider != proxy.ProviderNameGemini || usage.Models[0].Model != proxy.ModelNameGemini25Flash || usage.Models[0].Data.Requests != len(requestCases) {
+		t.Fatalf("models=%+v", usage.Models)
+	}
+}
+
 func TestManagementAdminUsersDashboard(t *testing.T) {
 	chatServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		responseWriter.Header().Set("Content-Type", "application/json")
@@ -2441,6 +2526,13 @@ type managementUsageTestResponse struct {
 			Requests int `json:"requests"`
 		} `json:"data"`
 	} `json:"providers"`
+	Models []struct {
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+		Data     struct {
+			Requests int `json:"requests"`
+		} `json:"data"`
+	} `json:"models"`
 	StatusCodes []struct {
 		StatusCode int `json:"status_code"`
 		Requests   int `json:"requests"`

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -286,15 +286,25 @@ func textRequestDefaultsForProvider(rawProvider string, requestTenant tenant, pr
 	if providerExplicit {
 		defaults.model = constants.EmptyString
 	}
-	if !requestTenant.managed || !providerExplicit {
+	if !providerExplicit {
 		return defaults
 	}
 	providerCandidate := strings.TrimSpace(rawProvider)
-	providerIdentifier, providerError := providers.canonicalProviderID(providerCandidate)
-	if providerError != nil {
+	providerDefinition, catalogDefaultModel, resolutionError := providers.resolveTextModel(
+		providerCandidate,
+		constants.EmptyString,
+		constants.EmptyString,
+		constants.EmptyString,
+		false,
+	)
+	if resolutionError != nil {
 		return defaults
 	}
-	settings, hasSettings := requestTenant.providerSettings[providerIdentifier]
+	defaults.model = catalogDefaultModel.string()
+	if !requestTenant.managed {
+		return defaults
+	}
+	settings, hasSettings := requestTenant.providerSettings[providerDefinition.identifier]
 	if !hasSettings {
 		return defaults
 	}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -171,15 +171,15 @@ func chatHandler(upstreamProviders *providerRouter, providers *providerRegistry,
 	return func(ginContext *gin.Context) {
 		requestStart := time.Now()
 		requestTenant := authenticatedTenantFromContext(ginContext)
+		textDefaults := textRequestDefaultsForProvider(ginContext.Query(queryParameterProvider), requestTenant, providers)
 		if rejectClientProviderCredentialsFromQuery(ginContext) {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 		validator := newModelValidator(providers.forTenant(requestTenant))
-		textDefaults := textRequestDefaultsForProvider(ginContext.Query(queryParameterProvider), requestTenant, providers)
 		chatRequest, ok := chatRequestFromQuery(ginContext, textDefaults, validator, structuredLogger)
 		if !ok {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointText, managedTenants, structuredLogger)
@@ -191,18 +191,19 @@ func chatJSONHandler(upstreamProviders *providerRouter, providers *providerRegis
 	return func(ginContext *gin.Context) {
 		requestStart := time.Now()
 		requestTenant := authenticatedTenantFromContext(ginContext)
+		textDefaults := textRequestDefaultsForProvider(ginContext.Query(queryParameterProvider), requestTenant, providers)
 		if rejectClientProviderCredentialsFromQuery(ginContext) {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxPromptBytes)
 		bodyBytes, readBodyOK := readJSONProxyBody(ginContext)
 		if !readBodyOK {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 		if rejectClientProviderCredentialsFromJSONBody(ginContext, bodyBytes) {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 		var payload chatRequestPayload
@@ -210,15 +211,14 @@ func chatJSONHandler(upstreamProviders *providerRouter, providers *providerRegis
 		jsonDecoder.DisallowUnknownFields()
 		if decodeError := jsonDecoder.Decode(&payload); decodeError != nil {
 			ginContext.String(http.StatusBadRequest, errorInvalidJSONRequest)
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 
 		validator := newModelValidator(providers.forTenant(requestTenant))
-		textDefaults := textRequestDefaultsForProvider(ginContext.Query(queryParameterProvider), requestTenant, providers)
 		chatRequest, ok := chatRequestFromPayload(ginContext, payload, textDefaults, validator)
 		if !ok {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, payload.Model, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointText, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, payload.Model, textDefaults), requestStart)
 			return
 		}
 		submitChatRequest(ginContext, upstreamProviders, chatRequest, requestTenant, usageEndpointText, managedTenants, structuredLogger)
@@ -229,18 +229,19 @@ func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerReg
 	return func(ginContext *gin.Context) {
 		requestStart := time.Now()
 		requestTenant := authenticatedTenantFromContext(ginContext)
+		textDefaults := textRequestDefaultsForProvider(ginContext.Query(queryParameterProvider), requestTenant, providers)
 		if rejectClientProviderCredentialsFromQuery(ginContext) {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 		ginContext.Request.Body = http.MaxBytesReader(ginContext.Writer, ginContext.Request.Body, maxRequestBytes)
 		bodyBytes, readBodyOK := readJSONProxyBody(ginContext)
 		if !readBodyOK {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 		if rejectClientProviderCredentialsFromJSONBody(ginContext, bodyBytes) {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 		var payload chatV2RequestPayload
@@ -248,15 +249,14 @@ func chatV2JSONHandler(upstreamProviders *providerRouter, providers *providerReg
 		jsonDecoder.DisallowUnknownFields()
 		if decodeError := jsonDecoder.Decode(&payload); decodeError != nil {
 			ginContext.String(http.StatusBadRequest, errorInvalidJSONRequest)
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, constants.EmptyString, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, constants.EmptyString, textDefaults), requestStart)
 			return
 		}
 
 		validator := newModelValidator(providers.forTenant(requestTenant))
-		textDefaults := textRequestDefaultsForProvider(ginContext.Query(queryParameterProvider), requestTenant, providers)
 		chatRequest, ok := chatRequestFromV2Payload(ginContext, payload, textDefaults, validator, requestTenant, assetStore)
 		if !ok {
-			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, requestTenant.defaults), usageTextModelIdentifier(ginContext, payload.Model, requestTenant.defaults), requestStart)
+			recordManagedUsageValidationFailure(managedTenants, structuredLogger, ginContext, requestTenant, usageEndpointV2, usageTextProviderIdentifier(ginContext, textDefaults), usageTextModelIdentifier(ginContext, payload.Model, textDefaults), requestStart)
 			return
 		}
 		defer chatRequest.messages.closeMedia()
@@ -757,7 +757,7 @@ func recordManagedUsageValidationFailure(managedTenants *managedTenantStore, str
 	recordManagedUsage(managedTenants, structuredLogger, ginContext, requestTenant, endpoint, providerIdentifier, modelIdentifier, statusCode, nil, requestStart)
 }
 
-func usageTextProviderIdentifier(ginContext *gin.Context, defaults tenantDefaults) string {
+func usageTextProviderIdentifier(ginContext *gin.Context, defaults textRequestDefaults) string {
 	providerIdentifier := strings.TrimSpace(ginContext.Query(queryParameterProvider))
 	if providerIdentifier != constants.EmptyString {
 		return providerIdentifier
@@ -765,7 +765,7 @@ func usageTextProviderIdentifier(ginContext *gin.Context, defaults tenantDefault
 	return defaults.provider
 }
 
-func usageTextModelIdentifier(ginContext *gin.Context, bodyModel string, defaults tenantDefaults) string {
+func usageTextModelIdentifier(ginContext *gin.Context, bodyModel string, defaults textRequestDefaults) string {
 	modelIdentifier := strings.TrimSpace(ginContext.Query(queryParameterModel))
 	if modelIdentifier != constants.EmptyString {
 		return modelIdentifier


### PR DESCRIPTION
## Summary

Fix usage attribution for failed text requests when a provider is explicitly selected without a model.

Validation failures previously recorded the tenant-wide default model, which could produce invalid provider/model combinations in usage reports—for example, a Gemini request attributed to an OpenAI default model. Handlers now resolve the selected provider’s route defaults before validation and use that same provider/model pair when recording failures.

## Coverage

- Applies consistent failure attribution across query-based text requests, JSON text requests, and `/v2` requests.
- Preserves successful-request usage behavior and public responses.
- Adds management coverage confirming failed GET, POST, and `/v2` requests selected for Gemini are recorded under Gemini’s saved default model.
- Updates issue tracking with the resolved routing behavior and module release status.