### PR TITLE
I230: Adopt the versionless selected application manifest

### DIFF
--- a/.mprlab/AGENTS.DOCKER.md
+++ b/.mprlab/AGENTS.DOCKER.md
@@ -19,7 +19,7 @@ Docker and container guidance for this repository. Use this guide only when Dock
 
 - Treat local orchestration and production orchestration as different contracts.
 - MPR Lab has no current plan to put these contracts together.
-- Keep app-owned local orchestration during a migration to `schema_version: 3`.
+- Keep app-owned local orchestration separate from the current selected application manifest.
 - A local topology can be different from the production topology.
 - Keep local orchestration files outside `.mprlab/deploy/`.
 - Do not use local orchestration files as production lifecycle inputs.

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -563,6 +563,8 @@ retain satisfied historical dependencies.
   - The compiled lifecycle test rejects a `schema_version` field.
   - Current operator documents describe the permanent versionless contract.
   - The final repository validation passed.
+  - Gateway commit `753c727` planned release for application commit
+    `490acd7` with 218 tasks passed, 4 changed, and 0 failed.
 
 - [x] [I229] (P0) Add schema-constrained, resumable semantic-review requests.
   Goal:

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -563,6 +563,9 @@ retain satisfied historical dependencies.
   - The compiled lifecycle test rejects a `schema_version` field.
   - Current operator documents describe the permanent versionless contract.
   - The final repository validation passed.
+  - Hosted GitHub `Test` attempt 1 ended with exit 137 when the workflow's
+    outer 350-second timeout stopped gate 10 after gates 1 through 9 passed.
+    Attempt 2 completed successfully at `2026-08-20T23:19:58Z`.
   - Gateway commit `753c727` planned release for application commit
     `490acd7` with 218 tasks passed, 4 changed, and 0 failed.
 

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -562,7 +562,7 @@ retain satisfied historical dependencies.
   - The selected application manifest now has no schema number.
   - The compiled lifecycle test rejects a `schema_version` field.
   - Current operator documents describe the permanent versionless contract.
-  - The final repository and gateway plan validations passed.
+  - The final repository validation passed.
 
 - [x] [I229] (P0) Add schema-constrained, resumable semantic-review requests.
   Goal:

--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -544,6 +544,26 @@ retain satisfied historical dependencies.
 
 ## Improvements
 
+- [x] [I230] (P0) Use the permanent versionless selected application manifest.
+  Goal:
+  The selected application manifest uses one permanent contract without a
+  schema number.
+  Requirements:
+  - Remove `schema_version` from `.mprlab/deploy/resources.yml`.
+  - Require only `owner`, `release`, and `resources` at the manifest root.
+  - Reject each numbered selected application manifest form.
+  - Keep independent schema contracts unchanged.
+  - Keep local orchestration separate from the production manifest.
+  Validation:
+  - Run `make ci` after the last repository change.
+  - Run the gateway `plan-app-release` target against the committed branch.
+
+  Resolution:
+  - The selected application manifest now has no schema number.
+  - The compiled lifecycle test rejects a `schema_version` field.
+  - Current operator documents describe the permanent versionless contract.
+  - The final repository and gateway plan validations passed.
+
 - [x] [I229] (P0) Add schema-constrained, resumable semantic-review requests.
   Goal:
   Let Creative Director submit one semantic-review inference with a declared

--- a/.mprlab/deploy/resources.yml
+++ b/.mprlab/deploy/resources.yml
@@ -1,6 +1,5 @@
 ---
 mprlab_resources:
-  schema_version: 4
   owner: llm-proxy
   release:
     scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Removed schema versioning from the selected application manifest.
 - Added provider-enforced JSON Schema output and tenant-bound durable reconciliation for canonical `POST /v2` requests.
 - Added all seven documented MiniMax M2 text routes with current limits and standard PAYG prices.
 - Added Qwen 3.7 Max, Qwen 3.7 Plus, and Qwen 3.6 Flash text routes for Singapore DashScope workspaces.

--- a/README.md
+++ b/README.md
@@ -1347,7 +1347,7 @@ This repository exposes the standard local targets used by MPR app repos:
 | `make test-live-provider-media` | Verify OpenAI, Anthropic, Gemini, Moonshot, and xAI keys, then send one paid canonical image request through each provider. |
 | `make test-live-gemini` | Compatibility wrapper for `make test-live-providers` with `LLM_PROXY_LIVE_PROVIDERS=gemini`. |
 | `make live-test` | Send paid production `POST /v2` requests through the Default tenant using only `LLM_PROXY_SECRET`: echo checks for OpenAI, Anthropic, Meta, Gemini, and Moonshot, plus large completion cases for OpenAI, Anthropic, Meta, and Gemini. |
-| `make release` | Delegate this clean checkout and its schema-v4 resource declaration to the exact sibling `../mprlab-gateway` release transaction. |
+| `make release` | Delegate this clean checkout and its current resource declaration to the exact sibling `../mprlab-gateway` release transaction. |
 | `make publish` | Delegate publication of the exact sealed release to `../mprlab-gateway`; it does not rebuild or deploy. |
 | `make deploy` | Delegate convergence of only this app's declared runtime, route, health, Pages, and TAuth resources to `../mprlab-gateway`. |
 

--- a/docs/implementation/provider-routing-plan.md
+++ b/docs/implementation/provider-routing-plan.md
@@ -631,7 +631,7 @@ references, route pairs, defaults, and capabilities. Obsolete
 unknown configuration keys. Managed tenants own client keys, provider
 credentials, and routing defaults in the database.
 
-The repository owns the schema-v4 production declaration in
+The repository owns the permanent versionless production declaration in
 `.mprlab/deploy/resources.yml`. The repository also owns the standard
 `make release`, `make publish`, and `make deploy` entrypoints. These targets use
 the exact `../mprlab-gateway` sibling. The gateway owns SemVer selection, schema

--- a/tests/lifecycle_contract_test.go
+++ b/tests/lifecycle_contract_test.go
@@ -30,7 +30,7 @@ var expectedSiblingGatewayWrapper = strings.Join([]string{
 	"\t\tMPRLAB_APP_ROOT=\"$${application_root}\"",
 }, "\n")
 
-func TestOperationalRepositoryOwnsSchemaV4Lifecycle(testingInstance *testing.T) {
+func TestOperationalRepositoryOwnsVersionlessLifecycle(testingInstance *testing.T) {
 	repositoryRoot := operationalRepositoryRoot(testingInstance)
 	manifestPath := filepath.Join(repositoryRoot, filepath.FromSlash(lifecycleManifestRelativePath))
 	manifestBytes, readError := os.ReadFile(manifestPath)
@@ -49,9 +49,6 @@ func TestOperationalRepositoryOwnsSchemaV4Lifecycle(testingInstance *testing.T) 
 	if !available {
 		testingInstance.Fatalf("lifecycle manifest has no mprlab_resources mapping: %#v", document)
 	}
-	if schemaVersion, schemaAvailable := resourcesDocument["schema_version"].(int); !schemaAvailable || schemaVersion != 4 {
-		testingInstance.Fatalf("unexpected lifecycle schema version: %#v", resourcesDocument["schema_version"])
-	}
 	if owner, ownerAvailable := resourcesDocument["owner"].(string); !ownerAvailable || owner != "llm-proxy" {
 		testingInstance.Fatalf("unexpected lifecycle owner: %#v", resourcesDocument["owner"])
 	}
@@ -62,8 +59,13 @@ func TestOperationalRepositoryOwnsSchemaV4Lifecycle(testingInstance *testing.T) 
 	if _, dependenciesAvailable := resourcesDocument["dependencies"]; dependenciesAvailable {
 		testingInstance.Fatalf("lifecycle manifest must not declare top-level dependencies: %#v", resourcesDocument["dependencies"])
 	}
-	if len(resourcesDocument) != 4 {
-		testingInstance.Fatalf("lifecycle manifest must contain only schema_version, owner, release, and resources: %#v", resourcesDocument)
+	resourceKeys := make([]string, 0, len(resourcesDocument))
+	for key := range resourcesDocument {
+		resourceKeys = append(resourceKeys, key)
+	}
+	slices.Sort(resourceKeys)
+	if !slices.Equal(resourceKeys, []string{"owner", "release", "resources"}) {
+		testingInstance.Fatalf("lifecycle manifest must contain only owner, release, and resources: %#v", resourcesDocument)
 	}
 
 	resources, resourcesAvailable := resourcesDocument["resources"].([]any)
@@ -238,7 +240,7 @@ func TestOperationalRepositoryOwnsSchemaV4Lifecycle(testingInstance *testing.T) 
 		}
 	}
 	for _, forbiddenContract := range []string{
-		"schema_version: 1",
+		"schema_version:",
 		"environment_files:",
 		"profiles:",
 		"secret:",


### PR DESCRIPTION
## Summary

- remove `mprlab_resources.schema_version` from the selected application manifest
- make the compiled lifecycle contract require exactly `owner`, `release`, and `resources` and reject numbered forms
- update current operator guidance while preserving independent schema contracts and historical records

## Validation

- local `make ci`: PASS (11 gates, 94 browser tests, 100.0% Go statement coverage)
- hosted `Test` run 32426634034 attempt 1: exit 137 when the workflow outer 350-second timeout stopped gate 10 after gates 1-9 passed
- hosted `Test` run 32426634034 attempt 2: PASS, completed 2026-08-20T23:19:58Z
- current-head hosted `Test` run 32437473697: PASS, completed 2026-08-21T01:50:35Z
- gateway `make plan-app-release` from disposable normal clones: PASS (gateway `753c727`, app `2ba4ddc706a8d986e489cd3c5336b79cecc4a2ac`, 218 ok, 4 changed, 0 failed)

## Stack

1. Merge this PR into `master`.
2. Review and merge [PR #291](https://github.com/tyemirov/llm-proxy/pull/291), which targets this branch.

## Dependency

- Depends on https://github.com/MarcoPoloResearchLab/mprlab-gateway/pull/287
