### PR TITLE
gix/add-candidate-acceptance-and-retire-failed-routes

### DIFF
--- a/.mprlab/ISSUES.md
+++ b/.mprlab/ISSUES.md
@@ -25,6 +25,64 @@ retain satisfied historical dependencies.
 
 ## BugFixes
 
+- [x] [B158] (P2) Preserve the Gemini candidate reasoning matrix default.
+  Goal:
+  The Gemini candidate command tests all supported thinking levels by default.
+  Evidence:
+  - Expected: `test_live_providers.sh --gemini-candidates` uses the candidate
+    script default.
+  - Actual: The parent script supplies `false` and skips the supported thinking
+    levels.
+  Requirements:
+  - Use `true` as the candidate mode default.
+  - Preserve an explicit `false` value from the operator.
+  - Keep the registered provider mode default unchanged.
+  Validation:
+  - Prove that candidate mode sends all supported thinking levels without an
+    environment override.
+  - Prove that an explicit `false` value reaches the candidate script unchanged.
+  - Run `make ci` after the last repository change.
+  Resolution:
+  - Gemini candidate mode now uses `true` as its reasoning matrix default.
+  - An explicit `false` value remains authoritative.
+  - Registered provider mode keeps its `false` default.
+  - The operational test proves both candidate behaviors through the public
+    parent script.
+  - `make go-test` passed with 100.0 percent Go statement coverage.
+  - The final `make ci` passed all 11 gates in 138 seconds with 100.0 percent
+    Go statement coverage.
+
+- [x] [B157] (P1) Apply pending model replacements before route validation.
+  Goal:
+  A schema-version-9 database reaches the current schema with a retired Gemini
+  selection.
+  Evidence:
+  - Expected: Startup applies the schema-version-10 and schema-version-11 model
+    replacements before current route validation.
+  - Actual: The schema-version-10 migration validates the retired Gemini 3.1
+    selection and stops startup.
+  Requirements:
+  - Apply all pending model replacements in one database transaction.
+  - Validate the final routing state after all replacements.
+  - Record each pending schema version only after successful validation.
+  - Roll back all replacements and version records after a migration error.
+  - Preserve provider connections, profiles, tenant defaults, timestamps, and
+    historical usage records.
+  Validation:
+  - Prove the schema-version-9 to schema-version-11 migration for each retired
+    Gemini 3.1 selection.
+  - Prove transaction rollback after a pending migration error.
+  - Run `make ci` after the last repository change.
+  Resolution:
+  - Startup applies all pending model replacements in one transaction.
+  - Startup validates routing after the final replacement and then records each
+    schema version.
+  - The schema-version-9 test covers each retired Gemini 3.1 selection and a
+    missing schema-version-11 policy.
+  - `make go-test` passed with 100.0 percent Go statement coverage.
+  - The final `make ci` passed all 11 gates in 140 seconds with 100.0 percent
+    Go statement coverage.
+
 - [x] [B156] (P0) Mount the provider catalog in local orchestration.
   Goal:
   The local API starts with the canonical provider catalog.
@@ -890,6 +948,134 @@ retain satisfied historical dependencies.
 
 
 ## Improvements
+
+- [ ] [I235] (P1) Add explicit model activation to the provider catalog.
+  Goal:
+  Keep exact model data in the provider catalog without exposing an unaccepted
+  model route.
+  Requirements:
+  - Add a required `enabled` Boolean field to each exact model in
+    `configs/providers.yml`.
+  - Do not use an implicit default for the field.
+  - Include only enabled exact models and their provider offerings in the
+    immutable runtime registry.
+  - Exclude disabled exact models from route resolution, defaults, management
+    projections, public capabilities, and standard live-test discovery.
+  - Permit a disabled exact model to retain its provider offerings, limits,
+    controls, and prices in the provider catalog.
+  - Reject a provider default that references a disabled exact model.
+  - Require an explicit model migration for each stored selection that
+    references a disabled exact model.
+  - Update the provider catalog documentation and all current catalog records.
+  Validation:
+  - Prove that startup rejects a missing or invalid `enabled` value.
+  - Prove that startup rejects a disabled provider default.
+  - Prove that public discovery omits a disabled exact model and its offerings.
+  - Prove that route resolution rejects a disabled exact model before provider
+    dispatch.
+  - Prove that an explicit migration moves a disabled stored selection to an
+    enabled exact model.
+  - Run `make ci` after the last application change.
+
+- [!] [I234] (P1) Restore Gemini 3.1 Pro Preview after live acceptance.
+  Goal:
+  Restore the exact upstream route only after its current Google contract
+  passes.
+  Evidence:
+  - Google publishes `gemini-3.1-pro-preview` as the only Gemini 3.1 Pro API
+    model. Google does not publish a stable `gemini-3.1-pro` model ID.
+  - I232 removed the preview route after two provider verification requests
+    returned HTTP 429.
+  Requirements:
+  - Do a test of the omitted, `low`, `medium`, and `high` thinking levels.
+  - Prove background completion, active retrieval, cancellation, and deletion.
+  - Restore only the exact `gemini-3.1-pro-preview` model ID after all live
+    checks pass.
+  - Do not add a `gemini-3.1-pro` alias or change the Gemini default model.
+  - Keep the completed schema-version-11 migration unchanged.
+  - Restore the catalog, public capabilities, route constants, tests, and
+    current documentation together.
+  Validation:
+  - Run the exact paid candidate acceptance before source changes.
+  - Run `make ci` after the last application change.
+  Blocked: The omitted-thinking acceptance request returned HTTP 429. The test
+  stopped before the other thinking levels and background lifecycle. The
+  provider catalog remains unchanged.
+
+- [!] [I233] (P1) Add Gemini candidate models to the live test.
+  Goal:
+  Make the Gemini live test validate two stable candidates before public route
+  registration.
+  Evidence:
+  - I207 remains blocked because active retrieval and cancellation did not
+    pass for `gemini-3.6-flash` or `gemini-3.7-flash`.
+  - The current harness discovers only registered provider offerings. It
+    cannot validate an unregistered candidate route.
+  Requirements:
+  - Add both exact candidates to the default `make test-live-gemini` flow.
+  - Send omitted and supported thinking levels to the official Interactions
+    API.
+  - Prove one completed background lifecycle for each candidate.
+  - Prove active retrieval, cancellation, and deletion for each candidate.
+  - Keep both candidates outside the public provider catalog until I207
+    satisfies its registration gate.
+  - Load `GEMINI_API_KEY` through the current safe environment boundary.
+    Never print the key or private provider response bodies.
+  - Add black-box CLI coverage with a local fake provider boundary.
+  Validation:
+  - Run the candidate mode with the repository private environment file.
+  - Run `make ci` after the last implementation change.
+  Progress:
+  - Added the exact-model candidate mode to the default Gemini wrapper. The
+    mode validates the thinking matrix, completion, active retrieval,
+    cancellation, and deletion without registering either public route.
+  - Added local fake-provider coverage for the direct request matrix and the
+    wrapper order.
+  - Paid reasoning passed for the omitted, `minimal`, `low`, `medium`, and
+    `high` Gemini 3.6 Flash requests. Its stored completion reached
+    `completed` and deletion succeeded.
+  Blocked: The long Gemini 3.6 Flash cancellation resource was not readable
+  during any of seven bounded active retrieval attempts. Google returned HTTP
+  400 on the final attempt. The harness stopped before cancellation and before
+  the Gemini 3.7 Flash matrix. I207 remains blocked, and neither candidate is
+  registered in the public provider catalog.
+
+- [x] [I232] (P1) Remove two Gemini model routes.
+  Goal:
+  Keep only the selected Gemini exact models in the current provider catalog.
+  Evidence:
+  - `gemini-3.1-flash-lite` passed provider verification but failed its live
+    smoke request with proxy HTTP `502` and upstream HTTP `400`.
+  - `gemini-3.1-pro-preview` returned HTTP `429` during two provider
+    verification attempts. Its live smoke request did not start.
+  Requirements:
+  - Remove both exact models and their provider offerings.
+  - Migrate each stored selection to `gemini-3.5-flash` in one bounded
+    operation.
+  - Preserve provider connections, system prompts, timestamps, and historical
+    usage records.
+  - Reject both removed models after the migration.
+  - Remove both models from public documentation and generated capability
+    data.
+  Validation:
+  - Prove that public capabilities omit both removed models.
+  - Prove the stored profile and same-provider default migration for both
+    removed models.
+  - Run `make ci` after the last repository change.
+  Resolution:
+  - The canonical catalog now contains Gemini 3.5 Flash and Gemini 3 Flash
+    Preview. Public capabilities contain 62 models and 63 offerings.
+  - Managed schema version 11 atomically replaces both removed selections
+    with Gemini 3.5 Flash. It preserves provider connections, system prompts,
+    timestamps, and historical usage records.
+  - Public routing rejects both removed model IDs before provider dispatch.
+    The management profile and generated public resources omit both models.
+  - Changed files include the provider catalog, managed-store migration,
+    public and migration regressions, current documentation, the resource
+    generator, and its generated Gemini pages. No event contract changed.
+  - `make go-test` passed with 100.0 percent Go statement coverage.
+    `make frontend-test` passed all 95 browser scenarios. The final `make ci`
+    passed all 11 gates in 134 seconds with 100.0 percent Go coverage.
 
 - [x] [I231] (P1) Remove Gemini 2.5 model routes.
   Goal:

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ when the provider offering has a code-owned transport.
 |-----------------|----------|-------------------------------|
 | All 11 OpenAI text models in the GPT-4 and GPT-5 families | OpenAI | `image` |
 | All 10 Claude text models in the Fable, Sonnet, Opus, and Haiku families | Anthropic | `image` |
-| All 4 Gemini text models | Gemini | `image`, `audio` |
+| Both Gemini text models | Gemini | `image`, `audio` |
 | `grok-4.5` | xAI | `image` |
 | Every other configured model | Its configured provider | None |
 
@@ -370,8 +370,8 @@ The loader rejects unknown fields and unsupported schema versions. It also
 rejects invalid identities, references, defaults, protocols, capabilities,
 limits, and prices.
 
-The current snapshot contains 11 providers, 64 exact models, 65 provider
-offerings, and 65 price records. The application compiles one immutable
+The current snapshot contains 11 providers, 62 exact models, 63 provider
+offerings, and 63 price records. The application compiles one immutable
 registry from this snapshot.
 
 Each provider offering references one exact model and one provider transport.
@@ -1044,6 +1044,12 @@ provider profile and current default in one transaction. It preserves tenant
 and profile timestamps and all historical usage model identifiers. Current
 startup rejects retired Gemini routes instead of accepting an alias or fallback.
 
+The bounded schema-version-11 migration replaces stored
+`gemini-3.1-flash-lite` and `gemini-3.1-pro-preview` selections with
+`gemini-3.5-flash`. It updates the provider profile and same-provider tenant
+default in one transaction. It preserves provider connections, system prompts,
+timestamps, and historical usage model identifiers.
+
 Server settings and browser-facing MPR UI/TAuth bootstrap settings remain in
 `config.yml`. Provider definitions and static endpoints remain in
 `providers.yml`. Each managed DashScope workspace URL is tenant-owned and is
@@ -1287,7 +1293,7 @@ This repository exposes the standard local targets used by MPR app repos:
 | `make test-live-provider-harness` | Save a temporary managed OpenAI connection and route one request through a loopback provider. |
 | `make test-live-providers` | Start a disposable managed tenant, verify every available provider key through the canonical management operation, and run that provider's live text smoke only after verification succeeds; use `LIVE_ENV_FILE=/path/to/env` to load key values. |
 | `make test-live-provider-media` | Verify OpenAI, Anthropic, Gemini, Moonshot, and xAI keys, then send one paid canonical image request through each provider. |
-| `make test-live-gemini` | Compatibility wrapper for `make test-live-providers` with `LLM_PROXY_LIVE_PROVIDERS=gemini`. |
+| `make test-live-gemini` | Run direct acceptance for the exact Gemini 3.6 Flash and Gemini 3.7 Flash candidates, then run registered Gemini routes through `make test-live-providers`. |
 | `make live-test` | Send paid production `POST /v2` requests through the Default tenant using only `LLM_PROXY_SECRET`: echo checks for OpenAI, Anthropic, Meta, Gemini, and Moonshot, plus large completion cases for OpenAI, Anthropic, Meta, and Gemini. |
 | `make release` | Delegate this clean checkout and its current resource declaration to the exact sibling `../mprlab-gateway` release transaction. |
 | `make publish` | Delegate publication of the exact sealed release to `../mprlab-gateway`; it does not rebuild or deploy. |
@@ -1303,6 +1309,21 @@ default is operational; an override is included in both verification and smoke.
 Set `LLM_PROXY_LIVE_ALL_MODELS=true` to discover every text model for each
 selected provider. The harness uses the validated public catalog and runs one
 verification and one explicit-model smoke request for each model.
+
+The Gemini wrapper first sends direct Interactions requests for the exact
+`gemini-3.6-flash` and `gemini-3.7-flash` candidates. It sends one request with
+the thinking level omitted and one request for every thinking level supported
+by the exact model. It then proves active retrieval, completion, cancellation,
+and deletion for stored background interactions. Google documents both exact
+models as stable Interactions models and documents the background resource
+lifecycle in its
+[Gemini 3.6 Flash](https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash),
+[Gemini 3.7 Flash](https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash),
+and [background execution](https://ai.google.dev/gemini-api/docs/background-execution)
+guides. These candidates remain outside the public provider catalog until the
+complete lifecycle succeeds. Set
+`LLM_PROXY_LIVE_GEMINI_CANDIDATES=false` only when a run must exercise the
+registered Gemini routes without candidate acceptance.
 
 `make ci` runs each declared gate sequentially through one top-level runner.
 Coverage is written to a fresh private artifact for that invocation and
@@ -2273,9 +2294,7 @@ effort through the proxy.
 | `glm-5.1` | Z.AI | Yes | - | No |
 | `glm-5.2` | Z.AI | No | `131072` | No |
 | `gemini-3.5-flash` | Gemini | Yes | `65536` | No |
-| `gemini-3.1-pro-preview` | Gemini | No | `65536` | No |
 | `gemini-3-flash-preview` | Gemini | No | `65536` | No |
-| `gemini-3.1-flash-lite` | Gemini | No | `65536` | No |
 | `claude-opus-4-8` | Anthropic/Claude | No | `128000` | No |
 | `claude-fable-5` | Anthropic/Claude | No | `128000` | No |
 | `claude-sonnet-5` | Anthropic/Claude | No | `128000` | No |

--- a/configs/providers.yml
+++ b/configs/providers.yml
@@ -35,6 +35,16 @@ model_migrations:
       operation: text
       source_model: gemini-2.5-pro
       target_model: gemini-3.5-flash
+    - managed_schema_version: 11
+      provider: gemini
+      operation: text
+      source_model: gemini-3.1-flash-lite
+      target_model: gemini-3.5-flash
+    - managed_schema_version: 11
+      provider: gemini
+      operation: text
+      source_model: gemini-3.1-pro-preview
+      target_model: gemini-3.5-flash
 operations:
     - id: text
       input_artifacts:
@@ -451,28 +461,10 @@ models:
       media_inputs:
         - image
         - audio
-    - id: gemini-3.1-pro-preview
-      publisher: google
-      family: gemini
-      version: gemini-3.1-pro-preview
-      operations:
-        - text
-      media_inputs:
-        - image
-        - audio
     - id: gemini-3-flash-preview
       publisher: google
       family: gemini
       version: gemini-3-flash-preview
-      operations:
-        - text
-      media_inputs:
-        - image
-        - audio
-    - id: gemini-3.1-flash-lite
-      publisher: google
-      family: gemini
-      version: gemini-3.1-flash-lite
       operations:
         - text
       media_inputs:
@@ -2504,128 +2496,8 @@ providers:
               source: https://ai.google.dev/gemini-api/docs/pricing
               last_verified: "2026-08-10"
               unavailable_reason: Exact published pricing has not been imported for this provider offering.
-        - model: gemini-3.1-pro-preview
-          upstream_model: gemini-3.1-pro-preview
-          transport: text_pollable
-          operations:
-            - text
-          output_token_limit: 65536
-          media_inputs:
-            - image
-            - audio
-          media_limits:
-            - id: inline_request_bytes
-              media_type: all
-              transport: inline
-              status: bounded
-              value: 20000000
-              unit: bytes
-              scope: request_encoded_bytes
-              source: https://ai.google.dev/gemini-api/docs/file-input-methods
-              last_verified: "2026-08-11"
-            - id: image_count
-              media_type: image
-              transport: any
-              status: bounded
-              value: 3600
-              unit: files
-              scope: request
-              source: https://ai.google.dev/gemini-api/docs/image-understanding
-              last_verified: "2026-08-11"
-            - id: audio_count
-              media_type: audio
-              transport: any
-              status: unknown
-              unit: files
-              scope: request
-              source: https://ai.google.dev/gemini-api/docs/audio
-              last_verified: "2026-08-11"
-            - id: image_file_bytes
-              media_type: image
-              transport: file
-              status: bounded
-              value: 2000000000
-              unit: bytes
-              scope: attachment
-              source: https://ai.google.dev/gemini-api/docs/files
-              last_verified: "2026-08-11"
-            - id: audio_file_bytes
-              media_type: audio
-              transport: file
-              status: bounded
-              value: 2000000000
-              unit: bytes
-              scope: attachment
-              source: https://ai.google.dev/gemini-api/docs/files
-              last_verified: "2026-08-11"
-          prices:
-            - operation: text
-              available: false
-              source: https://ai.google.dev/gemini-api/docs/pricing
-              last_verified: "2026-08-10"
-              unavailable_reason: Exact published pricing has not been imported for this provider offering.
         - model: gemini-3-flash-preview
           upstream_model: gemini-3-flash-preview
-          transport: text_pollable
-          operations:
-            - text
-          output_token_limit: 65536
-          media_inputs:
-            - image
-            - audio
-          media_limits:
-            - id: inline_request_bytes
-              media_type: all
-              transport: inline
-              status: bounded
-              value: 20000000
-              unit: bytes
-              scope: request_encoded_bytes
-              source: https://ai.google.dev/gemini-api/docs/file-input-methods
-              last_verified: "2026-08-11"
-            - id: image_count
-              media_type: image
-              transport: any
-              status: bounded
-              value: 3600
-              unit: files
-              scope: request
-              source: https://ai.google.dev/gemini-api/docs/image-understanding
-              last_verified: "2026-08-11"
-            - id: audio_count
-              media_type: audio
-              transport: any
-              status: unknown
-              unit: files
-              scope: request
-              source: https://ai.google.dev/gemini-api/docs/audio
-              last_verified: "2026-08-11"
-            - id: image_file_bytes
-              media_type: image
-              transport: file
-              status: bounded
-              value: 2000000000
-              unit: bytes
-              scope: attachment
-              source: https://ai.google.dev/gemini-api/docs/files
-              last_verified: "2026-08-11"
-            - id: audio_file_bytes
-              media_type: audio
-              transport: file
-              status: bounded
-              value: 2000000000
-              unit: bytes
-              scope: attachment
-              source: https://ai.google.dev/gemini-api/docs/files
-              last_verified: "2026-08-11"
-          prices:
-            - operation: text
-              available: false
-              source: https://ai.google.dev/gemini-api/docs/pricing
-              last_verified: "2026-08-10"
-              unavailable_reason: Exact published pricing has not been imported for this provider offering.
-        - model: gemini-3.1-flash-lite
-          upstream_model: gemini-3.1-flash-lite
           transport: text_pollable
           operations:
             - text

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -15,10 +15,10 @@ The current provider catalog has these records:
 - 11 provider definitions.
 - 11 model publishers.
 - 24 model families.
-- 64 exact models.
-- 65 provider offerings.
-- 65 price records.
-- Seven managed model migrations.
+- 62 exact models.
+- 63 provider offerings.
+- 63 price records.
+- Nine managed model migrations.
 - Six protocol adapters.
 - Two lifecycle values.
 

--- a/internal/proxy/management_failures_migration_internal_test.go
+++ b/internal/proxy/management_failures_migration_internal_test.go
@@ -528,16 +528,18 @@ func TestManagedTenantInitializationPropagatesModelIdentityFailure(t *testing.T)
 func TestManagedModelMigrationPolicyIsRequiredByEachDatabaseMigration(t *testing.T) {
 	fixture := newManagedModelIdentityMigrationFixture(t)
 
-	missingSelectionPolicy := internalManagementProviderRegistry()
-	delete(missingSelectionPolicy.modelMigrations, managedGemini3OnlySchemaVersion)
-	selectionError := migrateManagedModelSelections(fixture.database, fixture.providerKeyCipher, missingSelectionPolicy, managedGemini3OnlySchemaVersion)
-	if !errors.Is(selectionError, errManagedTenantSchemaMigration) || !strings.Contains(selectionError.Error(), "operation=read_model_migrations") {
-		t.Fatalf("missing selection policy error=%v", selectionError)
+	for _, schemaVersion := range managedModelSelectionSchemaVersions {
+		missingSelectionPolicy := internalManagementProviderRegistry()
+		delete(missingSelectionPolicy.modelMigrations, schemaVersion)
+		selectionError := migrateManagedModelSelections(fixture.database, fixture.providerKeyCipher, missingSelectionPolicy, schemaVersion)
+		if !errors.Is(selectionError, errManagedTenantSchemaMigration) || !strings.Contains(selectionError.Error(), "operation=read_model_migrations") {
+			t.Fatalf("missing selection policy version=%d error=%v", schemaVersion, selectionError)
+		}
 	}
 
 	retirementSelectionPolicy := internalManagementProviderRegistry()
 	retirementSelectionPolicy.modelMigrations[managedGemini3OnlySchemaVersion] = retirementSelectionPolicy.modelMigrations[managedQwenCloudRetirementVersion]
-	selectionError = migrateManagedModelSelections(fixture.database, fixture.providerKeyCipher, retirementSelectionPolicy, managedGemini3OnlySchemaVersion)
+	selectionError := migrateManagedModelSelections(fixture.database, fixture.providerKeyCipher, retirementSelectionPolicy, managedGemini3OnlySchemaVersion)
 	if !errors.Is(selectionError, errManagedTenantSchemaMigration) || !strings.Contains(selectionError.Error(), "operation=read_model_migrations") {
 		t.Fatalf("retirement selection policy error=%v", selectionError)
 	}

--- a/internal/proxy/management_gemini_migration_internal_test.go
+++ b/internal/proxy/management_gemini_migration_internal_test.go
@@ -13,7 +13,7 @@ import (
 	"gorm.io/gorm"
 )
 
-type managedGemini3OnlyMigrationFixture struct {
+type managedGeminiModelSelectionMigrationFixture struct {
 	database          *gorm.DB
 	providerKeyCipher managedProviderKeyCipher
 	providers         *providerRegistry
@@ -21,11 +21,12 @@ type managedGemini3OnlyMigrationFixture struct {
 	tenants           []managedTenantRecord
 	usage             []managedUsageEventRecord
 	targetModel       string
+	schemaVersion     int
 }
 
-func newManagedGemini3OnlyMigrationFixture(t *testing.T) managedGemini3OnlyMigrationFixture {
+func newManagedGeminiModelSelectionMigrationFixture(t *testing.T, schemaVersion int, databaseName string) managedGeminiModelSelectionMigrationFixture {
 	t.Helper()
-	database, openError := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "gemini-3-only.db")), &gorm.Config{})
+	database, openError := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), databaseName)), &gorm.Config{})
 	if openError != nil {
 		t.Fatalf("open Gemini 3-only fixture: %v", openError)
 	}
@@ -42,7 +43,7 @@ func newManagedGemini3OnlyMigrationFixture(t *testing.T) managedGemini3OnlyMigra
 	}
 	providerKeyCipher := internalManagedProviderKeyCipher()
 	providers := internalManagementProviderRegistry()
-	migrations := providers.modelMigrationsFor(managedGemini3OnlySchemaVersion, ProviderNameGemini, ModelOperationText)
+	migrations := providers.modelMigrationsFor(schemaVersion, ProviderNameGemini, ModelOperationText)
 	retiredModels := make([]string, 0, len(migrations))
 	targetModel := ""
 	for _, migration := range migrations {
@@ -56,9 +57,9 @@ func newManagedGemini3OnlyMigrationFixture(t *testing.T) managedGemini3OnlyMigra
 	if len(retiredModels) == 0 || targetModel == "" {
 		t.Fatal("Gemini model migrations are missing")
 	}
-	fixture := managedGemini3OnlyMigrationFixture{
+	fixture := managedGeminiModelSelectionMigrationFixture{
 		database: database, providerKeyCipher: providerKeyCipher,
-		providers: providers, targetModel: targetModel,
+		providers: providers, targetModel: targetModel, schemaVersion: schemaVersion,
 		profiles: make([]managedProviderProfileRecord, 0, len(retiredModels)),
 		tenants:  make([]managedTenantRecord, 0, len(retiredModels)),
 		usage:    make([]managedUsageEventRecord, 0, len(retiredModels)),
@@ -108,13 +109,13 @@ func newManagedGemini3OnlyMigrationFixture(t *testing.T) managedGemini3OnlyMigra
 		fixture.profiles = append(fixture.profiles, profile)
 		fixture.usage = append(fixture.usage, usage)
 	}
-	if createError := database.Create(&managedSchemaMigrationRecord{Version: managedProviderConnectionsSchemaVersion, AppliedAt: now}).Error; createError != nil {
+	if createError := database.Create(&managedSchemaMigrationRecord{Version: schemaVersion - 1, AppliedAt: now}).Error; createError != nil {
 		t.Fatalf("seed Gemini schema version: %v", createError)
 	}
 	return fixture
 }
 
-func (fixture managedGemini3OnlyMigrationFixture) assertUnchanged(t *testing.T) {
+func (fixture managedGeminiModelSelectionMigrationFixture) assertUnchanged(t *testing.T) {
 	t.Helper()
 	for index, expectedProfile := range fixture.profiles {
 		var profile managedProviderProfileRecord
@@ -130,50 +131,77 @@ func (fixture managedGemini3OnlyMigrationFixture) assertUnchanged(t *testing.T) 
 		}
 	}
 	var currentVersionCount int64
-	if countError := fixture.database.Model(&managedSchemaMigrationRecord{}).Where(&managedSchemaMigrationRecord{Version: managedGemini3OnlySchemaVersion}).Count(&currentVersionCount).Error; countError != nil || currentVersionCount != 0 {
+	if countError := fixture.database.Model(&managedSchemaMigrationRecord{}).Where(&managedSchemaMigrationRecord{Version: fixture.schemaVersion}).Count(&currentVersionCount).Error; countError != nil || currentVersionCount != 0 {
 		t.Fatalf("Gemini schema version count=%d error=%v", currentVersionCount, countError)
 	}
 }
 
-func TestManagedGemini3OnlyMigrationMovesRoutingStateAndPreservesUsage(t *testing.T) {
-	fixture := newManagedGemini3OnlyMigrationFixture(t)
-	if migrationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers); migrationError != nil {
-		t.Fatalf("migrate Gemini 3-only schema: %v", migrationError)
-	}
-	for index, previousProfile := range fixture.profiles {
-		var profile managedProviderProfileRecord
-		if queryError := fixture.database.Where(&managedProviderProfileRecord{TenantID: previousProfile.TenantID, ProviderID: ProviderNameGemini}).First(&profile).Error; queryError != nil {
-			t.Fatalf("load migrated Gemini profile: %v", queryError)
-		}
-		var tenant managedTenantRecord
-		if queryError := fixture.database.Where(&managedTenantRecord{TenantID: previousProfile.TenantID}).First(&tenant).Error; queryError != nil {
-			t.Fatalf("load migrated Gemini tenant: %v", queryError)
-		}
-		if profile.TextModel != fixture.targetModel || !profile.UpdatedAt.Equal(previousProfile.UpdatedAt) || tenant.DefaultModel != fixture.targetModel || !tenant.UpdatedAt.Equal(fixture.tenants[index].UpdatedAt) {
-			t.Fatalf("migrated Gemini profile=%+v tenant=%+v", profile, tenant)
-		}
-	}
-	var historicalUsage []managedUsageEventRecord
-	if queryError := fixture.database.Where(&managedUsageEventRecord{ProviderID: ProviderNameGemini}).Order("id").Find(&historicalUsage).Error; queryError != nil || len(historicalUsage) != len(fixture.usage) {
-		t.Fatalf("historical Gemini usage=%+v error=%v", historicalUsage, queryError)
-	}
-	for index := range historicalUsage {
-		if historicalUsage[index].ModelID != fixture.usage[index].ModelID {
-			t.Fatalf("historical Gemini usage changed=%+v", historicalUsage)
-		}
-	}
-	var latest managedSchemaMigrationRecord
-	if queryError := fixture.database.Order("version DESC").First(&latest).Error; queryError != nil || latest.Version != managedGemini3OnlySchemaVersion {
-		t.Fatalf("latest Gemini schema version=%+v error=%v", latest, queryError)
-	}
-	if validationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers); validationError != nil {
-		t.Fatalf("reopen Gemini 3-only schema: %v", validationError)
+func (fixture managedGeminiModelSelectionMigrationFixture) setStartingSchemaVersion(t *testing.T, schemaVersion int) {
+	t.Helper()
+	updateResult := fixture.database.Model(&managedSchemaMigrationRecord{}).
+		Where(&managedSchemaMigrationRecord{Version: fixture.schemaVersion - 1}).
+		UpdateColumn(managedSchemaVersionColumn, schemaVersion)
+	if updateResult.Error != nil || updateResult.RowsAffected != 1 {
+		t.Fatalf("set Gemini starting schema version=%d rows=%d error=%v", schemaVersion, updateResult.RowsAffected, updateResult.Error)
 	}
 }
 
-func TestManagedGemini3OnlyMigrationStartsFromSchemaEight(t *testing.T) {
+func TestManagedGeminiModelSelectionMigrationsMoveRoutingStateAndPreserveUsage(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		migrationSchemaVersion int
+		startingSchemaVersion  int
+	}{
+		{name: "Gemini 2.5 retirement", migrationSchemaVersion: managedGemini3OnlySchemaVersion, startingSchemaVersion: managedProviderConnectionsSchemaVersion},
+		{name: "Gemini 3.1 route retirement", migrationSchemaVersion: managedGeminiRouteRetirementVersion, startingSchemaVersion: managedGemini3OnlySchemaVersion},
+		{name: "Gemini 3.1 route retirement from schema 9", migrationSchemaVersion: managedGeminiRouteRetirementVersion, startingSchemaVersion: managedProviderConnectionsSchemaVersion},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newManagedGeminiModelSelectionMigrationFixture(t, testCase.migrationSchemaVersion, "gemini-model-selection.db")
+			fixture.setStartingSchemaVersion(t, testCase.startingSchemaVersion)
+			if migrationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers); migrationError != nil {
+				t.Fatalf("migrate Gemini model selection schema: %v", migrationError)
+			}
+			for index, previousProfile := range fixture.profiles {
+				var profile managedProviderProfileRecord
+				if queryError := fixture.database.Where(&managedProviderProfileRecord{TenantID: previousProfile.TenantID, ProviderID: ProviderNameGemini}).First(&profile).Error; queryError != nil {
+					t.Fatalf("load migrated Gemini profile: %v", queryError)
+				}
+				var tenant managedTenantRecord
+				if queryError := fixture.database.Where(&managedTenantRecord{TenantID: previousProfile.TenantID}).First(&tenant).Error; queryError != nil {
+					t.Fatalf("load migrated Gemini tenant: %v", queryError)
+				}
+				if profile.TextModel != fixture.targetModel || !profile.UpdatedAt.Equal(previousProfile.UpdatedAt) || tenant.DefaultModel != fixture.targetModel || !tenant.UpdatedAt.Equal(fixture.tenants[index].UpdatedAt) {
+					t.Fatalf("migrated Gemini profile=%+v tenant=%+v", profile, tenant)
+				}
+			}
+			var historicalUsage []managedUsageEventRecord
+			if queryError := fixture.database.Where(&managedUsageEventRecord{ProviderID: ProviderNameGemini}).Order("id").Find(&historicalUsage).Error; queryError != nil || len(historicalUsage) != len(fixture.usage) {
+				t.Fatalf("historical Gemini usage=%+v error=%v", historicalUsage, queryError)
+			}
+			for index := range historicalUsage {
+				if historicalUsage[index].ModelID != fixture.usage[index].ModelID {
+					t.Fatalf("historical Gemini usage changed=%+v", historicalUsage)
+				}
+			}
+			var latest managedSchemaMigrationRecord
+			if queryError := fixture.database.Order("version DESC").First(&latest).Error; queryError != nil || latest.Version != managedTenantSchemaVersion {
+				t.Fatalf("latest Gemini schema version=%+v error=%v", latest, queryError)
+			}
+			if validationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers); validationError != nil {
+				t.Fatalf("reopen Gemini model selection schema: %v", validationError)
+			}
+		})
+	}
+}
+
+func TestManagedGeminiModelSelectionMigrationsStartFromSchemaEight(t *testing.T) {
 	providers := internalManagementProviderRegistry()
-	migrations := providers.modelMigrationsFor(managedGemini3OnlySchemaVersion, ProviderNameGemini, ModelOperationText)
+	var migrations []managedModelMigration
+	for _, schemaVersion := range managedModelSelectionSchemaVersions {
+		migrations = append(migrations, providers.modelMigrationsFor(schemaVersion, ProviderNameGemini, ModelOperationText)...)
+	}
 	for _, migration := range migrations {
 		t.Run(migration.source, func(t *testing.T) {
 			fixture := newManagedProviderConnectionsMigrationFixture(t, ProviderNameGemini, migration.source, "")
@@ -233,7 +261,7 @@ func TestManagedGemini3OnlyMigrationStartsFromSchemaEight(t *testing.T) {
 				t.Fatalf("migrated Gemini usage=%+v error=%v", migratedUsage, queryError)
 			}
 			var latest managedSchemaMigrationRecord
-			if queryError := fixture.database.Order("version DESC").First(&latest).Error; queryError != nil || latest.Version != managedGemini3OnlySchemaVersion {
+			if queryError := fixture.database.Order("version DESC").First(&latest).Error; queryError != nil || latest.Version != managedTenantSchemaVersion {
 				t.Fatalf("latest Gemini schema version=%+v error=%v", latest, queryError)
 			}
 		})
@@ -298,7 +326,7 @@ func TestManagedGeminiPredecessorProjectionRollsBackStageFailures(t *testing.T) 
 }
 
 func TestManagedModelSelectionMigrationUsesCatalogTarget(t *testing.T) {
-	fixture := newManagedGemini3OnlyMigrationFixture(t)
+	fixture := newManagedGeminiModelSelectionMigrationFixture(t, managedGemini3OnlySchemaVersion, "gemini-3-only-catalog.db")
 	schema := internalCanonicalProviderCatalog().Schema()
 	alternateTarget := ""
 	for _, provider := range schema.Providers {
@@ -344,14 +372,40 @@ func TestManagedModelSelectionMigrationUsesCatalogTarget(t *testing.T) {
 	}
 }
 
-func TestManagedGemini3OnlyMigrationRejectsIncompletePredecessorSchema(t *testing.T) {
-	fixture := newManagedGemini3OnlyMigrationFixture(t)
-	if dropError := fixture.database.Migrator().DropTable(&managedProviderProfileRecord{}); dropError != nil {
-		t.Fatalf("drop predecessor profile table: %v", dropError)
+func TestManagedGeminiModelSelectionMigrationsRejectIncompletePredecessorSchemas(t *testing.T) {
+	testCases := []struct {
+		name          string
+		schemaVersion int
+	}{
+		{name: "Gemini 2.5 retirement", schemaVersion: managedGemini3OnlySchemaVersion},
+		{name: "Gemini 3.1 route retirement", schemaVersion: managedGeminiRouteRetirementVersion},
 	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newManagedGeminiModelSelectionMigrationFixture(t, testCase.schemaVersion, "gemini-model-selection-incomplete.db")
+			if dropError := fixture.database.Migrator().DropTable(&managedProviderProfileRecord{}); dropError != nil {
+				t.Fatalf("drop predecessor profile table: %v", dropError)
+			}
+			migrationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers)
+			if !errors.Is(migrationError, errManagedTenantSchemaMigration) || !strings.Contains(migrationError.Error(), "operation=validate_current_schema table="+managedProviderConnectionTable) {
+				t.Fatalf("Gemini predecessor schema error=%v", migrationError)
+			}
+		})
+	}
+}
+
+func TestManagedGeminiRouteRetirementRejectsMissingMigrationPolicy(t *testing.T) {
+	fixture := newManagedGeminiModelSelectionMigrationFixture(t, managedGeminiRouteRetirementVersion, "gemini-route-retirement-missing-policy.db")
+	fixture.setStartingSchemaVersion(t, managedProviderConnectionsSchemaVersion)
+	delete(fixture.providers.modelMigrations, managedGeminiRouteRetirementVersion)
 	migrationError := initializeManagedTenantSchema(fixture.database, fixture.providerKeyCipher, fixture.providers)
-	if !errors.Is(migrationError, errManagedTenantSchemaMigration) || !strings.Contains(migrationError.Error(), "operation=validate_current_schema table="+managedProviderConnectionTable) {
-		t.Fatalf("Gemini predecessor schema error=%v", migrationError)
+	if !errors.Is(migrationError, errManagedTenantSchemaMigration) || !strings.Contains(migrationError.Error(), "operation=read_model_migrations") {
+		t.Fatalf("Gemini route-retirement migration error=%v", migrationError)
+	}
+	fixture.assertUnchanged(t)
+	var predecessorVersionCount int64
+	if countError := fixture.database.Model(&managedSchemaMigrationRecord{}).Where(&managedSchemaMigrationRecord{Version: managedGemini3OnlySchemaVersion}).Count(&predecessorVersionCount).Error; countError != nil || predecessorVersionCount != 0 {
+		t.Fatalf("Gemini predecessor schema version count=%d error=%v", predecessorVersionCount, countError)
 	}
 }
 
@@ -359,23 +413,23 @@ func TestManagedGemini3OnlyMigrationRollsBackStageFailures(t *testing.T) {
 	testCases := []struct {
 		name      string
 		want      string
-		configure func(*testing.T, managedGemini3OnlyMigrationFixture)
+		configure func(*testing.T, managedGeminiModelSelectionMigrationFixture)
 	}{
 		{
 			name: "profile backfill", want: "operation=backfill table=" + managedProviderProfileTable,
-			configure: func(t *testing.T, fixture managedGemini3OnlyMigrationFixture) {
+			configure: func(t *testing.T, fixture managedGeminiModelSelectionMigrationFixture) {
 				registerManagedGORMError(t, fixture.database, "gemini_profile_backfill", "update", managedProviderProfileTable, errInternalTestDatabase)
 			},
 		},
 		{
 			name: "tenant backfill", want: "operation=backfill table=" + managedTenantTable,
-			configure: func(t *testing.T, fixture managedGemini3OnlyMigrationFixture) {
+			configure: func(t *testing.T, fixture managedGeminiModelSelectionMigrationFixture) {
 				registerManagedGORMError(t, fixture.database, "gemini_tenant_backfill", "update", managedTenantTable, errInternalTestDatabase)
 			},
 		},
 		{
 			name: "validation", want: "operation=validate table=" + managedProviderConnectionTable,
-			configure: func(t *testing.T, fixture managedGemini3OnlyMigrationFixture) {
+			configure: func(t *testing.T, fixture managedGeminiModelSelectionMigrationFixture) {
 				if updateError := fixture.database.Model(&managedProviderConnectionRecord{}).Where(&managedProviderConnectionRecord{TenantID: fixture.tenants[0].TenantID, ProviderID: ProviderNameGemini, FieldID: CatalogCredentialAPIKey}).UpdateColumn("value", "invalid").Error; updateError != nil {
 					t.Fatalf("corrupt Gemini connection: %v", updateError)
 				}
@@ -383,14 +437,14 @@ func TestManagedGemini3OnlyMigrationRollsBackStageFailures(t *testing.T) {
 		},
 		{
 			name: "record version", want: "operation=record_version table=" + managedSchemaMigrationTable,
-			configure: func(t *testing.T, fixture managedGemini3OnlyMigrationFixture) {
+			configure: func(t *testing.T, fixture managedGeminiModelSelectionMigrationFixture) {
 				registerManagedGORMError(t, fixture.database, "gemini_record_version", "create", managedSchemaMigrationTable, errInternalTestDatabase)
 			},
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			fixture := newManagedGemini3OnlyMigrationFixture(t)
+			fixture := newManagedGeminiModelSelectionMigrationFixture(t, managedGemini3OnlySchemaVersion, "gemini-3-only-rollback.db")
 			testCase.configure(t, fixture)
 			migrationError := migrateManagedModelSelections(fixture.database, fixture.providerKeyCipher, fixture.providers, managedGemini3OnlySchemaVersion)
 			if !errors.Is(migrationError, errManagedTenantSchemaMigration) || !strings.Contains(migrationError.Error(), testCase.want) {

--- a/internal/proxy/management_store.go
+++ b/internal/proxy/management_store.go
@@ -52,7 +52,8 @@ const (
 	managedZAIProviderSchemaVersion         = 8
 	managedProviderConnectionsSchemaVersion = 9
 	managedGemini3OnlySchemaVersion         = 10
-	managedTenantSchemaVersion              = managedGemini3OnlySchemaVersion
+	managedGeminiRouteRetirementVersion     = 11
+	managedTenantSchemaVersion              = managedGeminiRouteRetirementVersion
 	managedSQLiteRuntimeQuery               = "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
 	retiredQwenCloudProviderIdentifier      = "qwencloud"
 	retiredGrokProviderIdentifier           = "grok"
@@ -107,6 +108,11 @@ var (
 	errManagedFinalTenantDeletion    = errors.New("managed_final_tenant_deletion")
 	errManagedTenantSchemaMigration  = errors.New("managed_tenant_schema_migration_failed")
 )
+
+var managedModelSelectionSchemaVersions = [...]int{
+	managedGemini3OnlySchemaVersion,
+	managedGeminiRouteRetirementVersion,
+}
 
 type managedTenantStore struct {
 	mutex             *managedTenantStoreMutex
@@ -601,7 +607,7 @@ func initializeManagedTenantSchema(database *gorm.DB, providerKeyCipher managedP
 		return fmt.Errorf("%w: operation=read_version table=%s: %v", errManagedTenantSchemaMigration, managedSchemaMigrationTable, queryError)
 	}
 	if migration.Version >= managedTenantOwnershipSchemaVersion && migration.Version < managedProviderConnectionsSchemaVersion {
-		if migrationError := migrateManagedPredecessorModelSelections(database, providers, managedGemini3OnlySchemaVersion); migrationError != nil {
+		if migrationError := migrateManagedPendingPredecessorModelSelections(database, providers); migrationError != nil {
 			return migrationError
 		}
 	}
@@ -681,8 +687,13 @@ func initializeManagedTenantSchema(database *gorm.DB, providerKeyCipher managedP
 		if migrator.HasTable(managedProviderKeyTable) || !migrator.HasTable(managedProviderConnectionTable) || !migrator.HasTable(managedProviderProfileTable) {
 			return fmt.Errorf("%w: operation=validate_current_schema table=%s", errManagedTenantSchemaMigration, managedProviderConnectionTable)
 		}
-		return migrateManagedModelSelections(database, providerKeyCipher, providers, managedGemini3OnlySchemaVersion)
+		return migrateManagedModelSelectionsAfter(database, providerKeyCipher, providers, managedProviderConnectionsSchemaVersion)
 	case managedGemini3OnlySchemaVersion:
+		if migrator.HasTable(managedProviderKeyTable) || !migrator.HasTable(managedProviderConnectionTable) || !migrator.HasTable(managedProviderProfileTable) {
+			return fmt.Errorf("%w: operation=validate_current_schema table=%s", errManagedTenantSchemaMigration, managedProviderConnectionTable)
+		}
+		return migrateManagedModelSelectionsAfter(database, providerKeyCipher, providers, managedGemini3OnlySchemaVersion)
+	case managedGeminiRouteRetirementVersion:
 		if migrator.HasTable(managedProviderKeyTable) || !migrator.HasTable(managedProviderConnectionTable) || !migrator.HasTable(managedProviderProfileTable) {
 			return fmt.Errorf("%w: operation=validate_current_schema table=%s", errManagedTenantSchemaMigration, managedProviderConnectionTable)
 		}
@@ -724,31 +735,50 @@ func migrateManagedProviderConnections(database *gorm.DB, providerKeyCipher mana
 	}); migrationError != nil {
 		return migrationError
 	}
-	return migrateManagedModelSelections(database, providerKeyCipher, providers, managedGemini3OnlySchemaVersion)
+	return migrateManagedModelSelectionsAfter(database, providerKeyCipher, providers, managedProviderConnectionsSchemaVersion)
 }
 
-func migrateManagedModelSelections(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry, schemaVersion int) error {
-	migrations, migrationsError := managedTextModelMigrations(providers, schemaVersion)
-	if migrationsError != nil {
-		return migrationsError
+func migrateManagedModelSelectionsAfter(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry, completedVersion int) error {
+	pendingVersions := make([]int, 0, len(managedModelSelectionSchemaVersions))
+	for _, schemaVersion := range managedModelSelectionSchemaVersions {
+		if schemaVersion <= completedVersion {
+			continue
+		}
+		pendingVersions = append(pendingVersions, schemaVersion)
+	}
+	return migrateManagedModelSelections(database, providerKeyCipher, providers, pendingVersions...)
+}
+
+func migrateManagedModelSelections(database *gorm.DB, providerKeyCipher managedProviderKeyCipher, providers *providerRegistry, schemaVersions ...int) error {
+	migrationsByVersion := make([][]managedModelMigration, len(schemaVersions))
+	for index, schemaVersion := range schemaVersions {
+		migrations, migrationsError := managedTextModelMigrations(providers, schemaVersion)
+		if migrationsError != nil {
+			return migrationsError
+		}
+		migrationsByVersion[index] = migrations
 	}
 	return database.Transaction(func(transaction *gorm.DB) error {
-		for _, migration := range migrations {
-			profileResult := transaction.Model(&managedProviderProfileRecord{}).
-				Where(&managedProviderProfileRecord{ProviderID: migration.provider, TextModel: migration.source}).
-				UpdateColumn("text_model", migration.target)
-			if profileResult.Error != nil {
-				return fmt.Errorf("%w: operation=backfill table=%s provider=%s: %v", errManagedTenantSchemaMigration, managedProviderProfileTable, migration.provider, profileResult.Error)
-			}
-			if migrationError := migrateManagedTenantModelSelection(transaction, migration); migrationError != nil {
-				return migrationError
+		for _, migrations := range migrationsByVersion {
+			for _, migration := range migrations {
+				profileResult := transaction.Model(&managedProviderProfileRecord{}).
+					Where(&managedProviderProfileRecord{ProviderID: migration.provider, TextModel: migration.source}).
+					UpdateColumn("text_model", migration.target)
+				if profileResult.Error != nil {
+					return fmt.Errorf("%w: operation=backfill table=%s provider=%s: %v", errManagedTenantSchemaMigration, managedProviderProfileTable, migration.provider, profileResult.Error)
+				}
+				if migrationError := migrateManagedTenantModelSelection(transaction, migration); migrationError != nil {
+					return migrationError
+				}
 			}
 		}
 		if validationError := validateManagedConnectionRoutingDefaults(transaction, providerKeyCipher, providers); validationError != nil {
 			return validationError
 		}
-		if createError := transaction.Create(&managedSchemaMigrationRecord{Version: schemaVersion, AppliedAt: time.Now().UTC()}).Error; createError != nil {
-			return fmt.Errorf("%w: operation=record_version table=%s: %v", errManagedTenantSchemaMigration, managedSchemaMigrationTable, createError)
+		for _, schemaVersion := range schemaVersions {
+			if createError := transaction.Create(&managedSchemaMigrationRecord{Version: schemaVersion, AppliedAt: time.Now().UTC()}).Error; createError != nil {
+				return fmt.Errorf("%w: operation=record_version table=%s version=%d: %v", errManagedTenantSchemaMigration, managedSchemaMigrationTable, schemaVersion, createError)
+			}
 		}
 		return nil
 	})
@@ -768,6 +798,17 @@ func migrateManagedPredecessorModelSelections(database *gorm.DB, providers *prov
 				return fmt.Errorf("%w: operation=backfill table=%s provider=%s: %v", errManagedTenantSchemaMigration, managedProviderKeyTable, migration.provider, providerResult.Error)
 			}
 			if migrationError := migrateManagedTenantModelSelection(transaction, migration); migrationError != nil {
+				return migrationError
+			}
+		}
+		return nil
+	})
+}
+
+func migrateManagedPendingPredecessorModelSelections(database *gorm.DB, providers *providerRegistry) error {
+	return database.Transaction(func(transaction *gorm.DB) error {
+		for _, schemaVersion := range managedModelSelectionSchemaVersions {
+			if migrationError := migrateManagedPredecessorModelSelections(transaction, providers, schemaVersion); migrationError != nil {
 				return migrationError
 			}
 		}
@@ -1344,7 +1385,13 @@ func canonicalManagedTextModel(providers *providerRegistry, provider string, mod
 }
 
 func canonicalManagedPendingTextModel(providers *providerRegistry, provider string, model string) (string, bool) {
-	return providers.modelMigrationTarget(managedGemini3OnlySchemaVersion, provider, ModelOperationText, model)
+	changed := false
+	for _, schemaVersion := range managedModelSelectionSchemaVersions {
+		var modelChanged bool
+		model, modelChanged = providers.modelMigrationTarget(schemaVersion, provider, ModelOperationText, model)
+		changed = changed || modelChanged
+	}
+	return model, changed
 }
 
 func canonicalManagedTenantDefaults(providers *providerRegistry, defaults TenantDefaults) (TenantDefaults, bool) {

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -1581,7 +1581,7 @@ func TestManagementProfileListsCurrentCatalogModels(t *testing.T) {
 			proxy.ModelNameMiniMaxM27HighSpeed,
 		},
 		proxy.ProviderNameZAI:       {"glm-5.2"},
-		proxy.ProviderNameGemini:    {"gemini-3.1-pro-preview", "gemini-3-flash-preview"},
+		proxy.ProviderNameGemini:    {"gemini-3-flash-preview", proxy.ModelNameGemini35Flash},
 		proxy.ProviderNameAnthropic: {"claude-fable-5", "claude-sonnet-5"},
 		proxy.ProviderNameXAI:       {"grok-4.5", "grok-4.20-0309-reasoning", "grok-4.20-0309-non-reasoning"},
 	}
@@ -1615,6 +1615,9 @@ func TestManagementProfileListsCurrentCatalogModels(t *testing.T) {
 	}
 	if textDefaultsByProvider[proxy.ProviderNameDashScope] != proxy.ModelNameDashScopeQwenPlus {
 		t.Fatalf("profile provider=%s default=%s want=%s", proxy.ProviderNameDashScope, textDefaultsByProvider[proxy.ProviderNameDashScope], proxy.ModelNameDashScopeQwenPlus)
+	}
+	if configuredGeminiModels := modelsByProvider[proxy.ProviderNameGemini]; !reflect.DeepEqual(configuredGeminiModels, expectedModels[proxy.ProviderNameGemini]) {
+		t.Fatalf("profile provider=%s models=%v want=%v", proxy.ProviderNameGemini, configuredGeminiModels, expectedModels[proxy.ProviderNameGemini])
 	}
 	if configuredMiniMaxModels := modelsByProvider[proxy.ProviderNameMiniMax]; !reflect.DeepEqual(configuredMiniMaxModels, expectedModels[proxy.ProviderNameMiniMax]) {
 		t.Fatalf("profile provider=%s models=%v want=%v", proxy.ProviderNameMiniMax, configuredMiniMaxModels, expectedModels[proxy.ProviderNameMiniMax])

--- a/internal/proxy/provider_routing_test.go
+++ b/internal/proxy/provider_routing_test.go
@@ -1393,7 +1393,7 @@ func TestProviderRoutingSurfacesChatCompletionTokenUsage(t *testing.T) {
 }
 
 func TestProviderRoutingSupportsGeminiInteractionsWithBackgroundPolling(t *testing.T) {
-	const currentGeminiModel = "gemini-3.1-pro-preview"
+	const currentGeminiModel = "gemini-3-flash-preview"
 	const interactionIdentifier = "gemini-background-poll"
 
 	var capturedPayload map[string]any
@@ -1900,9 +1900,7 @@ func TestProviderRoutingRejectsAssistantHistoryForAllGeminiRoutes(t *testing.T) 
 	}
 	models := []string{
 		proxy.ModelNameGemini35Flash,
-		"gemini-3.1-pro-preview",
 		"gemini-3-flash-preview",
-		proxy.ModelNameGemini31FlashLite,
 	}
 	for _, model := range models {
 		body := `{"messages":[{"role":"user","content":"Review."},{"role":"assistant","content":"Draft."},{"role":"user","content":"Continue."}],"model":"` + model + `"}`
@@ -2310,6 +2308,8 @@ func TestProviderRoutingRejectsGeminiUnsupportedAndInvalidRequests(t *testing.T)
 		{name: "retired Gemini 2.5 Flash", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=gemini&model=gemini-2.5-flash", expectedCode: http.StatusBadRequest},
 		{name: "retired Gemini 2.5 Flash-Lite", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=gemini&model=gemini-2.5-flash-lite", expectedCode: http.StatusBadRequest},
 		{name: "retired Gemini 2.5 Pro", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=gemini&model=gemini-2.5-pro", expectedCode: http.StatusBadRequest},
+		{name: "retired Gemini 3.1 Flash-Lite", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=gemini&model=gemini-3.1-flash-lite", expectedCode: http.StatusBadRequest},
+		{name: "retired Gemini 3.1 Pro Preview", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=gemini&model=gemini-3.1-pro-preview", expectedCode: http.StatusBadRequest},
 		{name: "unsupported web search", method: http.MethodGet, target: "/?key=" + TestSecret + "&prompt=hello&provider=gemini&web_search=true", expectedCode: http.StatusBadRequest},
 		{name: "unsupported dictation", method: http.MethodPost, target: "/dictate?key=" + TestSecret + "&provider=gemini", expectedCode: http.StatusBadRequest},
 	}

--- a/internal/proxy/provider_types.go
+++ b/internal/proxy/provider_types.go
@@ -82,8 +82,6 @@ const (
 	ModelNameZAIGLM = "glm-5.1"
 	// ModelNameGemini35Flash identifies Gemini 3.5 Flash.
 	ModelNameGemini35Flash = "gemini-3.5-flash"
-	// ModelNameGemini31FlashLite identifies Gemini 3.1 Flash-Lite.
-	ModelNameGemini31FlashLite = "gemini-3.1-flash-lite"
 	// ModelNameClaudeOpus48 identifies Claude Opus 4.8.
 	ModelNameClaudeOpus48 = "claude-opus-4-8"
 	// ModelNameClaudeSonnet46 identifies Claude Sonnet 4.6.

--- a/scripts/generate_seo_resources.mjs
+++ b/scripts/generate_seo_resources.mjs
@@ -1409,7 +1409,7 @@ text = client.post_messages(
     modifiedDate: PROVIDER_CATALOG_RESOURCE_MODIFIED_DATE,
     primaryKeyword: "Gemini Interactions proxy",
     title: "Gemini Interactions proxy for stored 3.x model calls",
-    description: "Route four registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.",
+    description: "Route two registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.",
     audience: "Developers adding Gemini as a provider without bringing Gemini-specific payloads into every app.",
     problem: "Stored Gemini Interactions require polling and cleanup, which shared proxy callers must not have to coordinate.",
     solution: "LLM Proxy polls and cleans up registered Gemini 3.x resources while callers keep one blocking request.",
@@ -1447,11 +1447,11 @@ text = client.post_messages(
     - 403
     - 404`,
     },
-    quickVerdict: "Use this route for four registered Gemini 3.x models when the proxy must own stored-resource polling, visibility retries, and cleanup.",
+    quickVerdict: "Use this route for two registered Gemini 3.x models when the proxy must own stored-resource polling, visibility retries, and cleanup.",
     faq: [
       {
         question: "Which Gemini models does this route register?",
-        answer: "The catalog registers Gemini 3.5 Flash, Gemini 3 Flash Preview, Gemini 3.1 Flash Lite, and Gemini 3.1 Pro Preview.",
+        answer: "The catalog registers Gemini 3.5 Flash and Gemini 3 Flash Preview.",
       },
       {
         question: "Can a Gemini request contain assistant history?",
@@ -1803,7 +1803,7 @@ text = client.post_messages(
     ],
     examples: [
       ["OpenAI smoke", "Run LLM_PROXY_LIVE_PROVIDERS=openai with a live env file."],
-      ["Gemini wrapper", "Use make test-live-gemini as the Gemini-specific compatibility target."],
+      ["Gemini wrapper", "Use make test-live-gemini to accept the exact Gemini 3.6 and 3.7 candidates before testing registered Gemini routes."],
       ["Post-deploy check", "After publishing, run selected live smokes for providers touched by config changes."],
     ],
     limitations: [

--- a/scripts/test_live_gemini.sh
+++ b/scripts/test_live_gemini.sh
@@ -7,6 +7,14 @@ fi
 
 export LLM_PROXY_LIVE_PROVIDERS="${LLM_PROXY_LIVE_PROVIDERS:-gemini}"
 export LLM_PROXY_LIVE_REASONING_MATRIX="${LLM_PROXY_LIVE_REASONING_MATRIX:-true}"
+LLM_PROXY_LIVE_GEMINI_CANDIDATES="${LLM_PROXY_LIVE_GEMINI_CANDIDATES:-true}"
+if [[ "${LLM_PROXY_LIVE_GEMINI_CANDIDATES}" != "true" && "${LLM_PROXY_LIVE_GEMINI_CANDIDATES}" != "false" ]]; then
+  echo "error: LLM_PROXY_LIVE_GEMINI_CANDIDATES must be true or false" >&2
+  exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "${LLM_PROXY_LIVE_GEMINI_CANDIDATES}" == "true" && $# -eq 0 ]]; then
+  "${SCRIPT_DIR}/test_live_providers.sh" --gemini-candidates
+fi
 exec "${SCRIPT_DIR}/test_live_providers.sh" "$@"

--- a/scripts/test_live_gemini_candidates.sh
+++ b/scripts/test_live_gemini_candidates.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  builtin printf '%s\n' 'Usage: scripts/test_live_gemini_candidates.sh
+
+Runs paid Google Interactions acceptance for the exact Gemini 3.6 Flash and
+Gemini 3.7 Flash candidate models. The test covers each supported thinking
+level, one omitted level, background completion, active retrieval,
+cancellation, and deletion.
+
+Required environment:
+  GEMINI_API_KEY
+
+Optional environment:
+  LLM_PROXY_LIVE_REASONING_MATRIX  Exact true or false. Default: true.
+  LLM_PROXY_LIVE_TIMEOUT           Per-request curl timeout. Default: 45.'
+}
+
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+fi
+
+command -v curl >/dev/null 2>&1 || { echo "error: curl is required for Gemini candidate acceptance" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "error: python3 is required for Gemini candidate acceptance" >&2; exit 1; }
+[[ -n "${GEMINI_API_KEY:-}" ]] || { echo "error: GEMINI_API_KEY is required for Gemini candidate acceptance" >&2; exit 1; }
+
+REASONING_MATRIX="${LLM_PROXY_LIVE_REASONING_MATRIX:-true}"
+if [[ "${REASONING_MATRIX}" != "true" && "${REASONING_MATRIX}" != "false" ]]; then
+  echo "error: LLM_PROXY_LIVE_REASONING_MATRIX must be true or false" >&2
+  exit 1
+fi
+REQUEST_TIMEOUT="${LLM_PROXY_LIVE_TIMEOUT:-45}"
+if [[ ! "${REQUEST_TIMEOUT}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: LLM_PROXY_LIVE_TIMEOUT must be a positive integer" >&2
+  exit 1
+fi
+
+readonly GEMINI_INTERACTIONS_URL="https://generativelanguage.googleapis.com/v1beta/interactions"
+readonly GEMINI_API_REVISION="2026-05-20"
+readonly VISIBILITY_RETRY_LIMIT=6
+readonly POLL_LIMIT=12
+readonly POLL_INTERVAL_SECONDS=5
+
+TMP_DIR="$(mktemp -d)"
+chmod 700 "${TMP_DIR}"
+INTERACTION_IDS=()
+CREATED_INTERACTION_ID=""
+
+gemini_request() {
+  local method="$1"
+  local request_url="$2"
+  local response_path="$3"
+  local request_path="${4:-}"
+  local curl_arguments=(
+    -sS
+    --max-time "${REQUEST_TIMEOUT}"
+    -X "${method}"
+    -H "x-goog-api-key: ${GEMINI_API_KEY}"
+    -H "Api-Revision: ${GEMINI_API_REVISION}"
+    -o "${response_path}"
+    -w "%{http_code}"
+  )
+  if [[ -n "${request_path}" ]]; then
+    curl_arguments+=(
+      -H "Content-Type: application/json"
+      --data-binary "@${request_path}"
+    )
+  fi
+  curl "${curl_arguments[@]}" "${request_url}"
+}
+
+delete_interaction() {
+  local interaction_id="$1"
+  local response_path="${TMP_DIR}/delete-response.json"
+  local http_status
+  http_status="$(gemini_request DELETE "${GEMINI_INTERACTIONS_URL}/${interaction_id}" "${response_path}")"
+  if [[ "${http_status}" != "200" && "${http_status}" != "204" ]]; then
+    echo "error: Gemini candidate deletion failed: status=${http_status}" >&2
+    return 1
+  fi
+  local remaining_ids=()
+  local candidate_id
+  for candidate_id in "${INTERACTION_IDS[@]}"; do
+    if [[ "${candidate_id}" != "${interaction_id}" ]]; then
+      remaining_ids+=("${candidate_id}")
+    fi
+  done
+  INTERACTION_IDS=("${remaining_ids[@]}")
+}
+
+cleanup() {
+  local exit_status=$?
+  local interaction_id
+  trap - EXIT HUP INT TERM
+  for interaction_id in "${INTERACTION_IDS[@]}"; do
+    gemini_request DELETE "${GEMINI_INTERACTIONS_URL}/${interaction_id}" "${TMP_DIR}/cleanup-response.json" >/dev/null 2>&1 || true
+  done
+  rm -rf "${TMP_DIR}"
+  return "${exit_status}"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+write_reasoning_request() {
+  local model="$1"
+  local reasoning_effort="$2"
+  local request_path="$3"
+  python3 -c '
+import json
+import pathlib
+import sys
+
+payload = {
+    "model": sys.argv[1],
+    "input": "Reply with exactly OK and no punctuation.",
+    "background": False,
+    "store": False,
+}
+if sys.argv[2]:
+    payload["generation_config"] = {"thinking_level": sys.argv[2]}
+pathlib.Path(sys.argv[3]).write_text(
+    json.dumps(payload, separators=(",", ":")),
+    encoding="utf-8",
+)
+' "${model}" "${reasoning_effort}" "${request_path}"
+  chmod 600 "${request_path}"
+}
+
+write_background_request() {
+  local model="$1"
+  local lifecycle="$2"
+  local request_path="$3"
+  python3 -c '
+import json
+import pathlib
+import sys
+
+if sys.argv[2] == "completion":
+    prompt = "Reply with exactly OK and no punctuation."
+    output_limit = 4096
+else:
+    prompt = "Write the integers from 1 through 10000 in ascending order."
+    output_limit = 65536
+payload = {
+    "model": sys.argv[1],
+    "input": prompt,
+    "background": True,
+    "store": True,
+    "generation_config": {
+        "max_output_tokens": output_limit,
+        "thinking_level": "high",
+    },
+}
+pathlib.Path(sys.argv[3]).write_text(
+    json.dumps(payload, separators=(",", ":")),
+    encoding="utf-8",
+)
+' "${model}" "${lifecycle}" "${request_path}"
+  chmod 600 "${request_path}"
+}
+
+interaction_summary() {
+  local response_path="$1"
+  python3 -c '
+import json
+import pathlib
+import sys
+
+interaction = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+identifier = interaction.get("id", "")
+status = interaction.get("status", "")
+texts = []
+for step in interaction.get("steps", []):
+    if isinstance(step, dict) and step.get("type") == "model_output":
+        for content in step.get("content", []):
+            if isinstance(content, dict) and isinstance(content.get("text"), str):
+                texts.append(content["text"])
+print(json.dumps({
+    "id": identifier,
+    "status": status,
+    "text": "".join(texts).strip(),
+}, separators=(",", ":")))
+' "${response_path}"
+}
+
+summary_field() {
+  local summary="$1"
+  local field="$2"
+  python3 -c '
+import json
+import sys
+
+value = json.loads(sys.argv[1]).get(sys.argv[2], "")
+if not isinstance(value, str):
+    raise SystemExit(1)
+print(value)
+' "${summary}" "${field}"
+}
+
+run_reasoning_request() {
+  local model="$1"
+  local reasoning_effort="$2"
+  local effort_label="${reasoning_effort:-omitted}"
+  local request_path="${TMP_DIR}/reasoning-${model}-${effort_label}.json"
+  local response_path="${TMP_DIR}/reasoning-${model}-${effort_label}-response.json"
+  local http_status
+  local summary
+  write_reasoning_request "${model}" "${reasoning_effort}" "${request_path}"
+  http_status="$(gemini_request POST "${GEMINI_INTERACTIONS_URL}" "${response_path}" "${request_path}")"
+  if [[ "${http_status}" != "200" ]]; then
+    echo "error: Gemini candidate reasoning failed: model=${model} reasoning_effort=${effort_label} status=${http_status}" >&2
+    exit 1
+  fi
+  summary="$(interaction_summary "${response_path}")"
+  if [[ "$(summary_field "${summary}" status)" != "completed" ||
+    "$(summary_field "${summary}" text)" != "OK" ]]; then
+    echo "error: Gemini candidate reasoning returned an invalid response: model=${model} reasoning_effort=${effort_label}" >&2
+    exit 1
+  fi
+  echo "live Gemini candidate reasoning passed: model=${model} reasoning_effort=${effort_label} status=200"
+}
+
+create_background_interaction() {
+  local model="$1"
+  local lifecycle="$2"
+  local request_path="${TMP_DIR}/${lifecycle}-${model}.json"
+  local response_path="${TMP_DIR}/${lifecycle}-${model}-create-response.json"
+  local http_status
+  local summary
+  local interaction_id
+  local interaction_status
+  write_background_request "${model}" "${lifecycle}" "${request_path}"
+  http_status="$(gemini_request POST "${GEMINI_INTERACTIONS_URL}" "${response_path}" "${request_path}")"
+  if [[ "${http_status}" != "200" ]]; then
+    echo "error: Gemini candidate background create failed: model=${model} lifecycle=${lifecycle} status=${http_status}" >&2
+    exit 1
+  fi
+  summary="$(interaction_summary "${response_path}")"
+  interaction_id="$(summary_field "${summary}" id)"
+  interaction_status="$(summary_field "${summary}" status)"
+  if [[ ! "${interaction_id}" =~ ^[A-Za-z0-9._~-]+$ ||
+    ( "${interaction_status}" != "queued" && "${interaction_status}" != "in_progress" ) ]]; then
+    echo "error: Gemini candidate background create returned an invalid resource: model=${model} lifecycle=${lifecycle}" >&2
+    exit 1
+  fi
+  INTERACTION_IDS+=("${interaction_id}")
+  CREATED_INTERACTION_ID="${interaction_id}"
+}
+
+retrieve_active_interaction() {
+  local model="$1"
+  local lifecycle="$2"
+  local interaction_id="$3"
+  local response_path="${TMP_DIR}/${lifecycle}-${model}-active-response.json"
+  local attempt
+  local http_status
+  local summary
+  local interaction_status
+  for ((attempt = 0; attempt <= VISIBILITY_RETRY_LIMIT; attempt += 1)); do
+    http_status="$(gemini_request GET "${GEMINI_INTERACTIONS_URL}/${interaction_id}" "${response_path}")"
+    if [[ "${http_status}" == "200" ]]; then
+      summary="$(interaction_summary "${response_path}")"
+      interaction_status="$(summary_field "${summary}" status)"
+      if [[ "$(summary_field "${summary}" id)" != "${interaction_id}" ||
+        ( "${interaction_status}" != "queued" && "${interaction_status}" != "in_progress" ) ]]; then
+        echo "error: Gemini candidate active retrieval returned an invalid resource: model=${model} lifecycle=${lifecycle} status=${interaction_status}" >&2
+        exit 1
+      fi
+      return
+    fi
+    if [[ ( "${http_status}" != "400" && "${http_status}" != "403" && "${http_status}" != "404" ) || "${attempt}" -eq "${VISIBILITY_RETRY_LIMIT}" ]]; then
+      echo "error: Gemini candidate active retrieval failed: model=${model} lifecycle=${lifecycle} status=${http_status}" >&2
+      exit 1
+    fi
+    sleep "${POLL_INTERVAL_SECONDS}"
+  done
+}
+
+complete_background_interaction() {
+  local model="$1"
+  local interaction_id="$2"
+  local response_path="${TMP_DIR}/completion-${model}-poll-response.json"
+  local attempt
+  local http_status
+  local summary
+  local interaction_status
+  for ((attempt = 0; attempt < POLL_LIMIT; attempt += 1)); do
+    sleep "${POLL_INTERVAL_SECONDS}"
+    http_status="$(gemini_request GET "${GEMINI_INTERACTIONS_URL}/${interaction_id}" "${response_path}")"
+    if [[ "${http_status}" != "200" ]]; then
+      echo "error: Gemini candidate completion retrieval failed: model=${model} status=${http_status}" >&2
+      exit 1
+    fi
+    summary="$(interaction_summary "${response_path}")"
+    interaction_status="$(summary_field "${summary}" status)"
+    if [[ "${interaction_status}" == "queued" || "${interaction_status}" == "in_progress" ]]; then
+      continue
+    fi
+    if [[ "${interaction_status}" != "completed" ||
+      "$(summary_field "${summary}" id)" != "${interaction_id}" ||
+      "$(summary_field "${summary}" text)" != "OK" ]]; then
+      echo "error: Gemini candidate completion returned an invalid resource: model=${model} status=${interaction_status}" >&2
+      exit 1
+    fi
+    delete_interaction "${interaction_id}"
+    echo "live Gemini candidate completion lifecycle passed: model=${model} status=completed"
+    return
+  done
+  echo "error: Gemini candidate completion did not reach a terminal state: model=${model}" >&2
+  exit 1
+}
+
+cancel_background_interaction() {
+  local model="$1"
+  local interaction_id="$2"
+  local response_path="${TMP_DIR}/cancellation-${model}-response.json"
+  local http_status
+  local summary
+  http_status="$(gemini_request POST "${GEMINI_INTERACTIONS_URL}/${interaction_id}/cancel" "${response_path}")"
+  if [[ "${http_status}" != "200" ]]; then
+    echo "error: Gemini candidate cancellation failed: model=${model} status=${http_status}" >&2
+    exit 1
+  fi
+  summary="$(interaction_summary "${response_path}")"
+  if [[ "$(summary_field "${summary}" id)" != "${interaction_id}" ||
+    "$(summary_field "${summary}" status)" != "cancelled" ]]; then
+    echo "error: Gemini candidate cancellation returned an invalid resource: model=${model}" >&2
+    exit 1
+  fi
+  delete_interaction "${interaction_id}"
+  echo "live Gemini candidate cancellation lifecycle passed: model=${model} status=cancelled"
+}
+
+run_candidate_model() {
+  local model="$1"
+  shift
+  local reasoning_effort
+  local completion_id
+  local cancellation_id
+  run_reasoning_request "${model}" ""
+  if [[ "${REASONING_MATRIX}" == "true" ]]; then
+    for reasoning_effort in "$@"; do
+      run_reasoning_request "${model}" "${reasoning_effort}"
+    done
+  fi
+  create_background_interaction "${model}" completion
+  completion_id="${CREATED_INTERACTION_ID}"
+  complete_background_interaction "${model}" "${completion_id}"
+  create_background_interaction "${model}" cancellation
+  cancellation_id="${CREATED_INTERACTION_ID}"
+  retrieve_active_interaction "${model}" cancellation "${cancellation_id}"
+  cancel_background_interaction "${model}" "${cancellation_id}"
+}
+
+run_candidate_model gemini-3.6-flash minimal low medium high
+run_candidate_model gemini-3.7-flash low medium high
+echo "live Gemini candidate acceptance passed: models=gemini-3.6-flash,gemini-3.7-flash"

--- a/scripts/test_live_providers.sh
+++ b/scripts/test_live_providers.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   builtin printf '%s\n' 'Usage:
-  scripts/test_live_providers.sh [--media | --preflight | --write-config <path>]
+  scripts/test_live_providers.sh [--gemini-candidates | --media | --preflight | --write-config <path>]
 
 Builds the current llm-proxy binary, verifies each available provider key
 through the authenticated management operation, and only then runs its live
@@ -25,13 +25,17 @@ Optional environment:
                              Exact true or false. When true, send one omitted
                              reasoning-effort request and one request for each
                              effort published by the selected exact route.
-                             Default: false.
+                             Default: false. Gemini candidate default: true.
   LLM_PROXY_LIVE_PORT        Local port for the temporary proxy. Default: a
                              freshly allocated loopback port.
   LLM_PROXY_LIVE_TIMEOUT     Per-request curl timeout in seconds. Default: 45.
   GO                         Go binary. Default: go.
 
 Options:
+  --gemini-candidates        Run paid direct acceptance for Gemini 3.6 Flash
+                             and Gemini 3.7 Flash. This mode does not register
+                             either candidate in the public provider catalog.
+
   --media                    Run paid image routes from the public catalog.
                              LLM_PROXY_LIVE_PROVIDERS can select a subset.
                              LLM_PROXY_LIVE_ALL_MODELS=true runs every selected
@@ -909,9 +913,14 @@ run_managed_config_preflight() {
 
 PREFLIGHT_ONLY=false
 MEDIA_ONLY=false
+GEMINI_CANDIDATES_ONLY=false
 WRITE_CONFIG_PATH=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --gemini-candidates)
+      GEMINI_CANDIDATES_ONLY=true
+      shift
+      ;;
     --media)
       MEDIA_ONLY=true
       shift
@@ -936,9 +945,10 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
-if [[ "${MEDIA_ONLY}" == "true" && ( "${PREFLIGHT_ONLY}" == "true" || -n "${WRITE_CONFIG_PATH}" ) ]] ||
-  [[ "${PREFLIGHT_ONLY}" == "true" && -n "${WRITE_CONFIG_PATH}" ]]; then
-  echo "error: --media, --preflight, and --write-config are mutually exclusive" >&2
+if [[ "${MEDIA_ONLY}" == "true" && ( "${PREFLIGHT_ONLY}" == "true" || "${GEMINI_CANDIDATES_ONLY}" == "true" || -n "${WRITE_CONFIG_PATH}" ) ]] ||
+  [[ "${PREFLIGHT_ONLY}" == "true" && ( "${GEMINI_CANDIDATES_ONLY}" == "true" || -n "${WRITE_CONFIG_PATH}" ) ]] ||
+  [[ "${GEMINI_CANDIDATES_ONLY}" == "true" && -n "${WRITE_CONFIG_PATH}" ]]; then
+  echo "error: --gemini-candidates, --media, --preflight, and --write-config are mutually exclusive" >&2
   exit 1
 fi
 
@@ -983,10 +993,21 @@ if [[ "${LIVE_ALL_MODELS}" != "true" && "${LIVE_ALL_MODELS}" != "false" ]]; then
   echo "error: LLM_PROXY_LIVE_ALL_MODELS must be true or false" >&2
   exit 1
 fi
-LIVE_REASONING_MATRIX="$(env_or_default LLM_PROXY_LIVE_REASONING_MATRIX false)"
+LIVE_REASONING_MATRIX_DEFAULT=false
+if [[ "${GEMINI_CANDIDATES_ONLY}" == "true" ]]; then
+  LIVE_REASONING_MATRIX_DEFAULT=true
+fi
+LIVE_REASONING_MATRIX="$(env_or_default LLM_PROXY_LIVE_REASONING_MATRIX "${LIVE_REASONING_MATRIX_DEFAULT}")"
 if [[ "${LIVE_REASONING_MATRIX}" != "true" && "${LIVE_REASONING_MATRIX}" != "false" ]]; then
   echo "error: LLM_PROXY_LIVE_REASONING_MATRIX must be true or false" >&2
   exit 1
+fi
+LIVE_TIMEOUT="$(env_or_default LLM_PROXY_LIVE_TIMEOUT 45)"
+if [[ "${GEMINI_CANDIDATES_ONLY}" == "true" ]]; then
+  LLM_PROXY_LIVE_REASONING_MATRIX="${LIVE_REASONING_MATRIX}" \
+    LLM_PROXY_LIVE_TIMEOUT="${LIVE_TIMEOUT}" \
+    "${ROOT_DIR}/scripts/test_live_gemini_candidates.sh"
+  exit 0
 fi
 
 if [[ -n "${LLM_PROXY_LIVE_PORT:-}" ]]; then
@@ -994,7 +1015,6 @@ if [[ -n "${LLM_PROXY_LIVE_PORT:-}" ]]; then
 else
   PORT="$(allocate_loopback_port)"
 fi
-LIVE_TIMEOUT="$(env_or_default LLM_PROXY_LIVE_TIMEOUT 45)"
 if [[ -n "${WRITE_CONFIG_PATH}" ]]; then
   mkdir -p "$(dirname "${WRITE_CONFIG_PATH}")"
   CONFIG_PATH="$(cd "$(dirname "${WRITE_CONFIG_PATH}")" && pwd)/$(basename "${WRITE_CONFIG_PATH}")"

--- a/site/resources/gemini-interactions-proxy/index.html
+++ b/site/resources/gemini-interactions-proxy/index.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Gemini Interactions proxy for stored 3.x model calls</title>
-    <meta name="description" content="Route four registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.">
+    <meta name="description" content="Route two registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.">
     <link rel="canonical" href="https://llm-proxy.mprlab.com/resources/gemini-interactions-proxy/">
     <meta property="og:title" content="Gemini Interactions proxy for stored 3.x model calls">
-    <meta property="og:description" content="Route four registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.">
+    <meta property="og:description" content="Route two registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://llm-proxy.mprlab.com/resources/gemini-interactions-proxy/">
     <meta name="twitter:card" content="summary">
@@ -27,9 +27,9 @@
     <link rel="stylesheet" href="/assets/llm-proxy/styles.css">
     <link rel="stylesheet" href="/assets/llm-proxy/resources.css">
     <script defer src="/assets/llm-proxy/js/googleAnalytics.js"></script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gemini Interactions proxy for stored 3.x model calls","description":"Route four registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.","url":"https://llm-proxy.mprlab.com/resources/gemini-interactions-proxy/","datePublished":"2026-07-06","dateModified":"2026-08-22","mainEntityOfPage":"https://llm-proxy.mprlab.com/resources/gemini-interactions-proxy/","about":["LLM Proxy","Provider routing","Gemini Interactions proxy"],"author":{"@type":"Person","name":"Tyemirov","url":"https://github.com/tyemirov"}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gemini Interactions proxy for stored 3.x model calls","description":"Route two registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.","url":"https://llm-proxy.mprlab.com/resources/gemini-interactions-proxy/","datePublished":"2026-07-06","dateModified":"2026-08-22","mainEntityOfPage":"https://llm-proxy.mprlab.com/resources/gemini-interactions-proxy/","about":["LLM Proxy","Provider routing","Gemini Interactions proxy"],"author":{"@type":"Person","name":"Tyemirov","url":"https://github.com/tyemirov"}}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://llm-proxy.mprlab.com/"},{"@type":"ListItem","position":2,"name":"Resources","item":"https://llm-proxy.mprlab.com/resources/"},{"@type":"ListItem","position":3,"name":"Gemini Interactions proxy for stored 3.x model calls","item":"https://llm-proxy.mprlab.com/resources/gemini-interactions-proxy/"}]}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Which Gemini models does this route register?","acceptedAnswer":{"@type":"Answer","text":"The catalog registers Gemini 3.5 Flash, Gemini 3 Flash Preview, Gemini 3.1 Flash Lite, and Gemini 3.1 Pro Preview."}},{"@type":"Question","name":"Can a Gemini request contain assistant history?","acceptedAnswer":{"@type":"Answer","text":"No. Each Gemini Interactions route rejects an assistant message before it sends an upstream request."}},{"@type":"Question","name":"What happens when Gemini returns an incomplete interaction?","acceptedAnswer":{"@type":"Answer","text":"The proxy cleans up the stored interaction and returns a provider error. It does not replay the partial output."}},{"@type":"Question","name":"How does the proxy handle delayed Gemini resource visibility?","acceptedAnswer":{"@type":"Answer","text":"The Gemini transport declares six retries at five-second intervals for HTTP 400, 403, and 404 responses after creation."}},{"@type":"Question","name":"What should I read next?","acceptedAnswer":{"@type":"Answer","text":"A closely related resource is Integrate once through one multi-provider LLM proxy, which covers multi-provider LLM proxy."}}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Which Gemini models does this route register?","acceptedAnswer":{"@type":"Answer","text":"The catalog registers Gemini 3.5 Flash and Gemini 3 Flash Preview."}},{"@type":"Question","name":"Can a Gemini request contain assistant history?","acceptedAnswer":{"@type":"Answer","text":"No. Each Gemini Interactions route rejects an assistant message before it sends an upstream request."}},{"@type":"Question","name":"What happens when Gemini returns an incomplete interaction?","acceptedAnswer":{"@type":"Answer","text":"The proxy cleans up the stored interaction and returns a provider error. It does not replay the partial output."}},{"@type":"Question","name":"How does the proxy handle delayed Gemini resource visibility?","acceptedAnswer":{"@type":"Answer","text":"The Gemini transport declares six retries at five-second intervals for HTTP 400, 403, and 404 responses after creation."}},{"@type":"Question","name":"What should I read next?","acceptedAnswer":{"@type":"Answer","text":"A closely related resource is Integrate once through one multi-provider LLM proxy, which covers multi-provider LLM proxy."}}]}</script>
     <script defer src="https://loopaware.mprlab.com/pixel.js?site_id=839f018b-97a9-4955-a489-4ad5cb626f4f"></script>
   </head>
   <body class="resource-page">
@@ -65,12 +65,12 @@
           <header class="resource-hero">
             <p class="eyebrow">Provider routing</p>
             <h1>Gemini Interactions proxy for stored 3.x model calls</h1>
-            <p class="resource-deck">Route four registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.</p>
+            <p class="resource-deck">Route two registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.</p>
             <p class="resource-audience">Developers adding Gemini as a provider without bringing Gemini-specific payloads into every app.</p>
             <p class="resource-byline">Reviewed 2026-08-22 by <a href="https://github.com/tyemirov" rel="author">Tyemirov on GitHub</a>.</p>
             <aside class="resource-verdict" aria-label="Quick verdict">
               <strong>Quick verdict</strong>
-              <p>Use this route for four registered Gemini 3.x models when the proxy must own stored-resource polling, visibility retries, and cleanup.</p>
+              <p>Use this route for two registered Gemini 3.x models when the proxy must own stored-resource polling, visibility retries, and cleanup.</p>
             </aside>
             <div class="resource-actions">
               <a class="resource-button" href="/docs/">Open API reference</a>
@@ -195,7 +195,7 @@
 
                     <details>
                       <summary>Which Gemini models does this route register?</summary>
-                      <p>The catalog registers Gemini 3.5 Flash, Gemini 3 Flash Preview, Gemini 3.1 Flash Lite, and Gemini 3.1 Pro Preview.</p>
+                      <p>The catalog registers Gemini 3.5 Flash and Gemini 3 Flash Preview.</p>
                     </details>
 
 

--- a/site/resources/index.html
+++ b/site/resources/index.html
@@ -168,7 +168,7 @@
                         <a class="resource-index-card" href="/resources/gemini-interactions-proxy/">
                           <span>Gemini Interactions proxy</span>
                           <strong>Gemini Interactions proxy for stored 3.x model calls</strong>
-                          <p>Route four registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.</p>
+                          <p>Route two registered Gemini 3.x models through stored Interactions with provider-configured visibility retries, cleanup, and one blocking proxy request.</p>
                         </a>
 
 

--- a/site/resources/live-provider-smoke-tests/index.html
+++ b/site/resources/live-provider-smoke-tests/index.html
@@ -145,7 +145,7 @@
 
                     <section class="resource-card">
                       <h3>Gemini wrapper</h3>
-                      <p>Use make test-live-gemini as the Gemini-specific compatibility target.</p>
+                      <p>Use make test-live-gemini to accept the exact Gemini 3.6 and 3.7 candidates before testing registered Gemini routes.</p>
                     </section>
 
 

--- a/tests/capabilities_test.go
+++ b/tests/capabilities_test.go
@@ -134,7 +134,7 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 	if catalogError != nil {
 		testingInstance.Fatalf("NewPublicCapabilityCatalog error: %v", catalogError)
 	}
-	if catalog.Revision == "" || len(catalog.Operations) != 3 || len(catalog.Prices) != 65 || len(catalog.Prices) != len(catalog.Offerings) || catalog.Counts.Providers != 11 || catalog.Counts.ModelPublishers != 11 || catalog.Counts.ModelFamilies != 24 || catalog.Counts.ModelFamilies != len(catalog.Families) || catalog.Counts.ExactModels != 64 || catalog.Counts.ExactModels != len(catalog.Models) || catalog.Counts.ProviderOfferings != 65 || catalog.Counts.ProviderOfferings != len(catalog.Offerings) || catalog.MaxPromptBytes != proxy.DefaultMaxPromptBytes || catalog.MaxInputAudioBytes != proxy.DefaultMaxInputAudioBytes {
+	if catalog.Revision == "" || len(catalog.Operations) != 3 || len(catalog.Prices) != 63 || len(catalog.Prices) != len(catalog.Offerings) || catalog.Counts.Providers != 11 || catalog.Counts.ModelPublishers != 11 || catalog.Counts.ModelFamilies != 24 || catalog.Counts.ModelFamilies != len(catalog.Families) || catalog.Counts.ExactModels != 62 || catalog.Counts.ExactModels != len(catalog.Models) || catalog.Counts.ProviderOfferings != 63 || catalog.Counts.ProviderOfferings != len(catalog.Offerings) || catalog.MaxPromptBytes != proxy.DefaultMaxPromptBytes || catalog.MaxInputAudioBytes != proxy.DefaultMaxInputAudioBytes {
 		testingInstance.Fatalf("catalog summary=%+v", catalog)
 	}
 	weightAccessFound := map[string]bool{}
@@ -153,6 +153,15 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 			proxy.PublicModelCapabilityImageInput,
 			proxy.PublicModelCapabilityText,
 		},
+		"gemini-3-flash-preview": {
+			proxy.PublicModelCapabilityAudioInput,
+			proxy.PublicModelCapabilityImageInput,
+			proxy.PublicModelCapabilityText,
+		},
+	}
+	retiredGeminiModels := map[string]struct{}{
+		"gemini-3.1-flash-lite":  {},
+		"gemini-3.1-pro-preview": {},
 	}
 	openAIDictationCapabilityFound := false
 	expectedKimiModels := map[string]struct{}{
@@ -166,6 +175,9 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 		proxy.ModelNameMuseSpark12: {},
 	}
 	for _, model := range catalog.Models {
+		if _, retired := retiredGeminiModels[model.Identifier]; retired {
+			testingInstance.Fatalf("public capability catalog exposed retired Gemini model=%s", model.Identifier)
+		}
 		if model.Publisher == "google" && !strings.HasPrefix(model.Identifier, "gemini-3") {
 			testingInstance.Fatalf("public capability catalog exposed retired Gemini model=%s", model.Identifier)
 		}
@@ -206,6 +218,9 @@ func TestPublicCapabilityCatalogProjectsValidatedRuntimeRegistry(testingInstance
 		}
 	}
 	for _, offering := range catalog.Offerings {
+		if _, retired := retiredGeminiModels[offering.Model]; retired {
+			testingInstance.Fatalf("public capability catalog exposed retired Gemini offering=%s", offering.Model)
+		}
 		if offering.Provider == proxy.ProviderNameOpenAI && offering.Model == proxy.DefaultDictationModel {
 			openAIDictationCapabilityFound = true
 		}
@@ -327,7 +342,7 @@ func TestPublicCapabilityCatalogPublishesExactProviderMediaLimits(testingInstanc
 	}
 	expectedOfferingCounts := map[string]int{
 		proxy.ProviderNameOpenAI:    11,
-		proxy.ProviderNameGemini:    4,
+		proxy.ProviderNameGemini:    2,
 		proxy.ProviderNameAnthropic: 10,
 		proxy.ProviderNameMoonshot:  4,
 		proxy.ProviderNameXAI:       1,

--- a/tests/e2e/management-ui.spec.js
+++ b/tests/e2e/management-ui.spec.js
@@ -442,7 +442,7 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).toContain('<routing-tree class="routing-tree" data-enhanced="false" aria-label="Interactive LLM routing map">');
   expect(html).toContain("One integration. Choose the exact route.");
   expect(html).toContain('<canvas class="routing-tree__connectors" data-route-canvas aria-hidden="true"></canvas>');
-  expect(html).toContain('<output class="routing-tree__counts" aria-live="polite" data-route-counts>12 families · 41 exact models · 41 offerings</output>');
+  expect(html).toContain('<output class="routing-tree__counts" aria-live="polite" data-route-counts>12 families · 39 exact models · 39 offerings</output>');
   expect(html).toContain('data-route-family="deepseek-r1"');
   expect(html).toContain('data-route-family="muse-spark"');
   expect(html).toContain('data-route-model="muse-spark-1.2" data-route-model-family="muse-spark"');
@@ -461,8 +461,8 @@ test("public landing explains the product and exposes the generated capability c
   expect(html).toContain('<strong>11</strong><span>Providers</span>');
   expect(html).toContain('<strong>11</strong><span>Publishers</span>');
   expect(html).toContain('<strong>24</strong><span>Families</span>');
-  expect(html).toContain('<strong>64</strong><span>Exact models</span>');
-  expect(html).toContain('<strong>65</strong><span>Offerings</span>');
+  expect(html).toContain('<strong>62</strong><span>Exact models</span>');
+  expect(html).toContain('<strong>63</strong><span>Offerings</span>');
   expect(html).toContain('data-catalog-sort-header="publisher"');
   expect(html).toContain('data-catalog-sort-header="model"');
   expect(html).toContain('data-catalog-sort-header="capabilities"');
@@ -840,8 +840,8 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(page.locator("#models > routing-tree")).toHaveCount(0);
   await expect(routingTree).toHaveAttribute("data-enhanced", "false");
   await expect(routingTree.locator("[data-route-family]")).toHaveCount(24);
-  await expect(routingTree.locator("[data-route-provider]")).toHaveCount(65);
-  await expect(routingTree.locator("[data-route-model]")).toHaveCount(64);
+  await expect(routingTree.locator("[data-route-provider]")).toHaveCount(63);
+  await expect(routingTree.locator("[data-route-model]")).toHaveCount(62);
   await expect(routingTree.locator("[data-route-weight-access]")).toHaveCount(2);
   await expect(routingTree.locator("[data-route-capability]")).toHaveCount(7);
   await expect(routingTree.locator('[data-route-weight-access="proprietary"]')).toHaveAttribute("aria-pressed", "true");
@@ -850,7 +850,7 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
   await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
   await expect(routingTree.locator('[data-route-family]:visible')).toHaveCount(12);
-  await expect(routingTree.locator("[data-route-counts]")).toHaveText("12 families · 41 exact models · 41 offerings");
+  await expect(routingTree.locator("[data-route-counts]")).toHaveText("12 families · 39 exact models · 39 offerings");
   await expect(routingTree.locator('[data-route-family="claude-fable"]')).toHaveAttribute("aria-pressed", "true");
   await expect(routingTree.locator('[data-route-model-group="claude-fable"]')).toBeVisible();
   await expect(routingTree.locator('[data-route-model-group="grok"]')).toBeHidden();
@@ -863,7 +863,7 @@ test("the routing tree and capability catalog remain complete without JavaScript
   await expect(catalog).toHaveAttribute("data-enhanced", "false");
   await expect(catalog.locator("[data-catalog-toolbar]")).toBeHidden();
   await expect(catalog.getByRole("columnheader")).toHaveText(["Publisher", "Model", "Provider offerings and capabilities"]);
-  await expect(catalog.locator("[data-catalog-row]")).toHaveCount(64);
+  await expect(catalog.locator("[data-catalog-row]")).toHaveCount(62);
   await expect(catalog.locator('[data-model="gpt-4o-mini-transcribe"]')).toContainText("Dictation");
   await expect(catalog.locator('[data-model="gpt-4o-mini"]')).toContainText("Image input");
   await expect(catalog.locator('[data-model="claude-fable-5"]')).toContainText("Image input");
@@ -912,8 +912,8 @@ test("visitors can filter and choose a model family, exact model, and provider o
   await expect(routingTree).toHaveAttribute("data-enhanced", "true");
   await expect(routingTree).toHaveAttribute("data-route-lines-rendered", "true");
   await expect(routingTree.locator("[data-route-family]")).toHaveCount(24);
-  await expect(routingTree.locator("[data-route-model]")).toHaveCount(64);
-  await expect(routingTree.locator("[data-route-provider]")).toHaveCount(65);
+  await expect(routingTree.locator("[data-route-model]")).toHaveCount(62);
+  await expect(routingTree.locator("[data-route-provider]")).toHaveCount(63);
   await expect(routingTree.locator("[data-route-weight-access]")).toHaveCount(2);
   await expect(routingTree.locator("[data-route-capability]")).toHaveCount(7);
   await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "true");
@@ -921,7 +921,7 @@ test("visitors can filter and choose a model family, exact model, and provider o
   await expect(textFilter).toHaveAttribute("aria-pressed", "true");
   await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
   await expect(routingTree.locator('[data-route-capability][aria-pressed="true"]')).toHaveCount(1);
-  await expect(counts).toHaveText("12 families · 41 exact models · 41 offerings");
+  await expect(counts).toHaveText("12 families · 39 exact models · 39 offerings");
   await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(12);
   await expect(routingTree.locator("[data-route-model]:visible")).toHaveCount(1);
   await expect(routingTree.locator("[data-route-provider]:visible")).toHaveCount(1);
@@ -941,10 +941,10 @@ test("visitors can filter and choose a model family, exact model, and provider o
   await imageInputFilter.click();
   await expect(imageInputFilter).toHaveAttribute("aria-pressed", "true");
   await expect(textFilter).toHaveAttribute("aria-pressed", "false");
-  await expect(counts).toHaveText("8 families · 26 exact models · 26 offerings");
+  await expect(counts).toHaveText("8 families · 24 exact models · 24 offerings");
   await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(8);
   await openWeightsFilter.click();
-  await expect(counts).toHaveText("10 families · 30 exact models · 30 offerings");
+  await expect(counts).toHaveText("10 families · 28 exact models · 28 offerings");
   await expect(routingTree.locator('[data-route-family="kimi-k2"]')).toBeVisible();
   await expect(routingTree.locator('[data-route-family="kimi-k3"]')).toBeVisible();
   await openWeightsFilter.click();
@@ -958,15 +958,15 @@ test("visitors can filter and choose a model family, exact model, and provider o
   await audioInputFilter.click();
   await expect(audioInputFilter).toHaveAttribute("aria-pressed", "true");
   await expect(imageInputFilter).toHaveAttribute("aria-pressed", "false");
-  await expect(counts).toHaveText("1 family · 4 exact models · 4 offerings");
+  await expect(counts).toHaveText("1 family · 2 exact models · 2 offerings");
   await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(1);
   await expect(routingTree.locator('[data-route-family="gemini"]')).toHaveAttribute("aria-pressed", "true");
-  await expect(routingTree.locator('[data-route-model-group="gemini"] [data-route-model]')).toHaveCount(4);
+  await expect(routingTree.locator('[data-route-model-group="gemini"] [data-route-model]')).toHaveCount(2);
   await expect(selectedProvider).toHaveText("gemini");
 
   await textFilter.click();
   await routingTree.locator('[data-route-family="claude-fable"]').click();
-  await expect(counts).toHaveText("12 families · 41 exact models · 41 offerings");
+  await expect(counts).toHaveText("12 families · 39 exact models · 39 offerings");
   await expect(selectedModel).toHaveText("claude-fable-5");
   await expect(selectedProvider).toHaveText("anthropic");
 
@@ -974,7 +974,7 @@ test("visitors can filter and choose a model family, exact model, and provider o
   await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "true");
   await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "true");
   await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(2);
-  await expect(counts).toHaveText("19 families · 58 exact models · 59 offerings");
+  await expect(counts).toHaveText("19 families · 56 exact models · 57 offerings");
   await expect(routingTree.locator("[data-route-family]:visible")).toHaveCount(19);
   await expect(selectedModel).toHaveText("claude-fable-5");
   await expect(selectedProvider).toHaveText("anthropic");
@@ -1029,12 +1029,12 @@ test("visitors can filter and choose a model family, exact model, and provider o
   await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "true");
   await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "true");
   await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(2);
-  await expect(counts).toHaveText("19 families · 58 exact models · 59 offerings");
+  await expect(counts).toHaveText("19 families · 56 exact models · 57 offerings");
   await openWeightsFilter.click();
   await expect(openWeightsFilter).toHaveAttribute("aria-pressed", "false");
   await expect(proprietaryFilter).toHaveAttribute("aria-pressed", "true");
   await expect(routingTree.locator('[data-route-weight-access][aria-pressed="true"]')).toHaveCount(1);
-  await expect(counts).toHaveText("12 families · 41 exact models · 41 offerings");
+  await expect(counts).toHaveText("12 families · 39 exact models · 39 offerings");
   await webSearchFilter.click();
   await expect(webSearchFilter).toHaveAttribute("aria-pressed", "true");
   await expect(textFilter).toHaveAttribute("aria-pressed", "false");
@@ -1164,8 +1164,8 @@ test("visitors can disclose filters, search every characteristic, and sort throu
   const modelHeader = catalog.locator('[data-catalog-sort-header="model"]');
   const capabilitiesHeader = catalog.locator('[data-catalog-sort-header="capabilities"]');
   await expect(catalog).toHaveAttribute("data-enhanced", "true");
-  await expect(rows).toHaveCount(64);
-  await expect(resultCount).toHaveText("64 of 64 models");
+  await expect(rows).toHaveCount(62);
+  await expect(resultCount).toHaveText("62 of 62 models");
   await expect(filterPanel).toBeHidden();
   await expect(searchSubmit).toHaveAttribute("aria-expanded", "false");
 
@@ -1187,20 +1187,20 @@ test("visitors can disclose filters, search every characteristic, and sort throu
   await expect(catalog.locator('[data-catalog-search-text*="synchronous"]')).toHaveCount(0);
   await searchInput.fill("gemini-3.5-flash image_input audio_input");
   await expect(filterPanel).toBeVisible();
-  await expect(resultCount).toHaveText("1 of 64 model");
+  await expect(resultCount).toHaveText("1 of 62 model");
   await expect(visibleRows).toHaveAttribute("data-model", "gemini-3.5-flash");
 
   await searchInput.fill("gpt-5.5-pro openai_responses xhigh");
-  await expect(resultCount).toHaveText("1 of 64 model");
+  await expect(resultCount).toHaveText("1 of 62 model");
   await expect(visibleRows).toHaveAttribute("data-model", "gpt-5.5-pro");
 
   await searchInput.fill("glm-5.2 131072 token");
-  await expect(resultCount).toHaveText("1 of 64 model");
+  await expect(resultCount).toHaveText("1 of 62 model");
   await expect(visibleRows).toHaveAttribute("data-model", "glm-5.2");
 
   await catalog.getByRole("button", { name: "Reset" }).click();
   await searchInput.fill("dictation");
-  await expect(resultCount).toHaveText("5 of 64 models");
+  await expect(resultCount).toHaveText("5 of 62 models");
   for (const visibleRow of await visibleRows.all()) {
     await expect(visibleRow).toHaveAttribute("data-capabilities", "dictation");
   }
@@ -1208,28 +1208,28 @@ test("visitors can disclose filters, search every characteristic, and sort throu
   await catalog.getByRole("button", { name: "Reset" }).click();
   await catalog.getByRole("checkbox", { name: "Image input" }).check();
   await catalog.getByRole("checkbox", { name: "Audio message input" }).check();
-  await expect(resultCount).toHaveText("4 of 64 models");
-  await expect(visibleRows).toHaveCount(4);
+  await expect(resultCount).toHaveText("2 of 62 models");
+  await expect(visibleRows).toHaveCount(2);
 
   await searchSubmit.click();
   await expect(filterPanel).toBeHidden();
-  await expect(resultCount).toHaveText("4 of 64 models");
+  await expect(resultCount).toHaveText("2 of 62 models");
   await searchSubmit.click();
   await expect(filterPanel).toBeVisible();
   await expect(catalog.getByRole("checkbox", { name: "Image input" })).toBeChecked();
   await expect(catalog.getByRole("checkbox", { name: "Audio message input" })).toBeChecked();
 
   await catalog.getByRole("checkbox", { name: "Dictation" }).check();
-  await expect(resultCount).toHaveText("0 of 64 models");
+  await expect(resultCount).toHaveText("0 of 62 models");
   await expect(catalog.locator("[data-catalog-empty]")).toBeVisible();
 
   await catalog.getByRole("button", { name: "Reset" }).click();
-  await expect(resultCount).toHaveText("64 of 64 models");
+  await expect(resultCount).toHaveText("62 of 62 models");
   await searchInput.press("Escape");
   await catalog.getByRole("button", { name: "Filter by Dictation" }).first().click();
   await expect(filterPanel).toBeVisible();
   await expect(catalog.getByRole("checkbox", { name: "Dictation" })).toBeChecked();
-  await expect(resultCount).toHaveText("5 of 64 models");
+  await expect(resultCount).toHaveText("5 of 62 models");
 
   await catalog.getByRole("button", { name: "Reset" }).click();
   await expect(publisherHeader).toHaveAttribute("aria-sort", "ascending");

--- a/tests/operational_contract_test.go
+++ b/tests/operational_contract_test.go
@@ -41,7 +41,8 @@ func TestOperationalHelpCommandsUseBuiltinOutput(testingInstance *testing.T) {
 		path             string
 		expectedFragment string
 	}{
-		{name: "live-providers", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), expectedFragment: "scripts/test_live_providers.sh [--media | --preflight | --write-config <path>]"},
+		{name: "live-providers", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"), expectedFragment: "scripts/test_live_providers.sh [--gemini-candidates | --media | --preflight | --write-config <path>]"},
+		{name: "live-gemini-candidates", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_gemini_candidates.sh"), expectedFragment: "Runs paid Google Interactions acceptance"},
 		{name: "production-live-test", path: filepath.Join(repositoryRoot, operationalScriptsDirectory, "live_test.sh"), expectedFragment: "Usage: make live-test"},
 	}
 	for _, helpCommand := range helpCommands {
@@ -1533,6 +1534,205 @@ func TestOperationalLiveConfigRequiresManagementAndSafelyLoadsDotenv(testingInst
 		if strings.Contains(configuration, forbiddenFragment) {
 			testingInstance.Fatalf("generated live config retained obsolete or secret-bearing %q: %s", forbiddenFragment, configuration)
 		}
+	}
+}
+
+func TestOperationalGeminiCandidateHarnessExercisesExactAcceptanceMatrix(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	toolDirectory := filepath.Join(fixtureRoot, "tools")
+	environmentFile := filepath.Join(fixtureRoot, "live.env")
+	capturePath := filepath.Join(fixtureRoot, "requests.log")
+	stateDirectory := filepath.Join(fixtureRoot, "state")
+	const providerCredential = "private-gemini-candidate-credential"
+	writeOperationalFile(testingInstance, environmentFile, "GEMINI_API_KEY="+providerCredential+"\n", 0o600)
+	writeOperationalFile(testingInstance, filepath.Join(toolDirectory, "sleep"), `#!/usr/bin/env bash
+exit 0
+`, 0o755)
+	writeOperationalFile(testingInstance, filepath.Join(toolDirectory, "curl"), `#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+arguments = sys.argv[1:]
+method = arguments[arguments.index("-X") + 1]
+output_path = pathlib.Path(arguments[arguments.index("-o") + 1])
+url = arguments[-1]
+headers = [arguments[index + 1] for index, value in enumerate(arguments) if value == "-H"]
+if not any(value.startswith("x-goog-api-key: ") for value in headers):
+    raise SystemExit(41)
+if "Api-Revision: 2026-05-20" not in headers:
+    raise SystemExit(42)
+payload = {}
+if "--data-binary" in arguments:
+    request_reference = arguments[arguments.index("--data-binary") + 1]
+    payload = json.loads(pathlib.Path(request_reference.removeprefix("@")).read_text(encoding="utf-8"))
+
+state_directory = pathlib.Path(os.environ["GEMINI_FAKE_STATE"])
+state_directory.mkdir(parents=True, exist_ok=True)
+model = payload.get("model", "")
+thinking_level = payload.get("generation_config", {}).get("thinking_level", "omitted")
+background = payload.get("background", "")
+lifecycle = ""
+if background is True:
+    lifecycle = "completion" if payload["generation_config"]["max_output_tokens"] == 4096 else "cancellation"
+    interaction_id = model + "-" + lifecycle
+else:
+    interaction_id = "sync"
+
+with pathlib.Path(os.environ["GEMINI_FAKE_CAPTURE"]).open("a", encoding="utf-8") as capture:
+    capture.write(f"{method} {url} model={model} background={background} thinking_level={thinking_level} lifecycle={lifecycle}\n")
+
+status_code = "200"
+response = {}
+base_url = "https://generativelanguage.googleapis.com/v1beta/interactions"
+if method == "POST" and url == base_url and background is False:
+    response = {"id": interaction_id, "status": "completed", "steps": [{"type": "model_output", "content": [{"type": "text", "text": "OK"}]}]}
+elif method == "POST" and url == base_url and background is True:
+    response = {"id": interaction_id, "status": "in_progress"}
+elif method == "GET" and url.startswith(base_url + "/"):
+    interaction_id = url.rsplit("/", 1)[-1]
+    if interaction_id.endswith("-completion"):
+        count_path = state_directory / (interaction_id + ".count")
+        count = int(count_path.read_text(encoding="utf-8")) if count_path.exists() else 0
+        count_path.write_text(str(count + 1), encoding="utf-8")
+        if count == 0:
+            response = {"id": interaction_id, "status": "in_progress"}
+        else:
+            response = {"id": interaction_id, "status": "completed", "steps": [{"type": "model_output", "content": [{"type": "text", "text": "OK"}]}]}
+    else:
+        response = {"id": interaction_id, "status": "in_progress"}
+elif method == "POST" and url.endswith("/cancel"):
+    interaction_id = url.removesuffix("/cancel").rsplit("/", 1)[-1]
+    response = {"id": interaction_id, "status": "cancelled"}
+elif method == "DELETE" and url.startswith(base_url + "/"):
+    status_code = "204"
+else:
+    raise SystemExit(43)
+
+output_path.write_text(json.dumps(response), encoding="utf-8")
+sys.stdout.write(status_code)
+`, 0o755)
+
+	environment := append(
+		os.Environ(),
+		"PATH="+toolDirectory+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"LIVE_ENV_FILE="+environmentFile,
+		"GEMINI_FAKE_CAPTURE="+capturePath,
+		"GEMINI_FAKE_STATE="+stateDirectory,
+	)
+	output := runOperationalCommand(
+		testingInstance,
+		repositoryRoot,
+		environment,
+		filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"),
+		"--gemini-candidates",
+	)
+	for _, expectedFragment := range []string{
+		"model=gemini-3.6-flash reasoning_effort=minimal status=200",
+		"model=gemini-3.7-flash reasoning_effort=high status=200",
+		"completion lifecycle passed: model=gemini-3.6-flash status=completed",
+		"cancellation lifecycle passed: model=gemini-3.7-flash status=cancelled",
+		"live Gemini candidate acceptance passed: models=gemini-3.6-flash,gemini-3.7-flash",
+	} {
+		if !strings.Contains(output, expectedFragment) {
+			testingInstance.Fatalf("candidate output omitted %q:\n%s", expectedFragment, output)
+		}
+	}
+	captureBytes, readError := os.ReadFile(capturePath)
+	if readError != nil {
+		testingInstance.Fatalf("read Gemini candidate request capture: %v", readError)
+	}
+	capture := string(captureBytes)
+	for _, exactCase := range []string{
+		"model=gemini-3.6-flash background=False thinking_level=omitted",
+		"model=gemini-3.6-flash background=False thinking_level=minimal",
+		"model=gemini-3.6-flash background=False thinking_level=low",
+		"model=gemini-3.6-flash background=False thinking_level=medium",
+		"model=gemini-3.6-flash background=False thinking_level=high",
+		"model=gemini-3.7-flash background=False thinking_level=omitted",
+		"model=gemini-3.7-flash background=False thinking_level=low",
+		"model=gemini-3.7-flash background=False thinking_level=medium",
+		"model=gemini-3.7-flash background=False thinking_level=high",
+	} {
+		if !strings.Contains(capture, exactCase) {
+			testingInstance.Fatalf("candidate request capture omitted %q:\n%s", exactCase, capture)
+		}
+	}
+	if strings.Contains(capture, "model=gemini-3.7-flash background=False thinking_level=minimal") {
+		testingInstance.Fatalf("candidate request capture sent unsupported Gemini 3.7 minimal thinking:\n%s", capture)
+	}
+	if strings.Count(capture, " POST ") != 0 || strings.Count(capture, "POST ") != 15 || strings.Count(capture, "GET ") != 6 || strings.Count(capture, "DELETE ") != 4 {
+		testingInstance.Fatalf("candidate request capture has an unexpected lifecycle matrix:\n%s", capture)
+	}
+	for _, privateValue := range []string{providerCredential, "x-goog-api-key"} {
+		if strings.Contains(output, privateValue) || strings.Contains(capture, privateValue) {
+			testingInstance.Fatalf("candidate harness exposed private value %q", privateValue)
+		}
+	}
+}
+
+func TestOperationalGeminiCandidateHarnessPreservesExplicitReasoningMatrixOverride(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	scriptDirectory := filepath.Join(fixtureRoot, operationalScriptsDirectory)
+	capturePath := filepath.Join(fixtureRoot, "reasoning-matrix.log")
+	copyOperationalFile(
+		testingInstance,
+		filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_providers.sh"),
+		filepath.Join(scriptDirectory, "test_live_providers.sh"),
+	)
+	writeOperationalFile(testingInstance, filepath.Join(scriptDirectory, "test_live_gemini_candidates.sh"), `#!/usr/bin/env bash
+set -euo pipefail
+builtin printf '%s\n' "${LLM_PROXY_LIVE_REASONING_MATRIX:?}" >"${GEMINI_MATRIX_CAPTURE:?}"
+`, 0o755)
+	runOperationalCommand(
+		testingInstance,
+		fixtureRoot,
+		append(
+			os.Environ(),
+			"GEMINI_MATRIX_CAPTURE="+capturePath,
+			"LLM_PROXY_LIVE_REASONING_MATRIX=false",
+		),
+		filepath.Join(scriptDirectory, "test_live_providers.sh"),
+		"--gemini-candidates",
+	)
+	captureBytes, readError := os.ReadFile(capturePath)
+	if readError != nil {
+		testingInstance.Fatalf("read Gemini reasoning-matrix override: %v", readError)
+	}
+	if string(captureBytes) != "false\n" {
+		testingInstance.Fatalf("Gemini reasoning-matrix override=%q, want false", captureBytes)
+	}
+}
+
+func TestOperationalGeminiWrapperRunsCandidatesBeforeRegisteredRoutes(testingInstance *testing.T) {
+	repositoryRoot := operationalRepositoryRoot(testingInstance)
+	fixtureRoot := testingInstance.TempDir()
+	scriptDirectory := filepath.Join(fixtureRoot, "scripts")
+	capturePath := filepath.Join(fixtureRoot, "wrapper.log")
+	copyOperationalFile(
+		testingInstance,
+		filepath.Join(repositoryRoot, operationalScriptsDirectory, "test_live_gemini.sh"),
+		filepath.Join(scriptDirectory, "test_live_gemini.sh"),
+	)
+	writeOperationalFile(testingInstance, filepath.Join(scriptDirectory, "test_live_providers.sh"), `#!/usr/bin/env bash
+set -euo pipefail
+builtin printf '%s\n' "$*" >>"${GEMINI_WRAPPER_CAPTURE:?}"
+`, 0o755)
+	runOperationalCommand(
+		testingInstance,
+		fixtureRoot,
+		append(os.Environ(), "GEMINI_WRAPPER_CAPTURE="+capturePath),
+		filepath.Join(scriptDirectory, "test_live_gemini.sh"),
+	)
+	captureBytes, readError := os.ReadFile(capturePath)
+	if readError != nil {
+		testingInstance.Fatalf("read Gemini wrapper capture: %v", readError)
+	}
+	if string(captureBytes) != "--gemini-candidates\n\n" {
+		testingInstance.Fatalf("Gemini wrapper invocation order=%q, want candidate then registered routes", captureBytes)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Retire Gemini `3.1-flash-lite` and `3.1-pro-preview` routes, catalog offerings, public capabilities, and generated documentation.
- Add schema-version-11 migration logic that atomically moves stored retired Gemini selections to `gemini-3.5-flash` while preserving connections, profiles, defaults, timestamps, prompts, and historical usage identifiers.
- Ensure pending model replacements are applied before final route validation, with transactional rollback if migration validation fails.
- Add direct live acceptance coverage for unregistered Gemini 3.6 Flash and 3.7 Flash candidates, including omitted and supported thinking levels plus background interaction retrieval, completion, cancellation, and deletion.
- Keep candidate validation enabled by default while allowing operators to explicitly disable it for registered-route-only runs.
- Update provider catalog counts, Gemini route documentation, smoke-test guidance, management UI coverage, and operational contracts for the retired routes and candidate workflow.

## Test Coverage

- Added migration regressions for retired Gemini selections, multi-version upgrades, and rollback behavior.
- Updated routing, management, capabilities, browser UI, and operational contract tests to reject retired routes and verify migrated selections.
- Added black-box coverage for the Gemini candidate request matrix and wrapper behavior.