### PR TITLE
gix/verify-pollable-gemini-key-lifecycle-before-persistence

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -482,22 +482,44 @@ retain satisfied historical dependencies.
     returned HTTP `200` with `in_progress`. Retrieval returned HTTP `403` with
     `permission_denied`, and deletion returned HTTP `200`. The check retained
     no provider resource ID or response body.
+  - PR #288 deployed as `v4.0.0` from application commit `48adaed`. The runtime
+    uses only tenant-managed provider credentials from the retained database.
+  - The deployed verifier sends `background: false` and `store: false` for all
+    Gemini models. It accepts a synchronous create response without retrieval.
+  - This verifier can accept a key that cannot retrieve a background
+    interaction. Production then rejects the first retrieval with HTTP `403`.
   Requirements:
-  - Preserve Gemini 3.5 Flash's stored background Interactions lifecycle, the
-    900-second request budget, response redaction, and the current deterministic
-    long-completion case.
-  - Keep the permission correction operational. Do not change the adapter or a
-    proxy rate window without new evidence of a source or configuration defect.
+  - For a pollable Gemini model, verify the stored background lifecycle.
+  - Create and retrieve one interaction with the candidate key.
+  - Cancel the interaction when the retrieved state is active.
+  - Delete every stored verification interaction.
+  - Persist the candidate only after all required lifecycle operations succeed.
+  - Reject a candidate when create succeeds and retrieval returns HTTP `403`.
+  - Preserve the prior key, settings, and defaults after a rejected replacement.
+  - Preserve the 900-second production request budget and response redaction.
   Validation:
+  - Prove the pollable verification request uses `background: true` and
+    `store: true`.
+  - Prove successful verification performs create, retrieve, cancel, and delete
+    before persistence.
+  - Prove retrieval HTTP `403` rejects the candidate and preserves prior state.
   - After the identified boundary is resolved, run the exact Gemini echo and
-    background cases with only the Default-tenant secret and prove HTTP `200`,
-    the final markers, validated request ids, and no response-body disclosure.
+    background cases with only `LLM_PROXY_SECRET`. Prove HTTP `200`, the final
+    markers, validated request ids, and no response-body disclosure.
   - For any source change, run the required baseline and final
     `timeout -k 350s -s SIGKILL 350s make ci` pair.
-  Blocked: the Gemini project owner or Google must grant the key and project
-  permission to retrieve Interactions resources. The owner can instead replace
-  the key with one from a project that has this access. Then rerun the two exact
-  Gemini cases.
+  Development resolution:
+  - On 2026-08-19, pollable Gemini verification now performs one stored
+    background create, one retrieval, cancellation of active work, and deletion.
+  - The management transaction starts only after the complete lifecycle succeeds.
+  - Regression coverage proves that retrieval HTTP `403` rejects a candidate,
+    cleans up the interaction, and preserves the prior credential and settings.
+  - The required baseline and final `make ci` runs passed all 11 gates with
+    100% Go statement coverage.
+  Blocked: release and deploy this source through the repository lifecycle.
+  Then save a new Google AI Studio Auth key in Default tenant Settings and run
+  the exact Gemini echo and background cases. Revoke the old Standard key only
+  after retrieval succeeds.
 - [ ] [B141] (P1) Center the X icon inside the top-right square.
   Goal:
   Align the X icon so it is visually centered within the square control in the top-right corner, matching the intended UI layout shown in the attached screenshot.

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -1851,6 +1851,10 @@ retain satisfied historical dependencies.
   - A reviewed governance normalization change with no unrelated product or runtime edits.
   Validation:
   - Run the MPR Lab governor in `--dry-run` and `--check` modes and require no pending managed-file changes.
+  Progress: 2026-08-20. Applied the current managed updates to
+  `.mprlab/POLICY.md` and `.mprlab/issues-md-format.md`. The Governor check is
+  clean. M013 still blocks completion because the root product-context decision
+  is open.
 - [ ] [M019] (P2) Refresh non-security direct dependency pins.
   Goal:
   Bring direct Go, frontend, and Python development dependencies to their current supported releases after the security graph is stable.

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -493,6 +493,8 @@ retain satisfied historical dependencies.
   - Create and retrieve one interaction with the candidate key.
   - Cancel the interaction when the retrieved state is active.
   - Delete every stored verification interaction.
+  - Do each verification lifecycle operation one time.
+  - Limit each successful provider response to 1 MiB.
   - Persist the candidate only after all required lifecycle operations succeed.
   - Reject a candidate when create succeeds and retrieval returns HTTP `403`.
   - Preserve the prior key, settings, and defaults after a rejected replacement.
@@ -503,6 +505,8 @@ retain satisfied historical dependencies.
   - Prove successful verification performs create, retrieve, cancel, and delete
     before persistence.
   - Prove retrieval HTTP `403` rejects the candidate and preserves prior state.
+  - Prove a lost lifecycle response does not retry its provider operation.
+  - Prove an oversized lifecycle response rejects the candidate.
   - After the identified boundary is resolved, run the exact Gemini echo and
     background cases with only `LLM_PROXY_SECRET`. Prove HTTP `200`, the final
     markers, validated request ids, and no response-body disclosure.
@@ -514,6 +518,10 @@ retain satisfied historical dependencies.
   - The management transaction starts only after the complete lifecycle succeeds.
   - Regression coverage proves that retrieval HTTP `403` rejects a candidate,
     cleans up the interaction, and preserves the prior credential and settings.
+  - Review corrections make each lifecycle operation a single attempt.
+  - Review corrections limit each successful lifecycle response to 1 MiB.
+  - The review follow-up `make ci` passed all 11 gates with 100% Go statement
+    coverage.
   - The required baseline and final `make ci` runs passed all 11 gates with
     100% Go statement coverage.
   Blocked: release and deploy this source through the repository lifecycle.

--- a/.mprlab/POLICY.md
+++ b/.mprlab/POLICY.md
@@ -27,6 +27,22 @@ This policy controls all agent work in this repository.
 - Hardcoded workflow, path, event, or message literals when a canonical constant or backend payload exists.
 - Unit tests as a substitute for public contract coverage.
 
+## Credential Discovery
+
+- Identify each required environment variable from the active command and repository contract.
+- Inspect the process environment before you request a login.
+- Inspect repository private environment files before you report a credential blocker.
+- Include ignored `.env`, `.env.*`, and `*.env` files in the authorized repository roots.
+- Treat tracked example and sample environment files as documentation only.
+- Search only for exact variable names. Do not print, copy, or record secret values.
+- When a command declares one repository environment file as its input, clear
+  its owned process variables and source only that file.
+- Use the command's standard environment lookup. Do not add a credential parser
+  or another input channel.
+- When available, use a non-mutating authentication command to verify the discovered value.
+- Request new credentials only after each authorized existing input fails verification.
+- Report a credential blocker only after you complete this gate.
+
 ## Validation
 
 - Use repository-native `make` targets when available.

--- a/.mprlab/issues-md-format.md
+++ b/.mprlab/issues-md-format.md
@@ -1,26 +1,44 @@
 # ISSUES.md Format
 
-This document describes the canonical ISSUES.md layout and the section-aware identifier scheme.
+This document describes the canonical ISSUES.md layout and section-aware identifier scheme.
 
 ## Structure
 
-- The file starts with a title line (for example, `# ISSUES`),
-  followed by optional guidance text.
-- Issues are grouped under level-2 headings (`## ...`).
-- Optional subheadings (`### ...`) may be used within a section for organization (for example, "Recurring"), but IDs must still match the parent section. Recurring semantics are canonically represented by the identifier suffix; parsers normalize entries under a `Recurring` subheading to that suffix.
-- Sections are:
-  - BugFixes
-  - Improvements
-  - Maintenance
-  - Features
-  - Planning
+- The file starts with a title line, for example `# ISSUES`.
+- Issues are grouped under level-2 headings.
+- Sections are `BugFixes`, `Improvements`, `Maintenance`, `Features`, and `Planning`.
+- Optional subheadings can organize a section, but issue IDs must still match the parent section.
 
-Section headings should not include numeric ranges; the section name alone is
-the category.
+## Issue Classification
 
-## Issue entries
+Classify each issue by its requested outcome. Priority, urgency, affected code, and title words do not control the section.
 
-Each issue entry is a single list item with this shape:
+Use this ordered test:
+
+1. Use `BugFixes` only for an observed and reproducible violation of a current canonical contract.
+2. Use `Features` for a new user or operator capability, public interface, resource kind, workflow, or product behavior.
+3. Use `Improvements` for a one-time change to an existing capability, architecture, test system, or acceptance boundary.
+4. Use `Maintenance` for repeatable upkeep under an unchanged solution contract. The same activity must remain valid for a future run.
+5. Use `Planning` for analysis, a decision, or a plan that does not authorize implementation.
+
+File each reproducible defect from an acceptance or migration issue as a separate BugFix issue. Split mixed outcomes across their correct sections.
+
+Use priority and blocked state as separate attributes. Correct a misclassified unresolved issue before implementation. Preserve completed issue IDs as historical references.
+
+## Resolved Issue Hygiene
+
+Before archival, review each resolved non-recurring issue for durable product,
+architecture, operator, security, testing, and skill consequences. Update each
+affected source-of-truth document or skill before you move the issue.
+
+Preserve the complete resolved entry and its identifier in the repository
+archive. Keep unresolved, blocked, planning, and recurring issues in the active
+tracker. Validate identifiers, dependencies, and duplicate IDs across both
+files.
+
+## Issue Entries
+
+Each issue entry is a single list item:
 
 ```text
 - [ ] [B042] (P1) {I007} Short title
@@ -28,80 +46,44 @@ Each issue entry is a single list item with this shape:
 
 Rules:
 
-- `[ ]` means open (unresolved), `[-]` means taken (actively being worked, but still unresolved), `[!]` means blocked (unresolved), `[x]` means closed (resolved).
-- The external ID is required.
-- Priority and dependencies are optional and appear immediately after the ID.
-- The title is required.
-- Blocked issues (`[!]`) MUST include a short explanation in the body (at minimum one indented line starting with `Blocked:`).
+- `[ ]` means open.
+- `[-]` means taken.
+- `[!]` means blocked and must include a `Blocked:` body line.
+- `[x]` means closed.
+- The external ID is necessary.
+- Priority `(P0)` through `(P2)` is optional.
+- Dependencies `{ID,ID}` are optional.
+- The title is necessary.
+- Write each new or changed title in ASD-STE100 Simplified Technical English.
 
 ## Identifiers
 
-Format: `<SectionLetter><SequenceNumber>[R]` with no repo prefix.
+Format: `<SectionLetter><SequenceNumber>[R]`.
 
 Section letters:
 
-- B = BugFixes
-- I = Improvements
-- M = Maintenance
-- F = Features
-- P = Planning
+- `B` = BugFixes
+- `I` = Improvements
+- `M` = Maintenance
+- `F` = Features
+- `P` = Planning
 
-Identifiers must match the section they appear in. Numbers increment
-independently per section. Use three digits (`001`-`999`) per section; after a
-section reaches its max (example: after B999), the next auto-number wraps to
-B001.
-A capital `R` suffix inside the identifier marks the entry as recurring
-(example: `[M001R]`). A separate `R` token after the identifier is invalid.
-Parsers accept lowercase `r` while reading and render uppercase `R` in
-canonical output.
-Recurring entries represent standing or repeated work that should remain
-visible during cleanup. Scheduling, timers, and job IDs are outside the
-ISSUES.md format.
-Legacy repo-prefixed identifiers (for example `IM-###`) are invalid.
+Numbers increment independently per section and use three digits. A capital `R` suffix marks a recurring issue, for example `[M400R]`. A separate `R` token after the identifier is invalid.
 
-## Priority and dependencies
+Recurring entries represent standing or repeated work. Scheduling, timers, and job IDs are outside the ISSUES.md format.
 
-- Priority uses `(P0)` through `(P2)` immediately after the ID.
-- Dependencies use `{ID,ID}` with comma-separated IDs.
+Legacy repo-prefixed identifiers are invalid.
 
-## Body text
+## Body Text
 
-- To attach a body on the same line, separate the title and body with a space,
-  an em dash (U+2014), and a space.
-- Additional body lines may follow on subsequent lines; indent by two spaces
-  to keep them attached to the issue.
-- Fenced code blocks are allowed in the body; indent them by two spaces as well.
-- Structured issue bodies should use plain labels rather than Markdown
-  headings. The canonical labels are `Goal:`, `Requirements:`,
-  `Deliverables:`, `Validation:`, and `Blocked:`.
-- `Goal:`, `Requirements:`, `Deliverables:`, and `Validation:` are recommended
-  guidance for human and AI producers. Parsers recognize them but do not require
-  every free-form issue body to contain all four labels.
-- `Blocked:` is required only for blocked issues (`[!]`) and must include the
-  concrete external dependency, missing input, or policy decision preventing
-  progress.
+Indent additional body lines by two spaces. Structured issue bodies must use plain labels:
 
-## Example
+- `Goal:`
+- `Requirements:`
+- `Deliverables:`
+- `Validation:`
+- `Blocked:`
 
-```text
-# ISSUES
+`Blocked:` is necessary only for blocked issues. It must identify the dependency, input, or policy decision that prevents progress.
 
-## BugFixes
-- [!] [B042] (P0) Fix crash on startup
-  Goal:
-  Prevent startup crashes during repository initialization.
-
-  Requirements:
-  Preserve the existing configuration loading contract.
-
-  Deliverables:
-  Patch the initialization path and document the failure mode.
-
-  Validation:
-  Reproduce the startup path with the affected configuration.
-
-  Blocked: waiting on upstream API credentials.
-  ```bash
-  timeout -k 30s -s SIGKILL 30s make test
-  ```
-```
+Write each new or changed body in ASD-STE100. Use `.mprlab/AGENTS.DOCS.md` and `.mprlab/TERMINOLOGY.md`.

--- a/README.md
+++ b/README.md
@@ -771,20 +771,22 @@ invalidates the prior request. Other provider-key edits still autosave through
 the same verify-before-persist operation when the user leaves the field,
 switches providers, or closes Settings.
 
-The verifier makes exactly one provider-authenticated, non-user-content
-operation through the selected transport and the shared upstream worker,
-queue, origin-rate-limit, and request-context boundaries. It does not retry,
-fall back, poll, continue in the background, or record managed usage. Only an
-accepted credential, model, and base URL combination enters the provider-key
-transaction. That transaction encrypts the key and saves its submitted base
-URL, model, and system prompt,
+The verifier uses the selected route's exact lifecycle for one fixed,
+non-user-content probe. Synchronous routes make one provider request. A
+pollable Gemini route creates one stored background interaction and retrieves
+it once. The verifier cancels an active interaction and deletes every stored
+interaction before it accepts the credential. Every request uses the shared
+upstream worker, queue, origin-rate-limit, and management request boundaries.
+The verifier does not retry, start a continuation, or record managed usage.
+Only an accepted credential, model, base URL, and lifecycle combination enters
+the provider-key transaction. That transaction encrypts the key and saves its
+submitted base URL, model, and system prompt,
 reconciles routing defaults, and returns the complete keyed profile. When the
-saved provider text model changes and the same provider owns the active text
-route, that transaction also updates the active routing model and clears a
-reasoning effort only when the new model does not support it. A different
-active provider remains unchanged. The browser then clears the raw draft and
-returns to the masked presentation. A successful first key unlocks mandatory
-Settings.
+saved provider text model changes, that transaction can update the active text
+route. It does this only when the same provider owns that route. It also clears
+a reasoning effort when the new model does not support it. A different active
+provider remains unchanged. The browser then clears the raw draft and returns
+to the masked presentation. A successful first key unlocks mandatory Settings.
 
 Credential/model rejection returns `422 provider_key_rejected`; an unconfirmed
 provider rate limit, timeout/cancellation, or outage/malformed response returns

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -418,9 +418,9 @@ omission keeps the existing tenant/provider-default behavior.
 
 Every nonempty `api_key` submitted to
 `PUT /api/management/tenants/:tenant_id/provider-keys/:provider` is an
-unverified new or replacement credential. After ownership, provider, and exact
-selected text-model resolution, the handler performs one fixed,
-non-user-content inference through the provider's canonical text transport:
+unverified new or replacement credential. The handler resolves ownership,
+provider, exact text model, wire contract, and execution lifecycle. It then
+performs one fixed, non-user-content probe through the canonical transport:
 
 - OpenAI Responses uses one synchronous, non-stored `POST /responses` with
   `background: false`, `store: false`, and a 16-token output limit.
@@ -429,27 +429,30 @@ non-user-content inference through the provider's canonical text transport:
 - DeepSeek, DashScope, Moonshot, MiniMax, SiliconFlow, Z.AI, Meta, and xAI
   Chat Completions models use one authenticated `POST /chat/completions`.
   The request uses the provider's declared token-limit parameter.
-- Gemini uses one synchronous, non-stored `POST /interactions` request with
-  `x-goog-api-key`, `Api-Revision: 2026-05-20`, `background: false`,
-  `store: false`, and `generation_config.max_output_tokens: 16`.
+- A synchronous Gemini model uses one non-stored `POST /interactions` request.
+  It sends `background: false`, `store: false`, and a 16-token output limit.
+- A pollable Gemini model creates one stored background interaction. It then
+  retrieves the interaction once. It cancels active work and deletes the
+  stored interaction before it accepts the credential.
 - Anthropic uses one Messages request with `x-api-key`,
   `anthropic-version: 2023-06-01`, and `max_tokens: 16`.
 
-The verifier uses the management request context and the same shared upstream
-worker, queue, and origin-rate-limit boundary as proxy traffic. It performs no
-retry, alternate endpoint, polling, continuation, background work, or managed
-usage recording. A transport success counts only when its canonical response
-envelope is structurally valid. Provider `4xx` credential/model rejection maps
-to `422 provider_key_rejected` except `408` timeout and `429` rate limit;
-upstream `504` also maps to timeout. Transport cancellation/deadline, outage,
-and malformed success map to the documented provider-neutral `504`, `503`, or
-`429` error. Candidate keys, fixed probe content, authenticated URLs, and raw
-upstream bodies never enter logs, management responses, profiles, or usage
-rows.
+The verifier uses the management request context and the shared upstream
+worker, queue, and origin-rate-limit boundary. It does not retry, use an
+alternative endpoint, start a continuation, or record managed usage. A pollable
+Gemini probe uses the production adapter's create, retrieve, cancel, and delete
+operations. A transport success counts only when its canonical response is
+valid. Provider `4xx` credential or model rejection maps to
+`422 provider_key_rejected`, except `408` and `429`. Upstream `504` also maps
+to timeout. Transport cancellation, deadline, outage, and malformed success
+map to the documented provider-neutral error. Candidate keys, probe content,
+authenticated URLs, and raw upstream bodies never enter logs, responses,
+profiles, or usage rows.
 
 Only successful verification enters the existing atomic provider-key
-transaction, which encrypts the credential, saves the submitted model and
-system prompt, reconciles routing defaults, and returns the complete profile.
+transaction. The transaction encrypts the credential and saves the submitted
+model and system prompt. It reconciles routing defaults and returns the
+complete profile.
 Every failure leaves a new provider unkeyed or preserves the prior verified
 replacement credential, settings, and defaults unchanged. An empty `api_key`
 is the canonical retain-existing-key settings update and bypasses verification.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -577,7 +577,19 @@ paths:
     put:
       operationId: putManagementProviderKey
       summary: Verify and save provider settings and a provider credential
-      description: A nonempty api_key performs exactly one provider-authenticated verification operation for the selected provider, text model, and provider base URL under the management request context and shared upstream admission/rate-limit boundary. Changing a saved DashScope base_url also verifies the retained key against the new URL. Only a successful verification atomically persists the credential and submitted settings, reconciles routing defaults, and returns a keyed profile. Rejection and unconfirmed transient outcomes never mutate the provider key, settings, defaults, or managed usage. An empty api_key retains the existing verified credential. The operation returns 409 without a mutation if that retained credential changes before the verified update can persist.
+      description: >-
+        A nonempty api_key verifies the selected provider, text model, base URL,
+        wire contract, and execution lifecycle. Synchronous routes use one
+        provider request. Pollable Gemini routes create and retrieve one stored
+        background interaction. The verifier cancels active work and deletes
+        the interaction before persistence. Changing a saved DashScope base_url
+        also verifies the retained key against the new URL. Only complete
+        verification atomically persists the credential and submitted settings.
+        It also reconciles routing defaults and returns a keyed profile.
+        Rejection and unconfirmed outcomes do not mutate provider state or
+        managed usage. An empty api_key retains the existing verified
+        credential. The operation returns 409 without a mutation when that
+        credential changes before persistence.
       tags:
         - Management
       security:

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -51,8 +51,11 @@ const (
 )
 
 type geminiInteractionsClient struct {
-	httpClient HTTPDoer
+	httpClient             HTTPDoer
+	performInteractionHTTP geminiInteractionHTTPPerformer
 }
+
+type geminiInteractionHTTPPerformer func(HTTPDoer, *http.Request, *zap.SugaredLogger) (int, []byte, http.Header, error)
 
 type geminiInteractionCleanupMode uint8
 
@@ -127,7 +130,19 @@ type geminiInteractionSnapshot struct {
 }
 
 func newGeminiInteractionsClient(httpClient HTTPDoer) *geminiInteractionsClient {
-	return &geminiInteractionsClient{httpClient: httpClient}
+	return newGeminiInteractionsClientWithHTTPPerformer(httpClient, performRetryingGeminiInteractionHTTP)
+}
+
+func newGeminiInteractionsClientWithHTTPPerformer(httpClient HTTPDoer, performer geminiInteractionHTTPPerformer) *geminiInteractionsClient {
+	return &geminiInteractionsClient{
+		httpClient:             httpClient,
+		performInteractionHTTP: performer,
+	}
+}
+
+func performRetryingGeminiInteractionHTTP(httpClient HTTPDoer, httpRequest *http.Request, structuredLogger *zap.SugaredLogger) (int, []byte, http.Header, error) {
+	statusCode, responseBytes, responseHeader, _, requestError := utils.PerformHTTPRequest(httpClient.Do, httpRequest, structuredLogger, logEventProviderRequestError)
+	return statusCode, responseBytes, responseHeader, requestError
 }
 
 func (client *geminiInteractionsClient) generateText(parentContext context.Context, apiKey string, baseURL string, modelIdentifier textModelDefinition, messages chatMessages, maxTokens *int, executionLifecycle textExecutionLifecycle, structuredOutput *structuredOutputSchema, structuredLogger *zap.SugaredLogger) (generation textGenerationResult, generationError error) {
@@ -289,7 +304,7 @@ func (client *geminiInteractionsClient) performInteractionRequest(parentContext 
 		httpRequest.Header.Set(headerContentType, mimeApplicationJSON)
 	}
 
-	statusCode, responseBytes, responseHeader, _, requestError := utils.PerformHTTPRequest(client.httpClient.Do, httpRequest, structuredLogger, logEventProviderRequestError)
+	statusCode, responseBytes, responseHeader, requestError := client.performInteractionHTTP(client.httpClient, httpRequest, structuredLogger)
 	if statusCode == http.StatusRequestEntityTooLarge && geminiInteractionPayloadHasMedia(payload) {
 		return nil, newProviderMediaLimitHTTPError(statusCode, responseHeader)
 	}

--- a/internal/proxy/management_provider_key_verification_test.go
+++ b/internal/proxy/management_provider_key_verification_test.go
@@ -164,6 +164,373 @@ func TestManagementProviderKeyVerificationUsesEveryCanonicalTransportBeforePersi
 	}
 }
 
+func TestManagementPollableGeminiProviderKeyVerificationCompletesStoredLifecycleBeforePersistence(t *testing.T) {
+	const (
+		candidateKey          = "candidate-pollable-gemini"
+		interactionIdentifier = "verification-interaction"
+	)
+	databasePath := t.TempDir() + "/managed-tenants.db"
+	requestSequence := make([]string, 0, 4)
+	var fixtureDatabaseProvider func() (*managedProviderKeyFixture, error)
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		assertGeminiInteractionHeaders(t, request, candidateKey)
+		requestSequence = append(requestSequence, request.Method+" "+request.URL.Path)
+		switch request.Method + " " + request.URL.Path {
+		case http.MethodPost + " " + testGeminiInteractionsPath:
+			payload := decodeGeminiInteractionRequest(t, request)
+			generationConfig, generationConfigOK := payload["generation_config"].(map[string]any)
+			input, inputOK := payload["input"].([]any)
+			if payload["model"] != proxy.ModelNameGemini35Flash ||
+				payload["background"] != true ||
+				payload["store"] != true ||
+				!generationConfigOK || generationConfig["max_output_tokens"] != float64(16) ||
+				!inputOK || len(input) != 1 || geminiInteractionStepText(t, input[0]) != testProviderKeyVerificationPrompt {
+				t.Errorf("pollable Gemini verification payload=%v", payload)
+			}
+			writeGeminiInteractionSnapshot(t, responseWriter, interactionIdentifier, "in_progress", "", nil)
+		case http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+			writeGeminiInteractionSnapshot(t, responseWriter, interactionIdentifier, "in_progress", "", nil)
+		case http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel":
+			writeGeminiInteractionDeleted(t, responseWriter)
+		case http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+			providerRecord, queryError := fixtureDatabaseProvider()
+			if queryError == nil || providerRecord != nil {
+				t.Errorf("candidate persisted before Gemini lifecycle completion")
+			}
+			writeGeminiInteractionDeleted(t, responseWriter)
+		default:
+			http.Error(responseWriter, "unexpected Gemini verification request", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(upstreamServer.Close)
+
+	router := newOperationalProviderKeyVerificationRouter(
+		t,
+		providerKeyVerificationConfiguration(upstreamServer.URL),
+		zap.NewNop().Sugar(),
+		databasePath,
+		TestTimeout,
+	)
+	sessionCookie := managementSessionCookie(t, "pollable-gemini-verification")
+	tenantID := managementDefaultTenantTestID(t, router, sessionCookie)
+	fixtureDatabase := openManagedFixtureDatabase(t, databasePath)
+	fixtureSQLDatabase, fixtureDatabaseError := fixtureDatabase.DB()
+	if fixtureDatabaseError != nil {
+		t.Fatalf("open managed fixture SQL database: %v", fixtureDatabaseError)
+	}
+	t.Cleanup(func() { _ = fixtureSQLDatabase.Close() })
+	fixtureDatabaseProvider = func() (*managedProviderKeyFixture, error) {
+		var record managedProviderKeyFixture
+		queryError := fixtureDatabase.Where("tenant_id = ? AND provider_id = ?", tenantID, proxy.ProviderNameGemini).First(&record).Error
+		if queryError != nil {
+			return nil, queryError
+		}
+		return &record, nil
+	}
+
+	response := putManagementProviderKey(
+		t,
+		router,
+		sessionCookie,
+		tenantID,
+		proxy.ProviderNameGemini,
+		candidateKey,
+		proxy.ModelNameGemini35Flash,
+		"pollable Gemini prompt",
+		context.Background(),
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+	}
+	expectedSequence := []string{
+		http.MethodPost + " " + testGeminiInteractionsPath,
+		http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+		http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+		http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+	}
+	if fmt.Sprint(requestSequence) != fmt.Sprint(expectedSequence) {
+		t.Fatalf("Gemini verification sequence=%v want=%v", requestSequence, expectedSequence)
+	}
+	profile := decodeProviderKeyVerificationProfile(t, response.Body.Bytes())
+	savedProvider := verificationProfileProvider(t, profile, proxy.ProviderNameGemini)
+	if !savedProvider.HasKey || savedProvider.TextModel != proxy.ModelNameGemini35Flash || savedProvider.SystemPrompt != "pollable Gemini prompt" {
+		t.Fatalf("saved provider=%+v", savedProvider)
+	}
+}
+
+func TestManagementPollableGeminiProviderKeyVerificationRejectsRetrievalAndPreservesPreviousKey(t *testing.T) {
+	const (
+		verifiedKey           = "verified-gemini-key"
+		candidateKey          = "retrieval-denied-gemini-key"
+		interactionIdentifier = "denied-retrieval-interaction"
+	)
+	requestSequence := make([]string, 0, 5)
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		apiKey := request.Header.Get("x-goog-api-key")
+		assertGeminiInteractionHeaders(t, request, apiKey)
+		requestSequence = append(requestSequence, apiKey+" "+request.Method+" "+request.URL.Path)
+		if apiKey == verifiedKey {
+			payload := decodeGeminiInteractionRequest(t, request)
+			if request.Method != http.MethodPost || request.URL.Path != testGeminiInteractionsPath || payload["background"] != false || payload["store"] != false {
+				t.Errorf("initial Gemini verification request=%s %s payload=%v", request.Method, request.URL.Path, payload)
+			}
+			writeProviderKeyVerificationSuccess(responseWriter, verificationTransportGemini)
+			return
+		}
+		if apiKey != candidateKey {
+			http.Error(responseWriter, "unexpected credential", http.StatusUnauthorized)
+			return
+		}
+		switch request.Method + " " + request.URL.Path {
+		case http.MethodPost + " " + testGeminiInteractionsPath:
+			payload := decodeGeminiInteractionRequest(t, request)
+			if payload["background"] != true || payload["store"] != true {
+				t.Errorf("replacement Gemini verification payload=%v", payload)
+			}
+			writeGeminiInteractionSnapshot(t, responseWriter, interactionIdentifier, "in_progress", "", nil)
+		case http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+			http.Error(responseWriter, `{"error":{"code":"permission_denied","private":"must not escape"}}`, http.StatusForbidden)
+		case http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel":
+			writeGeminiInteractionDeleted(t, responseWriter)
+		case http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+			writeGeminiInteractionDeleted(t, responseWriter)
+		default:
+			http.Error(responseWriter, "unexpected Gemini verification request", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(upstreamServer.Close)
+
+	databasePath := t.TempDir() + "/managed-tenants.db"
+	router := newOperationalProviderKeyVerificationRouter(
+		t,
+		providerKeyVerificationConfiguration(upstreamServer.URL),
+		zap.NewNop().Sugar(),
+		databasePath,
+		TestTimeout,
+	)
+	sessionCookie := managementSessionCookie(t, "pollable-gemini-retrieval-denial")
+	tenantID := managementDefaultTenantTestID(t, router, sessionCookie)
+	initialResponse := putManagementProviderKey(
+		t,
+		router,
+		sessionCookie,
+		tenantID,
+		proxy.ProviderNameGemini,
+		verifiedKey,
+		proxy.ModelNameGemini25Flash,
+		"retained Gemini prompt",
+		context.Background(),
+	)
+	if initialResponse.Code != http.StatusOK {
+		t.Fatalf("initial status=%d body=%q", initialResponse.Code, initialResponse.Body.String())
+	}
+	fixtureDatabase := openManagedFixtureDatabase(t, databasePath)
+	fixtureSQLDatabase, fixtureDatabaseError := fixtureDatabase.DB()
+	if fixtureDatabaseError != nil {
+		t.Fatalf("open managed fixture SQL database: %v", fixtureDatabaseError)
+	}
+	t.Cleanup(func() { _ = fixtureSQLDatabase.Close() })
+	var beforeReplacement managedProviderKeyFixture
+	if queryError := fixtureDatabase.Where("tenant_id = ? AND provider_id = ?", tenantID, proxy.ProviderNameGemini).First(&beforeReplacement).Error; queryError != nil {
+		t.Fatalf("load provider record before replacement: %v", queryError)
+	}
+
+	replacementResponse := putManagementProviderKey(
+		t,
+		router,
+		sessionCookie,
+		tenantID,
+		proxy.ProviderNameGemini,
+		candidateKey,
+		proxy.ModelNameGemini35Flash,
+		"must not persist",
+		context.Background(),
+	)
+	if replacementResponse.Code != http.StatusUnprocessableEntity || strings.TrimSpace(replacementResponse.Body.String()) != "provider_key_rejected" {
+		t.Fatalf("replacement status=%d body=%q", replacementResponse.Code, replacementResponse.Body.String())
+	}
+	var afterReplacement managedProviderKeyFixture
+	if queryError := fixtureDatabase.Where("tenant_id = ? AND provider_id = ?", tenantID, proxy.ProviderNameGemini).First(&afterReplacement).Error; queryError != nil {
+		t.Fatalf("load provider record after replacement: %v", queryError)
+	}
+	if beforeReplacement.EncryptedAPIKey != afterReplacement.EncryptedAPIKey ||
+		afterReplacement.TextModel != proxy.ModelNameGemini25Flash ||
+		afterReplacement.SystemPrompt != "retained Gemini prompt" ||
+		!beforeReplacement.UpdatedAt.Equal(afterReplacement.UpdatedAt) {
+		t.Fatalf("provider record changed before=%+v after=%+v", beforeReplacement, afterReplacement)
+	}
+	profile := requestProviderKeyVerificationProfile(t, router, sessionCookie, tenantID)
+	retainedProvider := verificationProfileProvider(t, profile, proxy.ProviderNameGemini)
+	if !retainedProvider.HasKey || retainedProvider.TextModel != proxy.ModelNameGemini25Flash || retainedProvider.SystemPrompt != "retained Gemini prompt" {
+		t.Fatalf("retained provider=%+v", retainedProvider)
+	}
+	revealRequest := authenticatedProviderKeyRevealRequest(
+		http.MethodPost,
+		managementTenantTestPath(tenantID, "/provider-keys/gemini/reveal"),
+		sessionCookie,
+		"http://localhost:8080",
+	)
+	revealResponse := httptest.NewRecorder()
+	router.ServeHTTP(revealResponse, revealRequest)
+	if revealResponse.Code != http.StatusOK || !strings.Contains(revealResponse.Body.String(), verifiedKey) || strings.Contains(revealResponse.Body.String(), candidateKey) {
+		t.Fatalf("retained reveal status=%d body=%q", revealResponse.Code, revealResponse.Body.String())
+	}
+	expectedSequence := []string{
+		verifiedKey + " " + http.MethodPost + " " + testGeminiInteractionsPath,
+		candidateKey + " " + http.MethodPost + " " + testGeminiInteractionsPath,
+		candidateKey + " " + http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+		candidateKey + " " + http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+		candidateKey + " " + http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+	}
+	if fmt.Sprint(requestSequence) != fmt.Sprint(expectedSequence) {
+		t.Fatalf("Gemini verification sequence=%v want=%v", requestSequence, expectedSequence)
+	}
+}
+
+func TestManagementPollableGeminiProviderKeyVerificationRejectsIncompleteLifecycles(t *testing.T) {
+	const interactionIdentifier = "incomplete-lifecycle-interaction"
+	lifecycleCases := []struct {
+		name             string
+		createStatus     int
+		createBody       string
+		retrieveStatus   int
+		retrieveBody     string
+		cancelStatus     int
+		deleteStatus     int
+		expectedStatus   int
+		expectedBody     string
+		expectedSequence []string
+	}{
+		{
+			name:             "create rejection",
+			createStatus:     http.StatusForbidden,
+			createBody:       `{"error":{"code":"permission_denied"}}`,
+			expectedStatus:   http.StatusUnprocessableEntity,
+			expectedBody:     "provider_key_rejected",
+			expectedSequence: []string{http.MethodPost + " " + testGeminiInteractionsPath},
+		},
+		{
+			name:             "create response missing identifier",
+			createStatus:     http.StatusOK,
+			createBody:       `{"status":"in_progress"}`,
+			expectedStatus:   http.StatusServiceUnavailable,
+			expectedBody:     "provider_key_verification_unavailable",
+			expectedSequence: []string{http.MethodPost + " " + testGeminiInteractionsPath},
+		},
+		{
+			name:           "create response invalid after identifier",
+			createStatus:   http.StatusOK,
+			createBody:     `{"id":"incomplete-lifecycle-interaction","status":"in_progress","usage":{"total_input_tokens":-1}}`,
+			cancelStatus:   http.StatusOK,
+			deleteStatus:   http.StatusOK,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "provider_key_verification_unavailable",
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+		{
+			name:           "retrieval response has unknown status",
+			createStatus:   http.StatusOK,
+			createBody:     `{"id":"incomplete-lifecycle-interaction","status":"in_progress"}`,
+			retrieveStatus: http.StatusOK,
+			retrieveBody:   `{"id":"incomplete-lifecycle-interaction","status":"unknown"}`,
+			deleteStatus:   http.StatusOK,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "provider_key_verification_unavailable",
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+		{
+			name:           "active interaction cancellation rejection",
+			createStatus:   http.StatusOK,
+			createBody:     `{"id":"incomplete-lifecycle-interaction","status":"in_progress"}`,
+			retrieveStatus: http.StatusOK,
+			retrieveBody:   `{"id":"incomplete-lifecycle-interaction","status":"in_progress"}`,
+			cancelStatus:   http.StatusForbidden,
+			deleteStatus:   http.StatusOK,
+			expectedStatus: http.StatusUnprocessableEntity,
+			expectedBody:   "provider_key_rejected",
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+				http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+	}
+
+	for _, lifecycleCase := range lifecycleCases {
+		t.Run(lifecycleCase.name, func(subTest *testing.T) {
+			candidateKey := "incomplete-lifecycle-" + strings.ReplaceAll(lifecycleCase.name, " ", "-")
+			requestSequence := make([]string, 0, len(lifecycleCase.expectedSequence))
+			upstreamServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+				assertGeminiInteractionHeaders(subTest, request, candidateKey)
+				requestOperation := request.Method + " " + request.URL.Path
+				requestSequence = append(requestSequence, requestOperation)
+				switch requestOperation {
+				case http.MethodPost + " " + testGeminiInteractionsPath:
+					payload := decodeGeminiInteractionRequest(subTest, request)
+					if payload["background"] != true || payload["store"] != true {
+						subTest.Errorf("pollable Gemini create payload=%v", payload)
+					}
+					responseWriter.WriteHeader(lifecycleCase.createStatus)
+					_, _ = responseWriter.Write([]byte(lifecycleCase.createBody))
+				case http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+					responseWriter.WriteHeader(lifecycleCase.retrieveStatus)
+					_, _ = responseWriter.Write([]byte(lifecycleCase.retrieveBody))
+				case http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel":
+					responseWriter.WriteHeader(lifecycleCase.cancelStatus)
+					_, _ = responseWriter.Write([]byte(`{}`))
+				case http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+					responseWriter.WriteHeader(lifecycleCase.deleteStatus)
+					_, _ = responseWriter.Write([]byte(`{}`))
+				default:
+					http.Error(responseWriter, "unexpected Gemini verification request", http.StatusBadRequest)
+				}
+			}))
+			subTest.Cleanup(upstreamServer.Close)
+
+			router := newOperationalProviderKeyVerificationRouter(
+				subTest,
+				providerKeyVerificationConfiguration(upstreamServer.URL),
+				zap.NewNop().Sugar(),
+				subTest.TempDir()+"/managed-tenants.db",
+				TestTimeout,
+			)
+			sessionCookie := managementSessionCookie(subTest, "pollable-gemini-incomplete-"+strings.ReplaceAll(lifecycleCase.name, " ", "-"))
+			tenantID := managementDefaultTenantTestID(subTest, router, sessionCookie)
+			response := putManagementProviderKey(
+				subTest,
+				router,
+				sessionCookie,
+				tenantID,
+				proxy.ProviderNameGemini,
+				candidateKey,
+				proxy.ModelNameGemini35Flash,
+				"must not persist",
+				context.Background(),
+			)
+			if response.Code != lifecycleCase.expectedStatus || strings.TrimSpace(response.Body.String()) != lifecycleCase.expectedBody {
+				subTest.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+			if fmt.Sprint(requestSequence) != fmt.Sprint(lifecycleCase.expectedSequence) {
+				subTest.Fatalf("Gemini verification sequence=%v want=%v", requestSequence, lifecycleCase.expectedSequence)
+			}
+			profile := requestProviderKeyVerificationProfile(subTest, router, sessionCookie, tenantID)
+			rejectedProvider := verificationProfileProvider(subTest, profile, proxy.ProviderNameGemini)
+			if rejectedProvider.HasKey || profile.Tenant.Defaults.Provider != "" || profile.Tenant.Defaults.Model != "" {
+				subTest.Fatalf("rejected provider=%+v defaults=%+v", rejectedProvider, profile.Tenant.Defaults)
+			}
+		})
+	}
+}
+
 func TestManagementXAIResponsesVerificationUsesTheXAIEndpoint(t *testing.T) {
 	openAIRequests := atomic.Int32{}
 	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {

--- a/internal/proxy/management_provider_key_verification_test.go
+++ b/internal/proxy/management_provider_key_verification_test.go
@@ -531,6 +531,228 @@ func TestManagementPollableGeminiProviderKeyVerificationRejectsIncompleteLifecyc
 	}
 }
 
+func TestManagementPollableGeminiProviderKeyVerificationDoesNotRetryLostLifecycleResponses(t *testing.T) {
+	const interactionIdentifier = "single-attempt-verification-interaction"
+	lifecycleCases := []struct {
+		name             string
+		failedRequest    string
+		expectedSequence []string
+	}{
+		{
+			name:             "create",
+			failedRequest:    http.MethodPost + " " + testGeminiInteractionsPath,
+			expectedSequence: []string{http.MethodPost + " " + testGeminiInteractionsPath},
+		},
+		{
+			name:          "retrieve",
+			failedRequest: http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+				http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+		{
+			name:          "cancel",
+			failedRequest: http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+				http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+		{
+			name:          "delete",
+			failedRequest: http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+				http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+	}
+
+	for _, lifecycleCase := range lifecycleCases {
+		t.Run(lifecycleCase.name, func(subTest *testing.T) {
+			candidateKey := "single-attempt-" + lifecycleCase.name + "-gemini-key"
+			requestAttempts := make(map[string]int)
+			requestSequence := make([]string, 0, len(lifecycleCase.expectedSequence))
+			verificationHTTPClient := coverageHTTPDoer(func(request *http.Request) (*http.Response, error) {
+				assertGeminiInteractionHeaders(subTest, request, candidateKey)
+				requestOperation := request.Method + " " + request.URL.Path
+				requestAttempts[requestOperation]++
+				requestSequence = append(requestSequence, requestOperation)
+				if requestOperation == lifecycleCase.failedRequest && requestAttempts[requestOperation] == 1 {
+					return nil, errors.New("Gemini lifecycle response lost after provider processing")
+				}
+				switch requestOperation {
+				case http.MethodPost + " " + testGeminiInteractionsPath,
+					http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+					return coverageHTTPResponse(http.StatusOK, `{"id":"`+interactionIdentifier+`","status":"in_progress"}`), nil
+				case http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+					http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+					return coverageHTTPResponse(http.StatusOK, `{}`), nil
+				default:
+					subTest.Fatalf("unexpected Gemini verification request=%s", requestOperation)
+					return nil, nil
+				}
+			})
+
+			previousHTTPClient := proxy.HTTPClient
+			proxy.HTTPClient = verificationHTTPClient
+			subTest.Cleanup(func() { proxy.HTTPClient = previousHTTPClient })
+			router := newOperationalProviderKeyVerificationRouter(
+				subTest,
+				providerKeyVerificationConfiguration("https://provider.invalid"),
+				zap.NewNop().Sugar(),
+				subTest.TempDir()+"/managed-tenants.db",
+				TestTimeout,
+			)
+			proxy.HTTPClient = previousHTTPClient
+			sessionCookie := managementSessionCookie(subTest, "pollable-gemini-single-attempt-"+lifecycleCase.name)
+			tenantID := managementDefaultTenantTestID(subTest, router, sessionCookie)
+			response := putManagementProviderKey(
+				subTest,
+				router,
+				sessionCookie,
+				tenantID,
+				proxy.ProviderNameGemini,
+				candidateKey,
+				proxy.ModelNameGemini35Flash,
+				"must not persist",
+				context.Background(),
+			)
+			if response.Code != http.StatusServiceUnavailable || strings.TrimSpace(response.Body.String()) != "provider_key_verification_unavailable" {
+				subTest.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+			if requestAttempts[lifecycleCase.failedRequest] != 1 {
+				subTest.Fatalf("Gemini %s attempts=%d want=1", lifecycleCase.name, requestAttempts[lifecycleCase.failedRequest])
+			}
+			if fmt.Sprint(requestSequence) != fmt.Sprint(lifecycleCase.expectedSequence) {
+				subTest.Fatalf("Gemini verification sequence=%v want=%v", requestSequence, lifecycleCase.expectedSequence)
+			}
+			profile := requestProviderKeyVerificationProfile(subTest, router, sessionCookie, tenantID)
+			rejectedProvider := verificationProfileProvider(subTest, profile, proxy.ProviderNameGemini)
+			if rejectedProvider.HasKey || profile.Tenant.Defaults.Provider != "" || profile.Tenant.Defaults.Model != "" {
+				subTest.Fatalf("rejected provider=%+v defaults=%+v", rejectedProvider, profile.Tenant.Defaults)
+			}
+		})
+	}
+}
+
+func TestManagementPollableGeminiProviderKeyVerificationRejectsOversizedLifecycleResponses(t *testing.T) {
+	const (
+		interactionIdentifier = "oversized-verification-interaction"
+		oversizedBody         = 1<<20 + 1
+	)
+	lifecycleCases := []struct {
+		name             string
+		oversizedRequest string
+		expectedSequence []string
+	}{
+		{
+			name:             "create",
+			oversizedRequest: http.MethodPost + " " + testGeminiInteractionsPath,
+			expectedSequence: []string{http.MethodPost + " " + testGeminiInteractionsPath},
+		},
+		{
+			name:             "retrieve",
+			oversizedRequest: http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+				http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+		{
+			name:             "cancel",
+			oversizedRequest: http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+				http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+		{
+			name:             "delete",
+			oversizedRequest: http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			expectedSequence: []string{
+				http.MethodPost + " " + testGeminiInteractionsPath,
+				http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+				http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+				http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier,
+			},
+		},
+	}
+
+	for _, lifecycleCase := range lifecycleCases {
+		t.Run(lifecycleCase.name, func(subTest *testing.T) {
+			candidateKey := "oversized-" + lifecycleCase.name + "-gemini-key"
+			requestSequence := make([]string, 0, len(lifecycleCase.expectedSequence))
+			verificationHTTPClient := coverageHTTPDoer(func(request *http.Request) (*http.Response, error) {
+				assertGeminiInteractionHeaders(subTest, request, candidateKey)
+				requestOperation := request.Method + " " + request.URL.Path
+				requestSequence = append(requestSequence, requestOperation)
+				if requestOperation == lifecycleCase.oversizedRequest {
+					return coverageHTTPResponse(http.StatusOK, strings.Repeat("x", oversizedBody)), nil
+				}
+				switch requestOperation {
+				case http.MethodPost + " " + testGeminiInteractionsPath,
+					http.MethodGet + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+					return coverageHTTPResponse(http.StatusOK, `{"id":"`+interactionIdentifier+`","status":"in_progress"}`), nil
+				case http.MethodPost + " " + testGeminiInteractionsPath + "/" + interactionIdentifier + "/cancel",
+					http.MethodDelete + " " + testGeminiInteractionsPath + "/" + interactionIdentifier:
+					return coverageHTTPResponse(http.StatusOK, `{}`), nil
+				default:
+					subTest.Fatalf("unexpected Gemini verification request=%s", requestOperation)
+					return nil, nil
+				}
+			})
+
+			previousHTTPClient := proxy.HTTPClient
+			proxy.HTTPClient = verificationHTTPClient
+			subTest.Cleanup(func() { proxy.HTTPClient = previousHTTPClient })
+			router := newOperationalProviderKeyVerificationRouter(
+				subTest,
+				providerKeyVerificationConfiguration("https://provider.invalid"),
+				zap.NewNop().Sugar(),
+				subTest.TempDir()+"/managed-tenants.db",
+				TestTimeout,
+			)
+			proxy.HTTPClient = previousHTTPClient
+			sessionCookie := managementSessionCookie(subTest, "pollable-gemini-oversized-"+lifecycleCase.name)
+			tenantID := managementDefaultTenantTestID(subTest, router, sessionCookie)
+			response := putManagementProviderKey(
+				subTest,
+				router,
+				sessionCookie,
+				tenantID,
+				proxy.ProviderNameGemini,
+				candidateKey,
+				proxy.ModelNameGemini35Flash,
+				"must not persist",
+				context.Background(),
+			)
+			if response.Code != http.StatusServiceUnavailable || strings.TrimSpace(response.Body.String()) != "provider_key_verification_unavailable" {
+				subTest.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+			}
+			if fmt.Sprint(requestSequence) != fmt.Sprint(lifecycleCase.expectedSequence) {
+				subTest.Fatalf("Gemini verification sequence=%v want=%v", requestSequence, lifecycleCase.expectedSequence)
+			}
+			profile := requestProviderKeyVerificationProfile(subTest, router, sessionCookie, tenantID)
+			rejectedProvider := verificationProfileProvider(subTest, profile, proxy.ProviderNameGemini)
+			if rejectedProvider.HasKey || profile.Tenant.Defaults.Provider != "" || profile.Tenant.Defaults.Model != "" {
+				subTest.Fatalf("rejected provider=%+v defaults=%+v", rejectedProvider, profile.Tenant.Defaults)
+			}
+		})
+	}
+}
+
 func TestManagementXAIResponsesVerificationUsesTheXAIEndpoint(t *testing.T) {
 	openAIRequests := atomic.Int32{}
 	openAIServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {

--- a/internal/proxy/provider_key_verifier.go
+++ b/internal/proxy/provider_key_verifier.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 const (
@@ -28,7 +30,7 @@ var (
 	errProviderKeyVerificationRateLimited = errors.New(providerKeyVerificationRateLimitedError)
 	errProviderKeyVerificationTimedOut    = errors.New(providerKeyVerificationTimedOutError)
 	errProviderKeyVerificationUnavailable = errors.New(providerKeyVerificationUnavailableError)
-	openAIVerificationAcceptedStatuses    = map[string]struct{}{
+	pollableVerificationAcceptedStatuses  = map[string]struct{}{
 		statusQueued:     {},
 		statusInProgress: {},
 		statusCompleted:  {},
@@ -38,7 +40,6 @@ var (
 		openAIResponsesPollableRouteCapabilities:          buildOpenAIProviderKeyVerificationRequest,
 		openAIResponsesSynchronousRouteCapabilities:       buildSynchronousResponsesProviderKeyVerificationRequest,
 		openAIChatCompletionsSynchronousRouteCapabilities: buildChatProviderKeyVerificationRequest,
-		geminiInteractionsPollableRouteCapabilities:       buildGeminiProviderKeyVerificationRequest,
 		geminiInteractionsSynchronousRouteCapabilities:    buildGeminiProviderKeyVerificationRequest,
 		anthropicMessagesSynchronousRouteCapabilities:     buildAnthropicProviderKeyVerificationRequest,
 	}
@@ -58,6 +59,7 @@ type operationalProviderKeyVerifier struct {
 	httpClient HTTPDoer
 	endpoints  *Endpoints
 	timeout    time.Duration
+	logger     *zap.SugaredLogger
 }
 
 type providerKeyVerificationRequestBuilder func(context.Context, *Endpoints, providerDefinition, textModelDefinition, string) (*http.Request, error)
@@ -82,11 +84,12 @@ type anthropicProviderKeyVerificationResponse struct {
 	Role string `json:"role"`
 }
 
-func newOperationalProviderKeyVerifier(httpClient HTTPDoer, endpoints *Endpoints, timeout time.Duration) *operationalProviderKeyVerifier {
+func newOperationalProviderKeyVerifier(httpClient HTTPDoer, endpoints *Endpoints, timeout time.Duration, logger *zap.SugaredLogger) *operationalProviderKeyVerifier {
 	return &operationalProviderKeyVerifier{
 		httpClient: httpClient,
 		endpoints:  endpoints,
 		timeout:    timeout,
+		logger:     logger,
 	}
 }
 
@@ -94,11 +97,17 @@ func (verifier *operationalProviderKeyVerifier) verify(parentContext context.Con
 	verificationContext, cancelVerification := context.WithTimeout(parentContext, verifier.timeout)
 	defer cancelVerification()
 
-	requestBuilder := providerKeyVerificationRequestBuilders[textRouteCapabilities{
+	routeCapabilities := textRouteCapabilities{
 		wireContract:       model.wireContract,
 		executionLifecycle: model.executionLifecycle,
-	}]
-	httpRequest, buildError := requestBuilder(verificationContext, verifier.endpoints, provider, model, strings.TrimSpace(apiKey))
+	}
+	trimmedAPIKey := strings.TrimSpace(apiKey)
+	if routeCapabilities == geminiInteractionsPollableRouteCapabilities {
+		return verifier.verifyPollableGeminiCredential(verificationContext, provider, model, trimmedAPIKey)
+	}
+
+	requestBuilder := providerKeyVerificationRequestBuilders[routeCapabilities]
+	httpRequest, buildError := requestBuilder(verificationContext, verifier.endpoints, provider, model, trimmedAPIKey)
 	if buildError != nil {
 		return errProviderKeyVerificationUnavailable
 	}
@@ -117,6 +126,39 @@ func (verifier *operationalProviderKeyVerifier) verify(parentContext context.Con
 	}
 	responseValidator := providerKeyVerificationResponseValidators[model.wireContract]
 	if !responseValidator(responseBytes) {
+		return errProviderKeyVerificationUnavailable
+	}
+	return nil
+}
+
+func (verifier *operationalProviderKeyVerifier) verifyPollableGeminiCredential(verificationContext context.Context, provider providerDefinition, model textModelDefinition, apiKey string) (verificationError error) {
+	geminiClient := newGeminiInteractionsClient(verifier.httpClient)
+	payload := geminiProviderKeyVerificationPayload(model, true)
+	createdSnapshot, createError := geminiClient.createInteraction(verificationContext, apiKey, provider.textBaseURL, payload, verifier.logger)
+	if strings.TrimSpace(createdSnapshot.identifier) == "" {
+		if createError != nil {
+			return providerKeyVerificationProviderError(verificationContext, createError)
+		}
+		return errProviderKeyVerificationUnavailable
+	}
+
+	cleanupMode := createdSnapshot.cleanupMode()
+	defer func() {
+		cleanupError := geminiClient.releaseInteraction(verificationContext, apiKey, provider.textBaseURL, createdSnapshot.identifier, cleanupMode, verifier.logger)
+		if verificationError == nil && cleanupError != nil {
+			verificationError = providerKeyVerificationProviderError(verificationContext, cleanupError)
+		}
+	}()
+	if createError != nil {
+		return providerKeyVerificationProviderError(verificationContext, createError)
+	}
+
+	retrievedSnapshot, retrieveError := geminiClient.getInteraction(verificationContext, apiKey, provider.textBaseURL, createdSnapshot.identifier, verifier.logger)
+	if retrieveError != nil {
+		return providerKeyVerificationProviderError(verificationContext, retrieveError)
+	}
+	cleanupMode = retrievedSnapshot.cleanupMode()
+	if !validPollableGeminiProviderKeyVerificationStatus(retrievedSnapshot.status) {
 		return errProviderKeyVerificationUnavailable
 	}
 	return nil
@@ -177,19 +219,7 @@ func buildChatProviderKeyVerificationRequest(requestContext context.Context, _ *
 }
 
 func buildGeminiProviderKeyVerificationRequest(requestContext context.Context, _ *Endpoints, provider providerDefinition, model textModelDefinition, apiKey string) (*http.Request, error) {
-	payload := geminiInteractionRequest{
-		Model: model.providerString(),
-		Input: []geminiInteractionStep{{
-			Type: geminiInteractionStepUserInput,
-			Content: []geminiInteractionContent{{
-				Type: geminiInteractionContentText,
-				Text: providerKeyVerificationPrompt,
-			}},
-		}},
-		GenerationConfig: &geminiInteractionGeneration{MaxOutputTokens: providerKeyVerificationMaxTokens},
-		Background:       false,
-		Store:            false,
-	}
+	payload := geminiProviderKeyVerificationPayload(model, false)
 	payloadBytes, _ := json.Marshal(payload)
 	return buildProviderKeyVerificationRequestWithHeaders(
 		requestContext,
@@ -201,6 +231,22 @@ func buildGeminiProviderKeyVerificationRequest(requestContext context.Context, _
 			geminiAPIRevisionHeader: geminiAPIRevisionValue,
 		},
 	)
+}
+
+func geminiProviderKeyVerificationPayload(model textModelDefinition, background bool) geminiInteractionRequest {
+	return geminiInteractionRequest{
+		Model: model.providerString(),
+		Input: []geminiInteractionStep{{
+			Type: geminiInteractionStepUserInput,
+			Content: []geminiInteractionContent{{
+				Type: geminiInteractionContentText,
+				Text: providerKeyVerificationPrompt,
+			}},
+		}},
+		GenerationConfig: &geminiInteractionGeneration{MaxOutputTokens: providerKeyVerificationMaxTokens},
+		Background:       background,
+		Store:            background,
+	}
 }
 
 func buildAnthropicProviderKeyVerificationRequest(requestContext context.Context, _ *Endpoints, provider providerDefinition, model textModelDefinition, apiKey string) (*http.Request, error) {
@@ -257,10 +303,18 @@ func providerKeyVerificationStatusError(statusCode int) error {
 	}
 }
 
+func providerKeyVerificationProviderError(requestContext context.Context, requestError error) error {
+	statusCode, _, _, hasProviderStatus := providerHTTPMetadata(requestError)
+	if hasProviderStatus {
+		return providerKeyVerificationStatusError(statusCode)
+	}
+	return providerKeyVerificationTransportError(requestContext, requestError)
+}
+
 func validOpenAIProviderKeyVerificationResponse(responseBytes []byte) bool {
 	var response openAIProviderKeyVerificationResponse
 	decodeError := json.Unmarshal(responseBytes, &response)
-	_, acceptedStatus := openAIVerificationAcceptedStatuses[strings.TrimSpace(response.Status)]
+	_, acceptedStatus := pollableVerificationAcceptedStatuses[strings.TrimSpace(response.Status)]
 	return decodeError == nil && strings.TrimSpace(response.ID) != "" && acceptedStatus
 }
 
@@ -275,6 +329,11 @@ func validGeminiProviderKeyVerificationResponse(responseBytes []byte) bool {
 	decodeError := json.Unmarshal(responseBytes, &response)
 	return decodeError == nil &&
 		(response.Status == statusCompleted || response.Status == statusIncomplete)
+}
+
+func validPollableGeminiProviderKeyVerificationStatus(status string) bool {
+	_, acceptedStatus := pollableVerificationAcceptedStatuses[strings.TrimSpace(status)]
+	return acceptedStatus
 }
 
 func validAnthropicProviderKeyVerificationResponse(responseBytes []byte) bool {

--- a/internal/proxy/provider_key_verifier.go
+++ b/internal/proxy/provider_key_verifier.go
@@ -120,9 +120,9 @@ func (verifier *operationalProviderKeyVerifier) verify(parentContext context.Con
 	if httpResponse.StatusCode < http.StatusOK || httpResponse.StatusCode >= http.StatusMultipleChoices {
 		return providerKeyVerificationStatusError(httpResponse.StatusCode)
 	}
-	responseBytes, readError := io.ReadAll(io.LimitReader(httpResponse.Body, providerKeyVerificationResponseLimit+1))
-	if readError != nil || int64(len(responseBytes)) > providerKeyVerificationResponseLimit {
-		return errProviderKeyVerificationUnavailable
+	responseBytes, responseError := readProviderKeyVerificationResponse(httpResponse.Body)
+	if responseError != nil {
+		return responseError
 	}
 	responseValidator := providerKeyVerificationResponseValidators[model.wireContract]
 	if !responseValidator(responseBytes) {
@@ -132,7 +132,7 @@ func (verifier *operationalProviderKeyVerifier) verify(parentContext context.Con
 }
 
 func (verifier *operationalProviderKeyVerifier) verifyPollableGeminiCredential(verificationContext context.Context, provider providerDefinition, model textModelDefinition, apiKey string) (verificationError error) {
-	geminiClient := newGeminiInteractionsClient(verifier.httpClient)
+	geminiClient := newGeminiInteractionsClientWithHTTPPerformer(verifier.httpClient, performProviderKeyVerificationGeminiInteractionHTTP)
 	payload := geminiProviderKeyVerificationPayload(model, true)
 	createdSnapshot, createError := geminiClient.createInteraction(verificationContext, apiKey, provider.textBaseURL, payload, verifier.logger)
 	if strings.TrimSpace(createdSnapshot.identifier) == "" {
@@ -162,6 +162,27 @@ func (verifier *operationalProviderKeyVerifier) verifyPollableGeminiCredential(v
 		return errProviderKeyVerificationUnavailable
 	}
 	return nil
+}
+
+func performProviderKeyVerificationGeminiInteractionHTTP(httpClient HTTPDoer, httpRequest *http.Request, _ *zap.SugaredLogger) (int, []byte, http.Header, error) {
+	httpResponse, requestError := httpClient.Do(httpRequest)
+	if requestError != nil {
+		return 0, nil, nil, requestError
+	}
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode < http.StatusOK || httpResponse.StatusCode >= http.StatusMultipleChoices {
+		return httpResponse.StatusCode, nil, httpResponse.Header, nil
+	}
+	responseBytes, responseError := readProviderKeyVerificationResponse(httpResponse.Body)
+	return httpResponse.StatusCode, responseBytes, httpResponse.Header, responseError
+}
+
+func readProviderKeyVerificationResponse(responseBody io.Reader) ([]byte, error) {
+	responseBytes, readError := io.ReadAll(io.LimitReader(responseBody, providerKeyVerificationResponseLimit+1))
+	if readError != nil || int64(len(responseBytes)) > providerKeyVerificationResponseLimit {
+		return nil, errProviderKeyVerificationUnavailable
+	}
+	return responseBytes, nil
 }
 
 func buildOpenAIProviderKeyVerificationRequest(requestContext context.Context, endpoints *Endpoints, _ providerDefinition, model textModelDefinition, apiKey string) (*http.Request, error) {

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -118,7 +118,7 @@ func buildRouter(configuration Configuration, structuredLogger *zap.SugaredLogge
 	geminiClient := newGeminiInteractionsClient(upstreamHTTPClient)
 	anthropicClient := newAnthropicMessagesClient(upstreamHTTPClient)
 	upstreamProviders := newProviderRouter(openAIClient, chatClient, geminiClient, anthropicClient)
-	keyVerifier := newOperationalProviderKeyVerifier(upstreamHTTPClient, configuration.Endpoints, time.Duration(configuration.RequestTimeoutSeconds)*time.Second)
+	keyVerifier := newOperationalProviderKeyVerifier(upstreamHTTPClient, configuration.Endpoints, time.Duration(configuration.RequestTimeoutSeconds)*time.Second, structuredLogger)
 	managedTenants, storeError := openManagedTenantStore(configuration.Management, providers)
 	if storeError != nil {
 		return nil, storeError

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -6,7 +6,7 @@
     <title>LLM Proxy HTTP API | LLM Proxy</title>
     <meta name="description" content="Human-readable API reference derived from the canonical LLM Proxy OpenAPI contract.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/docs/">
-    <meta name="openapi-source-sha256" content="97fa4f3ca48c18aa2ae935bef21262de0b40bbb694c991e3d249ff7146db1940">
+    <meta name="openapi-source-sha256" content="ab81cae6355f37c2360e06485d9f29a45f87ffede97c490757a5599e2440cd8a">
     <link rel="icon" type="image/svg+xml" href="/assets/llm-proxy/img/favicon.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/MarcoPoloResearchLab/mpr-ui@latest/mpr-ui.css">
     <link rel="stylesheet" href="/assets/llm-proxy/public-shell.css">
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
   </head>
-  <body class="resource-page api-reference-page" data-openapi-source-sha256="97fa4f3ca48c18aa2ae935bef21262de0b40bbb694c991e3d249ff7146db1940">
+  <body class="resource-page api-reference-page" data-openapi-source-sha256="ab81cae6355f37c2360e06485d9f29a45f87ffede97c490757a5599e2440cd8a">
     <mpr-header
       class="public-site-header"
       data-config-url="/config-ui.yaml"
@@ -49,7 +49,7 @@
         <div class="api-contract-meta" aria-label="Contract provenance">
           <span>OpenAPI 3.1.0</span>
           <span>API server https://llm-proxy-api.mprlab.com</span>
-          <span>Source SHA-256 <code>97fa4f3ca48c18aa2ae935bef21262de0b40bbb694c991e3d249ff7146db1940</code></span>
+          <span>Source SHA-256 <code>ab81cae6355f37c2360e06485d9f29a45f87ffede97c490757a5599e2440cd8a</code></span>
         </div>
         <div class="resource-actions" aria-label="OpenAPI schema actions">
           <a class="resource-button" href="#openapi-yaml">View YAML</a>
@@ -639,7 +639,19 @@ paths:
     put:
       operationId: putManagementProviderKey
       summary: Verify and save provider settings and a provider credential
-      description: A nonempty api_key performs exactly one provider-authenticated verification operation for the selected provider, text model, and provider base URL under the management request context and shared upstream admission/rate-limit boundary. Changing a saved DashScope base_url also verifies the retained key against the new URL. Only a successful verification atomically persists the credential and submitted settings, reconciles routing defaults, and returns a keyed profile. Rejection and unconfirmed transient outcomes never mutate the provider key, settings, defaults, or managed usage. An empty api_key retains the existing verified credential. The operation returns 409 without a mutation if that retained credential changes before the verified update can persist.
+      description: &gt;-
+        A nonempty api_key verifies the selected provider, text model, base URL,
+        wire contract, and execution lifecycle. Synchronous routes use one
+        provider request. Pollable Gemini routes create and retrieve one stored
+        background interaction. The verifier cancels active work and deletes
+        the interaction before persistence. Changing a saved DashScope base_url
+        also verifies the retained key against the new URL. Only complete
+        verification atomically persists the credential and submitted settings.
+        It also reconciles routing defaults and returns a keyed profile.
+        Rejection and unconfirmed outcomes do not mutate provider state or
+        managed usage. An empty api_key retains the existing verified
+        credential. The operation returns 409 without a mutation when that
+        credential changes before persistence.
       tags:
         - Management
       security:
@@ -3735,7 +3747,7 @@ components:
           <span class="api-operation-id">putManagementProviderKey</span>
         </header>
         <h2>Verify and save provider settings and a provider credential</h2>
-        <p>A nonempty api_key performs exactly one provider-authenticated verification operation for the selected provider, text model, and provider base URL under the management request context and shared upstream admission/rate-limit boundary. Changing a saved DashScope base_url also verifies the retained key against the new URL. Only a successful verification atomically persists the credential and submitted settings, reconciles routing defaults, and returns a keyed profile. Rejection and unconfirmed transient outcomes never mutate the provider key, settings, defaults, or managed usage. An empty api_key retains the existing verified credential. The operation returns 409 without a mutation if that retained credential changes before the verified update can persist.</p>
+        <p>A nonempty api_key verifies the selected provider, text model, base URL, wire contract, and execution lifecycle. Synchronous routes use one provider request. Pollable Gemini routes create and retrieve one stored background interaction. The verifier cancels active work and deletes the interaction before persistence. Changing a saved DashScope base_url also verifies the retained key against the new URL. Only complete verification atomically persists the credential and submitted settings. It also reconciles routing defaults and returns a keyed profile. Rejection and unconfirmed outcomes do not mutate provider state or managed usage. An empty api_key retains the existing verified credential. The operation returns 409 without a mutation when that credential changes before persistence.</p>
         <p class="api-security"><strong>Authentication:</strong> TAuthSession (cookie app_session_llm_proxy)</p>
         <p class="api-security"><strong>Required Content-Type:</strong> <code>application/json</code></p>
         <div class="api-contract-block">


### PR DESCRIPTION
## Summary

Ensure pollable Gemini credentials are verified against the full stored-interaction lifecycle before they can be saved.

For pollable Gemini models, credential verification now:

- Creates a stored background interaction.
- Retrieves the interaction to confirm retrieval permission.
- Cancels the interaction if it remains active.
- Deletes the stored verification interaction.
- Persists the credential and submitted provider settings only after every required lifecycle step succeeds.

This prevents accepting keys that can create Gemini interactions but cannot later retrieve them, which would otherwise cause production requests to fail after a seemingly successful credential update.

## Validation

Added coverage verifies that pollable Gemini verification:

- Uses stored background interaction settings.
- Performs create, retrieve, cancel, and delete in order.
- Does not persist the candidate key before cleanup completes.
- Rejects retrieval permission failures while cleaning up the interaction.
- Preserves an existing credential, settings, and routing defaults when replacement verification fails.

## Documentation

Updated the README, provider-routing design documentation, and management API description to define verification in terms of each provider route’s required execution lifecycle, including the stored Gemini interaction lifecycle.